### PR TITLE
feat(codegen): send x-amzn-query-mode header

### DIFF
--- a/clients/client-sqs/src/protocols/Aws_json1_0.ts
+++ b/clients/client-sqs/src/protocols/Aws_json1_0.ts
@@ -2087,6 +2087,7 @@ function sharedHeaders(operation: string): __HeaderBag {
   return {
     "content-type": "application/x-amz-json-1.0",
     "x-amz-target": `AmazonSQS.${operation}`,
+    "x-amzn-query-mode": "true",
   };
 }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsSmithyRpcV2Cbor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsSmithyRpcV2Cbor.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.aws.typescript.codegen;
 import software.amazon.smithy.aws.traits.protocols.AwsQueryCompatibleTrait;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.protocols.cbor.SmithyRpcV2Cbor;
 
 /**
@@ -32,6 +33,24 @@ public final class AwsSmithyRpcV2Cbor extends SmithyRpcV2Cbor {
                 };
                 """);
         }
+    }
+
+    @Override
+    protected void writeSharedRequestHeaders(ProtocolGenerator.GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+        writer.addImport("HeaderBag", "__HeaderBag", TypeScriptDependency.SMITHY_TYPES);
+        writer.openBlock("const SHARED_HEADERS: __HeaderBag = {", "};", () -> {
+            writer.write("'content-type': $S,", getDocumentContentType());
+            writer.write("""
+                "smithy-protocol": "rpc-v2-cbor",
+                "accept": "application/cbor",
+                """);
+            if (context.getService().hasTrait(AwsQueryCompatibleTrait.class)) {
+                writer.write("""
+                    "x-amzn-query-mode": "true",
+                    """);
+            }
+        });
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -144,6 +144,11 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
                     // AWS JSON RPC protocols use a combination of the service and operation shape names,
                     // separated by a '.' character, for the target header.
                     writer.write("'x-amz-target': `$L`,", targetHeader);
+                    if (serviceShape.hasTrait(AwsQueryCompatibleTrait.class)) {
+                        writer.write("""
+                            "x-amzn-query-mode": "true",
+                        """);
+                    }
                 }
         );
     }

--- a/packages/middleware-sdk-sqs/src/middleware-sdk-sqs.integ.spec.ts
+++ b/packages/middleware-sdk-sqs/src/middleware-sdk-sqs.integ.spec.ts
@@ -9,6 +9,8 @@ import { requireRequestsFrom } from "../../../private/aws-util-test/src";
 
 const sqsModel: any = require("../../../codegen/sdk-codegen/aws-models/sqs.json");
 const useAwsQuery = !!sqsModel.shapes["com.amazonaws.sqs#AmazonSQS"].traits["aws.protocols#awsQuery"];
+const isAwsQueryCompatible =
+  !!sqsModel.shapes["com.amazonaws.sqs#AmazonSQS"].traits["aws.protocols#awsQueryCompatible"];
 
 let hashError = "";
 const md5 = (str: string) =>
@@ -316,6 +318,28 @@ describe("middleware-sdk-sqs", () => {
 
         expect.hasAssertions();
       });
+    });
+  });
+
+  it("should send the x-amzn-query-mode header when in awsQueryCompatible mode", async () => {
+    const client = new SQS({
+      region: "us-west-2",
+      credentials: mockCredentials,
+      logger,
+    });
+
+    requireRequestsFrom(client).toMatch({
+      hostname: "abc.com",
+      protocol: "https:",
+      path: "/",
+      headers: {
+        "x-amzn-query-mode": "true",
+      },
+    });
+
+    await client.sendMessage({
+      QueueUrl: "https://abc.com/123/MyQueue",
+      MessageBody: "hello",
     });
   });
 


### PR DESCRIPTION
### Issue
n/a, spec update

### Description
Send the HTTP header `x-amzn-query-mode` set to `true` when using awsQueryCompatible. This applies only to the two supported protocols `awsJson1.0` (not 1.1), and `smithyRpcV2Cbor`. 

### Testing
added integration test assertion for qualifying service (SQS).
