### PR TITLE
test(karma-credential-loader): set credential expiration as date

### DIFF
--- a/packages/karma-credential-loader/src/index.ts
+++ b/packages/karma-credential-loader/src/index.ts
@@ -14,7 +14,14 @@ function createCredentialPreprocessor() {
     })();
     // This will affect the generated (ES5) JS
     const regionCode = `var defaultRegion = '${region}';`;
-    const credentialsCode = `var credentials = ${JSON.stringify(credentials)};`;
+    let credentialsCode = `var credentials = ${JSON.stringify(credentials)};
+delete credentials.expiration;`;
+
+    if (Number.isInteger(credentials.expiration?.getTime?.())) {
+      credentialsCode += `
+credentials.expiration = new Date(${credentials.expiration!.getTime()});`;
+    }
+
     const isBrowser = `var isBrowser = true;`;
     const contents = content.split("\n");
     let idx = -1;


### PR DESCRIPTION
### Issue
Internal JS-5339

### Description
This appears to write some code with 

```js 
var credentials = `${JSON.stringify(credentials)}`
```

however this would not serialize a Date object correctly.

### Testing
`b s3 - browser` (runs S3 client e2e browser tests)