### PR TITLE
chore(codegen): correct lex order in omit param codegen

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmittedEndpointParams.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmittedEndpointParams.java
@@ -6,8 +6,8 @@
  package software.amazon.smithy.aws.typescript.codegen;
 
  import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
- import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
  import software.amazon.smithy.typescript.codegen.endpointsV2.OmitEndpointParams;
+ import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
  import software.amazon.smithy.utils.SetUtils;
  import software.amazon.smithy.utils.SmithyInternalApi;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,8 +82,8 @@
     "@smithy/types": "^3.3.0",
     "fast-xml-parser": "4.2.5",
     "tslib": "^2.6.2",
-    "@smithy/node-config-provider": "^3.0.0",
-    "@smithy/util-middleware": "^3.0.0"
+    "@smithy/node-config-provider": "^3.1.4",
+    "@smithy/util-middleware": "^3.0.3"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",


### PR DESCRIPTION
### Description
corrects lex order for codegen imports for `AddOmittedEndpointParams` and updates dep versions (from our runtime dep check script)

### Testing
CI


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
