### PR TITLE
chore(codegen): make hasEventStreamInput utilities public

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventStreamHandlingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventStreamHandlingDependency.java
@@ -63,7 +63,7 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_EVENTSTREAM.dependency,
                                 "EventStream", HAS_MIDDLEWARE)
-                        .operationPredicate(AddEventStreamHandlingDependency::hasEventStreamInput)
+                        .operationPredicate((m, s, o) -> hasEventStreamInput(m, o))
                         .build()
         );
     }
@@ -138,7 +138,7 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
         }
     }
 
-    private static boolean hasEventStreamInput(Model model, ServiceShape service) {
+    public static boolean hasEventStreamInput(Model model, ServiceShape service) {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
         EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
@@ -150,8 +150,7 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
         return false;
     }
 
-    private static boolean hasEventStreamInput(Model model, ServiceShape service, OperationShape operation) {
-        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
-        return eventStreamIndex.getInputInfo(operation).isPresent();
+    public static boolean hasEventStreamInput(Model model, OperationShape operation) {
+        return EventStreamIndex.of(model).getInputInfo(operation).isPresent();
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
@@ -22,8 +22,6 @@ import java.util.function.Consumer;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.knowledge.EventStreamIndex;
-import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
@@ -56,7 +54,8 @@ public class AddTranscribeStreamingDependency implements TypeScriptIntegration {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.TRANSCRIBE_STREAMING_MIDDLEWARE.dependency,
                                 "TranscribeStreaming", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> isTranscribeStreaming(s) && hasEventStreamInput(m, s, o))
+                        .operationPredicate((m, s, o) -> isTranscribeStreaming(s)
+                            && AddEventStreamHandlingDependency.hasEventStreamInput(m, o))
                         .build()
         );
     }
@@ -93,11 +92,6 @@ public class AddTranscribeStreamingDependency implements TypeScriptIntegration {
     private static boolean isTranscribeStreaming(ServiceShape service) {
         String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
         return serviceId.equals("Transcribe Streaming");
-    }
-
-    private static boolean hasEventStreamInput(Model model, ServiceShape service, OperationShape operation) {
-        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
-        return eventStreamIndex.getInputInfo(operation).isPresent();
     }
 }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddWebsocketPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddWebsocketPlugin.java
@@ -24,7 +24,6 @@ import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.knowledge.EventStreamIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
@@ -62,7 +61,8 @@ public class AddWebsocketPlugin implements TypeScriptIntegration {
                         .withConventions(AwsDependency.MIDDLEWARE_WEBSOCKET.dependency,
                                 "WebSocket", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
                         .additionalPluginFunctionParamsSupplier((m, s, o) -> getPluginFunctionParams(m, s, o))
-                        .operationPredicate((m, s, o) -> isWebsocketSupported(s) && hasEventStreamRequest(m, o))
+                        .operationPredicate((m, s, o) -> isWebsocketSupported(s)
+                            && AddEventStreamHandlingDependency.hasEventStreamInput(m, o))
                         .build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_WEBSOCKET.dependency, "WebSocket",
@@ -131,11 +131,6 @@ public class AddWebsocketPlugin implements TypeScriptIntegration {
         String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
         return websocketServices.contains(serviceId);
     }
-
-    private static boolean hasEventStreamRequest(Model model, OperationShape operation) {
-        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
-        return eventStreamIndex.getInputInfo(operation).isPresent();
-  }
 
     private static Map<String, Object> getPluginFunctionParams(
         Model model,


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/6349#discussion_r1701930295

### Description
Makes hasEventStreamInput utilities public in AddEventStreamHandlingDependency, so that they can be used from dependent plugins

### Testing
Verified that TranscribeStreaming and RekognitionStreaming client codegen succeeds, and there are no changes.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
