### PR TITLE
chore(scripts): discover unused packages

### DIFF
--- a/scripts/validation/deprecated-packages.js
+++ b/scripts/validation/deprecated-packages.js
@@ -1,33 +1,98 @@
 const fs = require("node:fs");
-const fse = require("fs-extra");
 const path = require("node:path");
 
 const root = path.join(__dirname, "..", "..");
 const packages = path.join(root, "packages");
+const libs = path.join(root, "lib");
+const clients = path.join(root, "clients");
 
-const excluded = [];
+/**
+ * Throw and Error if any deprecated package is not marked private.
+ */
+{
+  const excluded = [];
 
-for (const folder of fs.readdirSync(packages)) {
-  const pkgJson = require(path.join(packages, folder, "package.json"));
-  if (excluded.includes(pkgJson.name)) {
-    continue;
-  }
-  if (pkgJson.private === true) {
-    fse.moveSync(path.join(packages, folder), path.join(root, "deprecated", "packages", folder));
+  const deprecatedPackages = path.join(root, "deprecated", "packages");
+  for (const folder of fs.readdirSync(deprecatedPackages)) {
+    const pkgJson = require(path.join(deprecatedPackages, folder, "package.json"));
+
+    if (excluded.includes(pkgJson.name)) {
+      continue;
+    }
+
+    if (pkgJson.private !== true) {
+      throw new Error("package in deprecated folder is not marked private:", folder);
+    } else {
+    }
   }
 }
 
-const deprecatedPackages = path.join(root, "deprecated", "packages");
-for (const folder of fs.readdirSync(deprecatedPackages)) {
-  const pkgJson = require(path.join(deprecatedPackages, folder, "package.json"));
+/**
+ * Analyze package dependency graph.
+ */
+{
+  const packagesData = fs.readdirSync(packages).map((pkg) => require(path.join(packages, pkg, "package.json")));
+  const libsData = fs.readdirSync(libs).map((pkg) => require(path.join(libs, pkg, "package.json")));
+  const clientsData = fs.readdirSync(clients).map((pkg) => require(path.join(clients, pkg, "package.json")));
 
-  if (excluded.includes(pkgJson.name)) {
-    continue;
-  }
+  const allPackages = [...packagesData, ...libsData, ...clientsData];
 
-  if (pkgJson.private !== true) {
-    throw new Error("package in deprecated folder is not marked private:", folder);
-  } else {
-    console.log(`"${pkgJson.name}"`);
-  }
+  const graph = new (class PackageGraph {
+    /**
+     * @param graph - map of pkg name to pkg.json objects.
+     */
+    constructor(graph) {
+      this.graph = graph;
+      for (const md of Object.values(graph)) {
+        md.dependents = md.dependents ?? {};
+        for (const dependency of Object.keys({ ...md.dependencies, ...md.devDependencies })) {
+          if (!graph[dependency]) {
+            // is external.
+            continue;
+          }
+          graph[dependency].dependents = graph[dependency].dependents ?? {};
+          graph[dependency].dependents[md.name] = 1;
+        }
+      }
+    }
+
+    entryPoints() {
+      const { graph } = this;
+      return Object.values(graph)
+        .filter((p) => {
+          if (p.name.startsWith("@aws-sdk/client-")) {
+            return false;
+          }
+          // return Object.keys(p.dependents).length === 0;
+          return true;
+        })
+        .sort((a, b) => {
+          return Object.keys(a.dependents).length - Object.keys(b.dependents).length;
+        })
+        .map((p) => {
+          const deps = Object.keys(p.dependents);
+          switch (p.name) {
+            case "@aws-sdk/karma-credential-loader":
+              return p.name + ": -- devtool --";
+          }
+          if (deps.length === 0) {
+            return p.name + ": ---- NONE ----";
+          }
+          if (deps.length > 100) {
+            return p.name + `: ** ${deps.length} packages (clients) **`;
+          }
+          if (deps.length > 5) {
+            return p.name + `: ** ${deps.length} packages **`;
+          }
+          return p.name + ": \n\t" + deps.join("\n\t");
+        });
+    }
+  })(
+    allPackages.reduce((gr, pkg) => {
+      gr[pkg.name] = pkg;
+      return gr;
+    }, {})
+  );
+
+  console.log(graph.entryPoints().join("\n"));
 }


### PR DESCRIPTION
script which prints out the dependency graph of packages

current output of packages and their dependents:

```
@aws-sdk/cloudfront-signer: ---- NONE ----
@aws-sdk/ec2-metadata-service: ---- NONE ----
@aws-sdk/karma-credential-loader: -- devtool --
@aws-sdk/middleware-api-key: ---- NONE ----
@aws-sdk/middleware-sdk-sts: ---- NONE ----
@aws-sdk/middleware-token: ---- NONE ----
@aws-sdk/polly-request-presigner: ---- NONE ----
@aws-sdk/rds-signer: ---- NONE ----
@aws-sdk/s3-presigned-post: ---- NONE ----
@aws-sdk/s3-request-presigner: ---- NONE ----
@aws-sdk/smithy-client: ---- NONE ----
@aws-sdk/util-create-request: ---- NONE ----
@aws-sdk/util-dns: ---- NONE ----
@aws-sdk/util-locate-window: ---- NONE ----
@aws-sdk/xhr-http-handler: ---- NONE ----
@aws-sdk/lib-dynamodb: ---- NONE ----
@aws-sdk/lib-storage: ---- NONE ----
@aws-sdk/body-checksum-browser: 
        @aws-sdk/client-glacier
@aws-sdk/body-checksum-node: 
        @aws-sdk/client-glacier
@aws-sdk/chunked-stream-reader-node: 
        @aws-sdk/body-checksum-node
@aws-sdk/credential-provider-cognito-identity: 
        @aws-sdk/credential-providers
@aws-sdk/endpoint-cache: 
        @aws-sdk/middleware-endpoint-discovery
@aws-sdk/middleware-expect-continue: 
        @aws-sdk/client-s3
@aws-sdk/middleware-flexible-checksums: 
        @aws-sdk/client-s3
@aws-sdk/middleware-location-constraint: 
        @aws-sdk/client-s3
@aws-sdk/middleware-sdk-api-gateway: 
        @aws-sdk/client-api-gateway
@aws-sdk/middleware-sdk-ec2: 
        @aws-sdk/client-ec2
@aws-sdk/middleware-sdk-glacier: 
        @aws-sdk/client-glacier
@aws-sdk/middleware-sdk-machinelearning: 
        @aws-sdk/client-machine-learning
@aws-sdk/middleware-sdk-route53: 
        @aws-sdk/client-route-53
@aws-sdk/middleware-sdk-s3-control: 
        @aws-sdk/client-s3-control
@aws-sdk/middleware-sdk-sqs: 
        @aws-sdk/client-sqs
@aws-sdk/middleware-sdk-transcribe-streaming: 
        @aws-sdk/client-transcribe-streaming
@aws-sdk/middleware-ssec: 
        @aws-sdk/client-s3
@aws-sdk/util-dynamodb: 
        @aws-sdk/lib-dynamodb
@aws-sdk/credential-provider-ini: 
        @aws-sdk/credential-provider-node
        @aws-sdk/credential-providers
@aws-sdk/credential-providers: 
        @aws-sdk/ec2-metadata-service
        @aws-sdk/rds-signer
@aws-sdk/middleware-bucket-endpoint: 
        @aws-sdk/middleware-sdk-s3-control
        @aws-sdk/client-s3
@aws-sdk/middleware-sdk-s3: 
        @aws-sdk/signature-v4-multi-region
        @aws-sdk/client-s3
@aws-sdk/middleware-signing: 
        @aws-sdk/middleware-sdk-sts
        @aws-sdk/middleware-websocket
@aws-sdk/middleware-websocket: 
        @aws-sdk/client-rekognitionstreaming
        @aws-sdk/client-transcribe-streaming
@aws-sdk/sha256-tree-hash: 
        @aws-sdk/body-checksum-browser
        @aws-sdk/body-checksum-node
@aws-sdk/signature-v4-crt: 
        @aws-sdk/client-eventbridge
        @aws-sdk/client-s3
@aws-sdk/credential-provider-env: 
        @aws-sdk/credential-provider-ini
        @aws-sdk/credential-provider-node
        @aws-sdk/credential-providers
@aws-sdk/credential-provider-http: 
        @aws-sdk/credential-provider-ini
        @aws-sdk/credential-provider-node
        @aws-sdk/credential-providers
@aws-sdk/credential-provider-process: 
        @aws-sdk/credential-provider-ini
        @aws-sdk/credential-provider-node
        @aws-sdk/credential-providers
@aws-sdk/credential-provider-sso: 
        @aws-sdk/credential-provider-ini
        @aws-sdk/credential-provider-node
        @aws-sdk/credential-providers
@aws-sdk/credential-provider-web-identity: 
        @aws-sdk/credential-provider-ini
        @aws-sdk/credential-provider-node
        @aws-sdk/credential-providers
@aws-sdk/middleware-endpoint-discovery: 
        @aws-sdk/client-dynamodb
        @aws-sdk/client-timestream-query
        @aws-sdk/client-timestream-write
@aws-sdk/middleware-sdk-rds: 
        @aws-sdk/client-docdb
        @aws-sdk/client-neptune
        @aws-sdk/client-rds
@aws-sdk/token-providers: 
        @aws-sdk/credential-provider-sso
        @aws-sdk/middleware-token
        @aws-sdk/client-codecatalyst
@aws-sdk/util-arn-parser: 
        @aws-sdk/middleware-bucket-endpoint
        @aws-sdk/middleware-sdk-s3
        @aws-sdk/middleware-sdk-s3-control
@aws-sdk/eventstream-handler-node: 
        @aws-sdk/client-lex-runtime-v2
        @aws-sdk/client-qbusiness
        @aws-sdk/client-rekognitionstreaming
        @aws-sdk/client-transcribe-streaming
@aws-sdk/middleware-eventstream: 
        @aws-sdk/client-lex-runtime-v2
        @aws-sdk/client-qbusiness
        @aws-sdk/client-rekognitionstreaming
        @aws-sdk/client-transcribe-streaming
@aws-sdk/xml-builder: 
        @aws-sdk/client-cloudfront
        @aws-sdk/client-route-53
        @aws-sdk/client-s3
        @aws-sdk/client-s3-control
@aws-sdk/signature-v4-multi-region: 
        @aws-sdk/s3-request-presigner
        @aws-sdk/signature-v4-crt
        @aws-sdk/client-cloudfront-keyvaluestore
        @aws-sdk/client-eventbridge
        @aws-sdk/client-s3
@aws-sdk/util-format-url: ** 8 packages **
@aws-sdk/credential-provider-node: ** 386 packages (clients) **
@aws-sdk/middleware-host-header: ** 386 packages (clients) **
@aws-sdk/middleware-logger: ** 386 packages (clients) **
@aws-sdk/middleware-recursion-detection: ** 386 packages (clients) **
@aws-sdk/middleware-user-agent: ** 386 packages (clients) **
@aws-sdk/region-config-resolver: ** 386 packages (clients) **
@aws-sdk/util-user-agent-browser: ** 386 packages (clients) **
@aws-sdk/core: ** 387 packages (clients) **
@aws-sdk/util-user-agent-node: ** 387 packages (clients) **
@aws-sdk/util-endpoints: ** 388 packages (clients) **
@aws-sdk/types: ** 441 packages (clients) **
```

Out of the list of packages with no dependents, they can be explained as such:

```
@aws-sdk/cloudfront-signer: ----public API ----
@aws-sdk/ec2-metadata-service: ----public API ----
@aws-sdk/polly-request-presigner: ----public API ----
@aws-sdk/rds-signer: ----public API ----
@aws-sdk/s3-presigned-post: ----public API ----
@aws-sdk/s3-request-presigner: ----public API ----
@aws-sdk/xhr-http-handler: ----public API ----
@aws-sdk/lib-dynamodb: ----public API ----
@aws-sdk/lib-storage: ----public API ----

@aws-sdk/util-create-request: ---- unused public API ----
@aws-sdk/util-dns: ---- unused internal API ??? ----
@aws-sdk/util-locate-window: ---- unused micro-function, public API ----

@aws-sdk/smithy-client: ---- needed by codegen ----

@aws-sdk/karma-credential-loader: -- devtool --
@aws-sdk/middleware-api-key: ---- deprecated by id&auth SRA, used in legacyAuth ----
@aws-sdk/middleware-sdk-sts: ---- deprecated by id&auth SRA, used in legacyAuth ----
@aws-sdk/middleware-token: ---- deprecated by id&auth SRA, used in legacyAuth ----
```