### PR TITLE
fix(credentials): used selected auth scheme identity instead of calling credentials provider

### DIFF
--- a/packages/middleware-user-agent/src/check-features.spec.ts
+++ b/packages/middleware-user-agent/src/check-features.spec.ts
@@ -1,0 +1,30 @@
+import { AwsHandlerExecutionContext } from "@aws-sdk/types";
+
+import { checkFeatures } from "./check-features";
+
+describe(checkFeatures.name, () => {
+  it("should not call the credentials provider to retrieve the identity", async () => {
+    const config = {
+      credentials: jest.fn(),
+    };
+
+    const context = {
+      __smithy_context: {
+        selectedHttpAuthScheme: {
+          identity: {
+            accountId: "123456789012",
+            $source: {},
+          },
+        },
+      },
+    } as AwsHandlerExecutionContext;
+
+    await checkFeatures(context, config, {
+      request: undefined,
+      input: undefined,
+    });
+
+    expect(config.credentials).not.toHaveBeenCalled();
+    expect(context.__aws_sdk_context?.features?.RESOLVED_ACCOUNT_ID).toBe("T");
+  });
+});

--- a/packages/middleware-user-agent/src/check-features.spec.ts
+++ b/packages/middleware-user-agent/src/check-features.spec.ts
@@ -27,4 +27,8 @@ describe(checkFeatures.name, () => {
     expect(config.credentials).not.toHaveBeenCalled();
     expect(context.__aws_sdk_context?.features?.RESOLVED_ACCOUNT_ID).toBe("T");
   });
+
+  it("should not throw an error if no fields are present", async () => {
+    await checkFeatures({}, {}, {} as any);
+  });
 });

--- a/packages/middleware-user-agent/src/check-features.ts
+++ b/packages/middleware-user-agent/src/check-features.ts
@@ -42,20 +42,16 @@ export async function checkFeatures(
     }
   }
 
-  if (typeof config.credentials === "function") {
-    try {
-      const credentials: AttributedAwsCredentialIdentity = await config.credentials?.();
-      if (credentials.accountId) {
-        setFeature(context, "RESOLVED_ACCOUNT_ID", "T");
-      }
-      for (const [key, value] of Object.entries(credentials.$source ?? {})) {
-        setFeature(context, key as keyof AwsSdkCredentialsFeatures, value);
-      }
-    } catch (e: unknown) {
-      // Sometimes config.credentials is a function but only throws
-      // as a way of informing users that something is missing.
-      // That error and any other credential retrieval errors are
-      // not relevant for feature-checking and should be ignored.
+  // TODO: later version of @smithy/types has explicit typing for this.
+  const identity = (context.__smithy_context?.selectedHttpAuthScheme as any)?.identity;
+
+  if ((identity as AttributedAwsCredentialIdentity)?.$source) {
+    const credentials = identity as AttributedAwsCredentialIdentity;
+    if (credentials.accountId) {
+      setFeature(context, "RESOLVED_ACCOUNT_ID", "T");
+    }
+    for (const [key, value] of Object.entries(credentials.$source ?? {})) {
+      setFeature(context, key as keyof AwsSdkCredentialsFeatures, value);
     }
   }
 }


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6553

### Description
Avoid calling the credential provider in the user agent middleware. This causes an endless loop if the credential provider involves calling an SDK client operation with the same middleware attached.

### Testing
New unit test