### PR TITLE
docs: fix typos

### DIFF
--- a/verdaccio/config.yaml
+++ b/verdaccio/config.yaml
@@ -15,7 +15,7 @@ web:
   title: Verdaccio
   # comment out to disable gravatar support
   # gravatar: false
-  # by default packages are ordercer ascendant (asc|desc)
+  # by default packages are ordered ascendant (asc|desc)
   # sort_packages: asc
 
 # auth:
@@ -53,9 +53,9 @@ packages:
     # if package is not available locally, proxy requests to 'npmjs' registry
     proxy: npmjs
 
-# You can specify HTTP/1.1 server keep alive timeout in seconds for incomming connections.
+# You can specify HTTP/1.1 server keep-alive timeout in seconds for incoming connections.
 # A value of 0 makes the http server behave similarly to Node.js versions prior to 8.0.0, which did not have a keep-alive timeout.
-# WORKAROUND: Through given configuration you can workaround following issue https://github.com/verdaccio/verdaccio/issues/301. Set to 0 in case 60 is not enought.
+# WORKAROUND: Through given configuration you can work around the following issue https://github.com/verdaccio/verdaccio/issues/301. Set to 0 in case 60 is not enough.
 server:
   keepAliveTimeout: 60
 

--- a/verdaccio/config.yaml
+++ b/verdaccio/config.yaml
@@ -15,7 +15,7 @@ web:
   title: Verdaccio
   # comment out to disable gravatar support
   # gravatar: false
-  # by default packages are ordered ascendant (asc|desc)
+  # by default packages are ordered ascending (asc|desc)
   # sort_packages: asc
 
 # auth:


### PR DESCRIPTION
Fixes typos in the comments in `verdaccio/config.yaml` file.