### PR TITLE
chore: pass turbo remote cache options in environment variables

### DIFF
--- a/scripts/turbo/index.js
+++ b/scripts/turbo/index.js
@@ -3,15 +3,7 @@ const { spawnProcess } = require("../utils/spawn-process");
 const path = require("path");
 
 const runTurbo = async (task, args, apiSecret, apiEndpoint) => {
-  let command = ["turbo", "run", task];
-  if (apiSecret && apiEndpoint) {
-    command = command.concat([
-      `--api=${apiEndpoint}`,
-      "--team=aws-sdk-js",
-      `--token=${apiSecret}`,
-      "--concurrency=100%",
-    ]);
-  }
+  let command = ["turbo", "run", task, "--concurrency=100%"];
   command = command.concat(args);
   const turboRoot = path.join(__dirname, "..", "..");
   try {
@@ -21,6 +13,12 @@ const runTurbo = async (task, args, apiSecret, apiEndpoint) => {
       env: {
         ...process.env,
         TURBO_TELEMETRY_DISABLED: "1",
+        ...(apiSecret &&
+          apiEndpoint && {
+            TURBO_API: apiEndpoint,
+            TURBO_TOKEN: apiSecret,
+            TURBO_TEAM: "aws-sdk-js",
+          }),
       },
     });
   } catch (error) {


### PR DESCRIPTION
### Issue
N/A

### Description
Passes turbo API and TOKEN in environment variables, so that they won't be printed in logs

### Testing

Verified that Remote cache is used with values from environment variables
```console
$ yarn build:all
...
 Tasks:    473 successful, 473 total
Cached:    473 cached, 473 total
  Time:    24.049s >>> FULL TURBO

Done in 24.85s.
```

### Additional context
Docs: https://turbo.build/repo/docs/reference/system-environment-variables

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
