### PR TITLE
fix(credential-provider-ini): fix recursive assume role and optional role_arn in credential_source

### DIFF
--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.spec.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.spec.ts
@@ -169,9 +169,15 @@ describe(resolveAssumeRoleCredentials.name, () => {
 
     const receivedCreds = await resolveAssumeRoleCredentials(mockProfileCurrent, mockProfilesWithSource, mockOptions);
     expect(receivedCreds).toStrictEqual(mockCreds);
-    expect(resolveProfileData).toHaveBeenCalledWith(mockProfileName, mockProfilesWithSource, mockOptions, {
-      mockProfileName: true,
-    });
+    expect(resolveProfileData).toHaveBeenCalledWith(
+      mockProfileName,
+      mockProfilesWithSource,
+      mockOptions,
+      {
+        mockProfileName: true,
+      },
+      false
+    );
     expect(resolveCredentialSource).not.toHaveBeenCalled();
     expect(mockOptions.roleAssumer).toHaveBeenCalledWith(mockSourceCredsFromProfile, {
       RoleArn: mockRoleAssumeParams.role_arn,

--- a/packages/credential-provider-ini/src/resolveProfileData.ts
+++ b/packages/credential-provider-ini/src/resolveProfileData.ts
@@ -15,7 +15,15 @@ export const resolveProfileData = async (
   profileName: string,
   profiles: ParsedIniData,
   options: FromIniInit,
-  visitedProfiles: Record<string, true> = {}
+  visitedProfiles: Record<string, true> = {},
+  /**
+   * This override comes from recursive calls only.
+   * It is used to flag a recursive profile section
+   * that does not have a role_arn, e.g. a credential_source
+   * with no role_arn, as part of a larger recursive assume-role
+   * call stack, and to re-enter the assume-role resolver function.
+   */
+  isAssumeRoleRecursiveCall = false
 ): Promise<AwsCredentialIdentity> => {
   const data = profiles[profileName];
 
@@ -28,7 +36,7 @@ export const resolveProfileData = async (
 
   // If this is the first profile visited, role assumption keys should be
   // given precedence over static credentials.
-  if (isAssumeRoleProfile(data, { profile: profileName, logger: options.logger })) {
+  if (isAssumeRoleRecursiveCall || isAssumeRoleProfile(data, { profile: profileName, logger: options.logger })) {
     return resolveAssumeRoleCredentials(profileName, profiles, options, visitedProfiles);
   }
 

--- a/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
+++ b/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
@@ -72,6 +72,7 @@ jest.mock("@aws-sdk/client-sso", () => {
 // This var must be hoisted.
 // eslint-disable-next-line no-var
 var stsSpy: jest.Spied<any> | any | undefined = undefined;
+const assumeRoleArns: string[] = [];
 
 jest.mock("@aws-sdk/client-sts", () => {
   const actual = jest.requireActual("@aws-sdk/client-sts");
@@ -80,6 +81,7 @@ jest.mock("@aws-sdk/client-sts", () => {
 
   stsSpy = jest.spyOn(actual.STSClient.prototype, "send").mockImplementation(async function (this: any, command: any) {
     if (command.constructor.name === "AssumeRoleCommand") {
+      assumeRoleArns.push(command.input.RoleArn);
       return {
         Credentials: {
           AccessKeyId: "STS_AR_ACCESS_KEY_ID",
@@ -91,6 +93,7 @@ jest.mock("@aws-sdk/client-sts", () => {
       };
     }
     if (command.constructor.name === "AssumeRoleWithWebIdentityCommand") {
+      assumeRoleArns.push(command.input.RoleArn);
       return {
         Credentials: {
           AccessKeyId: "STS_ARWI_ACCESS_KEY_ID",
@@ -177,6 +180,22 @@ describe("credential-provider-node integration test", () => {
   let sts: STS = null as any;
   let processSnapshot: typeof process.env = null as any;
 
+  const sink = {
+    data: [] as string[],
+    debug(log: string) {
+      this.data.push(log);
+    },
+    info(log: string) {
+      this.data.push(log);
+    },
+    warn(log: string) {
+      this.data.push(log);
+    },
+    error(log: string) {
+      this.data.push(log);
+    },
+  };
+
   const RESERVED_ENVIRONMENT_VARIABLES = {
     AWS_DEFAULT_REGION: 1,
     AWS_REGION: 1,
@@ -257,6 +276,8 @@ describe("credential-provider-node integration test", () => {
         output: "json",
       },
     };
+    assumeRoleArns.length = 0;
+    sink.data.length = 0;
   });
 
   afterAll(async () => {
@@ -511,7 +532,7 @@ describe("credential-provider-node integration test", () => {
       });
     });
 
-    it("should be able to combine a source_profile having credential_source with an origin profile having role_arn and source_profile", async () => {
+    it("should be able to combine a source_profile having only credential_source with an origin profile having role_arn and source_profile", async () => {
       process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI = "http://169.254.170.23";
       process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN = "container-authorization";
       iniProfileData.default.source_profile = "credential_source_profile";
@@ -529,6 +550,7 @@ describe("credential-provider-node integration test", () => {
           clientConfig: {
             region: "us-west-2",
           },
+          logger: sink,
         }),
       });
       await sts.getCallerIdentity({});
@@ -546,6 +568,105 @@ describe("credential-provider-node integration test", () => {
           awsContainerAuthorizationToken: process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN,
         })
       );
+      expect(assumeRoleArns).toEqual(["ROLE_ARN"]);
+      spy.mockClear();
+    });
+
+    it("should complete chained role_arn credentials", async () => {
+      process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI = "http://169.254.170.23";
+      process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN = "container-authorization";
+
+      iniProfileData.default.source_profile = "credential_source_profile_1";
+      iniProfileData.default.role_arn = "ROLE_ARN_3";
+
+      iniProfileData.credential_source_profile_1 = {
+        source_profile: "credential_source_profile_2",
+        role_arn: "ROLE_ARN_2",
+      };
+
+      iniProfileData.credential_source_profile_2 = {
+        credential_source: "EcsContainer",
+        role_arn: "ROLE_ARN_1",
+      };
+
+      const spy = jest.spyOn(credentialProviderHttp, "fromHttp");
+      sts = new STS({
+        region: "us-west-2",
+        requestHandler: mockRequestHandler,
+        credentials: defaultProvider({
+          awsContainerCredentialsFullUri: process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+          awsContainerAuthorizationToken: process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN,
+          clientConfig: {
+            region: "us-west-2",
+          },
+          logger: sink,
+        }),
+      });
+      await sts.getCallerIdentity({});
+      const credentials = await sts.config.credentials();
+      expect(credentials).toEqual({
+        accessKeyId: "STS_AR_ACCESS_KEY_ID",
+        secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
+        sessionToken: "STS_AR_SESSION_TOKEN",
+        expiration: new Date("3000-01-01T00:00:00.000Z"),
+        credentialScope: "us-stsar-1__us-west-2",
+      });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          awsContainerCredentialsFullUri: process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+          awsContainerAuthorizationToken: process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN,
+        })
+      );
+      expect(assumeRoleArns).toEqual(["ROLE_ARN_1", "ROLE_ARN_2", "ROLE_ARN_3"]);
+      spy.mockClear();
+    });
+
+    it("should complete chained role_arn credentials with optional role_arn in credential_source step", async () => {
+      process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI = "http://169.254.170.23";
+      process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN = "container-authorization";
+
+      iniProfileData.default.source_profile = "credential_source_profile_1";
+      iniProfileData.default.role_arn = "ROLE_ARN_3";
+
+      iniProfileData.credential_source_profile_1 = {
+        source_profile: "credential_source_profile_2",
+        role_arn: "ROLE_ARN_2",
+      };
+
+      iniProfileData.credential_source_profile_2 = {
+        credential_source: "EcsContainer",
+        // This scenario tests the option of having no role_arn in this step of the chain.
+      };
+
+      const spy = jest.spyOn(credentialProviderHttp, "fromHttp");
+      sts = new STS({
+        region: "us-west-2",
+        requestHandler: mockRequestHandler,
+        credentials: defaultProvider({
+          awsContainerCredentialsFullUri: process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+          awsContainerAuthorizationToken: process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN,
+          clientConfig: {
+            region: "us-west-2",
+          },
+          logger: sink,
+        }),
+      });
+      await sts.getCallerIdentity({});
+      const credentials = await sts.config.credentials();
+      expect(credentials).toEqual({
+        accessKeyId: "STS_AR_ACCESS_KEY_ID",
+        secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
+        sessionToken: "STS_AR_SESSION_TOKEN",
+        expiration: new Date("3000-01-01T00:00:00.000Z"),
+        credentialScope: "us-stsar-1__us-west-2",
+      });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          awsContainerCredentialsFullUri: process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
+          awsContainerAuthorizationToken: process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN,
+        })
+      );
+      expect(assumeRoleArns).toEqual(["ROLE_ARN_2", "ROLE_ARN_3"]);
       spy.mockClear();
     });
   });


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6225

### Description
This fixes chained assume role with ini role_arns and correctly enables optionality of the `role_arn` in the `credential_source` terminal profile section.

### scenario 1: no role_arn in credential_source
```
[profile default]
source_profile=A
role_arn=1

[profile A]
source_profile=B
role_arn=2

[profile B]
credential_source=EcsContainer
```

The SDK will:
- enter default profile
- navigate to source profile A
- navigate to source profile B
- obtain source credentials from EcsContainer
- complete profile B
- complete profile A assume role with role_arn=2
- complete profile default assume role with role_arn=1

### scenario 2: role_arn in credential_source
```
[profile default]
source_profile=A
role_arn=1

[profile A]
source_profile=B
role_arn=2

[profile B]
credential_source=EcsContainer
role_arn=3
```

The SDK will:
- enter default profile
- navigate to source profile A
- navigate to source profile B
- obtain source credentials from EcsContainer
- complete profile B assume role with role_arn=3
- complete profile A assume role with role_arn=2
- complete profile default assume role with role_arn=1

### Testing
Added integration tests
