### PR TITLE
fix(util-endpoints): check for entire resource-path being empty

### DIFF
--- a/packages/util-endpoints/src/lib/aws/parseArn.spec.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.spec.ts
@@ -15,6 +15,16 @@ describe(parseArn.name, () => {
       },
     ],
     [
+      "arn:aws:s3:us-west-2:123456789012::myendpoint",
+      {
+        partition: "aws",
+        service: "s3",
+        region: "us-west-2",
+        accountId: "123456789012",
+        resourceId: ["", "myendpoint"],
+      },
+    ],
+    [
       "arn:aws:s3:us-west-2:123456789012:accesspoint/myendpoint",
       {
         partition: "aws",

--- a/packages/util-endpoints/src/lib/aws/parseArn.spec.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.spec.ts
@@ -74,16 +74,6 @@ describe(parseArn.name, () => {
         resourceId: ["myTopic"],
       },
     ],
-    [
-      "arn:aws:s3:us-west-2:123456789012:my:folder/my:file",
-      {
-        partition: "aws",
-        service: "s3",
-        region: "us-west-2",
-        accountId: "123456789012",
-        resourceId: ["my", "folder", "my", "file"],
-      },
-    ],
   ];
 
   it.each(VALID_TEST_CASES)("returns for valid arn %s", (input: string, outout: EndpointARN) => {

--- a/packages/util-endpoints/src/lib/aws/parseArn.spec.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.spec.ts
@@ -74,6 +74,16 @@ describe(parseArn.name, () => {
         resourceId: ["myTopic"],
       },
     ],
+    [
+      "arn:aws:s3:us-west-2:123456789012:my:folder/my:file",
+      {
+        partition: "aws",
+        service: "s3",
+        region: "us-west-2",
+        accountId: "123456789012",
+        resourceId: ["my", "folder", "my", "file"],
+      },
+    ],
   ];
 
   it.each(VALID_TEST_CASES)("returns for valid arn %s", (input: string, outout: EndpointARN) => {

--- a/packages/util-endpoints/src/lib/aws/parseArn.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.ts
@@ -1,24 +1,31 @@
 import { EndpointARN } from "@smithy/types";
 
+const ARN_DELIMITER = ":";
+const RESOURCE_DELIMITER = "/";
+
 /**
  * Evaluates a single string argument value, and returns an object containing
  * details about the parsed ARN.
  * If the input was not a valid ARN, the function returns null.
  */
 export const parseArn = (value: string): EndpointARN | null => {
-  const segments = value.split(":");
+  const segments = value.split(ARN_DELIMITER);
 
   if (segments.length < 6) return null;
 
-  const [arn, partition, service, region, accountId, ...resourceId] = segments;
+  const [arn, partition, service, region, accountId, ...resourcePath] = segments;
 
-  if (arn !== "arn" || partition === "" || service === "" || resourceId[0] === "") return null;
+  if (arn !== "arn" || partition === "" || service === "" || resourcePath.join(ARN_DELIMITER) === "") return null;
+
+  const resourceId = resourcePath[0].includes(RESOURCE_DELIMITER)
+    ? resourcePath[0].split(RESOURCE_DELIMITER)
+    : resourcePath;
 
   return {
     partition,
     service,
     region,
     accountId,
-    resourceId: resourceId[0].includes("/") ? resourceId[0].split("/") : resourceId,
+    resourceId,
   };
 };

--- a/packages/util-endpoints/src/lib/aws/parseArn.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.ts
@@ -17,7 +17,9 @@ export const parseArn = (value: string): EndpointARN | null => {
 
   if (arn !== "arn" || partition === "" || service === "" || resourcePath.join(ARN_DELIMITER) === "") return null;
 
-  const resourceId = resourcePath.map((resource) => resource.split(RESOURCE_DELIMITER)).flat();
+  const resourceId = resourcePath[0].includes(RESOURCE_DELIMITER)
+    ? resourcePath[0].split(RESOURCE_DELIMITER)
+    : resourcePath;
 
   return {
     partition,

--- a/packages/util-endpoints/src/lib/aws/parseArn.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.ts
@@ -17,9 +17,7 @@ export const parseArn = (value: string): EndpointARN | null => {
 
   if (arn !== "arn" || partition === "" || service === "" || resourcePath.join(ARN_DELIMITER) === "") return null;
 
-  const resourceId = resourcePath[0].includes(RESOURCE_DELIMITER)
-    ? resourcePath[0].split(RESOURCE_DELIMITER)
-    : resourcePath;
+  const resourceId = resourcePath.map((resource) => resource.split(RESOURCE_DELIMITER)).flat();
 
   return {
     partition,

--- a/tests/endpoints-2.0/endpoints-integration.spec.ts
+++ b/tests/endpoints-2.0/endpoints-integration.spec.ts
@@ -82,10 +82,7 @@ function runTestCases(service: ServiceModel, namespace: ServiceNamespace) {
             const observedError = await (async () => defaultEndpointResolver(endpointParams as any))().catch(pass);
             expect(observedError).not.toBeUndefined();
             expect(observedError?.url).toBeUndefined();
-            // ToDo: debug why 'client-s3 > empty arn type' test case is failing
-            if (serviceId !== "s3" && documentation !== "empty arn type") {
-              expect(normalizeQuotes(String(observedError))).toContain(normalizeQuotes(error));
-            }
+            expect(normalizeQuotes(String(observedError))).toContain(normalizeQuotes(error));
           }
         }
       });


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/6379#issuecomment-2284943667

### Description
Check for entire resource-path being empty when parsing Arn

### Testing

Unit and Endpoint tests are successful
```console
$ yarn jest -c tests/endpoints-2.0/jest.config.js tests/endpoints-2.0/endpoints-integration.spec.ts
...
Test Suites: 1 passed, 1 total
Tests:       14672 passed, 14672 total
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
