### PR TITLE
fix(lib-storage): location in upload result must include custom port

### DIFF
--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -168,13 +168,14 @@ export class Upload extends EventEmitter {
     const Location: string = (() => {
       const endpointHostnameIncludesBucket = endpoint.hostname.startsWith(`${locationBucket}.`);
       const forcePathStyle = this.client.config.forcePathStyle;
+      const optionalPort = endpoint.port ? `:${endpoint.port}` : ``;
       if (forcePathStyle) {
-        return `${endpoint.protocol}//${endpoint.hostname}/${locationBucket}/${locationKey}`;
+        return `${endpoint.protocol}//${endpoint.hostname}${optionalPort}/${locationBucket}/${locationKey}`;
       }
       if (endpointHostnameIncludesBucket) {
-        return `${endpoint.protocol}//${endpoint.hostname}/${locationKey}`;
+        return `${endpoint.protocol}//${endpoint.hostname}${optionalPort}/${locationKey}`;
       }
-      return `${endpoint.protocol}//${locationBucket}.${endpoint.hostname}/${locationKey}`;
+      return `${endpoint.protocol}//${locationBucket}.${endpoint.hostname}${optionalPort}/${locationKey}`;
     })();
 
     this.singleUploadResult = {


### PR DESCRIPTION
### Description
If S3 endpoint contained an explicit port (for example `http://localstack:4566/`), then the `Location` property of the `Upload` command didn't include it.
In AWS-SDK V2 `upload` command did include the port in the Location URL.

### Testing
Relevant tests are added (and were failing before the fix).

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
