### PR TITLE
Explicit http credential source

### DIFF
--- a/packages/credential-provider-ini/src/resolveCredentialSource.spec.ts
+++ b/packages/credential-provider-ini/src/resolveCredentialSource.spec.ts
@@ -25,9 +25,7 @@ describe(resolveCredentialSource.name, () => {
   beforeEach(() => {
     (fromEnv as jest.Mock).mockReturnValue(() => Promise.resolve(mockFakeCreds));
     (fromContainerMetadata as jest.Mock).mockReturnValue(() => Promise.resolve(mockFakeCreds));
-    (fromHttp as jest.Mock).mockReturnValue(() => {
-      throw new CredentialsProviderError("try next", {});
-    });
+    (fromHttp as jest.Mock).mockReturnValue(() => Promise.resolve(mockFakeCreds));
     (fromInstanceMetadata as jest.Mock).mockReturnValue(() => Promise.resolve(mockFakeCreds));
   });
 
@@ -39,6 +37,7 @@ describe(resolveCredentialSource.name, () => {
     ["EcsContainer", fromContainerMetadata],
     ["Ec2InstanceMetadata", fromInstanceMetadata],
     ["Environment", fromEnv],
+    ["HTTP", fromHttp],
   ])("when credentialSource=%s, calls %p", async (credentialSource, fromFn) => {
     (fromFn as jest.Mock).mockReturnValue(() => Promise.resolve(mockCreds));
     const providerFactory = resolveCredentialSource(credentialSource, mockProfileName);
@@ -58,7 +57,7 @@ describe(resolveCredentialSource.name, () => {
       });
   });
 
-  it("throws error if credentialSource is not one of ['EcsContainer','Ec2InstanceMetadata','Environment']", async () => {
+  it("throws error if credentialSource is not one of ['EcsContainer','Ec2InstanceMetadata','Environment','HTTP']", async () => {
     const mockCredentialSource = "mockCredentialSource";
     const expectedError = new CredentialsProviderError(
       `Unsupported credential source in profile ${mockProfileName}. Got ${mockCredentialSource}, ` +
@@ -72,7 +71,7 @@ describe(resolveCredentialSource.name, () => {
     } catch (error) {
       expect(error).toStrictEqual(expectedError);
     }
-    [fromContainerMetadata, fromInstanceMetadata, fromEnv].forEach((fnNotCalled) => {
+    [fromContainerMetadata, fromInstanceMetadata, fromEnv, fromHttp].forEach((fnNotCalled) => {
       expect(fnNotCalled).not.toHaveBeenCalled();
     });
   });

--- a/packages/credential-provider-ini/src/resolveCredentialSource.spec.ts
+++ b/packages/credential-provider-ini/src/resolveCredentialSource.spec.ts
@@ -37,7 +37,7 @@ describe(resolveCredentialSource.name, () => {
     ["EcsContainer", fromContainerMetadata],
     ["Ec2InstanceMetadata", fromInstanceMetadata],
     ["Environment", fromEnv],
-    ["HTTP", fromHttp],
+    ["Http", fromHttp],
   ])("when credentialSource=%s, calls %p", async (credentialSource, fromFn) => {
     (fromFn as jest.Mock).mockReturnValue(() => Promise.resolve(mockCreds));
     const providerFactory = resolveCredentialSource(credentialSource, mockProfileName);
@@ -57,7 +57,7 @@ describe(resolveCredentialSource.name, () => {
       });
   });
 
-  it("throws error if credentialSource is not one of ['EcsContainer','Ec2InstanceMetadata','Environment','HTTP']", async () => {
+  it("throws error if credentialSource is not one of ['EcsContainer','Ec2InstanceMetadata','Environment','Http']", async () => {
     const mockCredentialSource = "mockCredentialSource";
     const expectedError = new CredentialsProviderError(
       `Unsupported credential source in profile ${mockProfileName}. Got ${mockCredentialSource}, ` +

--- a/packages/credential-provider-ini/src/resolveCredentialSource.ts
+++ b/packages/credential-provider-ini/src/resolveCredentialSource.ts
@@ -32,7 +32,7 @@ export const resolveCredentialSource = (
       const { fromEnv } = await import("@aws-sdk/credential-provider-env");
       return fromEnv(options);
     },
-    HTTP: async (options?: CredentialProviderOptions) => {
+    Http: async (options?: CredentialProviderOptions) => {
       logger?.debug("@aws-sdk/credential-provider-ini - credential_source is Environment");
       const { fromHttp } = await import("@aws-sdk/credential-provider-http");
       return fromHttp(options ?? {});

--- a/packages/credential-provider-ini/src/resolveCredentialSource.ts
+++ b/packages/credential-provider-ini/src/resolveCredentialSource.ts
@@ -18,10 +18,9 @@ export const resolveCredentialSource = (
 ): ((options?: CredentialProviderOptions) => Promise<AwsCredentialIdentityProvider>) => {
   const sourceProvidersMap = {
     EcsContainer: async (options?: CredentialProviderOptions) => {
-      const { fromHttp } = await import("@aws-sdk/credential-provider-http");
       const { fromContainerMetadata } = await import("@smithy/credential-provider-imds");
       logger?.debug("@aws-sdk/credential-provider-ini - credential_source is EcsContainer");
-      return chain(fromHttp(options ?? {}), fromContainerMetadata(options));
+      return fromContainerMetadata(options);
     },
     Ec2InstanceMetadata: async (options?: CredentialProviderOptions) => {
       logger?.debug("@aws-sdk/credential-provider-ini - credential_source is Ec2InstanceMetadata");
@@ -32,6 +31,11 @@ export const resolveCredentialSource = (
       logger?.debug("@aws-sdk/credential-provider-ini - credential_source is Environment");
       const { fromEnv } = await import("@aws-sdk/credential-provider-env");
       return fromEnv(options);
+    },
+    HTTP: async (options?: CredentialProviderOptions) => {
+      logger?.debug("@aws-sdk/credential-provider-ini - credential_source is Environment");
+      const { fromHttp } = await import("@aws-sdk/credential-provider-http");
+      return fromHttp(options ?? {});
     },
   };
   if (credentialSource in sourceProvidersMap) {

--- a/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
+++ b/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
@@ -517,7 +517,7 @@ describe("credential-provider-node integration test", () => {
       iniProfileData.default.source_profile = "credential_source_profile";
       iniProfileData.default.role_arn = "ROLE_ARN";
       iniProfileData.credential_source_profile = {
-        credential_source: "EcsContainer",
+        credential_source: "Http",
       };
       const spy = jest.spyOn(credentialProviderHttp, "fromHttp");
       sts = new STS({


### PR DESCRIPTION
### Description

The `EcsContainer` provider implies IMDS. Having the `fromHttp` provider tacked on the front of the chain is a bit misleading. This adds a new `credential_source` called `Http` which does what it says on the tin.

### Testing

Unit

### Additional context

This is obviously a breaking change but i suspect not many businesses are using it anyway. I also understand that this diverges from the spec and all the other SDKs would need to follow suit. Mainly raising this for discussion purposes.

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
