### PR TITLE
test(credential-providers): integration test for 'read config files from paths relative to homedir'

### DIFF
--- a/packages/credential-providers/jest.config.integ.js
+++ b/packages/credential-providers/jest.config.integ.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -16,7 +16,8 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "extract:docs": "api-extractor run --local",
-    "test": "jest"
+    "test": "jest",
+    "test:integration": "jest -c jest.config.integ.js"
   },
   "keywords": [
     "aws",

--- a/packages/credential-providers/src/fromSSO.integ.spec.ts
+++ b/packages/credential-providers/src/fromSSO.integ.spec.ts
@@ -1,0 +1,53 @@
+import { ListBucketsCommand, S3 } from "@aws-sdk/client-s3";
+import fs from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import { fromSSO } from "./fromSSO";
+
+const SAMPLE_CONFIG = `[profile dev]
+sso_session = my-sso
+sso_account_id = 111122223333
+sso_role_name = SampleRole
+
+[sso-session my-sso]
+sso_region = us-east-1
+sso_start_url = https://my-sso-portal.awsapps.com/start
+sso_registration_scopes = sso:account:access
+`;
+
+jest.mock("fs", () => {
+  return {
+    promises: {
+      readFile: jest.fn(),
+    },
+  };
+});
+
+describe("fromSSO integration test", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should expand relative homedir", async () => {
+    const mockReadFile = (fs.promises.readFile as jest.Mock).mockResolvedValue(SAMPLE_CONFIG);
+
+    const client = new S3({
+      region: "eu-west-1",
+      credentials: fromSSO({
+        profile: "dev",
+        filepath: "~/custom/path/to/credentials",
+        configFilepath: "~/custom/path/to/config",
+      }),
+    });
+
+    try {
+      await client.send(new ListBucketsCommand({}));
+    } catch (e) {
+      // do nothing
+    }
+
+    expect(mockReadFile).toHaveBeenCalledWith(join(homedir(), "custom/path/to/credentials"), "utf8");
+    expect(mockReadFile).toHaveBeenCalledWith(join(homedir(), "custom/path/to/config"), "utf8");
+  });
+});


### PR DESCRIPTION
### Issue
#5876

### Description
This PR adds an integration test for this change: https://github.com/smithy-lang/smithy-typescript/pull/1315

### Testing
`yarn test:integration`

### Additional context
Add any other context about the PR here.

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
