### PR TITLE
remove stray copy and paste line

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,8 +497,6 @@ abortController.abort();
 await requestPromise;
 ```
 
-For a full pagination deep dive, please check out our [blog post](https://aws.amazon.com/blogs/developer/pagination-using-async-iterators-in-modular-aws-sdk-for-javascript/).
-
 #### AbortController Example
 
 The following code snippet shows how to upload a file using S3's putObject API in the browser with support to abort the upload. First, create a controller using the `AbortController()` constructor, then grab a reference to its associated AbortSignal object using the AbortController.signal property. When the `PutObjectCommand` is called with `.send()` operation, pass in AbortController.signal as abortSignal in the httpOptions parameter. This will allow you to abort the PutObject operation by calling `abortController.abort()`.


### PR DESCRIPTION
I was reading the readme, and noticed that there was a reference to pagination in the abortcontroller section.

It looks like it was just a copy and paste error, as the actual blog post for abortcontroller is linked below the next paragraph.

This PR removes the offending/confusing line.

![image](https://github.com/user-attachments/assets/15b248ec-767a-4870-b5ec-f72bc84ae32a)
