### PR TITLE
feat(util-dynamodb): add option for using native array over sets

### DIFF
--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -242,18 +242,38 @@ describe("convertToNative", () => {
           new Set(input.map((numString) => ({ value: numString })))
         );
       });
+
+      it("with options.preferNativeArrays=true", () => {
+        expect(convertToNative({ NS: input }, { preferNativeArrays: true })).toEqual(input);
+      });
     });
 
-    it("binary set", () => {
-      const uint8Arr1 = new Uint8Array([...Array(4).keys()]);
-      const uint8Arr2 = new Uint8Array([...Array(2).keys()]);
-      const input = [uint8Arr1, uint8Arr2];
-      expect(convertToNative({ BS: input })).toEqual(new Set(input));
+    describe("binary set", () => {
+      it("without options.preferNativeArrays", () => {
+        const uint8Arr1 = new Uint8Array([...Array(4).keys()]);
+        const uint8Arr2 = new Uint8Array([...Array(2).keys()]);
+        const input = [uint8Arr1, uint8Arr2];
+        expect(convertToNative({ BS: input })).toEqual(new Set(input));
+      });
+
+      it("with options.preferNativeArrays=true", () => {
+        const uint8Arr1 = new Uint8Array([...Array(4).keys()]);
+        const uint8Arr2 = new Uint8Array([...Array(2).keys()]);
+        const input = [uint8Arr1, uint8Arr2];
+        expect(convertToNative({ BS: input })).toEqual(input);
+      });
     });
 
-    it("string set", () => {
-      const input = ["one", "two", "three"];
-      expect(convertToNative({ SS: input })).toEqual(new Set(input));
+    describe("string set", () => {
+      it("without options.preferNativeArrays", () => {
+        const input = ["one", "two", "three"];
+        expect(convertToNative({ SS: input })).toEqual(new Set(input));
+      });
+
+      it("with options.preferNativeArrays=true", () => {
+        const input = ["one", "two", "three"];
+        expect(convertToNative({ SS: input })).toEqual(input);
+      });
     });
   });
 

--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -244,7 +244,7 @@ describe("convertToNative", () => {
       });
 
       it("with options.preferNativeArrays=true", () => {
-        expect(convertToNative({ NS: input }, { preferNativeArrays: true })).toEqual(input);
+        expect(convertToNative({ NS: input }, { preferNativeArrays: true })).toEqual([1, 2, BigInt(9007199254740996)]);
       });
     });
 
@@ -260,7 +260,7 @@ describe("convertToNative", () => {
         const uint8Arr1 = new Uint8Array([...Array(4).keys()]);
         const uint8Arr2 = new Uint8Array([...Array(2).keys()]);
         const input = [uint8Arr1, uint8Arr2];
-        expect(convertToNative({ BS: input })).toEqual(input);
+        expect(convertToNative({ BS: input }, { preferNativeArrays: true })).toEqual(input);
       });
     });
 
@@ -272,7 +272,7 @@ describe("convertToNative", () => {
 
       it("with options.preferNativeArrays=true", () => {
         const input = ["one", "two", "three"];
-        expect(convertToNative({ SS: input })).toEqual(input);
+        expect(convertToNative({ SS: input }, { preferNativeArrays: true })).toEqual(input);
       });
     });
   });

--- a/packages/util-dynamodb/src/convertToNative.ts
+++ b/packages/util-dynamodb/src/convertToNative.ts
@@ -29,10 +29,19 @@ export const convertToNative = (data: AttributeValue, options?: unmarshallOption
         case "M":
           return convertMap(value as Record<string, AttributeValue>, options);
         case "NS":
+          if (options?.preferNativeArrays) {
+            return (value as string[]).map((item) => convertNumber(item, options));
+          }
           return new Set((value as string[]).map((item) => convertNumber(item, options)));
         case "BS":
+          if (options?.preferNativeArrays) {
+            return (value as Uint8Array[]).map(convertBinary);
+          }
           return new Set((value as Uint8Array[]).map(convertBinary));
         case "SS":
+          if (options?.preferNativeArrays) {
+            return (value as string[]).map(convertString);
+          }
           return new Set((value as string[]).map(convertString));
         default:
           throw new Error(`Unsupported type passed: ${key}`);

--- a/packages/util-dynamodb/src/unmarshall.ts
+++ b/packages/util-dynamodb/src/unmarshall.ts
@@ -20,6 +20,11 @@ export interface unmarshallOptions {
    * but false if directly using the unmarshall function (backwards compatibility).
    */
   convertWithoutMapWrapper?: boolean;
+
+  /**
+   * When true, return native JavaScript arrays instead of Sets.
+   */
+  preferNativeArrays?: boolean;
 }
 
 /**


### PR DESCRIPTION
### Description
By default when an dynamo object is unmarshalled, sets are converted to native javascript sets.

This is fine for some use cases, however for other cases that rely on `JSON.stringify` whether its for an API call or mapping somewhere else sets are converted to `undefined` in this process.

This change gives the ability to override the usage of sets and prefer to use native arrays. I am not sure if this name is perfect but also up for anything here.


Syntax

```typescript

const input = {
 NS: [1,2,3,4]
};

// without option
const obj = unmarshall(input)
// Output - new Set() {1,2,3,4}

// with option enabled
const obj = unmarshall(input, { preferNativeArrays: true})
// Output - [1,2,3,4]

```

### Testing
Unit tests updated to account for use case.

### Additional context
Some alternatives that I have used in the past for this are to manually clone deep with the modification like below.

```typescript
import cloneDeepWith from 'lodash.clonedeepwith'

cloneDeepWith(unmarshall(record.dynamodb!.NewImage! as never), (val: unknown) => {
          // Sets dont stringify at all. Thanks AWS
          if (val instanceof Set) {
            return [...val];
          }
        });
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
