### PR TITLE
chore(deps): bump fast-xml-parser from 4.2.5 to 4.4.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,7 +82,7 @@
     "@smithy/smithy-client": "^3.1.11",
     "@smithy/types": "^3.3.0",
     "@smithy/util-middleware": "^3.0.3",
-    "fast-xml-parser": "4.2.5",
+    "fast-xml-parser": "4.4.1",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -59,7 +59,7 @@
     "@smithy/util-stream": "^3.1.3",
     "@smithy/util-utf8": "^3.0.0",
     "entities": "2.2.0",
-    "fast-xml-parser": "4.2.5",
+    "fast-xml-parser": "4.4.1",
     "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "1e4e6ae17577ee46995e23ad67bcad9189c950e5",
+  SMITHY_TS_COMMIT: "c86fa1906dab07e676f3a4e9e0eb983e76064e7e",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6841,10 +6841,10 @@ fast-uri@^2.0.0, fast-uri@^2.1.0:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-2.2.0.tgz#519a0f849bef714aad10e9753d69d8f758f7445a"
   integrity sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==
 
-fast-xml-parser@4.2.5:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz#a6747a09296a6cb34f2ae634019bf1738f3b421f"
-  integrity sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==
+fast-xml-parser@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz#86dbf3f18edf8739326447bcaac31b4ae7f6514f"
+  integrity sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/6327

### Description
Bumps fast-xml-parser from 4.2.5 to 4.4.1

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
