### PR TITLE
test(scripts): skip preview legacy:e2e tests if client is not found

### DIFF
--- a/tests/e2e-legacy/preview.mjs
+++ b/tests/e2e-legacy/preview.mjs
@@ -11,22 +11,24 @@ const __dirname = getDirName();
 const execOptions = { ...process, cwd: __dirname, encoding: "utf-8" };
 const commitsSinceOriginHead = execSync(`git log --oneline origin/main..HEAD --format=%s`, execOptions).split("\n");
 
-const updatedClients = new Set();
+const updatedClientsSet = new Set();
 for (const commitMessage of commitsSinceOriginHead) {
   const prefix = commitMessage.split(":")[0];
   const scope = prefix.substring(prefix.indexOf("(") + 1, prefix.indexOf(")"));
   if (scope && scope.startsWith("client-")) {
-    updatedClients.add(`@aws-sdk/${scope}`);
+    updatedClientsSet.add(`@aws-sdk/${scope}`);
   }
 }
+
+const updatedClients = [...updatedClientsSet];
 console.info(`Updated packages: ${updatedClients}`);
 
-if (updatedClients.size === 0) {
+if (updatedClients.length === 0) {
   console.info(`Couldn't find clients in commit messages:\n '${commitsSinceOriginHead.join("\n")}'`);
-  process.exit(1);
+  process.exit(0);
 }
 
 const allTags = getAllTags();
-const changedPackageTags = getPackageTags([...updatedClients]);
+const changedPackageTags = getPackageTags(updatedClients);
 const tagsToTest = changedPackageTags.filter((tag) => allTags.includes(tag));
 runTestForTags(tagsToTest);


### PR DESCRIPTION
### Issue
Internal JS-5505

### Description
Skips preview legacy:e2e tests if client is not found

### Testing

Tested with preview build internal artifact

#### Before

Error is thrown:
```console
$ yarn test:e2e:legacy:preview
yarn run v1.22.22
$ ./tests/e2e-legacy/preview.mjs
Updated packages: [object Set]
Couldn't find clients in commit messages:
 ''
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

#### After

Error is not thrown
```console
$  yarn test:e2e:legacy:preview    
yarn run v1.22.22
$ ./tests/e2e-legacy/preview.mjs
Updated packages: 
Couldn't find clients in commit messages:
 ''
Done in 0.11s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
