### PR TITLE
fix(codegen): pass through sha256 in non-AWS sigv4 generated client

### DIFF
--- a/codegen/generic-client-test-codegen/model/weather.smithy
+++ b/codegen/generic-client-test-codegen/model/weather.smithy
@@ -3,16 +3,13 @@ $version: "2.0"
 namespace example.weather
 
 use aws.auth#sigv4
+use aws.protocols#restJson1
 
 @authDefinition
 @trait
 structure customAuth {}
 
-@trait
-@protocolDefinition
-structure fakeProtocol {}
-
-@fakeProtocol
+@restJson1
 @httpApiKeyAuth(name: "X-Api-Key", in: "header")
 @httpBearerAuth
 @sigv4(name: "weather")

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/SupportSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/SupportSigV4Auth.java
@@ -130,6 +130,7 @@ public final class SupportSigV4Auth implements HttpAuthTypeScriptIntegration {
                              */
                             signingProperties: {
                               context,
+                              sha256: (config as any).sha256,
                             },
                           };
                         },"""))

--- a/private/aws-protocoltests-ec2/src/endpoints.ts
+++ b/private/aws-protocoltests-ec2/src/endpoints.ts
@@ -18,6 +18,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-2",
       "ap-southeast-3",
       "ap-southeast-4",
+      "ap-southeast-5",
       "ca-central-1",
       "ca-west-1",
       "eu-central-1",

--- a/private/aws-protocoltests-json-10/src/endpoints.ts
+++ b/private/aws-protocoltests-json-10/src/endpoints.ts
@@ -18,6 +18,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-2",
       "ap-southeast-3",
       "ap-southeast-4",
+      "ap-southeast-5",
       "ca-central-1",
       "ca-west-1",
       "eu-central-1",

--- a/private/aws-protocoltests-json-machinelearning/src/endpoints.ts
+++ b/private/aws-protocoltests-json-machinelearning/src/endpoints.ts
@@ -18,6 +18,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-2",
       "ap-southeast-3",
       "ap-southeast-4",
+      "ap-southeast-5",
       "ca-central-1",
       "ca-west-1",
       "eu-central-1",

--- a/private/aws-protocoltests-json/src/endpoints.ts
+++ b/private/aws-protocoltests-json/src/endpoints.ts
@@ -18,6 +18,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-2",
       "ap-southeast-3",
       "ap-southeast-4",
+      "ap-southeast-5",
       "ca-central-1",
       "ca-west-1",
       "eu-central-1",

--- a/private/aws-protocoltests-query/src/endpoints.ts
+++ b/private/aws-protocoltests-query/src/endpoints.ts
@@ -18,6 +18,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-2",
       "ap-southeast-3",
       "ap-southeast-4",
+      "ap-southeast-5",
       "ca-central-1",
       "ca-west-1",
       "eu-central-1",

--- a/private/aws-protocoltests-restjson-apigateway/src/endpoints.ts
+++ b/private/aws-protocoltests-restjson-apigateway/src/endpoints.ts
@@ -67,6 +67,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-2",
       "ap-southeast-3",
       "ap-southeast-4",
+      "ap-southeast-5",
       "ca-central-1",
       "ca-west-1",
       "eu-central-1",

--- a/private/aws-protocoltests-restjson-glacier/src/endpoints.ts
+++ b/private/aws-protocoltests-restjson-glacier/src/endpoints.ts
@@ -75,6 +75,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-2",
       "ap-southeast-3",
       "ap-southeast-4",
+      "ap-southeast-5",
       "ca-central-1",
       "ca-west-1",
       "eu-central-1",

--- a/private/aws-protocoltests-restjson/src/endpoints.ts
+++ b/private/aws-protocoltests-restjson/src/endpoints.ts
@@ -18,6 +18,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-2",
       "ap-southeast-3",
       "ap-southeast-4",
+      "ap-southeast-5",
       "ca-central-1",
       "ca-west-1",
       "eu-central-1",

--- a/private/aws-protocoltests-restxml/src/endpoints.ts
+++ b/private/aws-protocoltests-restxml/src/endpoints.ts
@@ -18,6 +18,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-2",
       "ap-southeast-3",
       "ap-southeast-4",
+      "ap-southeast-5",
       "ca-central-1",
       "ca-west-1",
       "eu-central-1",

--- a/private/aws-util-test/src/clients/Weather.integ.spec.ts
+++ b/private/aws-util-test/src/clients/Weather.integ.spec.ts
@@ -1,0 +1,23 @@
+import { Weather } from "@aws-sdk/weather";
+
+import { requireRequestsFrom } from "../requests/test-http-handler";
+
+describe(Weather.name, () => {
+  it("should be able to make a request without errors", async () => {
+    const client = new Weather({
+      credentials: {
+        accessKeyId: "",
+        secretAccessKey: "",
+      },
+      endpoint: "https://localhost",
+    });
+
+    requireRequestsFrom(client).toMatch({
+      body: /./,
+    });
+
+    await client.onlySigv4Auth({});
+
+    expect.hasAssertions();
+  });
+});

--- a/private/weather-legacy-auth/package.json
+++ b/private/weather-legacy-auth/package.json
@@ -20,6 +20,7 @@
     "@aws-crypto/sha256-js": "5.2.0",
     "@aws-sdk/client-sso-oidc": "*",
     "@aws-sdk/client-sts": "*",
+    "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",
@@ -32,6 +33,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@smithy/config-resolver": "^3.0.5",
+    "@smithy/core": "^2.4.0",
     "@smithy/fetch-http-handler": "^3.2.4",
     "@smithy/hash-node": "^3.0.3",
     "@smithy/invalid-dependency": "^3.0.3",
@@ -53,11 +55,13 @@
     "@smithy/util-middleware": "^3.0.3",
     "@smithy/util-retry": "^3.0.3",
     "@smithy/util-utf8": "^3.0.0",
-    "tslib": "^2.6.2"
+    "tslib": "^2.6.2",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@tsconfig/node16": "16.1.3",
     "@types/node": "^16.18.96",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/private/weather-legacy-auth/src/commands/OnlyCustomAuthCommand.ts
+++ b/private/weather-legacy-auth/src/commands/OnlyCustomAuthCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyCustomAuthCommand, se_OnlyCustomAuthCommand } from "../protocols/Aws_restJson1";
 import { getSigV4AuthPlugin } from "@aws-sdk/middleware-signing";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -63,10 +64,6 @@ export class OnlyCustomAuthCommand extends $Command
   .s("Weather", "OnlyCustomAuth", {})
   .n("WeatherClient", "OnlyCustomAuthCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyCustomAuthCommand)
+  .de(de_OnlyCustomAuthCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/commands/OnlyCustomAuthOptionalCommand.ts
+++ b/private/weather-legacy-auth/src/commands/OnlyCustomAuthOptionalCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyCustomAuthOptionalCommand, se_OnlyCustomAuthOptionalCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlyCustomAuthOptionalCommand extends $Command
   .s("Weather", "OnlyCustomAuthOptional", {})
   .n("WeatherClient", "OnlyCustomAuthOptionalCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyCustomAuthOptionalCommand)
+  .de(de_OnlyCustomAuthOptionalCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/commands/OnlyHttpApiKeyAndBearerAuthCommand.ts
+++ b/private/weather-legacy-auth/src/commands/OnlyHttpApiKeyAndBearerAuthCommand.ts
@@ -1,6 +1,10 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
 import { getHttpApiKeyAuthPlugin } from "../middleware/HttpApiKeyAuth";
+import {
+  de_OnlyHttpApiKeyAndBearerAuthCommand,
+  se_OnlyHttpApiKeyAndBearerAuthCommand,
+} from "../protocols/Aws_restJson1";
 import { getSigV4AuthPlugin } from "@aws-sdk/middleware-signing";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -71,10 +75,6 @@ export class OnlyHttpApiKeyAndBearerAuthCommand extends $Command
   .s("Weather", "OnlyHttpApiKeyAndBearerAuth", {})
   .n("WeatherClient", "OnlyHttpApiKeyAndBearerAuthCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpApiKeyAndBearerAuthCommand)
+  .de(de_OnlyHttpApiKeyAndBearerAuthCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/commands/OnlyHttpApiKeyAndBearerAuthReversedCommand.ts
+++ b/private/weather-legacy-auth/src/commands/OnlyHttpApiKeyAndBearerAuthReversedCommand.ts
@@ -1,6 +1,10 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
 import { getHttpApiKeyAuthPlugin } from "../middleware/HttpApiKeyAuth";
+import {
+  de_OnlyHttpApiKeyAndBearerAuthReversedCommand,
+  se_OnlyHttpApiKeyAndBearerAuthReversedCommand,
+} from "../protocols/Aws_restJson1";
 import { getSigV4AuthPlugin } from "@aws-sdk/middleware-signing";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -71,10 +75,6 @@ export class OnlyHttpApiKeyAndBearerAuthReversedCommand extends $Command
   .s("Weather", "OnlyHttpApiKeyAndBearerAuthReversed", {})
   .n("WeatherClient", "OnlyHttpApiKeyAndBearerAuthReversedCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpApiKeyAndBearerAuthReversedCommand)
+  .de(de_OnlyHttpApiKeyAndBearerAuthReversedCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/commands/OnlyHttpApiKeyAuthCommand.ts
+++ b/private/weather-legacy-auth/src/commands/OnlyHttpApiKeyAuthCommand.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
 import { getHttpApiKeyAuthPlugin } from "../middleware/HttpApiKeyAuth";
+import { de_OnlyHttpApiKeyAuthCommand, se_OnlyHttpApiKeyAuthCommand } from "../protocols/Aws_restJson1";
 import { getSigV4AuthPlugin } from "@aws-sdk/middleware-signing";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -71,10 +72,6 @@ export class OnlyHttpApiKeyAuthCommand extends $Command
   .s("Weather", "OnlyHttpApiKeyAuth", {})
   .n("WeatherClient", "OnlyHttpApiKeyAuthCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpApiKeyAuthCommand)
+  .de(de_OnlyHttpApiKeyAuthCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/commands/OnlyHttpApiKeyAuthOptionalCommand.ts
+++ b/private/weather-legacy-auth/src/commands/OnlyHttpApiKeyAuthOptionalCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyHttpApiKeyAuthOptionalCommand, se_OnlyHttpApiKeyAuthOptionalCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlyHttpApiKeyAuthOptionalCommand extends $Command
   .s("Weather", "OnlyHttpApiKeyAuthOptional", {})
   .n("WeatherClient", "OnlyHttpApiKeyAuthOptionalCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpApiKeyAuthOptionalCommand)
+  .de(de_OnlyHttpApiKeyAuthOptionalCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/commands/OnlyHttpBearerAuthCommand.ts
+++ b/private/weather-legacy-auth/src/commands/OnlyHttpBearerAuthCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyHttpBearerAuthCommand, se_OnlyHttpBearerAuthCommand } from "../protocols/Aws_restJson1";
 import { getSigV4AuthPlugin } from "@aws-sdk/middleware-signing";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -63,10 +64,6 @@ export class OnlyHttpBearerAuthCommand extends $Command
   .s("Weather", "OnlyHttpBearerAuth", {})
   .n("WeatherClient", "OnlyHttpBearerAuthCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpBearerAuthCommand)
+  .de(de_OnlyHttpBearerAuthCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/commands/OnlyHttpBearerAuthOptionalCommand.ts
+++ b/private/weather-legacy-auth/src/commands/OnlyHttpBearerAuthOptionalCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyHttpBearerAuthOptionalCommand, se_OnlyHttpBearerAuthOptionalCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlyHttpBearerAuthOptionalCommand extends $Command
   .s("Weather", "OnlyHttpBearerAuthOptional", {})
   .n("WeatherClient", "OnlyHttpBearerAuthOptionalCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpBearerAuthOptionalCommand)
+  .de(de_OnlyHttpBearerAuthOptionalCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/commands/OnlySigv4AuthCommand.ts
+++ b/private/weather-legacy-auth/src/commands/OnlySigv4AuthCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlySigv4AuthCommand, se_OnlySigv4AuthCommand } from "../protocols/Aws_restJson1";
 import { getSigV4AuthPlugin } from "@aws-sdk/middleware-signing";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -63,10 +64,6 @@ export class OnlySigv4AuthCommand extends $Command
   .s("Weather", "OnlySigv4Auth", {})
   .n("WeatherClient", "OnlySigv4AuthCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlySigv4AuthCommand)
+  .de(de_OnlySigv4AuthCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/commands/OnlySigv4AuthOptionalCommand.ts
+++ b/private/weather-legacy-auth/src/commands/OnlySigv4AuthOptionalCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlySigv4AuthOptionalCommand, se_OnlySigv4AuthOptionalCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlySigv4AuthOptionalCommand extends $Command
   .s("Weather", "OnlySigv4AuthOptional", {})
   .n("WeatherClient", "OnlySigv4AuthOptionalCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlySigv4AuthOptionalCommand)
+  .de(de_OnlySigv4AuthOptionalCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/commands/SameAsServiceCommand.ts
+++ b/private/weather-legacy-auth/src/commands/SameAsServiceCommand.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
 import { SameAsServiceOutput } from "../models/models_0";
+import { de_SameAsServiceCommand, se_SameAsServiceCommand } from "../protocols/Aws_restJson1";
 import { getSigV4AuthPlugin } from "@aws-sdk/middleware-signing";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -66,10 +67,6 @@ export class SameAsServiceCommand extends $Command
   .s("Weather", "SameAsService", {})
   .n("WeatherClient", "SameAsServiceCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_SameAsServiceCommand)
+  .de(de_SameAsServiceCommand)
   .build() {}

--- a/private/weather-legacy-auth/src/protocols/Aws_restJson1.ts
+++ b/private/weather-legacy-auth/src/protocols/Aws_restJson1.ts
@@ -1,0 +1,443 @@
+// smithy-typescript generated code
+import { OnlyCustomAuthCommandInput, OnlyCustomAuthCommandOutput } from "../commands/OnlyCustomAuthCommand";
+import {
+  OnlyCustomAuthOptionalCommandInput,
+  OnlyCustomAuthOptionalCommandOutput,
+} from "../commands/OnlyCustomAuthOptionalCommand";
+import {
+  OnlyHttpApiKeyAndBearerAuthCommandInput,
+  OnlyHttpApiKeyAndBearerAuthCommandOutput,
+} from "../commands/OnlyHttpApiKeyAndBearerAuthCommand";
+import {
+  OnlyHttpApiKeyAndBearerAuthReversedCommandInput,
+  OnlyHttpApiKeyAndBearerAuthReversedCommandOutput,
+} from "../commands/OnlyHttpApiKeyAndBearerAuthReversedCommand";
+import { OnlyHttpApiKeyAuthCommandInput, OnlyHttpApiKeyAuthCommandOutput } from "../commands/OnlyHttpApiKeyAuthCommand";
+import {
+  OnlyHttpApiKeyAuthOptionalCommandInput,
+  OnlyHttpApiKeyAuthOptionalCommandOutput,
+} from "../commands/OnlyHttpApiKeyAuthOptionalCommand";
+import { OnlyHttpBearerAuthCommandInput, OnlyHttpBearerAuthCommandOutput } from "../commands/OnlyHttpBearerAuthCommand";
+import {
+  OnlyHttpBearerAuthOptionalCommandInput,
+  OnlyHttpBearerAuthOptionalCommandOutput,
+} from "../commands/OnlyHttpBearerAuthOptionalCommand";
+import { OnlySigv4AuthCommandInput, OnlySigv4AuthCommandOutput } from "../commands/OnlySigv4AuthCommand";
+import {
+  OnlySigv4AuthOptionalCommandInput,
+  OnlySigv4AuthOptionalCommandOutput,
+} from "../commands/OnlySigv4AuthOptionalCommand";
+import { SameAsServiceCommandInput, SameAsServiceCommandOutput } from "../commands/SameAsServiceCommand";
+import { WeatherServiceException as __BaseException } from "../models/WeatherServiceException";
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
+import { requestBuilder as rb } from "@smithy/core";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
+import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+  _json,
+  collectBody,
+  map,
+  take,
+  withBaseException,
+} from "@smithy/smithy-client";
+import {
+  Endpoint as __Endpoint,
+  ResponseMetadata as __ResponseMetadata,
+  SerdeContext as __SerdeContext,
+} from "@smithy/types";
+import { v4 as generateIdempotencyToken } from "uuid";
+
+/**
+ * serializeAws_restJson1OnlyCustomAuthCommand
+ */
+export const se_OnlyCustomAuthCommand = async (
+  input: OnlyCustomAuthCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyCustomAuth");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyCustomAuthOptionalCommand
+ */
+export const se_OnlyCustomAuthOptionalCommand = async (
+  input: OnlyCustomAuthOptionalCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyCustomAuthOptional");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpApiKeyAndBearerAuthCommand
+ */
+export const se_OnlyHttpApiKeyAndBearerAuthCommand = async (
+  input: OnlyHttpApiKeyAndBearerAuthCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpApiKeyAndBearerAuth");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpApiKeyAndBearerAuthReversedCommand
+ */
+export const se_OnlyHttpApiKeyAndBearerAuthReversedCommand = async (
+  input: OnlyHttpApiKeyAndBearerAuthReversedCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpApiKeyAndBearerAuthReversed");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpApiKeyAuthCommand
+ */
+export const se_OnlyHttpApiKeyAuthCommand = async (
+  input: OnlyHttpApiKeyAuthCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpApiKeyAuth");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpApiKeyAuthOptionalCommand
+ */
+export const se_OnlyHttpApiKeyAuthOptionalCommand = async (
+  input: OnlyHttpApiKeyAuthOptionalCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpApiKeyAuthOptional");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpBearerAuthCommand
+ */
+export const se_OnlyHttpBearerAuthCommand = async (
+  input: OnlyHttpBearerAuthCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpBearerAuth");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpBearerAuthOptionalCommand
+ */
+export const se_OnlyHttpBearerAuthOptionalCommand = async (
+  input: OnlyHttpBearerAuthOptionalCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpBearerAuthOptional");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlySigv4AuthCommand
+ */
+export const se_OnlySigv4AuthCommand = async (
+  input: OnlySigv4AuthCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlySigv4Auth");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlySigv4AuthOptionalCommand
+ */
+export const se_OnlySigv4AuthOptionalCommand = async (
+  input: OnlySigv4AuthOptionalCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlySigv4AuthOptional");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1SameAsServiceCommand
+ */
+export const se_SameAsServiceCommand = async (
+  input: SameAsServiceCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/SameAsService");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * deserializeAws_restJson1OnlyCustomAuthCommand
+ */
+export const de_OnlyCustomAuthCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyCustomAuthCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyCustomAuthOptionalCommand
+ */
+export const de_OnlyCustomAuthOptionalCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyCustomAuthOptionalCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpApiKeyAndBearerAuthCommand
+ */
+export const de_OnlyHttpApiKeyAndBearerAuthCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpApiKeyAndBearerAuthCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpApiKeyAndBearerAuthReversedCommand
+ */
+export const de_OnlyHttpApiKeyAndBearerAuthReversedCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpApiKeyAndBearerAuthReversedCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpApiKeyAuthCommand
+ */
+export const de_OnlyHttpApiKeyAuthCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpApiKeyAuthCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpApiKeyAuthOptionalCommand
+ */
+export const de_OnlyHttpApiKeyAuthOptionalCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpApiKeyAuthOptionalCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpBearerAuthCommand
+ */
+export const de_OnlyHttpBearerAuthCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpBearerAuthCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpBearerAuthOptionalCommand
+ */
+export const de_OnlyHttpBearerAuthOptionalCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpBearerAuthOptionalCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlySigv4AuthCommand
+ */
+export const de_OnlySigv4AuthCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlySigv4AuthCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlySigv4AuthOptionalCommand
+ */
+export const de_OnlySigv4AuthOptionalCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlySigv4AuthOptionalCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1SameAsServiceCommand
+ */
+export const de_SameAsServiceCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<SameAsServiceCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const doc = take(data, {
+    service: __expectString,
+  });
+  Object.assign(contents, doc);
+  return contents;
+};
+
+/**
+ * deserialize_Aws_restJson1CommandError
+ */
+const de_CommandError = async (output: __HttpResponse, context: __SerdeContext): Promise<never> => {
+  const parsedOutput: any = {
+    ...output,
+    body: await parseErrorBody(output.body, context),
+  };
+  const errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
+  const parsedBody = parsedOutput.body;
+  return throwDefaultError({
+    output,
+    parsedBody,
+    errorCode,
+  }) as never;
+};
+
+const throwDefaultError = withBaseException(__BaseException);
+const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
+  httpStatusCode: output.statusCode,
+  requestId:
+    output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"] ?? output.headers["x-amz-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
+});
+
+// Encode Uint8Array data into string with utf-8.
+const collectBodyString = (streamBody: any, context: __SerdeContext): Promise<string> =>
+  collectBody(streamBody, context).then((body) => context.utf8Encoder(body));
+
+const isSerializableHeaderValue = (value: any): boolean =>
+  value !== undefined &&
+  value !== null &&
+  value !== "" &&
+  (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
+  (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);

--- a/private/weather/package.json
+++ b/private/weather/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "5.2.0",
     "@aws-crypto/sha256-js": "5.2.0",
+    "@aws-sdk/core": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",
     "@aws-sdk/middleware-recursion-detection": "*",
@@ -51,11 +52,13 @@
     "@smithy/util-middleware": "^3.0.3",
     "@smithy/util-retry": "^3.0.3",
     "@smithy/util-utf8": "^3.0.0",
-    "tslib": "^2.6.2"
+    "tslib": "^2.6.2",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@tsconfig/node16": "16.1.3",
     "@types/node": "^16.18.96",
+    "@types/uuid": "^9.0.4",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",

--- a/private/weather/src/auth/httpAuthSchemeProvider.ts
+++ b/private/weather/src/auth/httpAuthSchemeProvider.ts
@@ -69,6 +69,7 @@ function createAwsAuthSigv4HttpAuthOption(authParameters: WeatherHttpAuthSchemeP
          */
         signingProperties: {
           context,
+          sha256: (config as any).sha256,
         },
       };
     },

--- a/private/weather/src/commands/OnlyCustomAuthCommand.ts
+++ b/private/weather/src/commands/OnlyCustomAuthCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyCustomAuthCommand, se_OnlyCustomAuthCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlyCustomAuthCommand extends $Command
   .s("Weather", "OnlyCustomAuth", {})
   .n("WeatherClient", "OnlyCustomAuthCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyCustomAuthCommand)
+  .de(de_OnlyCustomAuthCommand)
   .build() {}

--- a/private/weather/src/commands/OnlyCustomAuthOptionalCommand.ts
+++ b/private/weather/src/commands/OnlyCustomAuthOptionalCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyCustomAuthOptionalCommand, se_OnlyCustomAuthOptionalCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlyCustomAuthOptionalCommand extends $Command
   .s("Weather", "OnlyCustomAuthOptional", {})
   .n("WeatherClient", "OnlyCustomAuthOptionalCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyCustomAuthOptionalCommand)
+  .de(de_OnlyCustomAuthOptionalCommand)
   .build() {}

--- a/private/weather/src/commands/OnlyHttpApiKeyAndBearerAuthCommand.ts
+++ b/private/weather/src/commands/OnlyHttpApiKeyAndBearerAuthCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import {
+  de_OnlyHttpApiKeyAndBearerAuthCommand,
+  se_OnlyHttpApiKeyAndBearerAuthCommand,
+} from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +66,6 @@ export class OnlyHttpApiKeyAndBearerAuthCommand extends $Command
   .s("Weather", "OnlyHttpApiKeyAndBearerAuth", {})
   .n("WeatherClient", "OnlyHttpApiKeyAndBearerAuthCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpApiKeyAndBearerAuthCommand)
+  .de(de_OnlyHttpApiKeyAndBearerAuthCommand)
   .build() {}

--- a/private/weather/src/commands/OnlyHttpApiKeyAndBearerAuthReversedCommand.ts
+++ b/private/weather/src/commands/OnlyHttpApiKeyAndBearerAuthReversedCommand.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import {
+  de_OnlyHttpApiKeyAndBearerAuthReversedCommand,
+  se_OnlyHttpApiKeyAndBearerAuthReversedCommand,
+} from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +66,6 @@ export class OnlyHttpApiKeyAndBearerAuthReversedCommand extends $Command
   .s("Weather", "OnlyHttpApiKeyAndBearerAuthReversed", {})
   .n("WeatherClient", "OnlyHttpApiKeyAndBearerAuthReversedCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpApiKeyAndBearerAuthReversedCommand)
+  .de(de_OnlyHttpApiKeyAndBearerAuthReversedCommand)
   .build() {}

--- a/private/weather/src/commands/OnlyHttpApiKeyAuthCommand.ts
+++ b/private/weather/src/commands/OnlyHttpApiKeyAuthCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyHttpApiKeyAuthCommand, se_OnlyHttpApiKeyAuthCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlyHttpApiKeyAuthCommand extends $Command
   .s("Weather", "OnlyHttpApiKeyAuth", {})
   .n("WeatherClient", "OnlyHttpApiKeyAuthCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpApiKeyAuthCommand)
+  .de(de_OnlyHttpApiKeyAuthCommand)
   .build() {}

--- a/private/weather/src/commands/OnlyHttpApiKeyAuthOptionalCommand.ts
+++ b/private/weather/src/commands/OnlyHttpApiKeyAuthOptionalCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyHttpApiKeyAuthOptionalCommand, se_OnlyHttpApiKeyAuthOptionalCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlyHttpApiKeyAuthOptionalCommand extends $Command
   .s("Weather", "OnlyHttpApiKeyAuthOptional", {})
   .n("WeatherClient", "OnlyHttpApiKeyAuthOptionalCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpApiKeyAuthOptionalCommand)
+  .de(de_OnlyHttpApiKeyAuthOptionalCommand)
   .build() {}

--- a/private/weather/src/commands/OnlyHttpBearerAuthCommand.ts
+++ b/private/weather/src/commands/OnlyHttpBearerAuthCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyHttpBearerAuthCommand, se_OnlyHttpBearerAuthCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlyHttpBearerAuthCommand extends $Command
   .s("Weather", "OnlyHttpBearerAuth", {})
   .n("WeatherClient", "OnlyHttpBearerAuthCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpBearerAuthCommand)
+  .de(de_OnlyHttpBearerAuthCommand)
   .build() {}

--- a/private/weather/src/commands/OnlyHttpBearerAuthOptionalCommand.ts
+++ b/private/weather/src/commands/OnlyHttpBearerAuthOptionalCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlyHttpBearerAuthOptionalCommand, se_OnlyHttpBearerAuthOptionalCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlyHttpBearerAuthOptionalCommand extends $Command
   .s("Weather", "OnlyHttpBearerAuthOptional", {})
   .n("WeatherClient", "OnlyHttpBearerAuthOptionalCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlyHttpBearerAuthOptionalCommand)
+  .de(de_OnlyHttpBearerAuthOptionalCommand)
   .build() {}

--- a/private/weather/src/commands/OnlySigv4AuthCommand.ts
+++ b/private/weather/src/commands/OnlySigv4AuthCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlySigv4AuthCommand, se_OnlySigv4AuthCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlySigv4AuthCommand extends $Command
   .s("Weather", "OnlySigv4Auth", {})
   .n("WeatherClient", "OnlySigv4AuthCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlySigv4AuthCommand)
+  .de(de_OnlySigv4AuthCommand)
   .build() {}

--- a/private/weather/src/commands/OnlySigv4AuthOptionalCommand.ts
+++ b/private/weather/src/commands/OnlySigv4AuthOptionalCommand.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
+import { de_OnlySigv4AuthOptionalCommand, se_OnlySigv4AuthOptionalCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -62,10 +63,6 @@ export class OnlySigv4AuthOptionalCommand extends $Command
   .s("Weather", "OnlySigv4AuthOptional", {})
   .n("WeatherClient", "OnlySigv4AuthOptionalCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_OnlySigv4AuthOptionalCommand)
+  .de(de_OnlySigv4AuthOptionalCommand)
   .build() {}

--- a/private/weather/src/commands/SameAsServiceCommand.ts
+++ b/private/weather/src/commands/SameAsServiceCommand.ts
@@ -1,6 +1,7 @@
 // smithy-typescript generated code
 import { ServiceInputTypes, ServiceOutputTypes, WeatherClientResolvedConfig } from "../WeatherClient";
 import { SameAsServiceOutput } from "../models/models_0";
+import { de_SameAsServiceCommand, se_SameAsServiceCommand } from "../protocols/Aws_restJson1";
 import { getSerdePlugin } from "@smithy/middleware-serde";
 import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -65,10 +66,6 @@ export class SameAsServiceCommand extends $Command
   .s("Weather", "SameAsService", {})
   .n("WeatherClient", "SameAsServiceCommand")
   .f(void 0, void 0)
-  .ser(() => {
-    throw new Error("No supported protocol was found");
-  })
-  .de(() => {
-    throw new Error("No supported protocol was found");
-  })
+  .ser(se_SameAsServiceCommand)
+  .de(de_SameAsServiceCommand)
   .build() {}

--- a/private/weather/src/protocols/Aws_restJson1.ts
+++ b/private/weather/src/protocols/Aws_restJson1.ts
@@ -1,0 +1,443 @@
+// smithy-typescript generated code
+import { OnlyCustomAuthCommandInput, OnlyCustomAuthCommandOutput } from "../commands/OnlyCustomAuthCommand";
+import {
+  OnlyCustomAuthOptionalCommandInput,
+  OnlyCustomAuthOptionalCommandOutput,
+} from "../commands/OnlyCustomAuthOptionalCommand";
+import {
+  OnlyHttpApiKeyAndBearerAuthCommandInput,
+  OnlyHttpApiKeyAndBearerAuthCommandOutput,
+} from "../commands/OnlyHttpApiKeyAndBearerAuthCommand";
+import {
+  OnlyHttpApiKeyAndBearerAuthReversedCommandInput,
+  OnlyHttpApiKeyAndBearerAuthReversedCommandOutput,
+} from "../commands/OnlyHttpApiKeyAndBearerAuthReversedCommand";
+import { OnlyHttpApiKeyAuthCommandInput, OnlyHttpApiKeyAuthCommandOutput } from "../commands/OnlyHttpApiKeyAuthCommand";
+import {
+  OnlyHttpApiKeyAuthOptionalCommandInput,
+  OnlyHttpApiKeyAuthOptionalCommandOutput,
+} from "../commands/OnlyHttpApiKeyAuthOptionalCommand";
+import { OnlyHttpBearerAuthCommandInput, OnlyHttpBearerAuthCommandOutput } from "../commands/OnlyHttpBearerAuthCommand";
+import {
+  OnlyHttpBearerAuthOptionalCommandInput,
+  OnlyHttpBearerAuthOptionalCommandOutput,
+} from "../commands/OnlyHttpBearerAuthOptionalCommand";
+import { OnlySigv4AuthCommandInput, OnlySigv4AuthCommandOutput } from "../commands/OnlySigv4AuthCommand";
+import {
+  OnlySigv4AuthOptionalCommandInput,
+  OnlySigv4AuthOptionalCommandOutput,
+} from "../commands/OnlySigv4AuthOptionalCommand";
+import { SameAsServiceCommandInput, SameAsServiceCommandOutput } from "../commands/SameAsServiceCommand";
+import { WeatherServiceException as __BaseException } from "../models/WeatherServiceException";
+import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
+import { requestBuilder as rb } from "@smithy/core";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
+import {
+  expectNonNull as __expectNonNull,
+  expectObject as __expectObject,
+  expectString as __expectString,
+  _json,
+  collectBody,
+  map,
+  take,
+  withBaseException,
+} from "@smithy/smithy-client";
+import {
+  Endpoint as __Endpoint,
+  ResponseMetadata as __ResponseMetadata,
+  SerdeContext as __SerdeContext,
+} from "@smithy/types";
+import { v4 as generateIdempotencyToken } from "uuid";
+
+/**
+ * serializeAws_restJson1OnlyCustomAuthCommand
+ */
+export const se_OnlyCustomAuthCommand = async (
+  input: OnlyCustomAuthCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyCustomAuth");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyCustomAuthOptionalCommand
+ */
+export const se_OnlyCustomAuthOptionalCommand = async (
+  input: OnlyCustomAuthOptionalCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyCustomAuthOptional");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpApiKeyAndBearerAuthCommand
+ */
+export const se_OnlyHttpApiKeyAndBearerAuthCommand = async (
+  input: OnlyHttpApiKeyAndBearerAuthCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpApiKeyAndBearerAuth");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpApiKeyAndBearerAuthReversedCommand
+ */
+export const se_OnlyHttpApiKeyAndBearerAuthReversedCommand = async (
+  input: OnlyHttpApiKeyAndBearerAuthReversedCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpApiKeyAndBearerAuthReversed");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpApiKeyAuthCommand
+ */
+export const se_OnlyHttpApiKeyAuthCommand = async (
+  input: OnlyHttpApiKeyAuthCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpApiKeyAuth");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpApiKeyAuthOptionalCommand
+ */
+export const se_OnlyHttpApiKeyAuthOptionalCommand = async (
+  input: OnlyHttpApiKeyAuthOptionalCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpApiKeyAuthOptional");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpBearerAuthCommand
+ */
+export const se_OnlyHttpBearerAuthCommand = async (
+  input: OnlyHttpBearerAuthCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpBearerAuth");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlyHttpBearerAuthOptionalCommand
+ */
+export const se_OnlyHttpBearerAuthOptionalCommand = async (
+  input: OnlyHttpBearerAuthOptionalCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlyHttpBearerAuthOptional");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlySigv4AuthCommand
+ */
+export const se_OnlySigv4AuthCommand = async (
+  input: OnlySigv4AuthCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlySigv4Auth");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1OnlySigv4AuthOptionalCommand
+ */
+export const se_OnlySigv4AuthOptionalCommand = async (
+  input: OnlySigv4AuthOptionalCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/OnlySigv4AuthOptional");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * serializeAws_restJson1SameAsServiceCommand
+ */
+export const se_SameAsServiceCommand = async (
+  input: SameAsServiceCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const b = rb(input, context);
+  const headers: any = {};
+  b.bp("/SameAsService");
+  let body: any;
+  b.m("GET").h(headers).b(body);
+  return b.build();
+};
+
+/**
+ * deserializeAws_restJson1OnlyCustomAuthCommand
+ */
+export const de_OnlyCustomAuthCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyCustomAuthCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyCustomAuthOptionalCommand
+ */
+export const de_OnlyCustomAuthOptionalCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyCustomAuthOptionalCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpApiKeyAndBearerAuthCommand
+ */
+export const de_OnlyHttpApiKeyAndBearerAuthCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpApiKeyAndBearerAuthCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpApiKeyAndBearerAuthReversedCommand
+ */
+export const de_OnlyHttpApiKeyAndBearerAuthReversedCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpApiKeyAndBearerAuthReversedCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpApiKeyAuthCommand
+ */
+export const de_OnlyHttpApiKeyAuthCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpApiKeyAuthCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpApiKeyAuthOptionalCommand
+ */
+export const de_OnlyHttpApiKeyAuthOptionalCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpApiKeyAuthOptionalCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpBearerAuthCommand
+ */
+export const de_OnlyHttpBearerAuthCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpBearerAuthCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlyHttpBearerAuthOptionalCommand
+ */
+export const de_OnlyHttpBearerAuthOptionalCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlyHttpBearerAuthOptionalCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlySigv4AuthCommand
+ */
+export const de_OnlySigv4AuthCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlySigv4AuthCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1OnlySigv4AuthOptionalCommand
+ */
+export const de_OnlySigv4AuthOptionalCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<OnlySigv4AuthOptionalCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  await collectBody(output.body, context);
+  return contents;
+};
+
+/**
+ * deserializeAws_restJson1SameAsServiceCommand
+ */
+export const de_SameAsServiceCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<SameAsServiceCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return de_CommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const doc = take(data, {
+    service: __expectString,
+  });
+  Object.assign(contents, doc);
+  return contents;
+};
+
+/**
+ * deserialize_Aws_restJson1CommandError
+ */
+const de_CommandError = async (output: __HttpResponse, context: __SerdeContext): Promise<never> => {
+  const parsedOutput: any = {
+    ...output,
+    body: await parseErrorBody(output.body, context),
+  };
+  const errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
+  const parsedBody = parsedOutput.body;
+  return throwDefaultError({
+    output,
+    parsedBody,
+    errorCode,
+  }) as never;
+};
+
+const throwDefaultError = withBaseException(__BaseException);
+const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
+  httpStatusCode: output.statusCode,
+  requestId:
+    output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"] ?? output.headers["x-amz-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
+});
+
+// Encode Uint8Array data into string with utf-8.
+const collectBodyString = (streamBody: any, context: __SerdeContext): Promise<string> =>
+  collectBody(streamBody, context).then((body) => context.utf8Encoder(body));
+
+const isSerializableHeaderValue = (value: any): boolean =>
+  value !== undefined &&
+  value !== null &&
+  value !== "" &&
+  (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0) &&
+  (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);


### PR DESCRIPTION
### Issue
n/a

### Description
- converts the example `Weather` service client to have a protocol (restjson1). This makes it easier to test in integration mode.
- fix: pass through the sha256 ctor impl from config to signingProperties for non-AWS sigv4 services. This is the diff in `httpAuthSchemeProvider.ts` in weather/src/auth.

### Testing
Added new integration test stub for the "Weather" example client.

- [x] `yarn test:protocols`