### PR TITLE
fix(codegen): use AWS SDK default credentials as sigv4 default credentials

### DIFF
--- a/private/aws-util-test/src/clients/Weather.integ.spec.ts
+++ b/private/aws-util-test/src/clients/Weather.integ.spec.ts
@@ -20,4 +20,12 @@ describe(Weather.name, () => {
 
     expect.hasAssertions();
   });
+
+  it("should be assigned a default credentials object for sigv4 auth", async () => {
+    const client = new Weather({
+      endpoint: "https://localhost",
+    });
+
+    expect(client.config.credentials).toBeDefined();
+  });
 });

--- a/private/weather/package.json
+++ b/private/weather/package.json
@@ -19,7 +19,10 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "5.2.0",
     "@aws-crypto/sha256-js": "5.2.0",
+    "@aws-sdk/client-sso-oidc": "*",
+    "@aws-sdk/client-sts": "*",
     "@aws-sdk/core": "*",
+    "@aws-sdk/credential-provider-node": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",
     "@aws-sdk/middleware-recursion-detection": "*",

--- a/private/weather/src/runtimeConfig.browser.ts
+++ b/private/weather/src/runtimeConfig.browser.ts
@@ -26,6 +26,7 @@ export const getRuntimeConfig = (config: WeatherClientConfig) => {
     runtime: "browser",
     defaultsMode,
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
+    credentials: config?.credentials ?? (() => () => Promise.reject(new Error("Credentials are missing"))),
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ?? defaultUserAgent({ clientVersion: packageInfo.version }),
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,

--- a/private/weather/src/runtimeConfig.ts
+++ b/private/weather/src/runtimeConfig.ts
@@ -2,6 +2,7 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
+import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@smithy/config-resolver";
 import { Hash } from "@smithy/hash-node";
@@ -30,6 +31,7 @@ export const getRuntimeConfig = (config: WeatherClientConfig) => {
     runtime: "node",
     defaultsMode,
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
+    credentials: config?.credentials ?? credentialDefaultProvider(),
     defaultUserAgentProvider:
       config?.defaultUserAgentProvider ?? defaultUserAgent({ clientVersion: packageInfo.version }),
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),


### PR DESCRIPTION
### Issue
internal

### Description
For the scenario of a non-AWS service with the sigv4 trait, this PR modifies the ID&Auth SRA codegen behavior to provide the AWS SDK default credential chain as the default credentials object, for consistency with the legacyAuth behavior.

This was not present in the SRA implementation, presumably because of the desired separation between AWS and white label clients.

This only applies to codegen that uses both smithy-typescript and smithy-typescript-aws. If you only use smithy-typescript, it isn't currently aware of sigv4 at all. Sigv4 handling may need to be moved into smithy-typescript, but is out of scope of this PR.

### Testing
new integ test
