### PR TITLE
docs: update FetchHttpHandler link

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -88,7 +88,7 @@ This list is indexed by [v2 config parameters](https://docs.aws.amazon.com/AWSJa
   ```
 
   If the client is running in browsers, a different set of options is available. You can find more in [v3
-  reference for FetchHttpHandler](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/classes/_aws_sdk_fetch_http_handler.fetchhttphandler-1.html).
+  reference for FetchHttpHandler](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-fetch-http-handler/).
 
   ```javascript
   const { FetchHttpHandler } = require("@smithy/fetch-http-handler");


### PR DESCRIPTION
### Issue
N/A

### Description
The link to the docs was outdated and resulted in a 404 error. This PR updates the link to the correct and current URL.

### Testing
Manually checked the new link to ensure it correctly directs to the intended documentation page.

### Additional context
For reference, see the similar PR: [docs: update retry link](https://github.com/aws/aws-sdk-js-v3/pull/5178)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
