### PR TITLE
Bump codegen version to 0.22.0

### DIFF
--- a/clients/client-s3/src/models/models_0.ts
+++ b/clients/client-s3/src/models/models_0.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
+
 import { StreamingBlobTypes } from "@smithy/types";
 
 import { S3ServiceException as __BaseException } from "./S3ServiceException";

--- a/clients/client-s3/src/models/models_1.ts
+++ b/clients/client-s3/src/models/models_1.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
+
 import { StreamingBlobTypes } from "@smithy/types";
 
 import {
@@ -27,6 +28,7 @@ import {
   StorageClass,
   Tag,
 } from "./models_0";
+
 import { S3ServiceException as __BaseException } from "./S3ServiceException";
 
 /**

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.22.0 (2024-07-06)
+
+### Features
+* Added support for `AccountIdEndpointMode` when configuring client endpoint parameters ([#6036](https://github.com/aws/aws-sdk-js-v3/pull/6036))
+* Enabled the new identity and auth behavior by default ([#1352](https://github.com/smithy-lang/smithy-typescript/pull/1352))
+
+
 ## 0.21.0 (2024-05-22)
 
 ### Bug Fixes

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.21.1"
+    version = "0.22.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.21.1")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.22.0")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "efcbbf42baf48ed19d2634555b2545acbd974321",
+  SMITHY_TS_COMMIT: "e77488b746a5b98c0e64e009242382e56bed531f",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Description
- Bumps codegen versions to `0.22.0`
- Changelog entry needs to be added

### Testing
- Will generate clients and test before merging

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
