### PR TITLE
docs(client-s3): Fix incorrect GetObjectCommand Input/Output types

### DIFF
--- a/clients/client-s3/src/commands/GetObjectCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectCommand.ts
@@ -27,7 +27,7 @@ export { $Command };
  *
  * The input for {@link GetObjectCommand}.
  */
-export interface GetObjectCommandInput extends GetObjectRequest {}
+export interface GetObjectCommandInput extends GetObjectRequest { }
 /**
  * @public
  *
@@ -194,7 +194,7 @@ export interface GetObjectCommandOutput extends Omit<GetObjectOutput, "Body">, _
  * import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3"; // ES Modules import
  * // const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3"); // CommonJS import
  * const client = new S3Client(config);
- * const input = { // GetObjectRequest
+ * const input = { // GetObjectCommandInput
  *   Bucket: "STRING_VALUE", // required
  *   IfMatch: "STRING_VALUE",
  *   IfModifiedSince: new Date("TIMESTAMP"),
@@ -219,7 +219,7 @@ export interface GetObjectCommandOutput extends Omit<GetObjectOutput, "Body">, _
  * };
  * const command = new GetObjectCommand(input);
  * const response = await client.send(command);
- * // { // GetObjectOutput
+ * // { // GetObjectCommandOutput
  * //   Body: "<SdkStream>", // see \@smithy/types -> StreamingBlobPayloadOutputTypes
  * //   DeleteMarker: true || false,
  * //   AcceptRanges: "STRING_VALUE",
@@ -368,4 +368,4 @@ export class GetObjectCommand extends $Command
   .f(GetObjectRequestFilterSensitiveLog, GetObjectOutputFilterSensitiveLog)
   .ser(se_GetObjectCommand)
   .de(de_GetObjectCommand)
-  .build() {}
+  .build() { }

--- a/clients/client-s3/src/commands/GetObjectCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectCommand.ts
@@ -27,7 +27,7 @@ export { $Command };
  *
  * The input for {@link GetObjectCommand}.
  */
-export interface GetObjectCommandInput extends GetObjectRequest { }
+export interface GetObjectCommandInput extends GetObjectRequest {}
 /**
  * @public
  *
@@ -368,4 +368,4 @@ export class GetObjectCommand extends $Command
   .f(GetObjectRequestFilterSensitiveLog, GetObjectOutputFilterSensitiveLog)
   .ser(se_GetObjectCommand)
   .de(de_GetObjectCommand)
-  .build() { }
+  .build() {}


### PR DESCRIPTION
### Issue
Incorrect Types for Input and Output Object for client-s3 GetObjectCommand Documentation

### Description
Documentation Fix

### Testing
None - just a comment change.

### Additional context
None

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
