### PR TITLE
update error messge to NumberValue

### DIFF
--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -63,7 +63,7 @@ describe("convertToAttr", () => {
 
             expect(() => {
               convertToAttr(num, { convertClassInstanceToMap });
-            }).toThrowError(`${errorPrefix} Use BigInt.`);
+            }).toThrowError(`${errorPrefix} Use NumberValue, which is introduced from @aws-sdk/lib-dynamodb.`);
 
             const BigIntConstructor = BigInt;
             (BigInt as any) = undefined;
@@ -81,7 +81,7 @@ describe("convertToAttr", () => {
 
             expect(() => {
               convertToAttr(num, { convertClassInstanceToMap });
-            }).toThrowError(`${errorPrefix} Use BigInt.`);
+            }).toThrowError(`${errorPrefix} Use NumberValue, which is introduced from @aws-sdk/lib-dynamodb.`);
 
             const BigIntConstructor = BigInt;
             (BigInt as any) = undefined;

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -156,8 +156,8 @@ const convertToBinaryAttr = (data: NativeAttributeBinary): { B: NativeAttributeB
 const convertToStringAttr = (data: string | String): { S: string } => ({ S: data.toString() });
 const convertToBigIntAttr = (data: bigint): { N: string } => ({ N: data.toString() });
 
-const validateBigIntAndThrow = (errorPrefix: string) => {
-  throw new Error(`${errorPrefix} ${typeof BigInt === "function" ? "Use BigInt." : "Pass string value instead."} `);
+const validateBigIntAndThrow = (errorPrefix: string) => { 
+  throw new Error(`${errorPrefix} ${typeof BigInt === "function" ? "Use NumberValue, which is introduced from @aws-sdk/lib-dynamodb." : "Pass string value instead."} `);
 };
 
 const convertToNumberAttr = (num: number | Number): { N: string } => {


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"
#6571 

### Description
What does this implement/fix? Explain your changes.
The warning should indicate user to use [NumberValue](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-lib-dynamodb/)  instead of BigInt. 


### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
