### PR TITLE
chore: update fast-xml-parser for 3.186.4 release

### DIFF
--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-lex-runtime-service",
   "description": "AWS SDK for JavaScript Lex Runtime Service Client for Node.js, Browser and React Native",
-  "version": "3.186.3",
+  "version": "3.186.4",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "2.0.0",
     "@aws-crypto/sha256-js": "2.0.0",
-    "@aws-sdk/client-sts": "3.186.3",
+    "@aws-sdk/client-sts": "3.186.4",
     "@aws-sdk/config-resolver": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/fetch-http-handler": "*",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-lex-runtime-v2",
   "description": "AWS SDK for JavaScript Lex Runtime V2 Client for Node.js, Browser and React Native",
-  "version": "3.186.3",
+  "version": "3.186.4",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "2.0.0",
     "@aws-crypto/sha256-js": "2.0.0",
-    "@aws-sdk/client-sts": "3.186.3",
+    "@aws-sdk/client-sts": "3.186.4",
     "@aws-sdk/config-resolver": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/eventstream-handler-node": "*",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-location",
   "description": "AWS SDK for JavaScript Location Client for Node.js, Browser and React Native",
-  "version": "3.186.3",
+  "version": "3.186.4",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "2.0.0",
     "@aws-crypto/sha256-js": "2.0.0",
-    "@aws-sdk/client-sts": "3.186.3",
+    "@aws-sdk/client-sts": "3.186.4",
     "@aws-sdk/config-resolver": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/fetch-http-handler": "*",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-sdk/client-sts",
   "description": "AWS SDK for JavaScript Sts Client for Node.js, Browser and React Native",
-  "version": "3.186.3",
+  "version": "3.186.4",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
@@ -53,7 +53,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "4.2.5",
+    "fast-xml-parser": "4.4.1",
     "tslib": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Issue
Internal JS-5336

### Description

Update fast-xml-parser to `4.4.1` to release:

* `@aws-sdk/client-sts@3.186.4`
* `@aws-sdk/client-location@3.186.4`
* `@aws-sdk/client-lex-runtime-service@3.186.4`
* `@aws-sdk/client-lex-runtime-v2@3.186.4`

### Testing

Integration tests are successful for sts

```console
$ aws-sdk-js-v3>  yarn test:integration:legacy -t @sts 
yarn run v1.22.17
$ cucumber-js --fail-fast -t @sts
...........

2 scenarios (2 passed)
7 steps (7 passed)
0m00.110s (executing steps: 0m00.073s)
Done in 0.97s.
```

Tarballs to be published:
* [aws-sdk-client-lex-runtime-service-3.186.4.tgz](https://github.com/user-attachments/files/16501389/aws-sdk-client-lex-runtime-service-3.186.4.tgz)
* [aws-sdk-client-lex-runtime-v2-3.186.4.tgz](https://github.com/user-attachments/files/16501391/aws-sdk-client-lex-runtime-v2-3.186.4.tgz)
* [aws-sdk-client-location-3.186.4.tgz](https://github.com/user-attachments/files/16501392/aws-sdk-client-location-3.186.4.tgz)
* [aws-sdk-client-sts-3.186.4.tgz](https://github.com/user-attachments/files/16501393/aws-sdk-client-sts-3.186.4.tgz)

The tarballs were created by running:
* `git clean -dfx`
* `yarn`
* `yarn lerna run --scope @aws-sdk/client-sts --scope @aws-sdk/client-location --scope @aws-sdk/client-lex-runtime-v2 --scope @aws-sdk/client-lex-runtime-service --include-dependencies build`
* `yarn lerna run --scope @aws-sdk/client-sts --scope @aws-sdk/client-location --scope @aws-sdk/client-lex-runtime-v2 --scope @aws-sdk/client-lex-runtime-service build:types:downlevel`
* `yarn update:versions:current`
* `yarn lerna exec --scope @aws-sdk/client-sts --scope @aws-sdk/client-location --scope @aws-sdk/client-lex-runtime-v2 --scope @aws-sdk/client-lex-runtime-service npm pack`
  * Use npm@<=8, as the files glob doesn't work with npm@9 as per https://github.com/npm/cli/issues/6330

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
