### PR TITLE
fix(util-endpoints): parseArn when resourcePath contains both delimiters

### DIFF
--- a/packages/util-endpoints/src/lib/aws/parseArn.spec.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.spec.ts
@@ -74,6 +74,16 @@ describe(parseArn.name, () => {
         resourceId: ["myTopic"],
       },
     ],
+    [
+      "arn:aws:s3:us-west-2:123456789012:my:folder/my:file",
+      {
+        partition: "aws",
+        service: "s3",
+        region: "us-west-2",
+        accountId: "123456789012",
+        resourceId: ["my", "folder", "my", "file"],
+      },
+    ],
   ];
 
   it.each(VALID_TEST_CASES)("returns for valid arn %s", (input: string, outout: EndpointARN) => {

--- a/packages/util-endpoints/src/lib/aws/parseArn.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.ts
@@ -17,9 +17,7 @@ export const parseArn = (value: string): EndpointARN | null => {
 
   if (arn !== "arn" || partition === "" || service === "" || resourcePath.join(ARN_DELIMITER) === "") return null;
 
-  const resourceId = resourcePath[0].includes(RESOURCE_DELIMITER)
-    ? resourcePath[0].split(RESOURCE_DELIMITER)
-    : resourcePath;
+  const resourceId = resourcePath.map((resource) => resource.split(RESOURCE_DELIMITER)).flat();
 
   return {
     partition,


### PR DESCRIPTION
### Issue

* Refs: https://github.com/aws/aws-sdk-js-v3/pull/6380#discussion_r1714509368
* Confirmed internally that the resourceId for path `my:folder/my:file` should be `["my", "folder", "my", "file"]`

### Description
Handles case in parseArn when resourcePath contains both delimiters

### Testing
Unit tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
