### PR TITLE
fix(polly-request-presigner): override middleware name to allow concurrent presigning

### DIFF
--- a/packages/polly-request-presigner/src/getSignedUrls.spec.ts
+++ b/packages/polly-request-presigner/src/getSignedUrls.spec.ts
@@ -98,4 +98,18 @@ describe("getSignedUrl", () => {
     expect(mockPresign).toBeCalled();
     expect(mockPresign.mock.calls[0][1]).toMatchObject(options);
   });
+  it("should not throw if called concurrently", async () => {
+    const mockPresigned = "a presigned url";
+    mockPresign.mockReturnValue(mockPresigned);
+    const client = new PollyClient(clientParams);
+    const command = new SynthesizeSpeechCommand({
+      Text: "hello world, this is alex",
+      OutputFormat: "mp3",
+      VoiceId: "Kimberly",
+    });
+    const result = await Promise.all([getSignedUrl(client, command), getSignedUrl(client, command)]);
+    expect(result).toBeInstanceOf(Array);
+    expect(result).toHaveLength(2);
+    expect(mockPresign).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/polly-request-presigner/src/getSignedUrls.ts
+++ b/packages/polly-request-presigner/src/getSignedUrls.ts
@@ -55,6 +55,7 @@ export const getSignedUrl = async (
     name: "presignInterceptMiddleware",
     relation: "before",
     toMiddleware: "awsAuthMiddleware",
+    override: true,
   });
 
   let presigned: HttpRequest;


### PR DESCRIPTION
Adds a middleware override in the `getSignedUrl` function to prevent multiple instances of the same middleware from being added during concurrent calls. The accompanying test checks that concurrent calls to `getSignedUrl` do not add the middleware multiple times and complete without error.

Fixes 
https://github.com/aws/aws-sdk-js-v3/issues/2417

Reference: 
https://github.com/aws/aws-sdk-js-v3/pull/1884
https://github.com/aws/aws-sdk-js-v3/pull/2628