### PR TITLE
fix(core): add compatibility types for submodules

### DIFF
--- a/packages/core/account-id-endpoint.d.ts
+++ b/packages/core/account-id-endpoint.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+declare module "@aws-sdk/core/account-id-endpoint" {
+  export * from "@aws-sdk/core/dist-types/submodules/account-id-endpoint/index.d";
+}

--- a/packages/core/client.d.ts
+++ b/packages/core/client.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+declare module "@aws-sdk/core/client" {
+  export * from "@aws-sdk/core/dist-types/submodules/client/index.d";
+}

--- a/packages/core/httpAuthSchemes.d.ts
+++ b/packages/core/httpAuthSchemes.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+declare module "@aws-sdk/core/httpAuthSchemes" {
+  export * from "@aws-sdk/core/dist-types/submodules/httpAuthSchemes/index.d";
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,11 +62,15 @@
     }
   },
   "files": [
-    "dist-*/**",
+    "./account-id-endpoint.d.ts",
+    "./account-id-endpoint.js",
+    "./client.d.ts",
     "./client.js",
+    "./httpAuthSchemes.d.ts",
     "./httpAuthSchemes.js",
+    "./protocols.d.ts",
     "./protocols.js",
-    "./account-id-endpoint.js"
+    "dist-*/**"
   ],
   "sideEffects": false,
   "author": {

--- a/packages/core/protocols.d.ts
+++ b/packages/core/protocols.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+declare module "@aws-sdk/core/protocols" {
+  export * from "@aws-sdk/core/dist-types/submodules/protocols/index.d";
+}


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6502

### Description
Adds a `.d.ts` file in the core root so that an import like `@aws-sdk/core/submodule` not only maps via package.json exports, but also via traditional package relative pathing when contexts do not understand the exports metadata.

### Testing
created new linting rules for core submodules
