### PR TITLE
test(credential-provider-node): remove sts and sso client mocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test-protocols: build-s3-browser-bundle
 	npx vitest run -c vitest.config.protocols.integ.ts
 
 test-integration: build-s3-browser-bundle
+	rm -rf ./clients/client-sso/node_modules/\@smithy # todo(yarn) incompatible redundant nesting.
 	npx vitest run -c vitest.config.integ.ts
 	npx jest -c jest.config.integ.js
 	make test-protocols;


### PR DESCRIPTION
### Issue
Mocking of STS caused a bug in https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.667.0 to not be caught.

### Description
Removes the mocking of the STS and SSO clients in the credential provider chain's integration test. The mocking is moved to the HTTP Handler level.

### Testing
CI / running these integration tests.

Verifying that this would've caught the issue in v3.667.0:

```
git checkout v3.667.0
make tpk # builds packages only
b cred prov node - integ # runs integration tests, hangs
```

```
git checkout v3.668.0 # patched version
make tpk # builds packages only
b cred prov node - integ # runs integration tests, succeeds
```