### PR TITLE
chore(credential-provider-node): fix readme typo

### DIFF
--- a/packages/credential-provider-node/README.md
+++ b/packages/credential-provider-node/README.md
@@ -5,9 +5,9 @@
 
 ## AWS Credential Provider for Node.JS
 
-This module provides a factory function, `fromEnv`, that will attempt to source
-AWS credentials from a Node.JS environment. It will attempt to find credentials
-from the following sources (listed in order of precedence):
+This module provides a factory function, `defaultProvider`, that will attempt to
+source AWS credentials from a Node.JS environment. It will attempt to find
+credentials from the following sources (listed in order of precedence):
 
 - Environment variables exposed via `process.env`
 - SSO credentials from token cache


### PR DESCRIPTION
### Description
The README of `credential-provider-node` currently refers to `fromEnv` (which does not exist in the package). This change fixes README to instead refer to `defaultProvider`.

### Testing
N/A

### Additional context
Since the initial introduction of `packages/credential-provider-node/README.md` in https://github.com/aws/aws-sdk-js-v3/commit/012558d471faf3ef80dd83628f81ba065c286e8a, the README referred to `fromEnv`, which did not exist then, nor does it exist now.

Later sections of README refer to the same factory function as `defaultProvider`:

https://github.com/aws/aws-sdk-js-v3/blob/65eb2e631383a82deb009bcb0983ae114c0c7b26/packages/credential-provider-node/README.md?plain=1#L65-L67

This change fixes the inconsistency.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
