### PR TITLE
test(credential-provider-node): fix tests related to defaultProvider chain

### DIFF
--- a/packages/credential-provider-node/src/defaultProvider.spec.ts
+++ b/packages/credential-provider-node/src/defaultProvider.spec.ts
@@ -49,7 +49,17 @@ describe(defaultProvider.name, () => {
   const mockTokenFileFn = jest.fn().mockImplementation(() => credentials());
   const mockRemoteProviderFn = jest.fn().mockImplementation(() => finalCredentials());
 
+  const ORIGINAL_ENV = {
+    ...process.env,
+  };
+
   beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+    };
+    delete process.env.AWS_PROFILE;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
     [
       [fromEnv, mockEnvFn],
       [fromSSO, mockSsoFn],
@@ -64,6 +74,7 @@ describe(defaultProvider.name, () => {
 
   afterEach(async () => {
     jest.clearAllMocks();
+    process.env = ORIGINAL_ENV;
   });
 
   describe("without fromEnv", () => {
@@ -102,9 +113,7 @@ describe(defaultProvider.name, () => {
     });
 
     it(`if env['${ENV_PROFILE}'] is set`, async () => {
-      const ORIGINAL_ENV = process.env;
       process.env = {
-        ...ORIGINAL_ENV,
         [ENV_PROFILE]: "envProfile",
       };
 
@@ -117,8 +126,6 @@ describe(defaultProvider.name, () => {
         expect(fromFn).toHaveBeenCalledWith(mockInitWithoutProfile);
       }
       expect(fromSSO).not.toHaveBeenCalled();
-
-      process.env = ORIGINAL_ENV;
     });
   });
 

--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -84,11 +84,11 @@ export const defaultProvider = (init: DefaultProviderInit = {}): MemoizedProvide
               );
               multipleCredentialSourceWarningEmitted = true;
             }
-            throw new CredentialsProviderError("AWS_PROFILE is set, skipping fromEnv provider.", {
-              logger: init.logger,
-              tryNextLink: true,
-            });
           }
+          throw new CredentialsProviderError("AWS_PROFILE is set, skipping fromEnv provider.", {
+            logger: init.logger,
+            tryNextLink: true,
+          });
         }
         init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromEnv");
         return fromEnv(init)();


### PR DESCRIPTION
- uses more consistent (with prior functionality) control flow Exception to skip `fromEnv` in default credential provider chain instead of relying on the provider itself failing
