### PR TITLE
chore(ci): run codegen-ci only if the codegen folder has changes

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -3,8 +3,12 @@ name: codegen-ci
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'codegen/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'codegen/**'
 
 jobs:
   build:


### PR DESCRIPTION
### Issue
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

### Description
Runs codegen-ci only if the files in codegen folder has changes

### Testing
Verified that codegen-ci was not run for this PR

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
