### PR TITLE
chore(middleware-sdk-s3): add status code 400 for S3 region redirects

### DIFF
--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
@@ -38,7 +38,7 @@ export function regionRedirectMiddleware(clientConfig: PreviouslyResolved): Init
         if (
           clientConfig.followRegionRedirects &&
           // err.name === "PermanentRedirect" && --> removing the error name check, as that allows for HEAD operations (which have the 301 status code, but not the same error name) to be covered for region redirection as well
-          err?.$metadata?.httpStatusCode === 301
+          (err?.$metadata?.httpStatusCode === 301 || err?.$metadata?.httpStatusCode === 400)
         ) {
           try {
             const actualRegion = err.$response.headers["x-amz-bucket-region"];


### PR DESCRIPTION
### Issue
Internal JS-5479

### Description
Add status code 400 (in addition to 301) to also redirect regions for S3, if `followRegionRedirects` flag is set. 

### Testing
- [ ] unit test
```console

 PASS  src/validate-bucket-name.spec.ts (8.169 s)
 PASS  src/region-redirect-middleware.spec.ts (8.441 s)
 PASS  src/s3-express/functions/s3ExpressMiddleware.spec.ts
 PASS  src/s3-express/classes/S3ExpressIdentityCacheEntry.spec.ts
 PASS  src/s3-express/classes/S3ExpressIdentityCache.spec.ts (8.34 s)
 PASS  src/s3-express/classes/SignatureV4S3Express.spec.ts (8.549 s)

Test Suites: 9 passed, 9 total
Tests:       24 passed, 24 total
Snapshots:   0 total
Time:        8.999 s, estimated 10 s
Ran all test suites.
Done in 9.52s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
