### PR TITLE
fix(core/httpAuthSchemes): default sigv4aSigningRegionSet to undefined

### DIFF
--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4AConfig.spec.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4AConfig.spec.ts
@@ -1,0 +1,10 @@
+import { resolveAwsSdkSigV4AConfig } from "./resolveAwsSdkSigV4AConfig";
+
+describe(resolveAwsSdkSigV4AConfig.name, () => {
+  it("should normalize provider but default to undefined value", async () => {
+    const config = resolveAwsSdkSigV4AConfig({});
+
+    expect(typeof config.sigv4aSigningRegionSet).toEqual("function");
+    expect(await config.sigv4aSigningRegionSet()).toEqual(undefined);
+  });
+});

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4AConfig.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4AConfig.ts
@@ -39,7 +39,7 @@ export interface AwsSdkSigV4AAuthResolvedConfig {
 export const resolveAwsSdkSigV4AConfig = <T>(
   config: T & AwsSdkSigV4AAuthInputConfig & AwsSdkSigV4APreviouslyResolved
 ): T & AwsSdkSigV4AAuthResolvedConfig => {
-  config.sigv4aSigningRegionSet = normalizeProvider(config.sigv4aSigningRegionSet ?? []);
+  config.sigv4aSigningRegionSet = normalizeProvider(config.sigv4aSigningRegionSet);
   return config as T & AwsSdkSigV4AAuthResolvedConfig;
 };
 


### PR DESCRIPTION
### Issue
n/a

### Description
the normalized provider for the config value `sigv4aSigningRegionSet` should return `undefined` by default instead of an empty array.

### Testing
added unit test

- [x] yarn test:e2e passing