### PR TITLE
fix(middleware-sdk-transcribe-streaming): move middleware before signing

### DIFF
--- a/packages/middleware-sdk-transcribe-streaming/src/middleware-port.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/middleware-port.ts
@@ -27,7 +27,7 @@ export const websocketPortMiddleware =
 export const websocketPortMiddlewareOptions: RelativeMiddlewareOptions = {
   name: "websocketPortMiddleware",
   tags: ["WEBSOCKET", "EVENT_STREAM", "PORT"],
-  relation: "after",
-  toMiddleware: "eventStreamHeaderMiddleware",
+  relation: "before",
+  toMiddleware: "httpSigningMiddleware",
   override: true,
 };


### PR DESCRIPTION
### Issue
Internal JS-5337

### Description
Move websocketPortMiddleware before httpSigningMiddleware

### Testing
ToDo

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
