### PR TITLE
chore: show only turbo-computed task hashes in output

### DIFF
--- a/scripts/turbo/index.js
+++ b/scripts/turbo/index.js
@@ -3,8 +3,8 @@ const { spawnProcess } = require("../utils/spawn-process");
 const path = require("path");
 
 const runTurbo = async (task, args, apiSecret, apiEndpoint) => {
-  let command = ["turbo", "run", task, "--concurrency=100%"];
-  command = command.concat(args);
+  const command = ["turbo", "run", task, "--concurrency=100%", "--output-logs=hash-only"];
+  command.push(...args);
   const turboRoot = path.join(__dirname, "..", "..");
   try {
     return await spawnProcess("npx", command, {


### PR DESCRIPTION
### Issue
N/A

### Description
Limits turbo output to only turbo-computed task hashes

### Testing

#### Before

The default full output is around 6K lines
[turbo-output-full.txt](https://github.com/user-attachments/files/17015469/turbo-output-full.txt)

#### After

The hash-only output is around 485 lines
[turbo-output-hash-only.txt](https://github.com/user-attachments/files/17015483/turbo-output-hash-only.txt)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
