### PR TITLE
Fix missing `@smithy/core` dependency in `@aws-sdk/lib-dynamodb`

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -27,6 +27,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/util-dynamodb": "*",
+    "@smithy/core": "^2.3.2",
     "@smithy/smithy-client": "^3.1.12",
     "@smithy/types": "^3.3.0",
     "tslib": "^2.6.2"


### PR DESCRIPTION
### Description
Changes in https://github.com/aws/aws-sdk-js-v3/commit/922292b66614ea3a08779053ae8740dc28509d83 introduced a new direct dependency on `@smithy/core`. It was forgotten to be added to `package.json`.

### Additional context
This becomes an issue in environments where production dependencies only are distributed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.