### PR TITLE
Update utils.ts

### DIFF
--- a/lib/lib-dynamodb/src/commands/utils.ts
+++ b/lib/lib-dynamodb/src/commands/utils.ts
@@ -64,7 +64,7 @@ const processObj = (obj: any, processFunc: Function, keyNodes?: KeyNodes): any =
 const processKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNodeChildren) => {
   let accumulator: any;
   if (Array.isArray(obj)) {
-    accumulator = [...obj].filter((item) => typeof item !== "function");
+    accumulator = obj.filter((item) => typeof item !== "function");
   } else {
     accumulator = {};
     for (const [k, v] of Object.entries(obj)) {


### PR DESCRIPTION
Remove redundant spread `processKeysInObj`.

### Description
Avoid unnecessary memory allocation.

### Testing
Filter is already returning a shallow copy of the array see:
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#return_value
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#copying_an_array

### Additional context
Found this allocation when looking for a memory leak using chrome developer tools (allocation sampling). Other places in the file correctly uses `obj.filter`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
