### PR TITLE
chore(ci): update actions/checkout to v4

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -21,7 +21,7 @@ jobs:
         java: [17]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3

--- a/.github/workflows/commit-message-lint.yml
+++ b/.github/workflows/commit-message-lint.yml
@@ -10,7 +10,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4

--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -10,7 +10,7 @@ jobs:
   run-pre-commit-hooks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: set up Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
### Issue
* GitHub Blog https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
* Changelog for actions/checkout@v4 https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400

### Description
Updates actions/checkout to v4 as Node16 is deprecated

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
