### PR TITLE
test: fix TypeScript errors in endpoints-integration.spec.ts

### DIFF
--- a/tests/endpoints-2.0/endpoints-integration.spec.ts
+++ b/tests/endpoints-2.0/endpoints-integration.spec.ts
@@ -19,9 +19,9 @@ describe("client list", () => {
 for (const client of clientList) {
   const serviceName = client.slice(7);
 
-  let defaultEndpointResolver;
-  let namespace;
-  let model;
+  let defaultEndpointResolver: any;
+  let namespace: any;
+  let model: any;
 
   // this may also work with dynamic async import() in a beforeAll() block,
   // but needs more effort than using synchronous require().
@@ -41,7 +41,9 @@ for (const client of clientList) {
 
   describe(`client-${serviceName} endpoint test cases`, () => {
     if (defaultEndpointResolver && namespace && model) {
-      const [, service] = Object.entries(model.shapes).find(([k, v]) => v?.["type"] === "service") as any;
+      const [, service] = Object.entries(model.shapes).find(
+        ([k, v]) => typeof v === "object" && v !== null && "type" in v && v.type === "service"
+      ) as any;
       const [, tests] = Object.entries(service.traits).find(([k, v]) => k === "smithy.rules#endpointTests") as any;
       if (tests?.testCases) {
         runTestCases(tests, service, defaultEndpointResolver, "");
@@ -106,8 +108,8 @@ async function runTestCase(
     }
     if (isErrorExpectation(expectation)) {
       const { error } = expectation;
-      const pass = (err) => err;
-      const normalizeQuotes = (s) => s.replace(/`/g, "");
+      const pass = (err: any) => err;
+      const normalizeQuotes = (s: string) => s.replace(/`/g, "");
       if (operationInputs) {
         for (const operationInput of operationInputs) {
           const { operationName, operationParams = {} } = operationInput;


### PR DESCRIPTION
### Issue
Internal JS-5234

### Description
Fixes TypeScript errors in endpoints-integration.spec.ts

### Testing

#### Before

```console
$ yarn jest -c tests/endpoints-2.0/jest.config.js tests/endpoints-2.0/endpoints-integration.spec.ts
yarn run v1.22.22
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/jest -c tests/endpoints-2.0/jest.config.js tests/endpoints-2.0/endpoints-integration.spec.ts
 FAIL  tests/endpoints-2.0/endpoints-integration.spec.ts
  ● Test suite failed to run

    tests/endpoints-2.0/endpoints-integration.spec.ts:22:7 - error TS7034: Variable 'defaultEndpointResolver' implicitly has type 'any' in some locations where its type cannot be determined.

    22   let defaultEndpointResolver;
             ~~~~~~~~~~~~~~~~~~~~~~~
    tests/endpoints-2.0/endpoints-integration.spec.ts:23:7 - error TS7034: Variable 'namespace' implicitly has type 'any' in some locations where its type cannot be determined.

    23   let namespace;
             ~~~~~~~~~
    tests/endpoints-2.0/endpoints-integration.spec.ts:24:7 - error TS7034: Variable 'model' implicitly has type 'any' in some locations where its type cannot be determined.

    24   let model;
             ~~~~~
    tests/endpoints-2.0/endpoints-integration.spec.ts:43:9 - error TS7005: Variable 'defaultEndpointResolver' implicitly has an 'any' type.

    43     if (defaultEndpointResolver && namespace && model) {
               ~~~~~~~~~~~~~~~~~~~~~~~
    tests/endpoints-2.0/endpoints-integration.spec.ts:43:36 - error TS7005: Variable 'namespace' implicitly has an 'any' type.

    43     if (defaultEndpointResolver && namespace && model) {
                                          ~~~~~~~~~
    tests/endpoints-2.0/endpoints-integration.spec.ts:43:49 - error TS7005: Variable 'model' implicitly has an 'any' type.

    43     if (defaultEndpointResolver && namespace && model) {
                                                       ~~~~~
    tests/endpoints-2.0/endpoints-integration.spec.ts:44:73 - error TS7053: Element implicitly has an 'any' type because expression of type '"type"' can't be used to index type '{}'.
      Property 'type' does not exist on type '{}'.

    44       const [, service] = Object.entries(model.shapes).find(([k, v]) => v?.["type"] === "service") as any;
                                                                               ~~~~~~~~~~~
    tests/endpoints-2.0/endpoints-integration.spec.ts:109:21 - error TS7006: Parameter 'err' implicitly has an 'any' type.

    109       const pass = (err) => err;
                            ~~~
    tests/endpoints-2.0/endpoints-integration.spec.ts:110:32 - error TS7006: Parameter 's' implicitly has an 'any' type.

    110       const normalizeQuotes = (s) => s.replace(/`/g, "");
                                       ~

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        3.546 s
Ran all test suites matching /tests\/endpoints-2.0\/endpoints-integration.spec.ts/i.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

#### After

```console
$ yarn jest -c tests/endpoints-2.0/jest.config.js tests/endpoints-2.0/endpoints-integration.spec.ts
...
Test Suites: 1 passed, 1 total
Tests:       124 skipped, 14548 passed, 14672 total
Snapshots:   0 total
Time:        127.315 s
Ran all test suites matching /tests\/endpoints-2.0\/endpoints-integration.spec.ts/i.
Done in 128.22s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
