### PR TITLE
fix(client-elastic-beanstalk): update DescribeEnvironmentHealthResult…

### DIFF
--- a/clients/client-elastic-beanstalk/src/models/models_0.ts
+++ b/clients/client-elastic-beanstalk/src/models/models_0.ts
@@ -2992,7 +2992,7 @@ export interface DescribeEnvironmentHealthResult {
    *         <code>Updating</code>, <code>Terminating</code>, or <code>Terminated</code>.</p>
    * @public
    */
-  Status?: EnvironmentHealth;
+  Status?: EnvironmentStatus;
 
   /**
    * <p>The <a href="https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html">health color</a> of the


### PR DESCRIPTION
….Status with the correct type

### Issue
#6567

### Description
Update DescribeEnvironmentHealthResult.Status with the correct type.

### Testing
I don’t think testing is needed for this PR because it only changes the type of an interface property.

### Additional context
X

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
