### PR TITLE
fix(credential-providers): avoid sharing http2 requestHandler with inner STS

### DIFF
--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -101,11 +101,13 @@ export const getDefaultRoleAssumer = (
         stsOptions?.parentClientConfig?.region,
         credentialProviderLogger
       );
+      const isCompatibleRequestHandler = !isH2(requestHandler);
+
       stsClient = new stsClientCtor({
         // A hack to make sts client uses the credential in current closure.
         credentialDefaultProvider: () => async () => closureSourceCreds,
         region: resolvedRegion,
-        requestHandler: requestHandler as any,
+        requestHandler: isCompatibleRequestHandler ? (requestHandler as any) : undefined,
         logger: logger as any,
       });
     }
@@ -157,9 +159,11 @@ export const getDefaultRoleAssumerWithWebIdentity = (
         stsOptions?.parentClientConfig?.region,
         credentialProviderLogger
       );
+      const isCompatibleRequestHandler = !isH2(requestHandler);
+
       stsClient = new stsClientCtor({
         region: resolvedRegion,
-        requestHandler: requestHandler as any,
+        requestHandler: isCompatibleRequestHandler ? (requestHandler as any) : undefined,
         logger: logger as any,
       });
     }
@@ -206,3 +210,7 @@ export const decorateDefaultCredentialProvider =
       ),
       ...input,
     });
+
+const isH2 = (requestHandler: any): boolean => {
+  return requestHandler?.metadata?.handlerProtocol === "h2";
+};

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -98,11 +98,13 @@ export const getDefaultRoleAssumer = (
         stsOptions?.parentClientConfig?.region,
         credentialProviderLogger
       );
+      const isCompatibleRequestHandler = !isH2(requestHandler);
+
       stsClient = new stsClientCtor({
         // A hack to make sts client uses the credential in current closure.
         credentialDefaultProvider: () => async () => closureSourceCreds,
         region: resolvedRegion,
-        requestHandler: requestHandler as any,
+        requestHandler: isCompatibleRequestHandler ? (requestHandler as any) : undefined,
         logger: logger as any,
       });
     }
@@ -154,9 +156,11 @@ export const getDefaultRoleAssumerWithWebIdentity = (
         stsOptions?.parentClientConfig?.region,
         credentialProviderLogger
       );
+      const isCompatibleRequestHandler = !isH2(requestHandler);
+
       stsClient = new stsClientCtor({
         region: resolvedRegion,
-        requestHandler: requestHandler as any,
+        requestHandler: isCompatibleRequestHandler ? (requestHandler as any) : undefined,
         logger: logger as any,
       });
     }
@@ -203,3 +207,7 @@ export const decorateDefaultCredentialProvider =
       ),
       ...input,
     });
+
+const isH2 = (requestHandler: any): boolean => {
+  return requestHandler?.metadata?.handlerProtocol === "h2";
+};


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/5958

### Description
Avoid sharing the parent client requestHandler to the inner STS client if that handler is an HTTP2 handler.
All other types of known handlers: fetch, http1.1, websocket (because it defers to fetch for non-ws), xhr, are valid for STS.

### Testing
Made a TranscribeStreaming (HTTP2 default requesthandler) request and used the default provider chain such that it involved an STS credentials request. 

Verified this PR makes the difference in that not working -> working.

Sample code:

```js
import { TranscribeStreaming } from "@aws-sdk/client-transcribe-streaming";
import { fromIni } from "@aws-sdk/credential-providers";
import { createReadStream } from "node:fs";
import { join } from "node:path";

const audio = createReadStream(join("numbers.wav"));

process.env.AWS_PROFILE = "sts";

/**
 * When no credentials or requestHandler are specified, the http2
 * request handler default on the client is shared with the
 * inner STS client via config copying, but is invalid
 * for STS, which needs a regular http1 requestHandler.
 */

const ts = new TranscribeStreaming({
  region: "us-west-2",
  logger: console,
});

const LanguageCode = "en-GB";
const MediaEncoding = "pcm";
const MediaSampleRateHertz = 44100;
const result = await ts.startStreamTranscription({
  LanguageCode,
  MediaEncoding,
  MediaSampleRateHertz,
  AudioStream: (async function* () {
    for await (const chunk of audio) {
      yield { AudioEvent: { AudioChunk: chunk } };
    }
  })(),
});
const transcripts = [];
for await (const event of result.TranscriptResultStream) {
  transcripts.push(event);
}
console.log(transcripts);

```
