### PR TITLE
fix(middleware-sdk-s3): skip stream inspection if non-stream-like body

### DIFF
--- a/packages/middleware-sdk-s3/src/throw-200-exceptions.ts
+++ b/packages/middleware-sdk-s3/src/throw-200-exceptions.ts
@@ -48,6 +48,15 @@ export const throw200ExceptionsMiddleware =
       return result;
     }
 
+    const isSplittableStream =
+      typeof sourceBody?.stream === "function" ||
+      typeof sourceBody?.pipe === "function" ||
+      typeof sourceBody?.tee === "function";
+
+    if (!isSplittableStream) {
+      return result;
+    }
+
     let bodyCopy = sourceBody;
     let body = sourceBody;
 


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6324

Placeholder fix for the linked issue to avoid the error. 

Further changes or guidance needed to implement stream splitting of the `fetch` response body in React-Native.