### PR TITLE
chore(ci): update actions/setup-java to v4

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'corretto'


### PR DESCRIPTION
### Issue

Required for using Node.js 20.x in CI
* GitHub Blog https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
* Changelog for actions/setup-java@v4 https://github.com/actions/setup-java/releases/tag/v4.0.0

### Description
Update actions/setup-java to v4 as node 16 is deprecated

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
