### PR TITLE
chore(middleware-flexible-checksums): delay checksum validation until stream read

### DIFF
--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -40,6 +40,7 @@
     "@smithy/types": "^3.6.0",
     "@smithy/util-middleware": "^3.0.8",
     "@smithy/util-utf8": "^3.0.0",
+    "@smithy/util-stream": "^3.2.1",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/middleware-flexible-checksums/src/getChecksum.spec.ts
+++ b/packages/middleware-flexible-checksums/src/getChecksum.spec.ts
@@ -1,15 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import { getChecksum } from "./getChecksum";
-import { isStreaming } from "./isStreaming";
 import { stringHasher } from "./stringHasher";
 
-vi.mock("./isStreaming");
 vi.mock("./stringHasher");
 
 describe(getChecksum.name, () => {
   const mockOptions = {
-    streamHasher: vi.fn(),
     checksumAlgorithmFn: vi.fn(),
     base64Encoder: vi.fn(),
   };
@@ -26,21 +23,10 @@ describe(getChecksum.name, () => {
     vi.clearAllMocks();
   });
 
-  it("gets checksum from streamHasher if body is streaming", async () => {
-    vi.mocked(isStreaming).mockReturnValue(true);
-    mockOptions.streamHasher.mockResolvedValue(mockRawOutput);
-    const checksum = await getChecksum(mockBody, mockOptions);
-    expect(checksum).toEqual(mockOutput);
-    expect(stringHasher).not.toHaveBeenCalled();
-    expect(mockOptions.streamHasher).toHaveBeenCalledWith(mockOptions.checksumAlgorithmFn, mockBody);
-  });
-
-  it("gets checksum from stringHasher if body is not streaming", async () => {
-    vi.mocked(isStreaming).mockReturnValue(false);
+  it("gets checksum from stringHasher", async () => {
     vi.mocked(stringHasher).mockResolvedValue(mockRawOutput);
     const checksum = await getChecksum(mockBody, mockOptions);
     expect(checksum).toEqual(mockOutput);
-    expect(mockOptions.streamHasher).not.toHaveBeenCalled();
     expect(stringHasher).toHaveBeenCalledWith(mockOptions.checksumAlgorithmFn, mockBody);
   });
 });

--- a/packages/middleware-flexible-checksums/src/getChecksum.ts
+++ b/packages/middleware-flexible-checksums/src/getChecksum.ts
@@ -1,18 +1,11 @@
-import { ChecksumConstructor, Encoder, HashConstructor, StreamHasher } from "@smithy/types";
+import { ChecksumConstructor, Encoder, HashConstructor } from "@smithy/types";
 
-import { isStreaming } from "./isStreaming";
 import { stringHasher } from "./stringHasher";
 
 export interface GetChecksumDigestOptions {
-  streamHasher: StreamHasher<any>;
   checksumAlgorithmFn: ChecksumConstructor | HashConstructor;
   base64Encoder: Encoder;
 }
 
-export const getChecksum = async (
-  body: unknown,
-  { streamHasher, checksumAlgorithmFn, base64Encoder }: GetChecksumDigestOptions
-) => {
-  const digest = isStreaming(body) ? streamHasher(checksumAlgorithmFn, body) : stringHasher(checksumAlgorithmFn, body);
-  return base64Encoder(await digest);
-};
+export const getChecksum = async (body: unknown, { checksumAlgorithmFn, base64Encoder }: GetChecksumDigestOptions) =>
+  base64Encoder(await stringHasher(checksumAlgorithmFn, body));

--- a/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
+++ b/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
@@ -1,4 +1,5 @@
 import { HttpResponse } from "@smithy/protocol-http";
+import { createChecksumStream } from "@smithy/util-stream";
 import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import { PreviouslyResolved } from "./configuration";
@@ -6,17 +7,19 @@ import { ChecksumAlgorithm } from "./constants";
 import { getChecksum } from "./getChecksum";
 import { getChecksumAlgorithmListForResponse } from "./getChecksumAlgorithmListForResponse";
 import { getChecksumLocationName } from "./getChecksumLocationName";
+import { isStreaming } from "./isStreaming";
 import { selectChecksumAlgorithmFunction } from "./selectChecksumAlgorithmFunction";
 import { validateChecksumFromResponse } from "./validateChecksumFromResponse";
 
+vi.mock("@smithy/util-stream");
 vi.mock("./getChecksum");
 vi.mock("./getChecksumLocationName");
 vi.mock("./getChecksumAlgorithmListForResponse");
+vi.mock("./isStreaming");
 vi.mock("./selectChecksumAlgorithmFunction");
 
 describe(validateChecksumFromResponse.name, () => {
   const mockConfig = {
-    streamHasher: vi.fn(),
     base64Encoder: vi.fn(),
   } as unknown as PreviouslyResolved;
 
@@ -85,29 +88,41 @@ describe(validateChecksumFromResponse.name, () => {
   });
 
   describe("successful validation", () => {
-    afterEach(() => {
+    const validateCalls = (isStream: boolean) => {
       expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
       expect(selectChecksumAlgorithmFunction).toHaveBeenCalledTimes(1);
-      expect(getChecksum).toHaveBeenCalledTimes(1);
-    });
 
-    it("when checksum is populated for first algorithm", async () => {
+      if (isStream) {
+        expect(getChecksum).not.toHaveBeenCalled();
+        expect(createChecksumStream).toHaveBeenCalledTimes(1);
+      } else {
+        expect(getChecksum).toHaveBeenCalledTimes(1);
+        expect(createChecksumStream).not.toHaveBeenCalled();
+      }
+    };
+
+    it.each([false, true])("when checksum is populated for first algorithm when streaming: %s", async (isStream) => {
+      vi.mocked(isStreaming).mockReturnValue(isStream);
       const responseWithChecksum = getMockResponseWithHeader(mockResponseAlgorithms[0], mockChecksum);
       await validateChecksumFromResponse(responseWithChecksum, mockOptions);
       expect(getChecksumLocationName).toHaveBeenCalledTimes(1);
       expect(getChecksumLocationName).toHaveBeenCalledWith(mockResponseAlgorithms[0]);
+      validateCalls(isStream);
     });
 
-    it("when checksum is populated for second algorithm", async () => {
+    it.each([false, true])("when checksum is populated for second algorithm when streaming: %s", async (isStream) => {
+      vi.mocked(isStreaming).mockReturnValue(isStream);
       const responseWithChecksum = getMockResponseWithHeader(mockResponseAlgorithms[1], mockChecksum);
       await validateChecksumFromResponse(responseWithChecksum, mockOptions);
       expect(getChecksumLocationName).toHaveBeenCalledTimes(2);
       expect(getChecksumLocationName).toHaveBeenNthCalledWith(1, mockResponseAlgorithms[0]);
       expect(getChecksumLocationName).toHaveBeenNthCalledWith(2, mockResponseAlgorithms[1]);
+      validateCalls(isStream);
     });
   });
 
-  it("throw error if checksum value is not accurate", async () => {
+  it("throw error if checksum value is not accurate when not streaming", async () => {
+    vi.mocked(isStreaming).mockReturnValue(false);
     const incorrectChecksum = "incorrectChecksum";
     const responseWithChecksum = getMockResponseWithHeader(mockResponseAlgorithms[0], incorrectChecksum);
     try {
@@ -123,5 +138,18 @@ describe(validateChecksumFromResponse.name, () => {
     expect(selectChecksumAlgorithmFunction).toHaveBeenCalledTimes(1);
     expect(getChecksumLocationName).toHaveBeenCalledTimes(1);
     expect(getChecksum).toHaveBeenCalledTimes(1);
+    expect(createChecksumStream).not.toHaveBeenCalled();
+  });
+
+  it("return if checksum value is not accurate when streaming, as error will be thrown when stream is consumed", async () => {
+    vi.mocked(isStreaming).mockReturnValue(true);
+    const incorrectChecksum = "incorrectChecksum";
+    const responseWithChecksum = getMockResponseWithHeader(mockResponseAlgorithms[0], incorrectChecksum);
+    await validateChecksumFromResponse(responseWithChecksum, mockOptions);
+    expect(getChecksumAlgorithmListForResponse).toHaveBeenCalledWith(mockResponseAlgorithms);
+    expect(selectChecksumAlgorithmFunction).toHaveBeenCalledTimes(1);
+    expect(getChecksumLocationName).toHaveBeenCalledTimes(1);
+    expect(getChecksum).not.toHaveBeenCalled();
+    expect(createChecksumStream).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.ts
+++ b/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.ts
@@ -35,7 +35,7 @@ export const validateChecksumFromResponse = async (
       const { base64Encoder } = config;
 
       if (isStreaming(responseBody)) {
-        createChecksumStream({
+        response.body = createChecksumStream({
           expectedChecksum: checksumFromResponse,
           checksumSourceLocation: responseHeader,
           checksum: new checksumAlgorithmFn() as Checksum,


### PR DESCRIPTION
### Issue
Internal JS-5537

### Description
Delays checksum validation until stream read

### Testing

```js
import assert from "assert";
import { S3 } from "@aws-sdk/client-s3";
// import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";

const s3 = new S3({ region: "us-west-2" });
const Bucket = "test-flexible-checksums"; // Change to your bucket name
const Key = "test.txt";
const Body = "helloworld".repeat(10_000_000); // A string of size ~100MB

await s3.putObject({ Bucket, Key, Body, ChecksumAlgorithm: "CRC32" });

const apiCallStart = performance.now();
const response = await s3.getObject({ Bucket, Key, ChecksumMode: "ENABLED" });
console.log("time taken for request:", (performance.now() - apiCallStart).toFixed(2), "ms");

const transformStart = performance.now();
const body = await response.Body.transformToString();
console.log("time taken for transform:", (performance.now() - transformStart).toFixed(2), "ms");

assert(body === Body);
```

#### Before

Response checksum is validated when API call is made.
```console
time taken for request: 3141.02 ms
time taken for transform: 221.46 ms
```

#### After

Response checksum is validation when stream is consumed (i.e. when transform call is made)
```console
time taken for request: 1217.04 ms
time taken for transform: 2141.58 ms
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
