### PR TITLE
chore: update stale-issue bot

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   cleanup:
+    permissions:
+      issues: write
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v3
+    - uses: aws-actions/stale-issue-cleanup@v6
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -18,7 +18,6 @@ jobs:
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category
-        ancient-issue-message: Greetings! We’re closing this issue because it has been open a long time and hasn’t been updated in a while and may not be getting the attention it deserves. We encourage you to check if this is still an issue in the latest release and if you find that this is still a problem, please feel free to comment or open a new issue.
         stale-issue-message: This issue has not received a response in 1 week. If you still think there is a problem, please leave a comment to avoid the issue from automatically closing.
         stale-pr-message: This PR has not received a response in 1 week. If you still think there is a problem, please leave a comment to avoid the PR from automatically closing.
         # These labels are required
@@ -35,7 +34,6 @@ jobs:
         # Issue timing
         days-before-stale: 10
         days-before-close: 4
-        days-before-ancient: 365
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is


### PR DESCRIPTION
Version bump for [stale-issue-cleanup](https://github.com/aws-actions/stale-issue-cleanup) and minor changes.
- [add permissions to stale_issues.yml](https://github.com/aws/aws-sdk-js-v3/commit/dfaae9897be484acbc115aa4984d48dfac30f9c8)
- [remove ancient-issue bot](https://github.com/aws/aws-sdk-js-v3/commit/dfd7e8c8c9a70c8cafc1177a447b76a98d2133f4)
- [bump stale-issue-cleanup to v6](https://github.com/aws/aws-sdk-js-v3/commit/6b971cbd8231f95a54cf08c4ced01054b7da4361)