### PR TITLE
test(client-s3): dot segment in URI Label

### DIFF
--- a/clients/client-s3/test/unit/dotSegmentInUriLabel.spec.ts
+++ b/clients/client-s3/test/unit/dotSegmentInUriLabel.spec.ts
@@ -1,0 +1,72 @@
+/// <reference types="mocha" />
+import { HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
+import { HttpHandlerOptions } from "@smithy/types";
+import { S3 } from "../../src/S3";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+/**
+ * Throws an expected exception that contains the serialized request.
+ */
+class EXPECTED_REQUEST_SERIALIZATION_ERROR extends Error {
+  constructor(readonly request: HttpRequest) {
+    super();
+  }
+}
+
+class RequestSerializationTestHandler implements HttpHandler {
+  async handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+    throw new EXPECTED_REQUEST_SERIALIZATION_ERROR(request);
+  }
+  updateHttpClientConfig(key: never, value: never): void {}
+  httpHandlerConfigs() {
+    return {};
+  }
+}
+
+describe("Dot Segment in URI Label", () => {
+  it("S3PreservesLeadingDotSegmentInUriLabel", async () => {
+    const client = new S3({
+      requestHandler: new RequestSerializationTestHandler(),
+    });
+
+    try {
+      await client.getObject({
+        Bucket: "mybucket",
+        Key: "../key.txt",
+      });
+      fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    } catch (err) {
+      if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
+        fail(err);
+      }
+      const r = err.request;
+      expect(r.method).to.eql("GET");
+      expect(r.path).to.eql("/../key.txt");
+    }
+  });
+
+  it("S3PreservesEmbeddedDotSegmentInUriLabel", async () => {
+    const client = new S3({
+      requestHandler: new RequestSerializationTestHandler(),
+    });
+
+    try {
+      await client.getObject({
+        Bucket: "mybucket",
+        Key: "foo/../key.txt",
+      });
+      fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    } catch (err) {
+      if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
+        fail(err);
+      }
+      const r = err.request;
+      expect(r.method).to.eql("GET");
+      expect(r.path).to.eql("/foo/../key.txt");
+    }
+  });
+});

--- a/clients/client-s3/test/unit/dotSegmentInUriLabel.spec.ts
+++ b/clients/client-s3/test/unit/dotSegmentInUriLabel.spec.ts
@@ -11,7 +11,7 @@ const { expect } = chai;
 /**
  * Throws an expected exception that contains the serialized request.
  */
-class EXPECTED_REQUEST_SERIALIZATION_ERROR extends Error {
+class ExpectedRequestSerializationError extends Error {
   constructor(readonly request: HttpRequest) {
     super();
   }
@@ -19,7 +19,7 @@ class EXPECTED_REQUEST_SERIALIZATION_ERROR extends Error {
 
 class RequestSerializationTestHandler implements HttpHandler {
   async handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
-    throw new EXPECTED_REQUEST_SERIALIZATION_ERROR(request);
+    throw new ExpectedRequestSerializationError(request);
   }
   updateHttpClientConfig(key: never, value: never): void {}
   httpHandlerConfigs() {
@@ -40,7 +40,7 @@ describe("Dot Segment in URI Label", () => {
       });
       fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
     } catch (err) {
-      if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
+      if (!(err instanceof ExpectedRequestSerializationError)) {
         fail(err);
       }
       const r = err.request;
@@ -61,7 +61,7 @@ describe("Dot Segment in URI Label", () => {
       });
       fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
     } catch (err) {
-      if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
+      if (!(err instanceof ExpectedRequestSerializationError)) {
         fail(err);
       }
       const r = err.request;

--- a/clients/client-s3/test/unit/dotSegmentInUriLabel.spec.ts
+++ b/clients/client-s3/test/unit/dotSegmentInUriLabel.spec.ts
@@ -28,11 +28,12 @@ class RequestSerializationTestHandler implements HttpHandler {
 }
 
 describe("Dot Segment in URI Label", () => {
-  it("S3PreservesLeadingDotSegmentInUriLabel", async () => {
-    const client = new S3({
-      requestHandler: new RequestSerializationTestHandler(),
-    });
+  const client = new S3({
+    credentials: { accessKeyId: "mockAccessKeyId", secretAccessKey: "mockSecretAccessKey" },
+    requestHandler: new RequestSerializationTestHandler(),
+  });
 
+  it("S3PreservesLeadingDotSegmentInUriLabel", async () => {
     try {
       await client.getObject({
         Bucket: "mybucket",
@@ -50,10 +51,6 @@ describe("Dot Segment in URI Label", () => {
   });
 
   it("S3PreservesEmbeddedDotSegmentInUriLabel", async () => {
-    const client = new S3({
-      requestHandler: new RequestSerializationTestHandler(),
-    });
-
     try {
       await client.getObject({
         Bucket: "mybucket",


### PR DESCRIPTION
### Issue
Internal JS-5057

### Description
Adds unit tests for dog segment in URI label

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
