### PR TITLE
chore: allow turbo remote cache write only on AWS Codebuild

### DIFF
--- a/scripts/turbo/index.js
+++ b/scripts/turbo/index.js
@@ -19,6 +19,9 @@ const runTurbo = async (task, args, apiSecret, apiEndpoint) => {
             TURBO_TOKEN: apiSecret,
             TURBO_TEAM: "aws-sdk-js",
           }),
+        ...(!process.env.CODEBUILD_BUILD_ARN && {
+          TURBO_REMOTE_CACHE_READ_ONLY: "1",
+        }),
       },
     });
   } catch (error) {


### PR DESCRIPTION
### Issue
* Internal JS-5438
* Long-term fix for https://github.com/aws/aws-sdk-js-v3/issues/6464

### Description
Allows Turborepo remote cache write only on AWS Codebuild.
* Turborepo docs https://turbo.build/repo/docs/reference/system-environment-variables
* Environment variable `CODEBUILD_BUILD_ARN` is used for detecting CodeBuild in userland library `ci-info` https://github.com/watson/ci-info/blob/3e1488e98680f1f776785fe8708a157b7f00e568/vendors.json#L19-L23

This will ensure that any developments outside of CodeBuild environments, like developer workspaces, do not pollute the remote cache.

### Testing

#### repository

Verified that updated local cache from developer workspace is not uploaded to remote cache.
```console
$ make turbo-clean

$ yarn build:all
...
 Tasks:    473 successful, 473 total
Cached:    473 cached, 473 total
  Time:    25.822s >>> FULL TURBO

Done in 26.41s.

$ sed -i '$s/}/,  "foo":"bar"\n}/' clients/client-acm/package.json

$ git diff
diff --git a/clients/client-acm/package.json b/clients/client-acm/package.json
index 9651073052a..adec6dee759 100644
--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -99,4 +99,5 @@
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "clients/client-acm"
   }
+,  "foo":"bar"
 }

$ yarn build:all
...
@aws-sdk/client-acm:build: cache miss, executing 9bea6a701716bcc5
 WARNING  Remote cache is read-only, skipping upload
...
 Tasks:    473 successful, 473 total
Cached:    472 cached, 473 total
  Time:    24.255s
```

It uses local cache on re-run
```console
$ yarn build:all
...
 Tasks:    473 successful, 473 total
Cached:    473 cached, 473 total
  Time:    23.961s >>> FULL TURBO
```

Simulated by setting `CODEBUILD_BUILD_ARN` that Remote Cache will be populated
```console
$ make turbo-clean

$ CODEBUILD_BUILD_ARN="blah" yarn build:all
...
@aws-sdk/client-acm:build: cache miss, executing 9bea6a701716bcc5
...
 Tasks:    473 successful, 473 total
Cached:    472 cached, 473 total
  Time:    24.657s 
...

$ make turbo-clean

$ yarn build:all
...
@aws-sdk/client-acm:build: cache hit, suppressing logs 9bea6a701716bcc5
...
 Tasks:    473 successful, 473 total
Cached:    473 cached, 473 total
  Time:    24.608s >>> FULL TURBO
```

#### node REPL

```console
$ node
Welcome to Node.js v18.20.2.
Type ".help" for more information.
> obj = {...(!process.env.CODEBUILD_BUILD_ARN && { TURBO_REMOTE_CACHE_READ_ONLY: "1" })}
{ TURBO_REMOTE_CACHE_READ_ONLY: '1' }

$ CODEBUILD_BUILD_ARN="blah" node
Welcome to Node.js v18.20.2.
Type ".help" for more information.
> obj = {...(!process.env.CODEBUILD_BUILD_ARN && { TURBO_REMOTE_CACHE_READ_ONLY: "1" })}
{}
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
