### PR TITLE
chore(codegen): bump smithy-typescript version to 0.21.1

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.21.0"
+    version = "0.21.1"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.21.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.21.1")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "3798bc15d1af6facaae87ad610986e973336febc",
+  SMITHY_TS_COMMIT: "cf9d6fe3483ba027f98e87d1921c32dd94e2c1f9",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Refs: https://github.com/smithy-lang/smithy-typescript/pull/1299

### Description
Bumps smithy-typescript version to 0.21.1

There's no codegen diff, since it was merged in https://github.com/aws/aws-sdk-js-v3/pull/6171

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
