### PR TITLE
chore(credential-provider-node): emit warning when AWS_PROFILE is set alongside ENV credentials

### DIFF
--- a/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
+++ b/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
@@ -293,6 +293,25 @@ describe("credential-provider-node integration test", () => {
         credentialScope: "us-env-1",
       });
     });
+
+    it("should (for now) resolve AWS_PROFILE instead of static credentials from ENV if both are set. However, this is subject to change.", async () => {
+      process.env.AWS_ACCESS_KEY_ID = "ENV_ACCESS_KEY";
+      process.env.AWS_SECRET_ACCESS_KEY = "ENV_SECRET_KEY";
+      process.env.AWS_PROFILE = "default";
+
+      Object.assign(iniProfileData.default, {
+        aws_access_key_id: "INI_STATIC_ACCESS_KEY",
+        aws_secret_access_key: "INI_STATIC_SECRET_KEY",
+      });
+
+      await sts.getCallerIdentity({});
+      const credentials = await sts.config.credentials();
+
+      expect(credentials).toEqual({
+        accessKeyId: "INI_STATIC_ACCESS_KEY",
+        secretAccessKey: "INI_STATIC_SECRET_KEY",
+      });
+    });
   });
 
   describe("fromSSO", () => {

--- a/packages/credential-provider-node/src/defaultProvider.spec.ts
+++ b/packages/credential-provider-node/src/defaultProvider.spec.ts
@@ -34,6 +34,12 @@ describe(defaultProvider.name, () => {
 
   const mockInit = {
     profile: "mockProfile",
+    logger: {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+    },
   };
 
   const mockEnvFn = jest.fn().mockImplementation(() => credentials());

--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -1,4 +1,4 @@
-import { fromEnv } from "@aws-sdk/credential-provider-env";
+import { ENV_KEY, ENV_SECRET, fromEnv } from "@aws-sdk/credential-provider-env";
 import type { FromHttpOptions } from "@aws-sdk/credential-provider-http";
 import type { FromIniInit } from "@aws-sdk/credential-provider-ini";
 import type { FromProcessInit } from "@aws-sdk/credential-provider-process";
@@ -20,6 +20,11 @@ export type DefaultProviderInit = FromIniInit &
   FromProcessInit &
   (FromSSOInit & Partial<SsoCredentialsParameters>) &
   FromTokenFileInit;
+
+/**
+ * @internal
+ */
+let multipleCredentialSourceWarningEmitted = false;
 
 /**
  * Creates a credential provider that will attempt to find credentials from the
@@ -58,14 +63,36 @@ export type DefaultProviderInit = FromIniInit &
 export const defaultProvider = (init: DefaultProviderInit = {}): MemoizedProvider<AwsCredentialIdentity> =>
   memoize(
     chain(
-      ...(init.profile || process.env[ENV_PROFILE]
-        ? []
-        : [
-            async () => {
-              init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromEnv");
-              return fromEnv(init)();
-            },
-          ]),
+      async () => {
+        const profile = init.profile ?? process.env[ENV_PROFILE];
+        if (profile) {
+          const envStaticCredentialsAreSet = process.env[ENV_KEY] && process.env[ENV_SECRET];
+          if (envStaticCredentialsAreSet) {
+            if (!multipleCredentialSourceWarningEmitted) {
+              const warnFn =
+                init.logger?.warn && init.logger?.constructor?.name !== "NoOpLogger" ? init.logger.warn : console.warn;
+              warnFn(
+                `@aws-sdk/credential-provider-node - defaultProvider::fromEnv WARNING:
+    Multiple credential sources detected: 
+    Both AWS_PROFILE and the pair AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY static credentials are set.
+    This SDK will proceed with the AWS_PROFILE value.
+    
+    However, a future version may change this behavior to prefer the ENV static credentials.
+    Please ensure that your environment only sets either the AWS_PROFILE or the
+    AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY pair.
+`
+              );
+              multipleCredentialSourceWarningEmitted = true;
+            }
+            throw new CredentialsProviderError("AWS_PROFILE is set, skipping fromEnv provider.", {
+              logger: init.logger,
+              tryNextLink: true,
+            });
+          }
+        }
+        init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromEnv");
+        return fromEnv(init)();
+      },
       async () => {
         init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromSSO");
         const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoSession } = init;


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/2549

### Description
Emit a warning when the environment sets AWS_PROFILE in addition to the pair AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.

We should be resolving the credential pair based on AWS SDK JSv2, AWS CLI, and documentation, but the current implementation prefers AWS_PROFILE.
Because this has been released for a very long time, we should set a warning instead of directly switching over to preferring the credential pair. 

We could determine a specific date later on which to change the behavior over to preferring the credential pair.

### Testing
manual, integ, unit