### PR TITLE
chore(core): emit warning for Node.js versions < 18.x

### DIFF
--- a/packages/core/src/submodules/client/emitWarningIfUnsupportedVersion.spec.ts
+++ b/packages/core/src/submodules/client/emitWarningIfUnsupportedVersion.spec.ts
@@ -1,7 +1,7 @@
 describe("emitWarningIfUnsupportedVersion", () => {
   let emitWarningIfUnsupportedVersion: any;
   const emitWarning = process.emitWarning;
-  const supportedVersion = "16.0.0";
+  const supportedVersion = "18.0.0";
 
   beforeEach(() => {
     const module = require("./emitWarningIfUnsupportedVersion");
@@ -14,7 +14,7 @@ describe("emitWarningIfUnsupportedVersion", () => {
     process.emitWarning = emitWarning;
   });
 
-  describe.skip(`emits warning for Node.js <${supportedVersion}`, () => {
+  describe(`emits warning for Node.js <${supportedVersion}`, () => {
     const getPreviousMajorVersion = (major: number) => (major === 0 ? 0 : major - 1);
 
     const getPreviousMinorVersion = ([major, minor]: [number, number]) =>
@@ -38,12 +38,12 @@ describe("emitWarningIfUnsupportedVersion", () => {
       expect(process.emitWarning).toHaveBeenCalledTimes(1);
       expect(process.emitWarning).toHaveBeenCalledWith(
         `NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
-no longer support Node.js 14.x on May 1, 2024.
+no longer support Node.js 16.x on January 6, 2025.
 
 To continue receiving updates to AWS services, bug fixes, and security
-updates please upgrade to an active Node.js LTS version.
+updates please upgrade to a supported Node.js LTS version.
 
-More information can be found at: https://a.co/dzr2AJd`
+More information can be found at: https://a.co/74kJMmI`
       );
 
       // Verify that the warning emits only once.

--- a/packages/core/src/submodules/client/emitWarningIfUnsupportedVersion.ts
+++ b/packages/core/src/submodules/client/emitWarningIfUnsupportedVersion.ts
@@ -10,17 +10,16 @@ let warningEmitted = false;
  * @param version - The Node.js version string.
  */
 export const emitWarningIfUnsupportedVersion = (version: string) => {
-  if (version && !warningEmitted && parseInt(version.substring(1, version.indexOf("."))) < 16) {
+  if (version && !warningEmitted && parseInt(version.substring(1, version.indexOf("."))) < 18) {
     warningEmitted = true;
-    // ToDo: Turn back warning for future Node.js version deprecation
-    //     process.emitWarning(
-    //       `NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
-    // no longer support Node.js 14.x on May 1, 2024.
+    process.emitWarning(
+      `NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
+no longer support Node.js 16.x on January 6, 2025.
 
-    // To continue receiving updates to AWS services, bug fixes, and security
-    // updates please upgrade to an active Node.js LTS version.
+To continue receiving updates to AWS services, bug fixes, and security
+updates please upgrade to a supported Node.js LTS version.
 
-    // More information can be found at: https://a.co/dzr2AJd`
-    //     );
+More information can be found at: https://a.co/74kJMmI`
+    );
   }
 };


### PR DESCRIPTION
### Issue
Internal JS-5203

### Description
Emits warning for Node.js versions < 18.x

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
