### PR TITLE
Fix aws-sdk-core module import

### DIFF
--- a/clients/client-dynamodb/src/DynamoDBClient.ts
+++ b/clients/client-dynamodb/src/DynamoDBClient.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AccountIdEndpointMode } from "@aws-sdk/core/account-id-endpoint";
+import { AccountIdEndpointMode } from "@aws-sdk/core";
 import {
   EndpointDiscoveryInputConfig,
   EndpointDiscoveryResolvedConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,10 @@ export * from "./submodules/httpAuthSchemes/index";
  * Legacy submodule.
  */
 export * from "./submodules/protocols/index";
+/**
+ * Legacy submodule.
+ */
+export * from "./submodules/account-id-endpoint/index";
 
 /**
  * Warning: do not export any additional submodules from the root of this package. See readme.md for


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#6502"

### Description
While importing the account-id-endpoint from the aws-sdk/core, its not importing for the legacy typescript version.

### Testing
Module got imported successfully while compiling.

### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
