### PR TITLE
fix(client-s3-control): populate memberName as contextParams value

### DIFF
--- a/clients/client-s3-control/src/commands/DeleteAccessPointCommand.ts
+++ b/clients/client-s3-control/src/commands/DeleteAccessPointCommand.ts
@@ -90,7 +90,7 @@ export class DeleteAccessPointCommand extends $Command
   .ep({
     ...commonParams,
     RequiresAccountId: { type: "staticContextParams", value: true },
-    AccessPointName: { type: "contextParams", name: "AccessPointName" },
+    AccessPointName: { type: "contextParams", name: "Name" },
     AccountId: { type: "contextParams", name: "AccountId" },
   })
   .m(function (this: any, Command: any, cs: any, config: S3ControlClientResolvedConfig, o: any) {

--- a/clients/client-s3-control/src/commands/DeleteAccessPointPolicyCommand.ts
+++ b/clients/client-s3-control/src/commands/DeleteAccessPointPolicyCommand.ts
@@ -86,7 +86,7 @@ export class DeleteAccessPointPolicyCommand extends $Command
   .ep({
     ...commonParams,
     RequiresAccountId: { type: "staticContextParams", value: true },
-    AccessPointName: { type: "contextParams", name: "AccessPointName" },
+    AccessPointName: { type: "contextParams", name: "Name" },
     AccountId: { type: "contextParams", name: "AccountId" },
   })
   .m(function (this: any, Command: any, cs: any, config: S3ControlClientResolvedConfig, o: any) {

--- a/clients/client-s3-control/src/commands/GetAccessPointCommand.ts
+++ b/clients/client-s3-control/src/commands/GetAccessPointCommand.ts
@@ -111,7 +111,7 @@ export class GetAccessPointCommand extends $Command
   .ep({
     ...commonParams,
     RequiresAccountId: { type: "staticContextParams", value: true },
-    AccessPointName: { type: "contextParams", name: "AccessPointName" },
+    AccessPointName: { type: "contextParams", name: "Name" },
     AccountId: { type: "contextParams", name: "AccountId" },
   })
   .m(function (this: any, Command: any, cs: any, config: S3ControlClientResolvedConfig, o: any) {

--- a/clients/client-s3-control/src/commands/GetAccessPointPolicyCommand.ts
+++ b/clients/client-s3-control/src/commands/GetAccessPointPolicyCommand.ts
@@ -86,7 +86,7 @@ export class GetAccessPointPolicyCommand extends $Command
   .ep({
     ...commonParams,
     RequiresAccountId: { type: "staticContextParams", value: true },
-    AccessPointName: { type: "contextParams", name: "AccessPointName" },
+    AccessPointName: { type: "contextParams", name: "Name" },
     AccountId: { type: "contextParams", name: "AccountId" },
   })
   .m(function (this: any, Command: any, cs: any, config: S3ControlClientResolvedConfig, o: any) {

--- a/clients/client-s3-control/src/commands/GetAccessPointPolicyStatusCommand.ts
+++ b/clients/client-s3-control/src/commands/GetAccessPointPolicyStatusCommand.ts
@@ -77,7 +77,7 @@ export class GetAccessPointPolicyStatusCommand extends $Command
   .ep({
     ...commonParams,
     RequiresAccountId: { type: "staticContextParams", value: true },
-    AccessPointName: { type: "contextParams", name: "AccessPointName" },
+    AccessPointName: { type: "contextParams", name: "Name" },
     AccountId: { type: "contextParams", name: "AccountId" },
   })
   .m(function (this: any, Command: any, cs: any, config: S3ControlClientResolvedConfig, o: any) {

--- a/clients/client-s3-control/src/commands/PutAccessPointPolicyCommand.ts
+++ b/clients/client-s3-control/src/commands/PutAccessPointPolicyCommand.ts
@@ -89,7 +89,7 @@ export class PutAccessPointPolicyCommand extends $Command
   .ep({
     ...commonParams,
     RequiresAccountId: { type: "staticContextParams", value: true },
-    AccessPointName: { type: "contextParams", name: "AccessPointName" },
+    AccessPointName: { type: "contextParams", name: "Name" },
     AccountId: { type: "contextParams", name: "AccountId" },
   })
   .m(function (this: any, Command: any, cs: any, config: S3ControlClientResolvedConfig, o: any) {

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "7d4691ca45a17efbdfba4afb0a31b48edbf8ba60",
+  SMITHY_TS_COMMIT: "fa63800730b1a7a59e231965941d2006dc031662",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Codegen for https://github.com/smithy-lang/smithy-typescript/pull/1365

### Description
Populates memberName as contextParams value

### Testing

* The `generate-clients` was run on all clients, and confirmed that only S3Control was impacted.
* Endpoint tests are successful https://github.com/aws/aws-sdk-js-v3/pull/6373#issuecomment-2284447381

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
