### PR TITLE
fix(lib-dynamodb): missing @aws-sdk/core dependency in lib-dynamodb

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -27,6 +27,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/util-dynamodb": "*",
+    "@aws-sdk/core": "*",
     "@smithy/core": "^2.4.8",
     "@smithy/smithy-client": "^3.4.0",
     "@smithy/types": "^3.5.0",

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -26,8 +26,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/util-dynamodb": "*",
     "@aws-sdk/core": "*",
+    "@aws-sdk/util-dynamodb": "*",
     "@smithy/core": "^2.4.8",
     "@smithy/smithy-client": "^3.4.0",
     "@smithy/types": "^3.5.0",


### PR DESCRIPTION
### Issue
#6549

### Description
Changes added in dfda129  introduced a new direct dependency on `@aws-sdk/core` but it's not added in package.json. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
