### PR TITLE
chore(lib-dynamodb): use correct types

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -150,9 +150,9 @@ final class DocumentClientPaginationGenerator implements Runnable {
                 "export async function* paginate$L(config: $L, input: $L, ...additionalArguments: any): Paginator<$L>{",
                 "}",  operationName, paginationType, inputTypeName, outputTypeName, () -> {
             String destructuredInputTokenName = destructurePath(inputTokenName);
-            writer.write("// ToDo: replace with actual type instead of typeof input$L", destructuredInputTokenName);
-            writer.write("let token: typeof input$L | undefined = config.startingToken || undefined;",
-                    destructuredInputTokenName);
+            writer.write(
+                "let token: Record<string, NativeAttributeValue> | undefined = config.startingToken || undefined;"
+            );
 
             writer.write("let hasNext = true;");
             writer.write("let page: $L;", outputTypeName);
@@ -180,8 +180,6 @@ final class DocumentClientPaginationGenerator implements Runnable {
 
                 writer.write("hasNext = !!(token);");
             });
-
-            writer.write("// @ts-ignore");
             writer.write("return undefined;");
         });
     }
@@ -197,7 +195,6 @@ final class DocumentClientPaginationGenerator implements Runnable {
                 "const makePagedClientRequest = async (client: $L, input: $L, ...args: any): Promise<$L> => {",
                 "}", DocumentClientUtils.CLIENT_NAME, inputTypeName,
                 outputTypeName, () -> {
-            writer.write("// @ts-ignore");
             writer.write("return await client.send(new $L(input), ...args);", operationTypeName);
         });
     }

--- a/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
@@ -17,7 +17,6 @@ const makePagedClientRequest = async (
   input: QueryCommandInput,
   ...args: any
 ): Promise<QueryCommandOutput> => {
-  // @ts-ignore
   return await client.send(new QueryCommand(input), ...args);
 };
 /**
@@ -32,8 +31,7 @@ export async function* paginateQuery(
   input: QueryCommandInput,
   ...additionalArguments: any
 ): Paginator<QueryCommandOutput> {
-  // ToDo: replace with actual type instead of typeof input.ExclusiveStartKey
-  let token: typeof input.ExclusiveStartKey | undefined = config.startingToken || undefined;
+  let token: Record<string, NativeAttributeValue> | undefined = config.startingToken || undefined;
   let hasNext = true;
   let page: QueryCommandOutput;
   while (hasNext) {
@@ -48,6 +46,5 @@ export async function* paginateQuery(
     token = page.LastEvaluatedKey;
     hasNext = !!token;
   }
-  // @ts-ignore
   return undefined;
 }

--- a/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
@@ -17,7 +17,6 @@ const makePagedClientRequest = async (
   input: ScanCommandInput,
   ...args: any
 ): Promise<ScanCommandOutput> => {
-  // @ts-ignore
   return await client.send(new ScanCommand(input), ...args);
 };
 /**
@@ -32,8 +31,7 @@ export async function* paginateScan(
   input: ScanCommandInput,
   ...additionalArguments: any
 ): Paginator<ScanCommandOutput> {
-  // ToDo: replace with actual type instead of typeof input.ExclusiveStartKey
-  let token: typeof input.ExclusiveStartKey | undefined = config.startingToken || undefined;
+  let token: Record<string, NativeAttributeValue> | undefined = config.startingToken || undefined;
   let hasNext = true;
   let page: ScanCommandOutput;
   while (hasNext) {
@@ -48,6 +46,5 @@ export async function* paginateScan(
     token = page.LastEvaluatedKey;
     hasNext = !!token;
   }
-  // @ts-ignore
   return undefined;
 }


### PR DESCRIPTION
### Description
Use actual types instead of typeof input.ExclusiveStartKey in DynamoDB Query/Scan paginators.

### Testing
All tests are passing in yarn test:all

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
