### PR TITLE
docs: update NodeHttpHandler link

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -52,7 +52,7 @@ This list is indexed by [v2 config parameters](https://docs.aws.amazon.com/AWSJa
 
   A set of options to pass to the low-level HTTP request. These options are aggregated differently in v3. You can
   configure them by supplying a new `requestHandler`. Here's the example of setting http options in Node.js runtime. You
-  can find more in [v3 reference for NodeHttpHandler](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-node-http-handler/Class/NodeHttpHandler/).
+  can find more in [v3 reference for NodeHttpHandler](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-node-http-handler/).
 
   All v3 requests use HTTPS by default. You only need to provide custom httpsAgent.
 
@@ -112,10 +112,10 @@ This list is indexed by [v2 config parameters](https://docs.aws.amazon.com/AWSJa
   - `connectTimeout`
     - **v2**: Sets the socket to timeout after failing to establish a connection with the server after connectTimeout
       milliseconds.
-    - **v3**: `connectionTimeout` is available [in `NodeHttpHandler` options](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-node-http-handler/Class/NodeHttpHandler/).
+    - **v3**: `connectionTimeout` is available [in `NodeHttpHandler` options](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-node-http-handler/).
   - `timeout`
     - **v2**: The number of milliseconds a request can take before automatically being terminated.
-    - **v3**: `socketTimeout` is available [in `NodeHttpHandler` options](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-node-http-handler/Class/NodeHttpHandler/).
+    - **v3**: `socketTimeout` is available [in `NodeHttpHandler` options](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-node-http-handler/).
   - `xhrAsync`
     - **v2**: Whether the SDK will send asynchronous HTTP requests.
     - **v3**: **Deprecated**. Requests are _always_ asynchronous.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -52,7 +52,7 @@ This list is indexed by [v2 config parameters](https://docs.aws.amazon.com/AWSJa
 
   A set of options to pass to the low-level HTTP request. These options are aggregated differently in v3. You can
   configure them by supplying a new `requestHandler`. Here's the example of setting http options in Node.js runtime. You
-  can find more in [v3 reference for NodeHttpHandler](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/classes/_aws_sdk_node_http_handler.nodehttphandler-1.html).
+  can find more in [v3 reference for NodeHttpHandler](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-node-http-handler/Class/NodeHttpHandler/).
 
   All v3 requests use HTTPS by default. You only need to provide custom httpsAgent.
 
@@ -112,10 +112,10 @@ This list is indexed by [v2 config parameters](https://docs.aws.amazon.com/AWSJa
   - `connectTimeout`
     - **v2**: Sets the socket to timeout after failing to establish a connection with the server after connectTimeout
       milliseconds.
-    - **v3**: `connectionTimeout` is available [in `NodeHttpHandler` options](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/classes/_aws_sdk_node_http_handler.nodehttphandler-1.html).
+    - **v3**: `connectionTimeout` is available [in `NodeHttpHandler` options](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-node-http-handler/Class/NodeHttpHandler/).
   - `timeout`
     - **v2**: The number of milliseconds a request can take before automatically being terminated.
-    - **v3**: `socketTimeout` is available [in `NodeHttpHandler` options](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/classes/_aws_sdk_node_http_handler.nodehttphandler-1.html).
+    - **v3**: `socketTimeout` is available [in `NodeHttpHandler` options](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-node-http-handler/Class/NodeHttpHandler/).
   - `xhrAsync`
     - **v2**: Whether the SDK will send asynchronous HTTP requests.
     - **v3**: **Deprecated**. Requests are _always_ asynchronous.


### PR DESCRIPTION
### Issue
N/A

### Description
The link to the docs was outdated and resulted in a 404 error. This PR updates the link to the correct and current URL.

### Testing
Manually checked the new link to ensure it correctly directs to the intended documentation page.

### Additional context
For reference, see the similar PR: [docs: update retry link](https://github.com/aws/aws-sdk-js-v3/pull/5178)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
