### PR TITLE
test(client-s3): convert some read ops to waiters

### DIFF
--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
@@ -1,15 +1,32 @@
-import { S3 } from "@aws-sdk/client-s3";
+import { S3, S3ClientConfig, waitUntilBucketExists, waitUntilBucketNotExists } from "@aws-sdk/client-s3";
 import { GetCallerIdentityCommandOutput, STS } from "@aws-sdk/client-sts";
-import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
+import { afterAll, beforeAll, describe, expect, onTestFailed, test as it } from "vitest";
 
 const testValue = "Hello S3 global client!";
 
 describe("S3 Global Client Test", () => {
+  const errors = [] as any[];
+  let testFailed = false;
+  const setTestFailed = () => {
+    testFailed = true;
+  };
+
   const regionConfigs = [
-    { region: "us-east-1", followRegionRedirects: true },
-    { region: "eu-west-1", followRegionRedirects: true },
-    { region: "us-west-2", followRegionRedirects: true },
-  ];
+    { region: "us-east-1", followRegionRedirects: true } as S3ClientConfig,
+    { region: "eu-west-1", followRegionRedirects: true } as S3ClientConfig,
+    { region: "us-west-2", followRegionRedirects: true } as S3ClientConfig,
+  ].map((config) => {
+    config.logger = {
+      trace() {},
+      debug() {},
+      info() {},
+      warn() {},
+      error(entry: any) {
+        errors.push(entry);
+      },
+    };
+    return config;
+  });
   const s3Clients = regionConfigs.map((config) => new S3(config));
   const stsClient = new STS({});
 
@@ -24,16 +41,33 @@ describe("S3 Global Client Test", () => {
   beforeAll(async () => {
     callerID = await stsClient.getCallerIdentity({});
     bucketNames = regionConfigs.map((config) => `${callerID.Account}-${randId}-redirect-${config.region}`);
-    await Promise.all(bucketNames.map((bucketName, index) => deleteBucket(s3Clients[index], bucketName)));
-    await Promise.all(bucketNames.map((bucketName, index) => s3Clients[index].createBucket({ Bucket: bucketName })));
+    await Promise.all(
+      bucketNames.map(async (bucketName, index) => {
+        await deleteBucket(s3Clients[index], bucketName);
+        return waitUntilBucketNotExists({ client: s3Clients[index], maxWaitTime: 60 }, { Bucket: bucketName });
+      })
+    );
+    await Promise.all(
+      bucketNames.map(async (bucketName, index) => {
+        await s3Clients[index].createBucket({ Bucket: bucketName });
+        return waitUntilBucketExists({ client: s3Clients[index], maxWaitTime: 60 }, { Bucket: bucketName });
+      })
+    );
     await Promise.all(bucketNames.map((bucketName, index) => s3Clients[index].headBucket({ Bucket: bucketName })));
   });
 
   afterAll(async () => {
     await Promise.all(bucketNames.map((bucketName, index) => deleteBucket(s3Clients[index], bucketName)));
+    if (testFailed) {
+      console.info("Test failed, logging errors collecting during test.");
+      for (const error of errors) {
+        console.error(error);
+      }
+    }
   });
 
   it("Should be able to put objects following region redirect", async () => {
+    onTestFailed(setTestFailed);
     // Upload objects to each bucket
     for (const bucketName of bucketNames) {
       for (const s3Client of s3Clients) {
@@ -44,6 +78,7 @@ describe("S3 Global Client Test", () => {
   });
 
   it("Should be able to get objects following region redirect", async () => {
+    onTestFailed(setTestFailed);
     // Fetch and assert objects
     for (const bucketName of bucketNames) {
       for (const s3Client of s3Clients) {
@@ -57,6 +92,7 @@ describe("S3 Global Client Test", () => {
   });
 
   it("Should delete objects following region redirect", async () => {
+    onTestFailed(setTestFailed);
     for (const bucketName of bucketNames) {
       for (const s3Client of s3Clients) {
         const objKey = `object-from-${await s3Client.config.region()}-client`;


### PR DESCRIPTION
### Issue
n/a

### Description
S3 has strong read-after-write consistency https://aws.amazon.com/about-aws/whats-new/2020/12/amazon-s3-now-delivers-strong-read-after-write-consistency-automatically-for-all-applications/.

However, some of our tests have failed randomly at certain read-after-write points, without clear error messaging. 
This PR adds loggers to the test clients and converts some read points to waiters to be more forgiving.

### Testing
Ran the tests in question.

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

