### PR TITLE
chore(middleware-flexible-checksums): re-order checksum implementations based on performance

### DIFF
--- a/packages/middleware-flexible-checksums/src/types.ts
+++ b/packages/middleware-flexible-checksums/src/types.ts
@@ -12,11 +12,10 @@ export const CLIENT_SUPPORTED_ALGORITHMS = [
 
 /**
  * Priority order for validating checksum algorithm. A faster algorithm has higher priority.
- * ToDo: update the priority order based on profiling of JavaScript implementations.
  */
 export const PRIORITY_ORDER_ALGORITHMS = [
+  ChecksumAlgorithm.SHA256,
+  ChecksumAlgorithm.SHA1,
   ChecksumAlgorithm.CRC32,
   ChecksumAlgorithm.CRC32C,
-  ChecksumAlgorithm.SHA1,
-  ChecksumAlgorithm.SHA256,
 ];


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/6499

### Description
Re-order checksum implementations based on performance

### Testing
CI

The S3 backend doesn't sent multiple checksum values in the headers today. The checksum returned is for the value provided during putObject call. The existing implementation ensures that it goes through the priority order for selecting an algorithm if multiple checksum values are available.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
