### PR TITLE
chore(middleware-flexible-checksums): move inline class NodeCrc32 outside

### DIFF
--- a/packages/middleware-flexible-checksums/src/getCrc32ChecksumAlgorithmFunction.ts
+++ b/packages/middleware-flexible-checksums/src/getCrc32ChecksumAlgorithmFunction.ts
@@ -3,26 +3,28 @@ import { numToUint8 } from "@aws-crypto/util";
 import { Checksum } from "@smithy/types";
 import * as zlib from "zlib";
 
+class NodeCrc32 implements Checksum {
+  checksum = 0;
+
+  update(data: Uint8Array) {
+    // @ts-expect-error crc32 is defined only for Node.js >=v20.15.0 and >=v22.2.0.
+    this.checksum = zlib.crc32(data, this.checksum);
+  }
+
+  async digest() {
+    return numToUint8(this.checksum);
+  }
+
+  reset() {
+    this.checksum = 0;
+  }
+}
+
 export const getCrc32ChecksumAlgorithmFunction = () => {
   // @ts-expect-error crc32 is defined only for Node.js >=v20.15.0 and >=v22.2.0.
   if (typeof zlib.crc32 === "undefined") {
     return AwsCrc32;
   }
 
-  return class NodeCrc32 implements Checksum {
-    checksum = 0;
-
-    update(data: Uint8Array) {
-      // @ts-expect-error crc32 is defined only for Node.js >=v20.15.0 and >=v22.2.0.
-      this.checksum = zlib.crc32(data, this.checksum);
-    }
-
-    async digest() {
-      return numToUint8(this.checksum);
-    }
-
-    reset() {
-      this.checksum = 0;
-    }
-  };
+  return NodeCrc32;
 };

--- a/packages/middleware-flexible-checksums/src/getCrc32ChecksumAlgorithmFunction.ts
+++ b/packages/middleware-flexible-checksums/src/getCrc32ChecksumAlgorithmFunction.ts
@@ -4,7 +4,7 @@ import { Checksum } from "@smithy/types";
 import * as zlib from "zlib";
 
 class NodeCrc32 implements Checksum {
-  checksum = 0;
+  private checksum = 0;
 
   update(data: Uint8Array) {
     // @ts-expect-error crc32 is defined only for Node.js >=v20.15.0 and >=v22.2.0.

--- a/packages/middleware-flexible-checksums/src/selectChecksumAlgorithmFunction.spec.ts
+++ b/packages/middleware-flexible-checksums/src/selectChecksumAlgorithmFunction.spec.ts
@@ -2,7 +2,7 @@ import { AwsCrc32c } from "@aws-crypto/crc32c";
 import { describe, expect, test as it, vi } from "vitest";
 
 import { ChecksumAlgorithm } from "./constants";
-// import { getCrc32ChecksumAlgorithmFunction } from "./getCrc32ChecksumAlgorithmFunction";
+import { getCrc32ChecksumAlgorithmFunction } from "./getCrc32ChecksumAlgorithmFunction";
 import { selectChecksumAlgorithmFunction } from "./selectChecksumAlgorithmFunction";
 
 describe(selectChecksumAlgorithmFunction.name, () => {
@@ -14,7 +14,7 @@ describe(selectChecksumAlgorithmFunction.name, () => {
 
   it.each([
     [ChecksumAlgorithm.MD5, mockConfig.md5],
-    // [ChecksumAlgorithm.CRC32, getCrc32ChecksumAlgorithmFunction()],
+    [ChecksumAlgorithm.CRC32, getCrc32ChecksumAlgorithmFunction()],
     [ChecksumAlgorithm.CRC32C, AwsCrc32c],
     [ChecksumAlgorithm.SHA1, mockConfig.sha1],
     [ChecksumAlgorithm.SHA256, mockConfig.sha256],


### PR DESCRIPTION
### Issue
Internal JS-5558

### Description

Move inline class NodeCrc32 outside the function, so that a new copy of it is not created.

It's not an issue right now, since the function getCrc32ChecksumAlgorithmFunction is called just once. But it lead to some test failures requiring us to disable a test case in https://github.com/aws/aws-sdk-js-v3/pull/6647

### Testing

The `yarn test:unit` is successful on both Node.js 18 and 20.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
