### PR TITLE
test(protocoltests): validate resolvedHost from httpRequestTests

### DIFF
--- a/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
+++ b/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
@@ -352,6 +352,9 @@ it("Ec2QueryEndpointTrait:Request", async () => {
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-www-form-urlencoded");
 
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.example.com");
+
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
     const bodyString = `Action=EndpointOperation&Version=2020-01-08`;
@@ -390,6 +393,9 @@ it("Ec2QueryEndpointTraitWithHostLabel:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-www-form-urlencoded");
+
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.bar.example.com");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;

--- a/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
+++ b/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
@@ -252,6 +252,9 @@ it("AwsJson10EndpointTrait:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/");
 
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.example.com");
+
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
     const bodyString = `{}`;
@@ -287,6 +290,9 @@ it("AwsJson10EndpointTraitWithHostLabel:Request", async () => {
     const r = err.request;
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/");
+
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.bar.example.com");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;

--- a/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
+++ b/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
@@ -477,6 +477,9 @@ it("AwsJson11EndpointTrait:Request", async () => {
     expect(r.headers["x-amz-target"]).toBeDefined();
     expect(r.headers["x-amz-target"]).toBe("JsonProtocol.EndpointOperation");
 
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.example.com");
+
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
     const bodyString = `{}`;
@@ -517,6 +520,9 @@ it("AwsJson11EndpointTraitWithHostLabel:Request", async () => {
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
     expect(r.headers["x-amz-target"]).toBeDefined();
     expect(r.headers["x-amz-target"]).toBe("JsonProtocol.EndpointWithHostLabelOperation");
+
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.bar.example.com");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;

--- a/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
+++ b/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
@@ -352,6 +352,9 @@ it("AwsQueryEndpointTrait:Request", async () => {
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-www-form-urlencoded");
 
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.example.com");
+
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
     const bodyString = `Action=EndpointOperation&Version=2020-01-08`;
@@ -390,6 +393,9 @@ it("AwsQueryEndpointTraitWithHostLabel:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-www-form-urlencoded");
+
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.bar.example.com");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -1634,6 +1634,9 @@ it("RestJsonEndpointTrait:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/EndpointOperation");
 
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.example.com");
+
     expect(r.body).toBeFalsy();
   }
 });
@@ -1665,6 +1668,9 @@ it("RestJsonEndpointTraitWithHostLabel:Request", async () => {
     const r = err.request;
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/EndpointWithHostLabelOperation");
+
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.bar.example.com");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;

--- a/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
@@ -888,6 +888,9 @@ it("RestXmlEndpointTrait:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/EndpointOperation");
 
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.example.com");
+
     expect(r.body).toBeFalsy();
   }
 });
@@ -925,6 +928,9 @@ it("RestXmlEndpointTraitWithHostLabelAndHttpBinding:Request", async () => {
     expect(r.headers["x-amz-account-id"]).toBeDefined();
     expect(r.headers["x-amz-account-id"]).toBe("bar");
 
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("bar.example.com");
+
     expect(r.body).toBeFalsy();
   }
 });
@@ -956,6 +962,9 @@ it("RestXmlEndpointTraitWithHostLabel:Request", async () => {
     const r = err.request;
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/EndpointWithHostLabelOperation");
+
+    expect(r.headers["host"]).toBeDefined();
+    expect(r.headers["host"]).toBe("foo.bar.example.com");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "cf9d6fe3483ba027f98e87d1921c32dd94e2c1f9",
+  SMITHY_TS_COMMIT: "78cb9a8fa99a2983d44e63f13266f093dacde90a",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Codegen for https://github.com/smithy-lang/smithy-typescript/pull/1300

### Description
Validates resolvedHost from httpRequestTests in protocoltests

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
