### PR TITLE
fix(credential-provider-node): add peerDependencies @aws-sdk/client-sts

### DIFF
--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -41,6 +41,9 @@
     "@smithy/types": "^3.3.0",
     "tslib": "^2.6.2"
   },
+  "peerDependencies": {
+    "@aws-sdk/client-sts": "*"
+  },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^16.18.96",


### PR DESCRIPTION
### Issue
- x

### Description

If the @aws-sdk/client-sts package is intended to be a singleton, it should be added to the peerDependencies of @aws-sdk/credential-provider-node.

Otherwise, in a Yarn Berry environment, you may encounter the following error:
```
@aws-sdk/credential-provider-node@npm:3.629.0 doesn't provide @aws-sdk/client-sts, requested by @aws-sdk/credential-provider-web-identity
```

- @aws-sdk/client-s3@latest has a dependency on @aws-sdk/credential-provider-node ([code](https://github.com/aws/aws-sdk-js-v3/blob/main/clients/client-s3/package.json#L32))
- @aws-sdk/credential-provider-node@latest has a dependency on @aws-sdk/credential-provider-web-identity ([code](https://github.com/aws/aws-sdk-js-v3/blob/main/packages/credential-provider-node/package.json#L36))
- @aws-sdk/credential-provider-web-identity@latest lists @aws-sdk/client-sts as a peerDependency ([code](https://github.com/aws/aws-sdk-js-v3/blob/main/packages/credential-provider-web-identity/package.json#L49))


### Testing

Before:
- Installing `@aws-sdk/client-s3` in a Yarn Berry environment results in the above error.

After:
- Installing `@aws-sdk/client-s3` in a Yarn Berry environment no longer triggers the error.


### Additional context
x

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
