### PR TITLE
Add missing generic parameter to ReadableStream type

### DIFF
--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -26,7 +26,7 @@ declare global {
   /**
    * @public
    */
-  export interface ReadableStream {}
+  export interface ReadableStream<R = any> {}
   /**
    * @public
    */


### PR DESCRIPTION
This was added to the upstream dom typings in the Nov 2018 update.

ref:
https://github.com/microsoft/TypeScript/commit/b830ef82147e9448bd63df17006a086e937feddb 
https://github.com/microsoft/TypeScript/pull/28343
https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/541

### Issue
n/a

### Description
This updates the `ReadableStream` type to match the upstream `dom.d.ts` from which it was mirrored in the first place.

This is needed because otherwise it can result in errors like these:

```text
node_modules/form-data-encoder/lib/index.d.ts:30:15 - error TS2315: Type 'ReadableStream' is not generic.

30     stream(): ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>;
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/form-data-encoder/lib/index.d.ts:30
```

### Testing
I tested this by making the change in my `node_modules` folder and building and testing our project.

### Additional context
Add any other context about the PR here.

### Checklist
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
