### PR TITLE
chore(codegen): remove fast-xml-parser from AwsDependency

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -59,7 +59,6 @@ public enum AwsDependency implements Dependency {
     BODY_CHECKSUM_GENERATOR_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-browser"),
     BODY_CHECKSUM_GENERATOR_NODE(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-node"),
     XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder"),
-    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "4.2.5"),
     UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^9.0.1"),
     UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^9.0.4"),
     MIDDLEWARE_EVENTSTREAM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-eventstream"),


### PR DESCRIPTION
### Issue
We've been using `fast-xml-parser` from `@aws-sdk/core` since v3.529.1 https://github.com/aws/aws-sdk-js-v3/pull/5869

### Description
Removes fast-xml-parser from AwsDependency

### Testing
Verified that there are no consumers of `AwsDependency.XML_PARSER` in codegen

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
