### PR TITLE
chore(middleware-flexible-checksums): use RequestChecksumCalculation and ResponseChecksumValidation without interceptor middleware

### DIFF
--- a/packages/middleware-flexible-checksums/src/configuration.ts
+++ b/packages/middleware-flexible-checksums/src/configuration.ts
@@ -38,6 +38,11 @@ export interface PreviouslyResolved {
   requestChecksumCalculation: Provider<string>;
 
   /**
+   * Determines when a checksum will be calculated for response payloads
+   */
+  responseChecksumValidation: Provider<string>;
+
+  /**
    * A constructor for a class implementing the {@link Hash} interface that computes SHA1 hashes.
    * @internal
    */

--- a/packages/middleware-flexible-checksums/src/configuration.ts
+++ b/packages/middleware-flexible-checksums/src/configuration.ts
@@ -38,11 +38,6 @@ export interface PreviouslyResolved {
   requestChecksumCalculation: Provider<string>;
 
   /**
-   * Determines when a checksum will be calculated for response payloads
-   */
-  responseChecksumValidation: Provider<string>;
-
-  /**
    * A constructor for a class implementing the {@link Hash} interface that computes SHA1 hashes.
    * @internal
    */

--- a/packages/middleware-flexible-checksums/src/configuration.ts
+++ b/packages/middleware-flexible-checksums/src/configuration.ts
@@ -4,6 +4,7 @@ import {
   Encoder,
   GetAwsChunkedEncodingStream,
   HashConstructor,
+  Provider,
   StreamCollector,
   StreamHasher,
 } from "@smithy/types";
@@ -30,6 +31,11 @@ export interface PreviouslyResolved {
    * @internal
    */
   md5: ChecksumConstructor | HashConstructor;
+
+  /**
+   * Determines when a checksum will be calculated for request payloads
+   */
+  requestChecksumCalculation: Provider<string>;
 
   /**
    * A constructor for a class implementing the {@link Hash} interface that computes SHA1 hashes.

--- a/packages/middleware-flexible-checksums/src/configuration.ts
+++ b/packages/middleware-flexible-checksums/src/configuration.ts
@@ -9,7 +9,7 @@ import {
   StreamHasher,
 } from "@smithy/types";
 
-import { RequestChecksumCalculation } from "./constants";
+import { RequestChecksumCalculation, ResponseChecksumValidation } from "./constants";
 
 export interface PreviouslyResolved {
   /**
@@ -38,6 +38,11 @@ export interface PreviouslyResolved {
    * Determines when a checksum will be calculated for request payloads
    */
   requestChecksumCalculation: Provider<RequestChecksumCalculation>;
+
+  /**
+   * Determines when a checksum will be calculated for response payloads
+   */
+  responseChecksumValidation: Provider<ResponseChecksumValidation>;
 
   /**
    * A constructor for a class implementing the {@link Hash} interface that computes SHA1 hashes.

--- a/packages/middleware-flexible-checksums/src/configuration.ts
+++ b/packages/middleware-flexible-checksums/src/configuration.ts
@@ -9,6 +9,8 @@ import {
   StreamHasher,
 } from "@smithy/types";
 
+import { RequestChecksumCalculation } from "./constants";
+
 export interface PreviouslyResolved {
   /**
    * The function that will be used to convert binary data to a base64-encoded string.
@@ -35,7 +37,7 @@ export interface PreviouslyResolved {
   /**
    * Determines when a checksum will be calculated for request payloads
    */
-  requestChecksumCalculation: Provider<string>;
+  requestChecksumCalculation: Provider<RequestChecksumCalculation>;
 
   /**
    * A constructor for a class implementing the {@link Hash} interface that computes SHA1 hashes.

--- a/packages/middleware-flexible-checksums/src/constants.ts
+++ b/packages/middleware-flexible-checksums/src/constants.ts
@@ -52,6 +52,9 @@ export const DEFAULT_RESPONSE_CHECKSUM_VALIDATION = RequestChecksumCalculation.W
  * Checksum Algorithms supported by the SDK.
  */
 export enum ChecksumAlgorithm {
+  /**
+   * @deprecated Use {@link ChecksumAlgorithm.CRC32} instead.
+   */
   MD5 = "MD5",
   CRC32 = "CRC32",
   CRC32C = "CRC32C",
@@ -70,7 +73,7 @@ export enum ChecksumLocation {
 /**
  * @internal
  */
-export const DEFAULT_CHECKSUM_ALGORITHM = ChecksumAlgorithm.MD5;
+export const DEFAULT_CHECKSUM_ALGORITHM = ChecksumAlgorithm.CRC32;
 
 /**
  * @internal

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.spec.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.spec.ts
@@ -2,7 +2,7 @@ import { HttpRequest } from "@smithy/protocol-http";
 import { BuildHandlerArguments } from "@smithy/types";
 
 import { PreviouslyResolved } from "./configuration";
-import { ChecksumAlgorithm } from "./constants";
+import { ChecksumAlgorithm, RequestChecksumCalculation } from "./constants";
 import { flexibleChecksumsMiddleware } from "./flexibleChecksumsMiddleware";
 import { getChecksumAlgorithmForRequest } from "./getChecksumAlgorithmForRequest";
 import { getChecksumLocationName } from "./getChecksumLocationName";
@@ -27,7 +27,9 @@ describe(flexibleChecksumsMiddleware.name, () => {
   const mockChecksumLocationName = "mock-checksum-location-name";
 
   const mockInput = {};
-  const mockConfig = {} as PreviouslyResolved;
+  const mockConfig = {
+    requestChecksumCalculation: () => Promise.resolve(RequestChecksumCalculation.WHEN_REQUIRED),
+  } as PreviouslyResolved;
   const mockMiddlewareConfig = { input: mockInput, requestChecksumRequired: false };
 
   const mockBody = { body: "mockRequestBody" };

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -58,6 +58,7 @@ export const flexibleChecksumsMiddleware =
     const { request } = args;
     const { body: requestBody, headers } = request;
     const { base64Encoder, streamHasher } = config;
+    const requestChecksumCalculation = await config.requestChecksumCalculation();
     const { input, requestChecksumRequired, requestAlgorithmMember } = middlewareConfig;
 
     const checksumAlgorithm = getChecksumAlgorithmForRequest(
@@ -65,6 +66,7 @@ export const flexibleChecksumsMiddleware =
       {
         requestChecksumRequired,
         requestAlgorithmMember,
+        requestChecksumCalculation,
       },
       !!context.isS3ExpressBucket
     );

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.spec.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.spec.ts
@@ -2,7 +2,7 @@ import { HttpRequest } from "@smithy/protocol-http";
 import { DeserializeHandlerArguments } from "@smithy/types";
 
 import { PreviouslyResolved } from "./configuration";
-import { ChecksumAlgorithm, ResponseChecksumValidation } from "./constants";
+import { ChecksumAlgorithm } from "./constants";
 import { flexibleChecksumsResponseMiddleware } from "./flexibleChecksumsResponseMiddleware";
 import { getChecksumLocationName } from "./getChecksumLocationName";
 import { FlexibleChecksumsMiddlewareConfig } from "./getFlexibleChecksumsPlugin";
@@ -23,9 +23,7 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
     commandName: "mockCommandName",
   };
 
-  const mockConfig = {
-    responseChecksumValidation: () => Promise.resolve(ResponseChecksumValidation.WHEN_REQUIRED),
-  } as PreviouslyResolved;
+  const mockConfig = {} as PreviouslyResolved;
   const mockRequestValidationModeMember = "ChecksumEnabled";
   const mockResponseAlgorithms = [ChecksumAlgorithm.CRC32, ChecksumAlgorithm.CRC32C];
   const mockMiddlewareConfig = {
@@ -67,7 +65,6 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
       const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, mockContext);
       await handler(mockArgs);
       expect(validateChecksumFromResponse).not.toHaveBeenCalled();
-      expect(mockNext).toHaveBeenCalledWith(mockArgs);
     });
 
     describe("response checksum", () => {
@@ -77,16 +74,12 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
         const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMwConfig)(mockNext, mockContext);
         await handler(mockArgs);
         expect(validateChecksumFromResponse).not.toHaveBeenCalled();
-        expect(mockNext).toHaveBeenCalledWith(mockArgs);
       });
 
       it("if requestValidationModeMember is not enabled in input", async () => {
         const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, mockContext);
-
-        const mockArgsWithoutEnabled = { ...mockArgs, input: {} };
-        await handler(mockArgsWithoutEnabled);
+        await handler({ ...mockArgs, input: {} });
         expect(validateChecksumFromResponse).not.toHaveBeenCalled();
-        expect(mockNext).toHaveBeenCalledWith(mockArgsWithoutEnabled);
       });
 
       it("if checksum is for S3 whole-object multipart GET", async () => {
@@ -99,13 +92,12 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
         expect(isChecksumWithPartNumber).toHaveBeenCalledTimes(1);
         expect(isChecksumWithPartNumber).toHaveBeenCalledWith(mockChecksum);
         expect(validateChecksumFromResponse).not.toHaveBeenCalled();
-        expect(mockNext).toHaveBeenCalledWith(mockArgs);
       });
     });
   });
 
   describe("validates checksum from response header", () => {
-    it("if requestValidationModeMember is enabled in input", async () => {
+    it("generic case", async () => {
       const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, mockContext);
 
       await handler(mockArgs);
@@ -113,25 +105,6 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
         config: mockConfig,
         responseAlgorithms: mockResponseAlgorithms,
       });
-      expect(mockNext).toHaveBeenCalledWith(mockArgs);
-    });
-
-    it(`if requestValidationModeMember is not enabled in input, but responseChecksumValidation returns ${ResponseChecksumValidation.WHEN_SUPPORTED}`, async () => {
-      const mockConfigWithResponseChecksumValidationSupported = {
-        ...mockConfig,
-        responseChecksumValidation: () => Promise.resolve(ResponseChecksumValidation.WHEN_SUPPORTED),
-      };
-      const handler = flexibleChecksumsResponseMiddleware(
-        mockConfigWithResponseChecksumValidationSupported,
-        mockMiddlewareConfig
-      )(mockNext, mockContext);
-
-      await handler({ ...mockArgs, input: {} });
-      expect(validateChecksumFromResponse).toHaveBeenCalledWith(mockResult.response, {
-        config: mockConfigWithResponseChecksumValidationSupported,
-        responseAlgorithms: mockResponseAlgorithms,
-      });
-      expect(mockNext).toHaveBeenCalledWith(mockArgs);
     });
 
     it("if checksum is for S3 GET without part number", async () => {
@@ -147,7 +120,6 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
         config: mockConfig,
         responseAlgorithms: mockResponseAlgorithms,
       });
-      expect(mockNext).toHaveBeenCalledWith(mockArgs);
     });
   });
 });

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.spec.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.spec.ts
@@ -2,7 +2,7 @@ import { HttpRequest } from "@smithy/protocol-http";
 import { DeserializeHandlerArguments } from "@smithy/types";
 
 import { PreviouslyResolved } from "./configuration";
-import { ChecksumAlgorithm } from "./constants";
+import { ChecksumAlgorithm, ResponseChecksumValidation } from "./constants";
 import { flexibleChecksumsResponseMiddleware } from "./flexibleChecksumsResponseMiddleware";
 import { getChecksumLocationName } from "./getChecksumLocationName";
 import { FlexibleChecksumsMiddlewareConfig } from "./getFlexibleChecksumsPlugin";
@@ -23,7 +23,9 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
     commandName: "mockCommandName",
   };
 
-  const mockConfig = {} as PreviouslyResolved;
+  const mockConfig = {
+    responseChecksumValidation: () => Promise.resolve(ResponseChecksumValidation.WHEN_REQUIRED),
+  } as PreviouslyResolved;
   const mockRequestValidationModeMember = "ChecksumEnabled";
   const mockResponseAlgorithms = [ChecksumAlgorithm.CRC32, ChecksumAlgorithm.CRC32C];
   const mockMiddlewareConfig = {
@@ -59,45 +61,40 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
   });
 
   describe("skips", () => {
-    it("if not an instance of HttpRequest", async () => {
-      const { isInstance } = HttpRequest;
-      (isInstance as unknown as jest.Mock).mockReturnValue(false);
-      const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, mockContext);
+    it("if requestValidationModeMember is not defined", async () => {
+      const mockMwConfig = Object.assign({}, mockMiddlewareConfig) as FlexibleChecksumsMiddlewareConfig;
+      delete mockMwConfig.requestValidationModeMember;
+      const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMwConfig)(mockNext, mockContext);
       await handler(mockArgs);
       expect(validateChecksumFromResponse).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(mockArgs);
     });
 
-    describe("response checksum", () => {
-      it("if requestValidationModeMember is not defined", async () => {
-        const mockMwConfig = Object.assign({}, mockMiddlewareConfig) as FlexibleChecksumsMiddlewareConfig;
-        delete mockMwConfig.requestValidationModeMember;
-        const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMwConfig)(mockNext, mockContext);
-        await handler(mockArgs);
-        expect(validateChecksumFromResponse).not.toHaveBeenCalled();
-      });
+    it("if requestValidationModeMember is not enabled in input", async () => {
+      const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, mockContext);
 
-      it("if requestValidationModeMember is not enabled in input", async () => {
-        const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, mockContext);
-        await handler({ ...mockArgs, input: {} });
-        expect(validateChecksumFromResponse).not.toHaveBeenCalled();
-      });
+      const mockArgsWithoutEnabled = { ...mockArgs, input: {} };
+      await handler(mockArgsWithoutEnabled);
+      expect(validateChecksumFromResponse).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(mockArgsWithoutEnabled);
+    });
 
-      it("if checksum is for S3 whole-object multipart GET", async () => {
-        (isChecksumWithPartNumber as jest.Mock).mockReturnValue(true);
-        const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, {
-          clientName: "S3Client",
-          commandName: "GetObjectCommand",
-        });
-        await handler(mockArgs);
-        expect(isChecksumWithPartNumber).toHaveBeenCalledTimes(1);
-        expect(isChecksumWithPartNumber).toHaveBeenCalledWith(mockChecksum);
-        expect(validateChecksumFromResponse).not.toHaveBeenCalled();
+    it("if checksum is for S3 whole-object multipart GET", async () => {
+      (isChecksumWithPartNumber as jest.Mock).mockReturnValue(true);
+      const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, {
+        clientName: "S3Client",
+        commandName: "GetObjectCommand",
       });
+      await handler(mockArgs);
+      expect(isChecksumWithPartNumber).toHaveBeenCalledTimes(1);
+      expect(isChecksumWithPartNumber).toHaveBeenCalledWith(mockChecksum);
+      expect(validateChecksumFromResponse).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(mockArgs);
     });
   });
 
   describe("validates checksum from response header", () => {
-    it("generic case", async () => {
+    it("if requestValidationModeMember is enabled in input", async () => {
       const handler = flexibleChecksumsResponseMiddleware(mockConfig, mockMiddlewareConfig)(mockNext, mockContext);
 
       await handler(mockArgs);
@@ -105,6 +102,25 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
         config: mockConfig,
         responseAlgorithms: mockResponseAlgorithms,
       });
+      expect(mockNext).toHaveBeenCalledWith(mockArgs);
+    });
+
+    it(`if requestValidationModeMember is not enabled in input, but responseChecksumValidation returns ${ResponseChecksumValidation.WHEN_SUPPORTED}`, async () => {
+      const mockConfigWithResponseChecksumValidationSupported = {
+        ...mockConfig,
+        responseChecksumValidation: () => Promise.resolve(ResponseChecksumValidation.WHEN_SUPPORTED),
+      };
+      const handler = flexibleChecksumsResponseMiddleware(
+        mockConfigWithResponseChecksumValidationSupported,
+        mockMiddlewareConfig
+      )(mockNext, mockContext);
+
+      await handler({ ...mockArgs, input: {} });
+      expect(validateChecksumFromResponse).toHaveBeenCalledWith(mockResult.response, {
+        config: mockConfigWithResponseChecksumValidationSupported,
+        responseAlgorithms: mockResponseAlgorithms,
+      });
+      expect(mockNext).toHaveBeenCalledWith(mockArgs);
     });
 
     it("if checksum is for S3 GET without part number", async () => {
@@ -120,6 +136,7 @@ describe(flexibleChecksumsResponseMiddleware.name, () => {
         config: mockConfig,
         responseAlgorithms: mockResponseAlgorithms,
       });
+      expect(mockNext).toHaveBeenCalledWith(mockArgs);
     });
   });
 });

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
@@ -10,7 +10,7 @@ import {
 } from "@smithy/types";
 
 import { PreviouslyResolved } from "./configuration";
-import { ChecksumAlgorithm, ResponseChecksumValidation } from "./constants";
+import { ChecksumAlgorithm } from "./constants";
 import { getChecksumAlgorithmListForResponse } from "./getChecksumAlgorithmListForResponse";
 import { getChecksumLocationName } from "./getChecksumLocationName";
 import { isChecksumWithPartNumber } from "./isChecksumWithPartNumber";
@@ -63,24 +63,14 @@ export const flexibleChecksumsResponseMiddleware =
     }
 
     const input = args.input;
-    const { requestValidationModeMember, responseAlgorithms } = middlewareConfig;
-    const responseChecksumValidation = await config.responseChecksumValidation();
-
-    const isResponseChecksumValidationNeeded =
-      requestValidationModeMember &&
-      (input[requestValidationModeMember] === "ENABLED" ||
-        responseChecksumValidation === ResponseChecksumValidation.WHEN_SUPPORTED);
-
-    if (isResponseChecksumValidationNeeded) {
-      input[requestValidationModeMember] = "ENABLED";
-    }
-
     const result = await next(args);
 
     const response = result.response as HttpResponse;
     let collectedStream: Uint8Array | undefined = undefined;
 
-    if (isResponseChecksumValidationNeeded) {
+    const { requestValidationModeMember, responseAlgorithms } = middlewareConfig;
+    // @ts-ignore Element implicitly has an 'any' type for input[requestValidationModeMember]
+    if (requestValidationModeMember && input[requestValidationModeMember] === "ENABLED") {
       const { clientName, commandName } = context;
       const isS3WholeObjectMultipartGetResponseChecksum =
         clientName === "S3Client" &&

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
@@ -10,7 +10,7 @@ import {
 } from "@smithy/types";
 
 import { PreviouslyResolved } from "./configuration";
-import { ChecksumAlgorithm } from "./constants";
+import { ChecksumAlgorithm, ResponseChecksumValidation } from "./constants";
 import { getChecksumAlgorithmListForResponse } from "./getChecksumAlgorithmListForResponse";
 import { getChecksumLocationName } from "./getChecksumLocationName";
 import { isChecksumWithPartNumber } from "./isChecksumWithPartNumber";
@@ -37,8 +37,8 @@ export interface FlexibleChecksumsResponseMiddlewareConfig {
  */
 export const flexibleChecksumsResponseMiddlewareOptions: RelativeMiddlewareOptions = {
   name: "flexibleChecksumsResponseMiddleware",
-  toMiddleware: "deserializerMiddleware",
-  relation: "after",
+  toMiddleware: "serializerMiddleware",
+  relation: "before",
   tags: ["BODY_CHECKSUM"],
   override: true,
 };
@@ -58,19 +58,25 @@ export const flexibleChecksumsResponseMiddleware =
     context: HandlerExecutionContext
   ): DeserializeHandler<any, Output> =>
   async (args: DeserializeHandlerArguments<any>): Promise<DeserializeHandlerOutput<Output>> => {
-    if (!HttpRequest.isInstance(args.request)) {
-      return next(args);
+    const input = args.input;
+    const { requestValidationModeMember, responseAlgorithms } = middlewareConfig;
+    const responseChecksumValidation = await config.responseChecksumValidation();
+
+    const isResponseChecksumValidationNeeded =
+      requestValidationModeMember &&
+      (input[requestValidationModeMember] === "ENABLED" ||
+        responseChecksumValidation === ResponseChecksumValidation.WHEN_SUPPORTED);
+
+    if (isResponseChecksumValidationNeeded) {
+      input[requestValidationModeMember] = "ENABLED";
     }
 
-    const input = args.input;
     const result = await next(args);
 
     const response = result.response as HttpResponse;
     let collectedStream: Uint8Array | undefined = undefined;
 
-    const { requestValidationModeMember, responseAlgorithms } = middlewareConfig;
-    // @ts-ignore Element implicitly has an 'any' type for input[requestValidationModeMember]
-    if (requestValidationModeMember && input[requestValidationModeMember] === "ENABLED") {
+    if (isResponseChecksumValidationNeeded) {
       const { clientName, commandName } = context;
       const isS3WholeObjectMultipartGetResponseChecksum =
         clientName === "S3Client" &&

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
@@ -1,12 +1,12 @@
-import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
+import { HttpResponse } from "@smithy/protocol-http";
 import {
-  DeserializeHandler,
-  DeserializeHandlerArguments,
-  DeserializeHandlerOutput,
-  DeserializeMiddleware,
   HandlerExecutionContext,
   MetadataBearer,
   RelativeMiddlewareOptions,
+  SerializeHandler,
+  SerializeHandlerArguments,
+  SerializeHandlerOutput,
+  SerializeMiddleware,
 } from "@smithy/types";
 
 import { PreviouslyResolved } from "./configuration";
@@ -52,12 +52,12 @@ export const flexibleChecksumsResponseMiddleware =
   (
     config: PreviouslyResolved,
     middlewareConfig: FlexibleChecksumsResponseMiddlewareConfig
-  ): DeserializeMiddleware<any, any> =>
+  ): SerializeMiddleware<any, any> =>
   <Output extends MetadataBearer>(
-    next: DeserializeHandler<any, Output>,
+    next: SerializeHandler<any, Output>,
     context: HandlerExecutionContext
-  ): DeserializeHandler<any, Output> =>
-  async (args: DeserializeHandlerArguments<any>): Promise<DeserializeHandlerOutput<Output>> => {
+  ): SerializeHandler<any, Output> =>
+  async (args: SerializeHandlerArguments<any>): Promise<SerializeHandlerOutput<Output>> => {
     const input = args.input;
     const { requestValidationModeMember, responseAlgorithms } = middlewareConfig;
     const responseChecksumValidation = await config.responseChecksumValidation();

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
@@ -83,7 +83,7 @@ export const flexibleChecksumsResponseMiddleware =
         commandName === "GetObjectCommand" &&
         getChecksumAlgorithmListForResponse(responseAlgorithms).every((algorithm: ChecksumAlgorithm) => {
           const responseHeader = getChecksumLocationName(algorithm);
-          const checksumFromResponse = response.headers[responseHeader];
+          const checksumFromResponse = response.headers?.[responseHeader];
           return !checksumFromResponse || isChecksumWithPartNumber(checksumFromResponse);
         });
       if (isS3WholeObjectMultipartGetResponseChecksum) {

--- a/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.spec.ts
+++ b/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.spec.ts
@@ -1,4 +1,4 @@
-import { ChecksumAlgorithm } from "./constants";
+import { DEFAULT_CHECKSUM_ALGORITHM, RequestChecksumCalculation } from "./constants";
 import { getChecksumAlgorithmForRequest } from "./getChecksumAlgorithmForRequest";
 import { CLIENT_SUPPORTED_ALGORITHMS } from "./types";
 
@@ -6,36 +6,88 @@ describe(getChecksumAlgorithmForRequest.name, () => {
   const mockRequestAlgorithmMember = "mockRequestAlgorithmMember";
 
   describe("when requestAlgorithmMember is not provided", () => {
-    it("returns MD5 if requestChecksumRequired is set", () => {
-      expect(getChecksumAlgorithmForRequest({}, { requestChecksumRequired: true })).toEqual(ChecksumAlgorithm.MD5);
+    describe(`when requestChecksumCalculation is '${RequestChecksumCalculation.WHEN_REQUIRED}'`, () => {
+      const mockOptions = { requestChecksumCalculation: RequestChecksumCalculation.WHEN_REQUIRED };
+
+      it(`returns ${DEFAULT_CHECKSUM_ALGORITHM} if requestChecksumRequired is set`, () => {
+        expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: true })).toEqual(
+          DEFAULT_CHECKSUM_ALGORITHM
+        );
+      });
+
+      it("returns undefined if requestChecksumRequired is false", () => {
+        expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: false })).toBeUndefined();
+      });
     });
 
-    it("returns undefined if requestChecksumRequired is false", () => {
-      expect(getChecksumAlgorithmForRequest({}, { requestChecksumRequired: false })).toBeUndefined();
+    describe(`when requestChecksumCalculation is '${RequestChecksumCalculation.WHEN_SUPPORTED}'`, () => {
+      const mockOptions = { requestChecksumCalculation: RequestChecksumCalculation.WHEN_SUPPORTED };
+
+      it(`returns ${DEFAULT_CHECKSUM_ALGORITHM} if requestChecksumRequired is set`, () => {
+        expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: true })).toEqual(
+          DEFAULT_CHECKSUM_ALGORITHM
+        );
+      });
+
+      it(`returns ${DEFAULT_CHECKSUM_ALGORITHM} if requestChecksumRequired is false`, () => {
+        expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: false })).toEqual(
+          DEFAULT_CHECKSUM_ALGORITHM
+        );
+      });
     });
   });
 
   describe("when requestAlgorithmMember is not set in input", () => {
-    const mockOptions = { requestAlgorithmMember: mockRequestAlgorithmMember };
+    const mockOptionsWithAlgoMember = { requestAlgorithmMember: mockRequestAlgorithmMember };
 
-    it("returns MD5 if requestChecksumRequired is set", () => {
-      expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: true })).toEqual(
-        ChecksumAlgorithm.MD5
-      );
+    describe(`when requestChecksumCalculation is '${RequestChecksumCalculation.WHEN_REQUIRED}'`, () => {
+      const mockOptions = {
+        ...mockOptionsWithAlgoMember,
+        requestChecksumCalculation: RequestChecksumCalculation.WHEN_REQUIRED,
+      };
+
+      it(`returns ${DEFAULT_CHECKSUM_ALGORITHM} if requestChecksumRequired is set`, () => {
+        expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: true })).toEqual(
+          DEFAULT_CHECKSUM_ALGORITHM
+        );
+      });
+
+      it("returns undefined if requestChecksumRequired is false", () => {
+        expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: false })).toBeUndefined();
+      });
     });
 
-    it("returns undefined if requestChecksumRequired is false", () => {
-      expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: false })).toBeUndefined();
+    describe(`when requestChecksumCalculation is '${RequestChecksumCalculation.WHEN_SUPPORTED}'`, () => {
+      const mockOptions = {
+        ...mockOptionsWithAlgoMember,
+        requestChecksumCalculation: RequestChecksumCalculation.WHEN_SUPPORTED,
+      };
+
+      it(`returns ${DEFAULT_CHECKSUM_ALGORITHM} if requestChecksumRequired is set`, () => {
+        expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: true })).toEqual(
+          DEFAULT_CHECKSUM_ALGORITHM
+        );
+      });
+
+      it(`returns ${DEFAULT_CHECKSUM_ALGORITHM} if requestChecksumRequired is false`, () => {
+        expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: false })).toEqual(
+          DEFAULT_CHECKSUM_ALGORITHM
+        );
+      });
     });
   });
 
   it("throws error if input[requestAlgorithmMember] if not supported by client", () => {
     const unsupportedAlgo = "unsupportedAlgo";
     const mockInput = { [mockRequestAlgorithmMember]: unsupportedAlgo };
-    const mockOptions = { requestChecksumRequired: true, requestAlgorithmMember: mockRequestAlgorithmMember };
+    const mockOptions = {
+      requestChecksumRequired: true,
+      requestAlgorithmMember: mockRequestAlgorithmMember,
+      requestChecksumCalculation: RequestChecksumCalculation.WHEN_REQUIRED,
+    };
     expect(() => {
       getChecksumAlgorithmForRequest(mockInput, mockOptions);
-    }).toThrowError(
+    }).toThrow(
       `The checksum algorithm "${unsupportedAlgo}" is not supported by the client.` +
         ` Select one of ${CLIENT_SUPPORTED_ALGORITHMS}.`
     );
@@ -44,7 +96,11 @@ describe(getChecksumAlgorithmForRequest.name, () => {
   describe("returns input[requestAlgorithmMember] if supported by client", () => {
     it.each(CLIENT_SUPPORTED_ALGORITHMS)("Supported algorithm: %s", (supportedAlgorithm) => {
       const mockInput = { [mockRequestAlgorithmMember]: supportedAlgorithm };
-      const mockOptions = { requestChecksumRequired: true, requestAlgorithmMember: mockRequestAlgorithmMember };
+      const mockOptions = {
+        requestChecksumRequired: true,
+        requestAlgorithmMember: mockRequestAlgorithmMember,
+        requestChecksumCalculation: RequestChecksumCalculation.WHEN_REQUIRED,
+      };
       expect(getChecksumAlgorithmForRequest(mockInput, mockOptions)).toEqual(supportedAlgorithm);
     });
   });

--- a/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.ts
+++ b/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.ts
@@ -1,4 +1,9 @@
-import { ChecksumAlgorithm, DEFAULT_CHECKSUM_ALGORITHM, S3_EXPRESS_DEFAULT_CHECKSUM_ALGORITHM } from "./constants";
+import {
+  ChecksumAlgorithm,
+  DEFAULT_CHECKSUM_ALGORITHM,
+  RequestChecksumCalculation,
+  S3_EXPRESS_DEFAULT_CHECKSUM_ALGORITHM,
+} from "./constants";
 import { CLIENT_SUPPORTED_ALGORITHMS } from "./types";
 
 export interface GetChecksumAlgorithmForRequestOptions {
@@ -11,6 +16,11 @@ export interface GetChecksumAlgorithmForRequestOptions {
    * Defines a top-level operation input member that is used to configure request checksum behavior.
    */
   requestAlgorithmMember?: string;
+
+  /**
+   * Determines when a checksum will be calculated for request payloads
+   */
+  requestChecksumCalculation: string;
 }
 
 /**
@@ -20,7 +30,11 @@ export interface GetChecksumAlgorithmForRequestOptions {
  */
 export const getChecksumAlgorithmForRequest = (
   input: any,
-  { requestChecksumRequired, requestAlgorithmMember }: GetChecksumAlgorithmForRequestOptions,
+  {
+    requestChecksumRequired,
+    requestAlgorithmMember,
+    requestChecksumCalculation,
+  }: GetChecksumAlgorithmForRequestOptions,
   isS3Express?: boolean
 ): ChecksumAlgorithm | undefined => {
   const defaultAlgorithm = isS3Express ? S3_EXPRESS_DEFAULT_CHECKSUM_ALGORITHM : DEFAULT_CHECKSUM_ALGORITHM;
@@ -28,8 +42,11 @@ export const getChecksumAlgorithmForRequest = (
   // Either the Operation input member that is used to configure request checksum behavior is not set, or
   // the value for input member to configure flexible checksum is not set.
   if (!requestAlgorithmMember || !input[requestAlgorithmMember]) {
-    // Select an algorithm only if request checksum is required.
-    return requestChecksumRequired ? defaultAlgorithm : undefined;
+    // Select an algorithm only if request checksum calculation is supported
+    // or request checksum is required.
+    return requestChecksumCalculation === RequestChecksumCalculation.WHEN_SUPPORTED || requestChecksumRequired
+      ? defaultAlgorithm
+      : undefined;
   }
 
   const checksumAlgorithm = input[requestAlgorithmMember];

--- a/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.ts
+++ b/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.ts
@@ -20,7 +20,7 @@ export interface GetChecksumAlgorithmForRequestOptions {
   /**
    * Determines when a checksum will be calculated for request payloads
    */
-  requestChecksumCalculation: string;
+  requestChecksumCalculation: RequestChecksumCalculation;
 }
 
 /**

--- a/private/aws-middleware-test/src/middleware-serde.spec.ts
+++ b/private/aws-middleware-test/src/middleware-serde.spec.ts
@@ -20,7 +20,7 @@ describe("middleware-serde", () => {
           "x-amz-acl": "private",
           "content-length": "509",
           Expect: "100-continue",
-          "content-md5": "qpwmS0vhCISEXes008aoXA==",
+          "x-amz-checksum-crc32": "XnKFaw==",
           host: "s3.us-west-2.amazonaws.com",
           "x-amz-content-sha256": "c0a89780e1aac5dfa17604e9e25616e7babba0b655db189be49b4c352543bb22",
         },


### PR DESCRIPTION
### Issue
Internal JS-5396

### Description
Uses values in RequestChecksumCalculation and ResponseChecksumValidation to decide flexible checksums algorithm.
Also deprecates MD5, and sets CRC32 as default.

### Testing

Unit testing

Also, verified that checksums are computed by default
```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";
import { NodeHttpHandler } from "@smithy/node-http-handler";

class CustomHandler extends NodeHttpHandler {
  constructor() {
    super();
  }

  async handle(request, options) {
    for (const [header, value] of Object.entries(request.headers)) {
      if (header.startsWith("x-amz-checksum-")) {
        console.log(`request['${header}']: '${value}'`);
      }
    }
    const response = await super.handle(request, options);
    for (const [header, value] of Object.entries(response.response.headers)) {
      if (header.startsWith("x-amz-checksum-")) {
        console.log(`response['${header}']: '${value}'`);
      }
    }
    return response;
  }
}

// WHEN_SUPPORTED is default.
const client = new S3({
  requestHandler: new CustomHandler(),
});

console.log("Put Object");
await client.putObject({
  Bucket: "test-flexible-checksums-v2",
  Key: "hello-world.txt",
  Body: "Hello World",
});

console.log("\nGet Object");
await client.getObject({
  Bucket: "test-flexible-checksums-v2",
  Key: "hello-world.txt",
});
```

Output
```js
Put Object
request['x-amz-checksum-crc32']: 'ShexVg=='
response['x-amz-checksum-crc32']: 'ShexVg=='

Get Object
request['x-amz-checksum-mode']: 'ENABLED'
request['x-amz-checksum-crc32']: 'AAAAAA=='
response['x-amz-checksum-crc32']: 'ShexVg=='
```

An integration test will be added in S3 as a follow-up.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
