### PR TITLE
chore(scripts): ignore directories with no package jsons

### DIFF
--- a/scripts/runtime-dependency-version-check/runtime-dep-version-check.js
+++ b/scripts/runtime-dependency-version-check/runtime-dep-version-check.js
@@ -54,7 +54,14 @@ readPackages(clientPackages);
 checkVersions();
 
 for (const pkg of nonClientPackages) {
-  const pkgJson = require(path.join(pkg, "package.json"));
+  const pkgJsonPath = path.join(pkg, "package.json");
+
+  // Check if package.json exists before requiring it
+  if (!fs.existsSync(pkgJsonPath)) {
+    continue;
+  }
+
+  const pkgJson = require(pkgJsonPath);
   const { dependencies = {}, devDependencies = {} } = pkgJson;
 
   for (const [name, version] of Object.entries(dependencies)) {
@@ -115,7 +122,7 @@ for (const pkg of nonClientPackages) {
     }
   }
 
-  fs.writeFileSync(path.join(pkg, "package.json"), JSON.stringify(pkgJson, null, 2) + "\n", "utf-8");
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + "\n", "utf-8");
 }
 
 readPackages(nonClientPackages);
@@ -147,7 +154,14 @@ function checkVersions() {
 
 function readPackages(packages) {
   for (const pkg of packages) {
-    const pkgJson = require(path.join(pkg, "package.json"));
+    const pkgJsonPath = path.join(pkg, "package.json");
+
+    // Check if package.json exists before requiring it
+    if (!fs.existsSync(pkgJsonPath)) {
+      continue;
+    }
+
+    const pkgJson = require(pkgJsonPath);
     const { dependencies = {}, devDependencies = {} } = pkgJson;
     for (const [name, version] of Object.entries(dependencies)) {
       if (version.startsWith("file:")) {


### PR DESCRIPTION
### Description
This script often throws a `Error: Cannot find module` for `package.json` of recently removed clients. This change makes the script continue if the `package.json` doesn't exist instead of throwing, which was interrupting pre-commit hooks and CI at the least. 

### Additional context
We were doing a `git clean` to resolve this, but sometimes that's not desirable. 


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
