### PR TITLE
test: enable protocol tests blocked by previous versions

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -305,34 +305,8 @@ final class AwsProtocolUtils {
             HttpMessageTestCase testCase,
             TypeScriptSettings settings
     ) {
-        // TODO: Remove when requestCompression has been implemented.
-        if (testCase.getId().startsWith("SDKAppliedContentEncoding_")
-            || testCase.getId().startsWith("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_")
-            || testCase.getId().startsWith("SDKAppendedGzipAfterProvidedEncoding_")) {
-            return true;
-        }
-
         // TODO: Remove when upstream tests update to serialize empty headers.
         if (testCase.getId().contains("NullAndEmptyHeaders")) {
-            return true;
-        }
-
-        if (testCase.getTags().contains("defaults")) {
-            return true;
-        }
-
-        // TODO: remove when there's a decision on separator to use
-        // https://github.com/awslabs/smithy/issues/1014
-        if (testCase.getId().equals("RestJsonInputAndOutputWithQuotedStringHeaders")) {
-            return true;
-        }
-
-        // TODO: implementation change pending.
-        List<String> extraUnionKey = Arrays.asList(
-            "RestXmlHttpPayloadWithUnsetUnion",
-            "RestJsonHttpPayloadWithUnsetUnion"
-        );
-        if (extraUnionKey.contains(testCase.getId())) {
             return true;
         }
 
@@ -341,8 +315,7 @@ final class AwsProtocolUtils {
             return true;
         }
 
-        // ToDo: https://github.com/aws/aws-sdk-js-v3/issues/6246
-        if (testCase.getId().equals("RestJsonMustSupportParametersInContentType")) {
+        if (testCase.getTags().contains("defaults")) {
             return true;
         }
 

--- a/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
+++ b/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
@@ -835,7 +835,7 @@ it("Ec2QueryNoInputAndOutput:Response", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_ec2Query:Request", async () => {
+it("SDKAppliedContentEncoding_ec2Query:Request", async () => {
   const client = new EC2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -868,7 +868,7 @@ it.skip("SDKAppliedContentEncoding_ec2Query:Request", async () => {
  * traits are ignored in the ec2Query protocol.
  *
  */
-it.skip("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_ec2Query:Request", async () => {
+it("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_ec2Query:Request", async () => {
   const client = new EC2ProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
+++ b/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
@@ -2751,7 +2751,7 @@ it.skip("AwsJson10ClientErrorCorrectsWhenServerFailsToSerializeRequiredValues:Re
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_awsJson1_0:Request", async () => {
+it("SDKAppliedContentEncoding_awsJson1_0:Request", async () => {
   const client = new JSONRPC10Client({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -2784,7 +2784,7 @@ it.skip("SDKAppliedContentEncoding_awsJson1_0:Request", async () => {
  * traits are ignored in the awsJson1_0 protocol.
  *
  */
-it.skip("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsJson1_0:Request", async () => {
+it("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsJson1_0:Request", async () => {
   const client = new JSONRPC10Client({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
+++ b/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
@@ -4410,7 +4410,7 @@ it("PutAndGetInlineDocumentsInput:Response", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_awsJson1_1:Request", async () => {
+it("SDKAppliedContentEncoding_awsJson1_1:Request", async () => {
   const client = new JsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -4443,7 +4443,7 @@ it.skip("SDKAppliedContentEncoding_awsJson1_1:Request", async () => {
  * traits are ignored in the awsJson1_1 protocol.
  *
  */
-it.skip("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsJson1_1:Request", async () => {
+it("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsJson1_1:Request", async () => {
   const client = new JsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
+++ b/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
@@ -1088,7 +1088,7 @@ it("QueryNoInputAndOutput:Response", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_awsQuery:Request", async () => {
+it("SDKAppliedContentEncoding_awsQuery:Request", async () => {
   const client = new QueryProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -1121,7 +1121,7 @@ it.skip("SDKAppliedContentEncoding_awsQuery:Request", async () => {
  * traits are ignored in the awsQuery protocol.
  *
  */
-it.skip("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsQuery:Request", async () => {
+it("SDKAppendsGzipAndIgnoresHttpProvidedEncoding_awsQuery:Request", async () => {
   const client = new QueryProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-restjson-apigateway/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson-apigateway/test/functional/restjson1.spec.ts
@@ -227,6 +227,6 @@ it("ApiGatewayAccept:Request", async () => {
     expect(r.headers["accept"]).toBeDefined();
     expect(r.headers["accept"]).toBe("application/json");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });

--- a/private/aws-protocoltests-restjson-glacier/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson-glacier/test/functional/restjson1.spec.ts
@@ -232,7 +232,7 @@ it("GlacierVersionHeader:Request", async () => {
     expect(r.headers["x-amz-glacier-version"]).toBeDefined();
     expect(r.headers["x-amz-glacier-version"]).toBe("2012-06-01");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -311,7 +311,7 @@ it.skip("GlacierAccountId:Request", async () => {
     expect(r.headers["x-amz-glacier-version"]).toBeDefined();
     expect(r.headers["x-amz-glacier-version"]).toBe("2012-06-01");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -36,10 +36,12 @@ import {
   parseEpochTimestamp as __parseEpochTimestamp,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   parseRfc7231DateTime as __parseRfc7231DateTime,
+  quoteHeader as __quoteHeader,
   resolvedPath as __resolvedPath,
   serializeDateTime as __serializeDateTime,
   serializeFloat as __serializeFloat,
   splitEvery as __splitEvery,
+  splitHeader as __splitHeader,
   strictParseByte as __strictParseByte,
   strictParseDouble as __strictParseDouble,
   strictParseFloat as __strictParseFloat,
@@ -1033,8 +1035,8 @@ export const se_InputAndOutputWithHeadersCommand = async (
     ],
     [_xb_]: [() => isSerializableHeaderValue(input[_hTB]), () => input[_hTB]!.toString()],
     [_xb__]: [() => isSerializableHeaderValue(input[_hFB]), () => input[_hFB]!.toString()],
-    [_xs__]: [() => isSerializableHeaderValue(input[_hSL]), () => (input[_hSL]! || []).join(", ")],
-    [_xs___]: [() => isSerializableHeaderValue(input[_hSS]), () => (input[_hSS]! || []).join(", ")],
+    [_xs__]: [() => isSerializableHeaderValue(input[_hSL]), () => (input[_hSL]! || []).map(__quoteHeader).join(", ")],
+    [_xs___]: [() => isSerializableHeaderValue(input[_hSS]), () => (input[_hSS]! || []).map(__quoteHeader).join(", ")],
     [_xi_]: [
       () => isSerializableHeaderValue(input[_hIL]),
       () => (input[_hIL]! || []).map((_entry) => _entry.toString() as any).join(", "),
@@ -1048,7 +1050,7 @@ export const se_InputAndOutputWithHeadersCommand = async (
       () => (input[_hTL]! || []).map((_entry) => __dateToUtcString(_entry).toString() as any).join(", "),
     ],
     [_xe]: input[_hE]!,
-    [_xe_]: [() => isSerializableHeaderValue(input[_hEL]), () => (input[_hEL]! || []).join(", ")],
+    [_xe_]: [() => isSerializableHeaderValue(input[_hEL]), () => (input[_hEL]! || []).map(__quoteHeader).join(", ")],
     [_xi__]: [() => isSerializableHeaderValue(input[_hIE]), () => input[_hIE]!.toString()],
     [_xi___]: [
       () => isSerializableHeaderValue(input[_hIEL]),
@@ -1987,7 +1989,7 @@ export const se_NullAndEmptyHeadersClientCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     [_xa]: input[_a]!,
     [_xb____]: input[_b_]!,
-    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).join(", ")],
+    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).map(__quoteHeader).join(", ")],
   });
   b.bp("/NullAndEmptyHeadersClient");
   let body: any;
@@ -2006,7 +2008,7 @@ export const se_NullAndEmptyHeadersServerCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     [_xa]: input[_a]!,
     [_xb____]: input[_b_]!,
-    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).join(", ")],
+    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).map(__quoteHeader).join(", ")],
   });
   b.bp("/NullAndEmptyHeadersServer");
   let body: any;
@@ -2910,8 +2912,10 @@ export const de_HttpPayloadWithUnionCommand = async (
   const contents: any = map({
     $metadata: deserializeMetadata(output),
   });
-  const data: Record<string, any> | undefined = __expectUnion(await parseBody(output.body, context));
-  contents.nested = _json(data);
+  const data: Record<string, any> | undefined = await parseBody(output.body, context);
+  if (Object.keys(data ?? {}).length) {
+    contents.nested = __expectUnion(_json(data));
+  }
   return contents;
 };
 
@@ -3135,19 +3139,19 @@ export const de_InputAndOutputWithHeadersCommand = async (
     [_hFB]: [() => void 0 !== output.headers[_xb__], () => __parseBoolean(output.headers[_xb__])],
     [_hSL]: [
       () => void 0 !== output.headers[_xs__],
-      () => (output.headers[_xs__] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xs__] || "").map((_entry) => _entry.trim() as any),
     ],
     [_hSS]: [
       () => void 0 !== output.headers[_xs___],
-      () => (output.headers[_xs___] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xs___] || "").map((_entry) => _entry.trim() as any),
     ],
     [_hIL]: [
       () => void 0 !== output.headers[_xi_],
-      () => (output.headers[_xi_] || "").split(",").map((_entry) => __strictParseInt32(_entry.trim()) as any),
+      () => __splitHeader(output.headers[_xi_] || "").map((_entry) => __strictParseInt32(_entry.trim()) as any),
     ],
     [_hBL]: [
       () => void 0 !== output.headers[_xb___],
-      () => (output.headers[_xb___] || "").split(",").map((_entry) => __parseBoolean(_entry.trim()) as any),
+      () => __splitHeader(output.headers[_xb___] || "").map((_entry) => __parseBoolean(_entry.trim()) as any),
     ],
     [_hTL]: [
       () => void 0 !== output.headers[_xt],
@@ -3159,12 +3163,12 @@ export const de_InputAndOutputWithHeadersCommand = async (
     [_hE]: [, output.headers[_xe]],
     [_hEL]: [
       () => void 0 !== output.headers[_xe_],
-      () => (output.headers[_xe_] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xe_] || "").map((_entry) => _entry.trim() as any),
     ],
     [_hIE]: [() => void 0 !== output.headers[_xi__], () => __strictParseInt32(output.headers[_xi__])],
     [_hIEL]: [
       () => void 0 !== output.headers[_xi___],
-      () => (output.headers[_xi___] || "").split(",").map((_entry) => __strictParseInt32(_entry.trim()) as any),
+      () => __splitHeader(output.headers[_xi___] || "").map((_entry) => __strictParseInt32(_entry.trim()) as any),
     ],
   });
   await collectBody(output.body, context);
@@ -3967,7 +3971,7 @@ export const de_NullAndEmptyHeadersClientCommand = async (
     [_b_]: [, output.headers[_xb____]],
     [_c]: [
       () => void 0 !== output.headers[_xc],
-      () => (output.headers[_xc] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xc] || "").map((_entry) => _entry.trim() as any),
     ],
   });
   await collectBody(output.body, context);
@@ -3990,7 +3994,7 @@ export const de_NullAndEmptyHeadersServerCommand = async (
     [_b_]: [, output.headers[_xb____]],
     [_c]: [
       () => void 0 !== output.headers[_xc],
-      () => (output.headers[_xc] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xc] || "").map((_entry) => _entry.trim() as any),
     ],
   });
   await collectBody(output.body, context);

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -373,7 +373,7 @@ it("RestJsonAllQueryStringTypes:Request", async () => {
     expect(queryString).toContain("IntegerEnumList=2");
     expect(queryString).toContain("IntegerEnumList=3");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -409,7 +409,7 @@ it("RestJsonQueryStringMap:Request", async () => {
     expect(queryString).toContain("QueryParamsStringKeyA=Foo");
     expect(queryString).toContain("QueryParamsStringKeyB=Bar");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -444,7 +444,7 @@ it("RestJsonQueryStringEscaping:Request", async () => {
     const queryString = buildQueryString(r.query);
     expect(queryString).toContain("String=%20%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -482,7 +482,7 @@ it("RestJsonSupportsNaNFloatQueryValues:Request", async () => {
     expect(queryString).toContain("Float=NaN");
     expect(queryString).toContain("Double=NaN");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -520,7 +520,7 @@ it("RestJsonSupportsInfinityFloatQueryValues:Request", async () => {
     expect(queryString).toContain("Float=Infinity");
     expect(queryString).toContain("Double=Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -558,7 +558,7 @@ it("RestJsonSupportsNegativeInfinityFloatQueryValues:Request", async () => {
     expect(queryString).toContain("Float=-Infinity");
     expect(queryString).toContain("Double=-Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -596,7 +596,7 @@ it("RestJsonZeroAndFalseQueryValues:Request", async () => {
     expect(queryString).toContain("Integer=0");
     expect(queryString).toContain("Boolean=false");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -631,7 +631,7 @@ it("RestJsonConstantAndVariableQueryStringMissingOneValue:Request", async () => 
     expect(queryString).toContain("foo=bar");
     expect(queryString).toContain("baz=bam");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -666,7 +666,7 @@ it("RestJsonConstantAndVariableQueryStringAllValues:Request", async () => {
     expect(queryString).toContain("baz=bam");
     expect(queryString).toContain("maybeSet=yes");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -699,7 +699,7 @@ it("RestJsonConstantQueryString:Request", async () => {
     expect(queryString).toContain("foo=bar");
     expect(queryString).toContain("hello");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -1507,7 +1507,7 @@ it("RestJsonEmptyInputAndEmptyOutput:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/EmptyInputAndEmptyOutput");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -1593,7 +1593,7 @@ it("RestJsonEndpointTrait:Request", async () => {
     expect(r.headers["host"]).toBeDefined();
     expect(r.headers["host"]).toBe("foo.example.com");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2222,7 +2222,7 @@ it("RestJsonHostWithPath:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/custom/HostWithPathOperation");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2403,7 +2403,7 @@ it("RestJsonHttpPayloadTraitsWithNoBlobBody:Request", async () => {
     expect(r.headers["x-foo"]).toBeDefined();
     expect(r.headers["x-foo"]).toBe("Foo");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2695,7 +2695,7 @@ it("RestJsonHttpPayloadWithUnion:Request", async () => {
 /**
  * No payload is sent if the union has no value.
  */
-it.skip("RestJsonHttpPayloadWithUnsetUnion:Request", async () => {
+it("RestJsonHttpPayloadWithUnsetUnion:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -2715,7 +2715,7 @@ it.skip("RestJsonHttpPayloadWithUnsetUnion:Request", async () => {
     expect(r.method).toBe("PUT");
     expect(r.path).toBe("/HttpPayloadWithUnion");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2764,7 +2764,7 @@ it("RestJsonHttpPayloadWithUnion:Response", async () => {
 /**
  * No payload is sent if the union has no value.
  */
-it.skip("RestJsonHttpPayloadWithUnsetUnion:Response", async () => {
+it("RestJsonHttpPayloadWithUnsetUnion:Response", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
@@ -2826,7 +2826,7 @@ it("RestJsonHttpPrefixHeadersArePresent:Request", async () => {
     expect(r.headers["x-foo-def"]).toBeDefined();
     expect(r.headers["x-foo-def"]).toBe("Def value");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2859,7 +2859,7 @@ it("RestJsonHttpPrefixHeadersAreNotPresent:Request", async () => {
     expect(r.headers["x-foo"]).toBeDefined();
     expect(r.headers["x-foo"]).toBe("Foo");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2965,7 +2965,7 @@ it("RestJsonSupportsNaNFloatLabels:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/FloatHttpLabels/NaN/NaN");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2995,7 +2995,7 @@ it("RestJsonSupportsInfinityFloatLabels:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/FloatHttpLabels/Infinity/Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3025,7 +3025,7 @@ it("RestJsonSupportsNegativeInfinityFloatLabels:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/FloatHttpLabels/-Infinity/-Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3055,7 +3055,7 @@ it("RestJsonHttpRequestWithGreedyLabelInPath:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/HttpRequestWithGreedyLabelInPath/foo/hello%2Fescape/baz/there/guy");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3091,7 +3091,7 @@ it("RestJsonInputWithHeadersAndAllParams:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/HttpRequestWithLabels/string/1/2/3/4.1/5.1/true/2019-12-16T23%3A48%3A18Z");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3129,7 +3129,7 @@ it("RestJsonHttpRequestLabelEscaping:Request", async () => {
       "/HttpRequestWithLabels/%20%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9/1/2/3/4.1/5.1/true/2019-12-16T23%3A48%3A18Z"
     );
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3166,7 +3166,7 @@ it("RestJsonHttpRequestWithLabelsAndTimestampFormat:Request", async () => {
       "/HttpRequestWithLabelsAndTimestampFormat/1576540098/Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT/2019-12-16T23%3A48%3A18Z/2019-12-16T23%3A48%3A18Z/1576540098/Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT/2019-12-16T23%3A48%3A18Z"
     );
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3195,7 +3195,7 @@ it("RestJsonToleratesRegexCharsInSegments:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/ReDosLiteral/abc/(a+)+");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3433,14 +3433,14 @@ it("RestJsonInputAndOutputWithStringHeaders:Request", async () => {
     expect(r.headers["x-stringset"]).toBeDefined();
     expect(r.headers["x-stringset"]).toBe("a, b, c");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
 /**
  * Tests requests with string list header bindings that require quoting
  */
-it.skip("RestJsonInputAndOutputWithQuotedStringHeaders:Request", async () => {
+it("RestJsonInputAndOutputWithQuotedStringHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -3465,7 +3465,7 @@ it.skip("RestJsonInputAndOutputWithQuotedStringHeaders:Request", async () => {
     expect(r.headers["x-stringlist"]).toBeDefined();
     expect(r.headers["x-stringlist"]).toBe('"b,c", "\\"def\\"", a');
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3515,7 +3515,7 @@ it("RestJsonInputAndOutputWithNumericHeaders:Request", async () => {
     expect(r.headers["x-short"]).toBeDefined();
     expect(r.headers["x-short"]).toBe("123");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3553,7 +3553,7 @@ it("RestJsonInputAndOutputWithBooleanHeaders:Request", async () => {
     expect(r.headers["x-booleanlist"]).toBeDefined();
     expect(r.headers["x-booleanlist"]).toBe("true, false, true");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3585,7 +3585,7 @@ it("RestJsonInputAndOutputWithTimestampHeaders:Request", async () => {
     expect(r.headers["x-timestamplist"]).toBeDefined();
     expect(r.headers["x-timestamplist"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3620,7 +3620,7 @@ it("RestJsonInputAndOutputWithEnumHeaders:Request", async () => {
     expect(r.headers["x-enumlist"]).toBeDefined();
     expect(r.headers["x-enumlist"]).toBe("Foo, Bar, Baz");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3655,7 +3655,7 @@ it("RestJsonInputAndOutputWithIntEnumHeaders:Request", async () => {
     expect(r.headers["x-integerenumlist"]).toBeDefined();
     expect(r.headers["x-integerenumlist"]).toBe("1, 2, 3");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3690,7 +3690,7 @@ it("RestJsonSupportsNaNFloatHeaderInputs:Request", async () => {
     expect(r.headers["x-float"]).toBeDefined();
     expect(r.headers["x-float"]).toBe("NaN");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3725,7 +3725,7 @@ it("RestJsonSupportsInfinityFloatHeaderInputs:Request", async () => {
     expect(r.headers["x-float"]).toBeDefined();
     expect(r.headers["x-float"]).toBe("Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3760,7 +3760,7 @@ it("RestJsonSupportsNegativeInfinityFloatHeaderInputs:Request", async () => {
     expect(r.headers["x-float"]).toBeDefined();
     expect(r.headers["x-float"]).toBe("-Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3804,7 +3804,7 @@ it("RestJsonInputAndOutputWithStringHeaders:Response", async () => {
 /**
  * Tests responses with string list header bindings that require quoting
  */
-it.skip("RestJsonInputAndOutputWithQuotedStringHeaders:Response", async () => {
+it("RestJsonInputAndOutputWithQuotedStringHeaders:Response", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, {
@@ -6543,7 +6543,7 @@ it("MediaTypeHeaderInputBase64:Request", async () => {
     expect(r.headers["x-json"]).toBeDefined();
     expect(r.headers["x-json"]).toBe("dHJ1ZQ==");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -6605,7 +6605,7 @@ it("RestJsonNoInputAndNoOutput:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/NoInputAndNoOutput");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -6658,7 +6658,7 @@ it("RestJsonNoInputAndOutput:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/NoInputAndOutputOutput");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -6747,7 +6747,7 @@ it.skip("RestJsonNullAndEmptyHeaders:Request", async () => {
     expect(r.headers["x-b"]).toBeUndefined();
     expect(r.headers["x-c"]).toBeUndefined();
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -6776,7 +6776,7 @@ it("RestJsonOmitsNullQuery:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/OmitsNullSerializesEmptyString");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -6808,7 +6808,7 @@ it("RestJsonSerializesEmptyQueryValue:Request", async () => {
     const queryString = buildQueryString(r.query);
     expect(queryString).toContain("Empty=");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -6843,7 +6843,7 @@ it("RestJsonOmitsEmptyListQueryValues:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/OmitsSerializingEmptyLists");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -7853,7 +7853,7 @@ it("PostUnionWithJsonNameResponse3:Response", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_restJson1:Request", async () => {
+it("SDKAppliedContentEncoding_restJson1:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -7886,7 +7886,7 @@ it.skip("SDKAppliedContentEncoding_restJson1:Request", async () => {
  * request compression encoding from the HTTP binding.
  *
  */
-it.skip("SDKAppendedGzipAfterProvidedEncoding_restJson1:Request", async () => {
+it("SDKAppendedGzipAfterProvidedEncoding_restJson1:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -7910,7 +7910,7 @@ it.skip("SDKAppendedGzipAfterProvidedEncoding_restJson1:Request", async () => {
     expect(r.path).toBe("/requestcompression/putcontentwithencoding");
 
     expect(r.headers["content-encoding"]).toBeDefined();
-    expect(r.headers["content-encoding"]).toBe("custom, gzip");
+    expect(r.headers["content-encoding"].replaceAll(", ", ",")).toBe("custom, gzip".replaceAll(", ", ","));
   }
 });
 
@@ -7942,7 +7942,7 @@ it("RestJsonQueryIdempotencyTokenAutoFill:Request", async () => {
     const queryString = buildQueryString(r.query);
     expect(queryString).toContain("token=00000000-0000-4000-8000-000000000000");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -7974,7 +7974,7 @@ it("RestJsonQueryIdempotencyTokenAutoFillIsSet:Request", async () => {
     const queryString = buildQueryString(r.query);
     expect(queryString).toContain("token=00000000-0000-4000-8000-000000000000");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -8011,7 +8011,7 @@ it("RestJsonQueryParamsStringListMap:Request", async () => {
     expect(queryString).toContain("baz=bar");
     expect(queryString).toContain("baz=qux");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -8048,7 +8048,7 @@ it("RestJsonQueryPrecedence:Request", async () => {
     expect(queryString).toContain("bar=named");
     expect(queryString).toContain("qux=alsoFromMap");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -9263,7 +9263,7 @@ it("RestJsonStreamingTraitsWithNoBlobBody:Request", async () => {
     expect(r.headers["x-foo"]).toBeDefined();
     expect(r.headers["x-foo"]).toBe("Foo");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -9423,7 +9423,7 @@ it("RestJsonStreamingTraitsRequireLengthWithNoBlobBody:Request", async () => {
     expect(r.headers["x-foo"]).toBeDefined();
     expect(r.headers["x-foo"]).toBe("Foo");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -9613,7 +9613,7 @@ it("RestJsonHttpWithNoInput:Request", async () => {
     expect(r.headers["content-length"]).toBeUndefined();
     expect(r.headers["content-type"]).toBeUndefined();
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -9643,7 +9643,7 @@ it("RestJsonHttpWithNoModeledBody:Request", async () => {
     expect(r.headers["content-length"]).toBeUndefined();
     expect(r.headers["content-type"]).toBeUndefined();
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -9678,7 +9678,7 @@ it("RestJsonHttpWithHeaderMemberNoModeledBody:Request", async () => {
     expect(r.headers["x-amz-test-id"]).toBeDefined();
     expect(r.headers["x-amz-test-id"]).toBe("t-12345");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -9708,7 +9708,7 @@ it("RestJsonHttpWithEmptyBlobPayload:Request", async () => {
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/octet-stream");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -9910,7 +9910,7 @@ it("RestJsonTimestampFormatHeaders:Request", async () => {
     expect(r.headers["x-targethttpdate"]).toBeDefined();
     expect(r.headers["x-targethttpdate"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -9984,7 +9984,7 @@ it("RestJsonUnitInputAndOutput:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/UnitInputAndOutput");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -24,9 +24,11 @@ import {
   parseEpochTimestamp as __parseEpochTimestamp,
   parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   parseRfc7231DateTime as __parseRfc7231DateTime,
+  quoteHeader as __quoteHeader,
   resolvedPath as __resolvedPath,
   serializeDateTime as __serializeDateTime,
   splitEvery as __splitEvery,
+  splitHeader as __splitHeader,
   strictParseByte as __strictParseByte,
   strictParseDouble as __strictParseDouble,
   strictParseFloat as __strictParseFloat,
@@ -973,8 +975,8 @@ export const se_InputAndOutputWithHeadersCommand = async (
     ],
     [_xb_]: [() => isSerializableHeaderValue(input[_hTB]), () => input[_hTB]!.toString()],
     [_xb__]: [() => isSerializableHeaderValue(input[_hFB]), () => input[_hFB]!.toString()],
-    [_xs__]: [() => isSerializableHeaderValue(input[_hSL]), () => (input[_hSL]! || []).join(", ")],
-    [_xs___]: [() => isSerializableHeaderValue(input[_hSS]), () => (input[_hSS]! || []).join(", ")],
+    [_xs__]: [() => isSerializableHeaderValue(input[_hSL]), () => (input[_hSL]! || []).map(__quoteHeader).join(", ")],
+    [_xs___]: [() => isSerializableHeaderValue(input[_hSS]), () => (input[_hSS]! || []).map(__quoteHeader).join(", ")],
     [_xi_]: [
       () => isSerializableHeaderValue(input[_hIL]),
       () => (input[_hIL]! || []).map((_entry) => _entry.toString() as any).join(", "),
@@ -988,7 +990,7 @@ export const se_InputAndOutputWithHeadersCommand = async (
       () => (input[_hTL]! || []).map((_entry) => __dateToUtcString(_entry).toString() as any).join(", "),
     ],
     [_xe]: input[_hE]!,
-    [_xe_]: [() => isSerializableHeaderValue(input[_hEL]), () => (input[_hEL]! || []).join(", ")],
+    [_xe_]: [() => isSerializableHeaderValue(input[_hEL]), () => (input[_hEL]! || []).map(__quoteHeader).join(", ")],
   });
   b.bp("/InputAndOutputWithHeaders");
   let body: any;
@@ -1059,7 +1061,7 @@ export const se_NullAndEmptyHeadersClientCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     [_xa]: input[_a]!,
     [_xb____]: input[_b_]!,
-    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).join(", ")],
+    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).map(__quoteHeader).join(", ")],
   });
   b.bp("/NullAndEmptyHeadersClient");
   let body: any;
@@ -1078,7 +1080,7 @@ export const se_NullAndEmptyHeadersServerCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     [_xa]: input[_a]!,
     [_xb____]: input[_b_]!,
-    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).join(", ")],
+    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).map(__quoteHeader).join(", ")],
   });
   b.bp("/NullAndEmptyHeadersServer");
   let body: any;
@@ -2102,8 +2104,10 @@ export const de_HttpPayloadWithUnionCommand = async (
   const contents: any = map({
     $metadata: deserializeMetadata(output),
   });
-  const data: Record<string, any> | undefined = __expectUnion(await parseBody(output.body, context));
-  contents.nested = de_UnionPayload(data, context);
+  const data: Record<string, any> | undefined = await parseBody(output.body, context);
+  if (Object.keys(data ?? {}).length) {
+    contents.nested = __expectUnion(de_UnionPayload(data, context));
+  }
   return contents;
 };
 
@@ -2337,19 +2341,19 @@ export const de_InputAndOutputWithHeadersCommand = async (
     [_hFB]: [() => void 0 !== output.headers[_xb__], () => __parseBoolean(output.headers[_xb__])],
     [_hSL]: [
       () => void 0 !== output.headers[_xs__],
-      () => (output.headers[_xs__] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xs__] || "").map((_entry) => _entry.trim() as any),
     ],
     [_hSS]: [
       () => void 0 !== output.headers[_xs___],
-      () => (output.headers[_xs___] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xs___] || "").map((_entry) => _entry.trim() as any),
     ],
     [_hIL]: [
       () => void 0 !== output.headers[_xi_],
-      () => (output.headers[_xi_] || "").split(",").map((_entry) => __strictParseInt32(_entry.trim()) as any),
+      () => __splitHeader(output.headers[_xi_] || "").map((_entry) => __strictParseInt32(_entry.trim()) as any),
     ],
     [_hBL]: [
       () => void 0 !== output.headers[_xb___],
-      () => (output.headers[_xb___] || "").split(",").map((_entry) => __parseBoolean(_entry.trim()) as any),
+      () => __splitHeader(output.headers[_xb___] || "").map((_entry) => __parseBoolean(_entry.trim()) as any),
     ],
     [_hTL]: [
       () => void 0 !== output.headers[_xt],
@@ -2361,7 +2365,7 @@ export const de_InputAndOutputWithHeadersCommand = async (
     [_hE]: [, output.headers[_xe]],
     [_hEL]: [
       () => void 0 !== output.headers[_xe_],
-      () => (output.headers[_xe_] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xe_] || "").map((_entry) => _entry.trim() as any),
     ],
   });
   await collectBody(output.body, context);
@@ -2445,7 +2449,7 @@ export const de_NullAndEmptyHeadersClientCommand = async (
     [_b_]: [, output.headers[_xb____]],
     [_c]: [
       () => void 0 !== output.headers[_xc],
-      () => (output.headers[_xc] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xc] || "").map((_entry) => _entry.trim() as any),
     ],
   });
   await collectBody(output.body, context);
@@ -2468,7 +2472,7 @@ export const de_NullAndEmptyHeadersServerCommand = async (
     [_b_]: [, output.headers[_xb____]],
     [_c]: [
       () => void 0 !== output.headers[_xc],
-      () => (output.headers[_xc] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xc] || "").map((_entry) => _entry.trim() as any),
     ],
   });
   await collectBody(output.body, context);

--- a/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
@@ -347,7 +347,7 @@ it("AllQueryStringTypes:Request", async () => {
     expect(queryString).toContain("IntegerEnumList=1");
     expect(queryString).toContain("IntegerEnumList=2");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -383,7 +383,7 @@ it("RestXmlQueryStringMap:Request", async () => {
     expect(queryString).toContain("QueryParamsStringKeyA=Foo");
     expect(queryString).toContain("QueryParamsStringKeyB=Bar");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -415,7 +415,7 @@ it("RestXmlQueryStringEscaping:Request", async () => {
     const queryString = buildQueryString(r.query);
     expect(queryString).toContain("String=%20%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -449,7 +449,7 @@ it("RestXmlSupportsNaNFloatQueryValues:Request", async () => {
     expect(queryString).toContain("Float=NaN");
     expect(queryString).toContain("Double=NaN");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -483,7 +483,7 @@ it("RestXmlSupportsInfinityFloatQueryValues:Request", async () => {
     expect(queryString).toContain("Float=Infinity");
     expect(queryString).toContain("Double=Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -517,7 +517,7 @@ it("RestXmlSupportsNegativeInfinityFloatQueryValues:Request", async () => {
     expect(queryString).toContain("Float=-Infinity");
     expect(queryString).toContain("Double=-Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -551,7 +551,7 @@ it("RestXmlZeroAndFalseQueryValues:Request", async () => {
     expect(queryString).toContain("Integer=0");
     expect(queryString).toContain("Boolean=false");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -665,7 +665,7 @@ it("ConstantAndVariableQueryStringMissingOneValue:Request", async () => {
     expect(queryString).toContain("foo=bar");
     expect(queryString).toContain("baz=bam");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -700,7 +700,7 @@ it("ConstantAndVariableQueryStringAllValues:Request", async () => {
     expect(queryString).toContain("baz=bam");
     expect(queryString).toContain("maybeSet=yes");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -733,7 +733,7 @@ it("ConstantQueryString:Request", async () => {
     expect(queryString).toContain("foo=bar");
     expect(queryString).toContain("hello");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -842,7 +842,7 @@ it("EmptyInputAndEmptyOutput:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/EmptyInputAndEmptyOutput");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -896,7 +896,7 @@ it("RestXmlEndpointTrait:Request", async () => {
     expect(r.headers["host"]).toBeDefined();
     expect(r.headers["host"]).toBe("foo.example.com");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -936,7 +936,7 @@ it("RestXmlEndpointTraitWithHostLabelAndHttpBinding:Request", async () => {
     expect(r.headers["host"]).toBeDefined();
     expect(r.headers["host"]).toBe("bar.example.com");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -1550,7 +1550,7 @@ it("HttpPayloadTraitsWithNoBlobBody:Request", async () => {
     expect(r.headers["x-foo"]).toBeDefined();
     expect(r.headers["x-foo"]).toBe("Foo");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -1923,7 +1923,7 @@ it("RestXmlHttpPayloadWithUnion:Request", async () => {
 /**
  * No payload is sent if the union has no value.
  */
-it.skip("RestXmlHttpPayloadWithUnsetUnion:Request", async () => {
+it("RestXmlHttpPayloadWithUnsetUnion:Request", async () => {
   const client = new RestXmlProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -1943,7 +1943,7 @@ it.skip("RestXmlHttpPayloadWithUnsetUnion:Request", async () => {
     expect(r.method).toBe("PUT");
     expect(r.path).toBe("/HttpPayloadWithUnion");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -1992,7 +1992,7 @@ it("RestXmlHttpPayloadWithUnion:Response", async () => {
 /**
  * No payload is sent if the union has no value.
  */
-it.skip("RestXmlHttpPayloadWithUnsetUnion:Response", async () => {
+it("RestXmlHttpPayloadWithUnsetUnion:Response", async () => {
   const client = new RestXmlProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
@@ -2299,7 +2299,7 @@ it("HttpPrefixHeadersArePresent:Request", async () => {
     expect(r.headers["x-foo-def"]).toBeDefined();
     expect(r.headers["x-foo-def"]).toBe("Def value");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2332,7 +2332,7 @@ it("HttpPrefixHeadersAreNotPresent:Request", async () => {
     expect(r.headers["x-foo"]).toBeDefined();
     expect(r.headers["x-foo"]).toBe("Foo");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2445,7 +2445,7 @@ it("RestXmlSupportsNaNFloatLabels:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/FloatHttpLabels/NaN/NaN");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2475,7 +2475,7 @@ it("RestXmlSupportsInfinityFloatLabels:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/FloatHttpLabels/Infinity/Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2505,7 +2505,7 @@ it("RestXmlSupportsNegativeInfinityFloatLabels:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/FloatHttpLabels/-Infinity/-Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2535,7 +2535,7 @@ it("HttpRequestWithGreedyLabelInPath:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/HttpRequestWithGreedyLabelInPath/foo/hello/baz/there/guy");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2571,7 +2571,7 @@ it("InputWithHeadersAndAllParams:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/HttpRequestWithLabels/string/1/2/3/4.1/5.1/true/2019-12-16T23%3A48%3A18Z");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2609,7 +2609,7 @@ it("HttpRequestLabelEscaping:Request", async () => {
       "/HttpRequestWithLabels/%20%25%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%F0%9F%98%B9/1/2/3/4.1/5.1/true/2019-12-16T23%3A48%3A18Z"
     );
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2646,7 +2646,7 @@ it("HttpRequestWithLabelsAndTimestampFormat:Request", async () => {
       "/HttpRequestWithLabelsAndTimestampFormat/1576540098/Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT/2019-12-16T23%3A48%3A18Z/2019-12-16T23%3A48%3A18Z/1576540098/Mon%2C%2016%20Dec%202019%2023%3A48%3A18%20GMT/2019-12-16T23%3A48%3A18Z"
     );
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2828,7 +2828,7 @@ it("InputAndOutputWithStringHeaders:Request", async () => {
     expect(r.headers["x-stringset"]).toBeDefined();
     expect(r.headers["x-stringset"]).toBe("a, b, c");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2878,7 +2878,7 @@ it("InputAndOutputWithNumericHeaders:Request", async () => {
     expect(r.headers["x-short"]).toBeDefined();
     expect(r.headers["x-short"]).toBe("123");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2916,7 +2916,7 @@ it("InputAndOutputWithBooleanHeaders:Request", async () => {
     expect(r.headers["x-booleanlist"]).toBeDefined();
     expect(r.headers["x-booleanlist"]).toBe("true, false, true");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2948,7 +2948,7 @@ it("InputAndOutputWithTimestampHeaders:Request", async () => {
     expect(r.headers["x-timestamplist"]).toBeDefined();
     expect(r.headers["x-timestamplist"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -2983,7 +2983,7 @@ it("InputAndOutputWithEnumHeaders:Request", async () => {
     expect(r.headers["x-enumlist"]).toBeDefined();
     expect(r.headers["x-enumlist"]).toBe("Foo, Bar, Baz");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3018,7 +3018,7 @@ it("RestXmlSupportsNaNFloatHeaderInputs:Request", async () => {
     expect(r.headers["x-float"]).toBeDefined();
     expect(r.headers["x-float"]).toBe("NaN");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3053,7 +3053,7 @@ it("RestXmlSupportsInfinityFloatHeaderInputs:Request", async () => {
     expect(r.headers["x-float"]).toBeDefined();
     expect(r.headers["x-float"]).toBe("Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3088,7 +3088,7 @@ it("RestXmlSupportsNegativeInfinityFloatHeaderInputs:Request", async () => {
     expect(r.headers["x-float"]).toBeDefined();
     expect(r.headers["x-float"]).toBe("-Infinity");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3657,7 +3657,7 @@ it("NoInputAndNoOutput:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/NoInputAndNoOutput");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3706,7 +3706,7 @@ it("NoInputAndOutput:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/NoInputAndOutputOutput");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3763,7 +3763,7 @@ it.skip("NullAndEmptyHeaders:Request", async () => {
     expect(r.headers["x-b"]).toBeUndefined();
     expect(r.headers["x-c"]).toBeUndefined();
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3792,7 +3792,7 @@ it("RestXmlOmitsNullQuery:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/OmitsNullSerializesEmptyString");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3824,14 +3824,14 @@ it("RestXmlSerializesEmptyString:Request", async () => {
     const queryString = buildQueryString(r.query);
     expect(queryString).toContain("Empty=");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_restXml:Request", async () => {
+it("SDKAppliedContentEncoding_restXml:Request", async () => {
   const client = new RestXmlProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -3864,7 +3864,7 @@ it.skip("SDKAppliedContentEncoding_restXml:Request", async () => {
  * request compression encoding from the HTTP binding.
  *
  */
-it.skip("SDKAppendedGzipAfterProvidedEncoding_restXml:Request", async () => {
+it("SDKAppendedGzipAfterProvidedEncoding_restXml:Request", async () => {
   const client = new RestXmlProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -3888,7 +3888,7 @@ it.skip("SDKAppendedGzipAfterProvidedEncoding_restXml:Request", async () => {
     expect(r.path).toBe("/requestcompression/putcontentwithencoding");
 
     expect(r.headers["content-encoding"]).toBeDefined();
-    expect(r.headers["content-encoding"]).toBe("custom, gzip");
+    expect(r.headers["content-encoding"].replaceAll(", ", ",")).toBe("custom, gzip".replaceAll(", ", ","));
   }
 });
 
@@ -3920,7 +3920,7 @@ it("QueryIdempotencyTokenAutoFill:Request", async () => {
     const queryString = buildQueryString(r.query);
     expect(queryString).toContain("token=00000000-0000-4000-8000-000000000000");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3952,7 +3952,7 @@ it("QueryIdempotencyTokenAutoFillIsSet:Request", async () => {
     const queryString = buildQueryString(r.query);
     expect(queryString).toContain("token=00000000-0000-4000-8000-000000000000");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -3989,7 +3989,7 @@ it("RestXmlQueryParamsStringListMap:Request", async () => {
     expect(queryString).toContain("baz=bar");
     expect(queryString).toContain("baz=qux");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -4026,7 +4026,7 @@ it("RestXmlQueryPrecedence:Request", async () => {
     expect(queryString).toContain("bar=named");
     expect(queryString).toContain("qux=alsoFromMap");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 
@@ -4921,7 +4921,7 @@ it("TimestampFormatHeaders:Request", async () => {
     expect(r.headers["x-targethttpdate"]).toBeDefined();
     expect(r.headers["x-targethttpdate"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 

--- a/private/aws-protocoltests-smithy-rpcv2-cbor/test/functional/rpcv2cbor.spec.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor/test/functional/rpcv2cbor.spec.ts
@@ -698,7 +698,7 @@ it("no_input:Request", async () => {
     expect(r.headers["smithy-protocol"]).toBeDefined();
     expect(r.headers["smithy-protocol"]).toBe("rpc-v2-cbor");
 
-    expect(r.body).toBeFalsy();
+    expect(!r.body || r.body === `{}`).toBeTruthy();
   }
 });
 

--- a/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
@@ -37,9 +37,11 @@ import {
   parseEpochTimestamp as __parseEpochTimestamp,
   parseRfc3339DateTime as __parseRfc3339DateTime,
   parseRfc7231DateTime as __parseRfc7231DateTime,
+  quoteHeader as __quoteHeader,
   serializeDateTime as __serializeDateTime,
   serializeFloat as __serializeFloat,
   splitEvery as __splitEvery,
+  splitHeader as __splitHeader,
   strictParseByte as __strictParseByte,
   strictParseDouble as __strictParseDouble,
   strictParseFloat as __strictParseFloat,
@@ -1111,8 +1113,10 @@ export const deserializeHttpPayloadWithUnionRequest = async (
     }
   }
   const contents: any = map({});
-  const data: Record<string, any> | undefined = __expectUnion(await parseBody(output.body, context));
-  contents.nested = de_UnionPayload(data, context);
+  const data: Record<string, any> | undefined = await parseBody(output.body, context);
+  if (Object.keys(data ?? {}).length) {
+    contents.nested = __expectUnion(de_UnionPayload(data, context));
+  }
   return contents;
 };
 
@@ -1468,19 +1472,19 @@ export const deserializeInputAndOutputWithHeadersRequest = async (
     [_hFB]: [() => void 0 !== output.headers[_xb__], () => __parseBoolean(output.headers[_xb__])],
     [_hSL]: [
       () => void 0 !== output.headers[_xs__],
-      () => (output.headers[_xs__] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xs__] || "").map((_entry) => _entry.trim() as any),
     ],
     [_hSS]: [
       () => void 0 !== output.headers[_xs___],
-      () => (output.headers[_xs___] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xs___] || "").map((_entry) => _entry.trim() as any),
     ],
     [_hIL]: [
       () => void 0 !== output.headers[_xi_],
-      () => (output.headers[_xi_] || "").split(",").map((_entry) => __strictParseInt32(_entry.trim()) as any),
+      () => __splitHeader(output.headers[_xi_] || "").map((_entry) => __strictParseInt32(_entry.trim()) as any),
     ],
     [_hBL]: [
       () => void 0 !== output.headers[_xb___],
-      () => (output.headers[_xb___] || "").split(",").map((_entry) => __parseBoolean(_entry.trim()) as any),
+      () => __splitHeader(output.headers[_xb___] || "").map((_entry) => __parseBoolean(_entry.trim()) as any),
     ],
     [_hTL]: [
       () => void 0 !== output.headers[_xt],
@@ -1492,12 +1496,12 @@ export const deserializeInputAndOutputWithHeadersRequest = async (
     [_hE]: [, output.headers[_xe]],
     [_hEL]: [
       () => void 0 !== output.headers[_xe_],
-      () => (output.headers[_xe_] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xe_] || "").map((_entry) => _entry.trim() as any),
     ],
     [_hIE]: [() => void 0 !== output.headers[_xi__], () => __strictParseInt32(output.headers[_xi__])],
     [_hIEL]: [
       () => void 0 !== output.headers[_xi___],
-      () => (output.headers[_xi___] || "").split(",").map((_entry) => __strictParseInt32(_entry.trim()) as any),
+      () => __splitHeader(output.headers[_xi___] || "").map((_entry) => __strictParseInt32(_entry.trim()) as any),
     ],
   });
   await collectBody(output.body, context);
@@ -2942,7 +2946,7 @@ export const deserializeNullAndEmptyHeadersClientRequest = async (
     [_b_]: [, output.headers[_xb____]],
     [_c]: [
       () => void 0 !== output.headers[_xc],
-      () => (output.headers[_xc] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xc] || "").map((_entry) => _entry.trim() as any),
     ],
   });
   await collectBody(output.body, context);
@@ -2974,7 +2978,7 @@ export const deserializeNullAndEmptyHeadersServerRequest = async (
     [_b_]: [, output.headers[_xb____]],
     [_c]: [
       () => void 0 !== output.headers[_xc],
-      () => (output.headers[_xc] || "").split(",").map((_entry) => _entry.trim() as any),
+      () => __splitHeader(output.headers[_xc] || "").map((_entry) => _entry.trim() as any),
     ],
   });
   await collectBody(output.body, context);
@@ -4959,8 +4963,8 @@ export const serializeInputAndOutputWithHeadersResponse = async (
     ],
     [_xb_]: [() => isSerializableHeaderValue(input[_hTB]), () => input[_hTB]!.toString()],
     [_xb__]: [() => isSerializableHeaderValue(input[_hFB]), () => input[_hFB]!.toString()],
-    [_xs__]: [() => isSerializableHeaderValue(input[_hSL]), () => (input[_hSL]! || []).join(", ")],
-    [_xs___]: [() => isSerializableHeaderValue(input[_hSS]), () => (input[_hSS]! || []).join(", ")],
+    [_xs__]: [() => isSerializableHeaderValue(input[_hSL]), () => (input[_hSL]! || []).map(__quoteHeader).join(", ")],
+    [_xs___]: [() => isSerializableHeaderValue(input[_hSS]), () => (input[_hSS]! || []).map(__quoteHeader).join(", ")],
     [_xi_]: [
       () => isSerializableHeaderValue(input[_hIL]),
       () => (input[_hIL]! || []).map((_entry) => _entry.toString() as any).join(", "),
@@ -4974,7 +4978,7 @@ export const serializeInputAndOutputWithHeadersResponse = async (
       () => (input[_hTL]! || []).map((_entry) => __dateToUtcString(_entry).toString() as any).join(", "),
     ],
     [_xe]: input[_hE]!,
-    [_xe_]: [() => isSerializableHeaderValue(input[_hEL]), () => (input[_hEL]! || []).join(", ")],
+    [_xe_]: [() => isSerializableHeaderValue(input[_hEL]), () => (input[_hEL]! || []).map(__quoteHeader).join(", ")],
     [_xi__]: [() => isSerializableHeaderValue(input[_hIE]), () => input[_hIE]!.toString()],
     [_xi___]: [
       () => isSerializableHeaderValue(input[_hIEL]),
@@ -6551,7 +6555,7 @@ export const serializeNullAndEmptyHeadersClientResponse = async (
     "content-type": "application/json",
     [_xa]: input[_a]!,
     [_xb____]: input[_b_]!,
-    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).join(", ")],
+    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).map(__quoteHeader).join(", ")],
   });
   let body: any;
   body = "{}";
@@ -6591,7 +6595,7 @@ export const serializeNullAndEmptyHeadersServerResponse = async (
     "content-type": "application/json",
     [_xa]: input[_a]!,
     [_xb____]: input[_b_]!,
-    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).join(", ")],
+    [_xc]: [() => isSerializableHeaderValue(input[_c]), () => (input[_c]! || []).map(__quoteHeader).join(", ")],
   });
   let body: any;
   body = "{}";

--- a/private/aws-restjson-server/test/functional/restjson1.spec.ts
+++ b/private/aws-restjson-server/test/functional/restjson1.spec.ts
@@ -972,7 +972,7 @@ it("RestJsonConstantQueryString:ServerRequest", async () => {
 /**
  * A server should ignore parameters added to the content type
  */
-it.skip("RestJsonMustSupportParametersInContentType:ServerRequest", async () => {
+it("RestJsonMustSupportParametersInContentType:ServerRequest", async () => {
   const testFunction = jest.fn();
   testFunction.mockReturnValue(Promise.resolve({}));
   const testService: Partial<RestJsonService<{}>> = {
@@ -2823,7 +2823,7 @@ it("RestJsonHttpPayloadTraitsWithNoBlobBody:ServerResponse", async () => {
   expect(r.headers["x-foo"]).toBeDefined();
   expect(r.headers["x-foo"]).toBe("Foo");
 
-  expect(r.body).toBeFalsy();
+  expect(!r.body || r.body === `{}`).toBeTruthy();
 });
 
 /**
@@ -3089,7 +3089,7 @@ it("RestJsonHttpPayloadWithUnion:ServerRequest", async () => {
 /**
  * No payload is sent if the union has no value.
  */
-it.skip("RestJsonHttpPayloadWithUnsetUnion:ServerRequest", async () => {
+it("RestJsonHttpPayloadWithUnsetUnion:ServerRequest", async () => {
   const testFunction = jest.fn();
   testFunction.mockReturnValue(Promise.resolve({}));
   const testService: Partial<RestJsonService<{}>> = {
@@ -3181,7 +3181,7 @@ it("RestJsonHttpPayloadWithUnion:ServerResponse", async () => {
 /**
  * No payload is sent if the union has no value.
  */
-it.skip("RestJsonHttpPayloadWithUnsetUnion:ServerResponse", async () => {
+it("RestJsonHttpPayloadWithUnsetUnion:ServerResponse", async () => {
   class TestService implements Partial<RestJsonService<{}>> {
     HttpPayloadWithUnion(input: any, ctx: {}): Promise<HttpPayloadWithUnionServerOutput> {
       const response = {} as any;
@@ -3225,7 +3225,7 @@ it.skip("RestJsonHttpPayloadWithUnsetUnion:ServerResponse", async () => {
   expect(r.headers["content-length"]).toBeDefined();
   expect(r.headers["content-length"]).toBe("0");
 
-  expect(r.body).toBeFalsy();
+  expect(!r.body || r.body === `{}`).toBeTruthy();
 });
 
 /**
@@ -4183,7 +4183,7 @@ it("RestJsonInputAndOutputWithStringHeaders:ServerRequest", async () => {
 /**
  * Tests requests with string list header bindings that require quoting
  */
-it.skip("RestJsonInputAndOutputWithQuotedStringHeaders:ServerRequest", async () => {
+it("RestJsonInputAndOutputWithQuotedStringHeaders:ServerRequest", async () => {
   const testFunction = jest.fn();
   testFunction.mockReturnValue(Promise.resolve({}));
   const testService: Partial<RestJsonService<{}>> = {
@@ -4661,7 +4661,7 @@ it("RestJsonInputAndOutputWithStringHeaders:ServerResponse", async () => {
 /**
  * Tests responses with string list header bindings that require quoting
  */
-it.skip("RestJsonInputAndOutputWithQuotedStringHeaders:ServerResponse", async () => {
+it("RestJsonInputAndOutputWithQuotedStringHeaders:ServerResponse", async () => {
   class TestService implements Partial<RestJsonService<{}>> {
     InputAndOutputWithHeaders(input: any, ctx: {}): Promise<InputAndOutputWithHeadersServerOutput> {
       const response = {
@@ -27727,7 +27727,7 @@ it("RestJsonNoInputAndNoOutput:ServerResponse", async () => {
 
   expect(r.statusCode).toBe(200);
 
-  expect(r.body).toBeFalsy();
+  expect(!r.body || r.body === `{}`).toBeTruthy();
 });
 
 /**
@@ -28798,7 +28798,7 @@ it("PostUnionWithJsonNameResponse3:ServerResponse", async () => {
 /**
  * Compression algorithm encoding is appended to the Content-Encoding header.
  */
-it.skip("SDKAppliedContentEncoding_restJson1:ServerRequest", async () => {
+it("SDKAppliedContentEncoding_restJson1:ServerRequest", async () => {
   const testFunction = jest.fn();
   testFunction.mockReturnValue(Promise.resolve({}));
   const testService: Partial<RestJsonService<{}>> = {
@@ -28844,7 +28844,7 @@ it.skip("SDKAppliedContentEncoding_restJson1:ServerRequest", async () => {
  * request compression encoding from the HTTP binding.
  *
  */
-it.skip("SDKAppendedGzipAfterProvidedEncoding_restJson1:ServerRequest", async () => {
+it("SDKAppendedGzipAfterProvidedEncoding_restJson1:ServerRequest", async () => {
   const testFunction = jest.fn();
   testFunction.mockReturnValue(Promise.resolve({}));
   const testService: Partial<RestJsonService<{}>> = {
@@ -30579,7 +30579,7 @@ it("RestJsonStreamingTraitsWithNoBlobBody:ServerResponse", async () => {
   expect(r.headers["x-foo"]).toBeDefined();
   expect(r.headers["x-foo"]).toBe("Foo");
 
-  expect(r.body).toBeFalsy();
+  expect(!r.body || r.body === `{}`).toBeTruthy();
 });
 
 /**
@@ -31422,7 +31422,7 @@ it("RestJsonUnitInputAndOutputNoOutput:ServerResponse", async () => {
 
   expect(r.statusCode).toBe(200);
 
-  expect(r.body).toBeFalsy();
+  expect(!r.body || r.body === `{}`).toBeTruthy();
 });
 
 /**


### PR DESCRIPTION
closes https://github.com/aws/aws-sdk-js-v3/issues/6246

re-enable some previously skipped protocol tests

list of discovered fixes required:
- https://github.com/smithy-lang/smithy-typescript/pull/1416
- https://github.com/smithy-lang/smithy-typescript/pull/1417