### PR TITLE
test(endpoint): enable test for s3 empty arn type

### DIFF
--- a/tests/endpoints-2.0/endpoints-integration.spec.ts
+++ b/tests/endpoints-2.0/endpoints-integration.spec.ts
@@ -82,10 +82,7 @@ function runTestCases(service: ServiceModel, namespace: ServiceNamespace) {
             const observedError = await (async () => defaultEndpointResolver(endpointParams as any))().catch(pass);
             expect(observedError).not.toBeUndefined();
             expect(observedError?.url).toBeUndefined();
-            // ToDo: debug why 'client-s3 > empty arn type' test case is failing
-            if (serviceId !== "s3" && documentation !== "empty arn type") {
-              expect(normalizeQuotes(String(observedError))).toContain(normalizeQuotes(error));
-            }
+            expect(normalizeQuotes(String(observedError))).toContain(normalizeQuotes(error));
           }
         }
       });


### PR DESCRIPTION
### Issue
Internal JS-5234

### Description
Enables test for s3 empty arn type

### Testing
ToDo

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
