### PR TITLE
fix(middleware-sdk-s3): fix error with partially-read Node.js streams

### DIFF
--- a/packages/middleware-sdk-s3/src/throw-200-exceptions.ts
+++ b/packages/middleware-sdk-s3/src/throw-200-exceptions.ts
@@ -62,6 +62,11 @@ export const throw200ExceptionsMiddleware =
         return headStream(stream, MAX_BYTES_TO_INSPECT);
       },
     });
+    if (typeof bodyCopy?.destroy === "function") {
+      // discard partially-read Node.js Stream.
+      bodyCopy.destroy();
+    }
+
     const bodyStringTail = config.utf8Encoder(bodyBytes.subarray(bodyBytes.length - 16));
 
     // Throw on 200 response with empty body, legacy behavior allowlist.


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6293

### Description
In case of a long response, from e.g. ListObjects with many objects, a Node.js stream may be partially read, and the Node.js runtime will error out with code 13, awaiting an async operation that will never resolve.

### Testing
Tested manually in Node.js and browser.