### PR TITLE
Warning on retry

### DIFF
--- a/packages/credential-provider-http/src/fromHttp/fromHttp.browser.ts
+++ b/packages/credential-provider-http/src/fromHttp/fromHttp.browser.ts
@@ -11,7 +11,8 @@ import { retryWrapper } from "./retry-wrapper";
  * Creates a provider that gets credentials via HTTP request.
  */
 export const fromHttp = (options: FromHttpOptions = {}): AwsCredentialIdentityProvider => {
-  options.logger?.debug("@aws-sdk/credential-provider-http - fromHttp");
+  const { logger } = options;
+  logger?.debug("@aws-sdk/credential-provider-http - fromHttp");
   let host: string;
 
   const full = options.credentialsFullUri;
@@ -19,14 +20,14 @@ export const fromHttp = (options: FromHttpOptions = {}): AwsCredentialIdentityPr
   if (full) {
     host = full;
   } else {
-    throw new CredentialsProviderError("No HTTP credential provider host provided.", { logger: options.logger });
+    throw new CredentialsProviderError("No HTTP credential provider host provided.", { logger });
   }
 
   // throws if invalid format.
   const url = new URL(host);
 
   // throws if not to spec for provider.
-  checkUrl(url, options.logger);
+  checkUrl(url, logger);
 
   const requestHandler = new FetchHttpHandler();
 
@@ -39,7 +40,6 @@ export const fromHttp = (options: FromHttpOptions = {}): AwsCredentialIdentityPr
       const result = await requestHandler.handle(request);
       return getCredentials(result.response);
     },
-    options.maxRetries ?? 3,
-    options.timeout ?? 1000
+    { maxRetries: options.maxRetries ?? 3, delayMs: options.timeout ?? 1000, logger }
   );
 };

--- a/packages/credential-provider-http/src/fromHttp/fromHttp.spec.ts
+++ b/packages/credential-provider-http/src/fromHttp/fromHttp.spec.ts
@@ -13,14 +13,6 @@ const credentials = {
 
 const mockToken = "abcd";
 
-const mockResponse = {
-  AccessKeyId: credentials.accessKeyId,
-  SecretAccessKey: credentials.secretAccessKey,
-  Token: credentials.sessionToken,
-  AccountId: "123",
-  Expiration: new Date(credentials.expiration).toISOString(), // rfc3339
-};
-
 const mockHandle = jest.fn().mockResolvedValue({
   response: new HttpResponse({
     statusCode: 200,


### PR DESCRIPTION
### Description

The http provider fails silently after 3 retries and is very difficult to debug.

### Testing

N/A

### Additional context

In our case it turned out the pod identity agent wasn't running on the node and our istio gateway was throwing a 503. this was caught and silently failed then the default provider continued on it's merry way and failed loudly at another point.

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
