### PR TITLE
chore: disable turborepo telemetry

### DIFF
--- a/scripts/turbo/index.js
+++ b/scripts/turbo/index.js
@@ -15,7 +15,14 @@ const runTurbo = async (task, args, apiSecret, apiEndpoint) => {
   command = command.concat(args);
   const turboRoot = path.join(__dirname, "..", "..");
   try {
-    return await spawnProcess("npx", command, { stdio: "inherit", cwd: turboRoot });
+    return await spawnProcess("npx", command, {
+      stdio: "inherit",
+      cwd: turboRoot,
+      env: {
+        ...process.env,
+        TURBO_TELEMETRY_DISABLED: "1",
+      },
+    });
   } catch (error) {
     console.error("Error running turbo:", error);
     if (args?.length > 0) {


### PR DESCRIPTION
### Issue
https://turbo.build/repo/docs/telemetry

### Description
Disables turborepo telemetry

### Testing

#### Before

Telemetry events are emitted
```console
$ TURBO_TELEMETRY_DEBUG=1 yarn build:all
yarn run v1.22.22
$ node ./scripts/turbo build
turbo 2.1.2

[telemetry event]
{
  "generic": {
    "id": "9199be4c-f754-4e10-87eb-37379040604a",
    "key": "execution",
    "value": "started",
    "parent_id": null
  }
}

[telemetry event]
{
  "generic": {
    "id": "9199be4c-f754-4e10-87eb-37379040604a",
    "key": "platform",
    "value": "linux-64",
    "parent_id": null
  }
}
...
```

#### After

Telemetry events are not emitted
```console
$ TURBO_TELEMETRY_DEBUG=1 yarn build:all
yarn run v1.22.22
$ node ./scripts/turbo build
turbo 2.1.2

• Packages in scope: @aws-sdk/aws-client-api-test, ...
```


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
