### PR TITLE
feat(core/httpAuthSchemes): set configuration sources for sigv4a signingRegionSet

### DIFF
--- a/clients/client-cloudfront-keyvaluestore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,12 @@
 // smithy-typescript generated code
 import {
+  AwsSdkSigV4AAuthInputConfig,
+  AwsSdkSigV4AAuthResolvedConfig,
+  AwsSdkSigV4APreviouslyResolved,
   AwsSdkSigV4AuthInputConfig,
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
+  resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core";
 import { signatureV4CrtContainer } from "@aws-sdk/signature-v4-multi-region";
@@ -297,7 +301,7 @@ export const defaultCloudFrontKeyValueStoreHttpAuthSchemeProvider: CloudFrontKey
 /**
  * @internal
  */
-export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig {
+export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig, AwsSdkSigV4AAuthInputConfig {
   /**
    * Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
    * @internal
@@ -314,7 +318,7 @@ export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig {
 /**
  * @internal
  */
-export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedConfig {
+export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedConfig, AwsSdkSigV4AAuthResolvedConfig {
   /**
    * Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
    * @internal
@@ -332,10 +336,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
  * @internal
  */
 export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved
 ): T & HttpAuthSchemeResolvedConfig => {
   const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_1 = resolveAwsSdkSigV4AConfig(config_0);
   return {
-    ...config_0,
+    ...config_1,
   } as T & HttpAuthSchemeResolvedConfig;
 };

--- a/clients/client-cloudfront-keyvaluestore/src/runtimeConfig.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/runtimeConfig.ts
@@ -2,7 +2,7 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core";
+import { NODE_SIGV4A_CONFIG_OPTIONS, emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import {
@@ -52,6 +52,7 @@ export const getRuntimeConfig = (config: CloudFrontKeyValueStoreClientConfig) =>
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
+    sigv4aSigningRegionSet: config?.sigv4aSigningRegionSet ?? loadNodeConfig(NODE_SIGV4A_CONFIG_OPTIONS),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),
     useFipsEndpoint: config?.useFipsEndpoint ?? loadNodeConfig(NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-eventbridge/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-eventbridge/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,12 @@
 // smithy-typescript generated code
 import {
+  AwsSdkSigV4AAuthInputConfig,
+  AwsSdkSigV4AAuthResolvedConfig,
+  AwsSdkSigV4APreviouslyResolved,
   AwsSdkSigV4AuthInputConfig,
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
+  resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core";
 import { signatureV4CrtContainer } from "@aws-sdk/signature-v4-multi-region";
@@ -279,7 +283,7 @@ export const defaultEventBridgeHttpAuthSchemeProvider: EventBridgeHttpAuthScheme
 /**
  * @internal
  */
-export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig {
+export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig, AwsSdkSigV4AAuthInputConfig {
   /**
    * Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
    * @internal
@@ -296,7 +300,7 @@ export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig {
 /**
  * @internal
  */
-export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedConfig {
+export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedConfig, AwsSdkSigV4AAuthResolvedConfig {
   /**
    * Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
    * @internal
@@ -314,10 +318,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
  * @internal
  */
 export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved
 ): T & HttpAuthSchemeResolvedConfig => {
   const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_1 = resolveAwsSdkSigV4AConfig(config_0);
   return {
-    ...config_0,
+    ...config_1,
   } as T & HttpAuthSchemeResolvedConfig;
 };

--- a/clients/client-eventbridge/src/runtimeConfig.ts
+++ b/clients/client-eventbridge/src/runtimeConfig.ts
@@ -2,7 +2,7 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core";
+import { NODE_SIGV4A_CONFIG_OPTIONS, emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import {
@@ -52,6 +52,7 @@ export const getRuntimeConfig = (config: EventBridgeClientConfig) => {
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
+    sigv4aSigningRegionSet: config?.sigv4aSigningRegionSet ?? loadNodeConfig(NODE_SIGV4A_CONFIG_OPTIONS),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),
     useFipsEndpoint: config?.useFipsEndpoint ?? loadNodeConfig(NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-s3/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,12 @@
 // smithy-typescript generated code
 import {
+  AwsSdkSigV4AAuthInputConfig,
+  AwsSdkSigV4AAuthResolvedConfig,
+  AwsSdkSigV4APreviouslyResolved,
   AwsSdkSigV4AuthInputConfig,
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
+  resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core";
 import { signatureV4CrtContainer } from "@aws-sdk/signature-v4-multi-region";
@@ -281,7 +285,7 @@ export const defaultS3HttpAuthSchemeProvider: S3HttpAuthSchemeProvider = createE
 /**
  * @internal
  */
-export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig {
+export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig, AwsSdkSigV4AAuthInputConfig {
   /**
    * Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
    * @internal
@@ -298,7 +302,7 @@ export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig {
 /**
  * @internal
  */
-export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedConfig {
+export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedConfig, AwsSdkSigV4AAuthResolvedConfig {
   /**
    * Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
    * @internal
@@ -316,10 +320,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
  * @internal
  */
 export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved
 ): T & HttpAuthSchemeResolvedConfig => {
   const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_1 = resolveAwsSdkSigV4AConfig(config_0);
   return {
-    ...config_0,
+    ...config_1,
   } as T & HttpAuthSchemeResolvedConfig;
 };

--- a/clients/client-s3/src/runtimeConfig.ts
+++ b/clients/client-s3/src/runtimeConfig.ts
@@ -2,7 +2,7 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core";
+import { NODE_SIGV4A_CONFIG_OPTIONS, emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { NODE_USE_ARN_REGION_CONFIG_OPTIONS } from "@aws-sdk/middleware-bucket-endpoint";
 import { NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS } from "@aws-sdk/middleware-sdk-s3";
@@ -62,6 +62,7 @@ export const getRuntimeConfig = (config: S3ClientConfig) => {
       }),
     sha1: config?.sha1 ?? Hash.bind(null, "sha1"),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
+    sigv4aSigningRegionSet: config?.sigv4aSigningRegionSet ?? loadNodeConfig(NODE_SIGV4A_CONFIG_OPTIONS),
     streamCollector: config?.streamCollector ?? streamCollector,
     streamHasher: config?.streamHasher ?? streamHasher,
     useArnRegion: config?.useArnRegion ?? loadNodeConfig(NODE_USE_ARN_REGION_CONFIG_OPTIONS),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsTraitsUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsTraitsUtils.java
@@ -60,12 +60,16 @@ public final class AwsTraitsUtils {
     }
 
     public static boolean isSigV4AsymmetricService(Model model, TypeScriptSettings settings) {
-        if (ENDPOINT_RULESET_HTTP_AUTH_SCHEME_SERVICES.contains(settings.getService())) {
+        return isSigV4AsymmetricService(model, settings.getService(model));
+    }
+
+    public static boolean isSigV4AsymmetricService(Model model, ServiceShape service) {
+        if (ENDPOINT_RULESET_HTTP_AUTH_SCHEME_SERVICES.contains(service.getId())) {
             return true;
         }
 
         return ServiceIndex.of(model)
-            .getEffectiveAuthSchemes(settings.getService(), ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE)
+            .getEffectiveAuthSchemes(service, ServiceIndex.AuthSchemeMode.NO_AUTH_AWARE)
             .containsKey(SigV4ATrait.ID);
     }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,6 +77,7 @@
   "dependencies": {
     "@smithy/core": "^2.3.2",
     "@smithy/node-config-provider": "^3.1.4",
+    "@smithy/property-provider": "^3.1.3",
     "@smithy/protocol-http": "^4.1.0",
     "@smithy/signature-v4": "^4.1.0",
     "@smithy/smithy-client": "^3.1.12",

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4ASigner.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4ASigner.ts
@@ -22,7 +22,13 @@ export class AwsSdkSigV4ASigner extends AwsSdkSigV4Signer {
     const { config, signer, signingRegion, signingRegionSet, signingName } = await validateSigningProperties(
       signingProperties
     );
-    const multiRegionOverride: string | undefined = signingRegionSet?.join?.(",") ?? signingRegion;
+
+    const configResolvedSigningRegionSet = await config.sigv4aSigningRegionSet?.();
+
+    const multiRegionOverride: string | undefined = (
+      configResolvedSigningRegionSet ??
+      signingRegionSet ?? [signingRegion]
+    ).join(",");
 
     const signedRequest = await signer.sign(httpRequest, {
       signingDate: getSkewCorrectedDate(config.systemClockOffset),

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts
@@ -11,6 +11,7 @@ import {
 } from "@smithy/types";
 
 import { getDateHeader, getSkewCorrectedDate, getUpdatedSystemClockOffset } from "../utils";
+import { AwsSdkSigV4AAuthResolvedConfig } from "./resolveAwsSdkSigV4AConfig";
 
 /**
  * @internal
@@ -25,7 +26,7 @@ const throwSigningPropertyError = <T>(name: string, property: T | undefined): T 
 /**
  * @internal
  */
-interface AwsSdkSigV4Config {
+interface AwsSdkSigV4Config extends AwsSdkSigV4AAuthResolvedConfig {
   systemClockOffset: number;
   signer: (authScheme?: AuthScheme) => Promise<RequestSigner>;
 }

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/index.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/index.ts
@@ -1,3 +1,4 @@
 export { AwsSdkSigV4Signer, AWSSDKSigV4Signer, validateSigningProperties } from "./AwsSdkSigV4Signer";
 export { AwsSdkSigV4ASigner } from "./AwsSdkSigV4ASigner";
+export * from "./resolveAwsSdkSigV4AConfig";
 export * from "./resolveAwsSdkSigV4Config";

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4AConfig.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4AConfig.ts
@@ -1,0 +1,67 @@
+import { normalizeProvider } from "@smithy/core";
+import { LoadedConfigSelectors } from "@smithy/node-config-provider";
+import { ProviderError } from "@smithy/property-provider";
+import { Profile, Provider } from "@smithy/types";
+
+/**
+ * @public
+ */
+export interface AwsSdkSigV4AAuthInputConfig {
+  /**
+   * This option will override the AWS sigv4a
+   * signing regionSet from any other source.
+   *
+   * The lookup order is:
+   * 1. this value
+   * 2. configuration file value of sigv4a_signing_region_set.
+   * 3. environment value of AWS_SIGV4A_SIGNING_REGION_SET.
+   * 4. signingRegionSet given by endpoint resolution.
+   * 5. the singular region of the SDK client.
+   */
+  sigv4aSigningRegionSet?: string[] | undefined | Provider<string[] | undefined>;
+}
+
+/**
+ * @internal
+ */
+export interface AwsSdkSigV4APreviouslyResolved {}
+
+/**
+ * @internal
+ */
+export interface AwsSdkSigV4AAuthResolvedConfig {
+  sigv4aSigningRegionSet: Provider<string[] | undefined>;
+}
+
+/**
+ * @internal
+ */
+export const resolveAwsSdkSigV4AConfig = <T>(
+  config: T & AwsSdkSigV4AAuthInputConfig & AwsSdkSigV4APreviouslyResolved
+): T & AwsSdkSigV4AAuthResolvedConfig => {
+  config.sigv4aSigningRegionSet = normalizeProvider(config.sigv4aSigningRegionSet ?? []);
+  return config as T & AwsSdkSigV4AAuthResolvedConfig;
+};
+
+/**
+ * @internal
+ */
+export const NODE_SIGV4A_CONFIG_OPTIONS: LoadedConfigSelectors<string[] | undefined> = {
+  environmentVariableSelector(env: Record<string, string | undefined>): string[] | undefined {
+    if (env.AWS_SIGV4A_SIGNING_REGION_SET) {
+      return env.AWS_SIGV4A_SIGNING_REGION_SET.split(",").map((_) => _.trim());
+    }
+    throw new ProviderError("AWS_SIGV4A_SIGNING_REGION_SET not set in env.", {
+      tryNextLink: true,
+    });
+  },
+  configFileSelector(profile: Profile): string[] | undefined {
+    if (profile.sigv4a_signing_region_set) {
+      return ((profile.sigv4a_signing_region_set as string) ?? "").split(",").map((_) => _.trim());
+    }
+    throw new ProviderError("sigv4a_signing_region_set not set in profile.", {
+      tryNextLink: true,
+    });
+  },
+  default: undefined,
+};

--- a/private/aws-client-api-test/src/client-interface-tests/client-s3/impl/initializeWithMaximalConfiguration.ts
+++ b/private/aws-client-api-test/src/client-interface-tests/client-s3/impl/initializeWithMaximalConfiguration.ts
@@ -119,6 +119,7 @@ export const initializeWithMaximalConfiguration = () => {
     useGlobalEndpoint: false,
     signingEscapePath: false,
     bucketEndpoint: false,
+    sigv4aSigningRegionSet: [],
   };
 
   const s3 = new S3Client(config);


### PR DESCRIPTION
### Issue
JS-4976

### Description
This adds a config resolver for sigv4a and its config field "sigv4aSigningRegionSet" which is an optional list of AWS regions.

usage:

```js
  const s3 = new S3({
    region: "us-west-2",
    sigv4aSigningRegionSet: ["us-west-2", "us-east-1"],
  });
```

This is quite optional at this point, because endpoint resolution for Amazon S3 always returns a signingRegionSet of `*` if resolving the auth scheme to sigv4a. This will support future developments in multi-auth and expanded usage of sigv4a. 

### Testing
- [x] ci
- [x] e2e
- [x] e2e:legacy

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?