### PR TITLE
fix(util-dynamodb): perform global interface check in NativeAttributeBinary union

### DIFF
--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -1,5 +1,3 @@
-import type { Exact } from "@smithy/types";
-
 /**
  * A interface recognizable as a numeric value that stores the underlying number
  * as a string.
@@ -44,19 +42,17 @@ declare global {
   interface File {}
 }
 
-type Unavailable = never;
-type BlobDefined = Exact<Blob, {}> extends true ? false : true;
-type BlobOptionalType = BlobDefined extends true ? Blob : Unavailable;
+type IfDefined<T> = {} extends T ? never : T;
 
 /**
  * @public
  */
 export type NativeAttributeBinary =
   | ArrayBuffer
-  | BlobOptionalType
-  | Buffer
+  | IfDefined<Blob>
+  | IfDefined<Buffer>
   | DataView
-  | File
+  | IfDefined<File>
   | Int8Array
   | Uint8Array
   | Uint8ClampedArray


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6253

### Description
This filters out any global interfaces with no definite properties to prevent incorrect signature matching too broadly for the marshall function.

### Testing
tested in TypeScript https://www.typescriptlang.org/play/?#code/C4TwDgpgBAglC8UDeUCGAuKBXAdgEwgDMBLHCPKAXwG4AoUSKAIQWTQH5NcCSyKba9cNACyqEACMIAHgAqAPlZJKUCAA9gEfAGcosqOyhkAbhABOUTLLpDGADVZjJMpvOpA