### PR TITLE
fix(middleware-flexible-checksums): use union for new config types

### DIFF
--- a/packages/middleware-flexible-checksums/src/NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS.ts
+++ b/packages/middleware-flexible-checksums/src/NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS.ts
@@ -6,10 +6,12 @@ import { SelectorType, stringUnionSelector } from "./stringUnionSelector";
 export const ENV_REQUEST_CHECKSUM_CALCULATION = "AWS_REQUEST_CHECKSUM_CALCULATION";
 export const CONFIG_REQUEST_CHECKSUM_CALCULATION = "request_checksum_calculation";
 
-export const NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS: LoadedConfigSelectors<string> = {
+export const NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS: LoadedConfigSelectors<RequestChecksumCalculation> = {
   environmentVariableSelector: (env) =>
+    // @ts-expect-error Type 'string | undefined' is not assignable to type 'RequestChecksumCalculation | undefined'.
     stringUnionSelector(env, ENV_REQUEST_CHECKSUM_CALCULATION, RequestChecksumCalculation, SelectorType.ENV),
   configFileSelector: (profile) =>
+    // @ts-expect-error Type 'string | undefined' is not assignable to type 'RequestChecksumCalculation | undefined'.
     stringUnionSelector(profile, CONFIG_REQUEST_CHECKSUM_CALCULATION, RequestChecksumCalculation, SelectorType.CONFIG),
   default: DEFAULT_REQUEST_CHECKSUM_CALCULATION,
 };

--- a/packages/middleware-flexible-checksums/src/NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS.ts
+++ b/packages/middleware-flexible-checksums/src/NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS.ts
@@ -8,10 +8,8 @@ export const CONFIG_REQUEST_CHECKSUM_CALCULATION = "request_checksum_calculation
 
 export const NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS: LoadedConfigSelectors<RequestChecksumCalculation> = {
   environmentVariableSelector: (env) =>
-    // @ts-expect-error Type 'string | undefined' is not assignable to type 'RequestChecksumCalculation | undefined'.
     stringUnionSelector(env, ENV_REQUEST_CHECKSUM_CALCULATION, RequestChecksumCalculation, SelectorType.ENV),
   configFileSelector: (profile) =>
-    // @ts-expect-error Type 'string | undefined' is not assignable to type 'RequestChecksumCalculation | undefined'.
     stringUnionSelector(profile, CONFIG_REQUEST_CHECKSUM_CALCULATION, RequestChecksumCalculation, SelectorType.CONFIG),
   default: DEFAULT_REQUEST_CHECKSUM_CALCULATION,
 };

--- a/packages/middleware-flexible-checksums/src/NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS.ts
+++ b/packages/middleware-flexible-checksums/src/NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS.ts
@@ -1,15 +1,17 @@
 import { LoadedConfigSelectors } from "@smithy/node-config-provider";
 
-import { DEFAULT_RESPONSE_CHECKSUM_VALIDATION, RequestChecksumCalculation } from "./constants";
+import { DEFAULT_RESPONSE_CHECKSUM_VALIDATION, ResponseChecksumValidation } from "./constants";
 import { SelectorType, stringUnionSelector } from "./stringUnionSelector";
 
 export const ENV_RESPONSE_CHECKSUM_VALIDATION = "AWS_RESPONSE_CHECKSUM_VALIDATION";
 export const CONFIG_RESPONSE_CHECKSUM_VALIDATION = "response_checksum_validation";
 
-export const NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS: LoadedConfigSelectors<string> = {
+export const NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS: LoadedConfigSelectors<ResponseChecksumValidation> = {
   environmentVariableSelector: (env) =>
-    stringUnionSelector(env, ENV_RESPONSE_CHECKSUM_VALIDATION, RequestChecksumCalculation, SelectorType.ENV),
+    // @ts-expect-error Type 'string | undefined' is not assignable to type 'ResponseChecksumValidation | undefined'.
+    stringUnionSelector(env, ENV_RESPONSE_CHECKSUM_VALIDATION, ResponseChecksumValidation, SelectorType.ENV),
   configFileSelector: (profile) =>
-    stringUnionSelector(profile, CONFIG_RESPONSE_CHECKSUM_VALIDATION, RequestChecksumCalculation, SelectorType.CONFIG),
+    // @ts-expect-error Type 'string | undefined' is not assignable to type 'ResponseChecksumValidation | undefined'.
+    stringUnionSelector(profile, CONFIG_RESPONSE_CHECKSUM_VALIDATION, ResponseChecksumValidation, SelectorType.CONFIG),
   default: DEFAULT_RESPONSE_CHECKSUM_VALIDATION,
 };

--- a/packages/middleware-flexible-checksums/src/NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS.ts
+++ b/packages/middleware-flexible-checksums/src/NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS.ts
@@ -8,10 +8,8 @@ export const CONFIG_RESPONSE_CHECKSUM_VALIDATION = "response_checksum_validation
 
 export const NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS: LoadedConfigSelectors<ResponseChecksumValidation> = {
   environmentVariableSelector: (env) =>
-    // @ts-expect-error Type 'string | undefined' is not assignable to type 'ResponseChecksumValidation | undefined'.
     stringUnionSelector(env, ENV_RESPONSE_CHECKSUM_VALIDATION, ResponseChecksumValidation, SelectorType.ENV),
   configFileSelector: (profile) =>
-    // @ts-expect-error Type 'string | undefined' is not assignable to type 'ResponseChecksumValidation | undefined'.
     stringUnionSelector(profile, CONFIG_RESPONSE_CHECKSUM_VALIDATION, ResponseChecksumValidation, SelectorType.CONFIG),
   default: DEFAULT_RESPONSE_CHECKSUM_VALIDATION,
 };

--- a/packages/middleware-flexible-checksums/src/resolveFlexibleChecksumsConfig.spec.ts
+++ b/packages/middleware-flexible-checksums/src/resolveFlexibleChecksumsConfig.spec.ts
@@ -1,6 +1,11 @@
 import { normalizeProvider } from "@smithy/util-middleware";
 
-import { DEFAULT_REQUEST_CHECKSUM_CALCULATION, DEFAULT_RESPONSE_CHECKSUM_VALIDATION } from "./constants";
+import {
+  DEFAULT_REQUEST_CHECKSUM_CALCULATION,
+  DEFAULT_RESPONSE_CHECKSUM_VALIDATION,
+  RequestChecksumCalculation,
+  ResponseChecksumValidation,
+} from "./constants";
 import { resolveFlexibleChecksumsConfig } from "./resolveFlexibleChecksumsConfig";
 
 jest.mock("@smithy/util-middleware");
@@ -25,8 +30,8 @@ describe(resolveFlexibleChecksumsConfig.name, () => {
 
   it("normalizes client checksums configuration", () => {
     const mockInput = {
-      requestChecksumCalculation: "WHEN_REQUIRED",
-      responseChecksumValidation: "WHEN_REQUIRED",
+      requestChecksumCalculation: RequestChecksumCalculation.WHEN_REQUIRED,
+      responseChecksumValidation: ResponseChecksumValidation.WHEN_REQUIRED,
     };
     const resolvedConfig = resolveFlexibleChecksumsConfig(mockInput);
     expect(resolvedConfig).toEqual(mockInput);

--- a/packages/middleware-flexible-checksums/src/resolveFlexibleChecksumsConfig.ts
+++ b/packages/middleware-flexible-checksums/src/resolveFlexibleChecksumsConfig.ts
@@ -1,23 +1,28 @@
 import { Provider } from "@smithy/types";
 import { normalizeProvider } from "@smithy/util-middleware";
 
-import { DEFAULT_REQUEST_CHECKSUM_CALCULATION, DEFAULT_RESPONSE_CHECKSUM_VALIDATION } from "./constants";
+import {
+  DEFAULT_REQUEST_CHECKSUM_CALCULATION,
+  DEFAULT_RESPONSE_CHECKSUM_VALIDATION,
+  RequestChecksumCalculation,
+  ResponseChecksumValidation,
+} from "./constants";
 
 export interface FlexibleChecksumsInputConfig {
   /**
    * Determines when a checksum will be calculated for request payloads.
    */
-  requestChecksumCalculation?: string | Provider<string>;
+  requestChecksumCalculation?: RequestChecksumCalculation | Provider<RequestChecksumCalculation>;
 
   /**
    * Determines when checksum validation will be performed on response payloads.
    */
-  responseChecksumValidation?: string | Provider<string>;
+  responseChecksumValidation?: ResponseChecksumValidation | Provider<ResponseChecksumValidation>;
 }
 
 export interface FlexibleChecksumsResolvedConfig {
-  requestChecksumCalculation: Provider<string>;
-  responseChecksumValidation: Provider<string>;
+  requestChecksumCalculation: Provider<RequestChecksumCalculation>;
+  responseChecksumValidation: Provider<ResponseChecksumValidation>;
 }
 
 export const resolveFlexibleChecksumsConfig = <T>(

--- a/packages/middleware-flexible-checksums/src/stringUnionSelector.ts
+++ b/packages/middleware-flexible-checksums/src/stringUnionSelector.ts
@@ -15,7 +15,7 @@ export const stringUnionSelector = (
   key: string,
   union: Record<string, string>,
   type: SelectorType
-) => {
+): (typeof union)[keyof typeof union] | undefined => {
   if (!(key in obj)) return undefined;
 
   const value = obj[key]!.toUpperCase();

--- a/packages/middleware-flexible-checksums/src/stringUnionSelector.ts
+++ b/packages/middleware-flexible-checksums/src/stringUnionSelector.ts
@@ -10,12 +10,12 @@ export enum SelectorType {
  *
  * @internal
  */
-export const stringUnionSelector = (
+export const stringUnionSelector = <U extends object, K extends keyof U>(
   obj: Record<string, string | undefined>,
   key: string,
-  union: Record<string, string>,
+  union: U,
   type: SelectorType
-): (typeof union)[keyof typeof union] | undefined => {
+): U[K] | undefined => {
   if (!(key in obj)) return undefined;
 
   const value = obj[key]!.toUpperCase();
@@ -23,5 +23,5 @@ export const stringUnionSelector = (
     throw new TypeError(`Cannot load ${type} '${key}'. Expected one of ${Object.values(union)}, got '${obj[key]}'.`);
   }
 
-  return value;
+  return value as U[K];
 };


### PR DESCRIPTION
### Issue
Missed in https://github.com/aws/aws-sdk-js-v3/pull/6470

### Description
Use union for new config types `requestChecksumCalculation` and `responseChecksumValidation`

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
