### PR TITLE
fix: package.json `homepage` links to use the `main` branch

### DIFF
--- a/packages/cloudfront-signer/package.json
+++ b/packages/cloudfront-signer/package.json
@@ -44,7 +44,7 @@
       ]
     }
   },
-  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/cloudfront-signer",
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/cloudfront-signer",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -102,7 +102,7 @@
       ]
     }
   },
-  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/core",
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/core",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -54,7 +54,7 @@
   "files": [
     "dist-*/**"
   ],
-  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-sso",
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/credential-provider-sso",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -62,7 +62,7 @@
   "files": [
     "dist-*/**"
   ],
-  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-web-identity",
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/credential-provider-web-identity",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -47,7 +47,7 @@
   "files": [
     "dist-*/**"
   ],
-  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/signature-v4-crt",
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/signature-v4-crt",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",


### PR DESCRIPTION
### Description
So with the `fast-xml-parser` vulnerability I was trying to trace down if updating would help, and I started at the npm package page for [@aws-sdk/core](https://www.npmjs.com/package/@aws-sdk/core). The `homepage` link was out of date and led to a 404.

I looked at the `package.json` files in `clients/*` and `packages/*` looking for `homepage` values not using the `main` branch, and corrected them to `main`.

### Testing
No code testing, a documentation change.

### Checklist
- [X] If you wrote E2E tests, are they resilient to concurrent I/O?
- [X] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
