### PR TITLE
feat(iot): add waiter for fleet index

### DIFF
--- a/clients/client-iot/src/waiters/index.ts
+++ b/clients/client-iot/src/waiters/index.ts
@@ -1,0 +1,2 @@
+// smithy-typescript generated code
+export * from "./waitForIndexIsActive"

--- a/clients/client-iot/src/waiters/waitForIndexIsActive.ts
+++ b/clients/client-iot/src/waiters/waitForIndexIsActive.ts
@@ -1,0 +1,51 @@
+// smithy-typescript generated code
+import { IoTClient } from "../IoTClient";
+import {
+  DescribeIndexCommand,
+  DescribeIndexCommandInput,
+} from "../commands/DescribeIndexCommand";
+import {
+  WaiterConfiguration,
+  WaiterResult,
+  WaiterState,
+  checkExceptions,
+  createWaiter,
+} from "@smithy/util-waiter";
+
+const checkState = async (client: IoTClient, input: DescribeIndexCommandInput): Promise<WaiterResult> => {
+  let reason;
+  try {
+    let result: any = await client.send(new DescribeIndexCommand(input))
+    reason = result;
+    try {
+      let returnComparator = () => {
+        return result.indexStatus;
+      }
+      if (returnComparator() === "ACTIVE") {
+        return { state: WaiterState.SUCCESS, reason };
+      }
+    } catch (e) {}
+  }
+  catch (exception) {
+    reason = exception;
+  }
+  return { state: WaiterState.RETRY, reason };
+}
+/**
+ *
+ *  @deprecated Use waitUntilIndexIsActive instead. waitForIndexIsActive does not throw error in non-success cases.
+ */
+export const waitForIndexIsActive = async (params: WaiterConfiguration<IoTClient>, input: DescribeIndexCommandInput): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  return createWaiter({...serviceDefaults, ...params}, input, checkState);
+}
+/**
+ *
+ *  @param params - Waiter configuration options.
+ *  @param input - The input to DescribeIndexCommand for polling.
+ */
+export const waitUntilIndexIsActive = async (params: WaiterConfiguration<IoTClient>, input: DescribeIndexCommandInput): Promise<WaiterResult> => {
+  const serviceDefaults = { minDelay: 30, maxDelay: 120 };
+  const result = await createWaiter({...serviceDefaults, ...params}, input, checkState);
+  return checkExceptions(result);
+}

--- a/codegen/sdk-codegen/aws-models/iot.json
+++ b/codegen/sdk-codegen/aws-models/iot.json
@@ -13588,6 +13588,23 @@
           "method": "GET",
           "uri": "/indices/{indexName}",
           "code": 200
+        },
+        "smithy.waiters#waitable": {
+          "IndexIsActive": {
+            "acceptors": [
+              {
+                "state": "success",
+                "matcher": {
+                  "output": {
+                    "path": "indexStatus",
+                    "expected": "ACTIVE",
+                    "comparator": "stringEquals"
+                  }
+                }
+              }
+            ],
+            "minDelay": 30
+          }
         }
       }
     },


### PR DESCRIPTION
### Description
Noticed today that creating Thing indices isn't synchronous with the `updateIndexingConfiguration`-call.

Our use-case for this waiter is to create an initial thing index and wait for it to become active via CloudFormation through custom resources.

Successive fleet metrics resources depend on the index to be active or they fail a stack deployment.

From a few manual tests it takes somewhere between 30 and 60 seconds before the index is active.

### Testing
This PR doesn't include a dedicated test, but expands on the Smithy schema model.

Tested it manually, resulting in the following two states

```json
{
  "$metadata": {
    "httpStatusCode": 200,
    "requestId": "dc261241-2049-432b-8c45-4038c54d9aba",
    "attempts": 1,
    "totalRetryDelay": 0
  },
  "indexName": "AWS_Things",
  "indexStatus": "BUILDING",
  "schema": "MULTI_INDEXING_MODE"
}
{
  "$metadata": {
    "httpStatusCode": 200,
    "requestId": "72f44bee-9e9e-44ed-94a8-5407610306b3",
    "attempts": 1,
    "totalRetryDelay": 0
  },
  "indexName": "AWS_Things",
  "indexStatus": "ACTIVE",
  "schema": "MULTI_INDEXING_MODE"
}
```

-- happy to contribute an actual test if there's some convenient test setup for waiters that I don't know about.

### Additional context
N/A

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
