### PR TITLE
fix(turbo): improve error handling in build script & remove unnecessary filtering from build:ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bootstrap": "yarn",
     "bootstrap:ci": "yarn install --frozen-lockfile",
     "build:all": "yarn build:crypto-dependencies && node ./scripts/turbo build",
-    "build:ci": "node ./scripts/turbo build -F=[origin/main...HEAD]...",
+    "build:ci": "node ./scripts/turbo build",
     "build:clients:generic": "node ./scripts/turbo build -F=@aws-sdk/aws-echo-service...",
     "build:clients:since:release": "yarn build:packages && node ./scripts/turbo build $(lerna changed | grep -e '@aws-sdk/[client|lib]-*' | sed 's/^/ -F=/' | tr '\n' ' ')",
     "build:crypto-dependencies": "node ./scripts/turbo build -F=@aws-sdk/types... -F=@aws-sdk/util-locate-window...",

--- a/scripts/turbo/index.js
+++ b/scripts/turbo/index.js
@@ -18,6 +18,10 @@ const runTurbo = async (task, args, apiSecret, apiEndpoint) => {
     return await spawnProcess("npx", command, { stdio: "inherit", cwd: turboRoot });
   } catch (error) {
     console.error("Error running turbo:", error);
+    if (args?.length > 0) {
+      // Retry without additional filters
+      return await runTurbo(task, null, apiSecret, apiEndpoint);
+    }
   }
 };
 


### PR DESCRIPTION
### Issue
Previously, Turborepo build errors due to package filtering or other optional arguments would result in a CI build failure. This code change adds a fallback for these errors, rebuilding the package without any optional arguments. It also removes unnecessary filtering from the build:ci script in package.json. 


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
