### PR TITLE
chore(scripts): omit stdio in benchmark-size runner

### DIFF
--- a/scripts/benchmark-size/runner/local-registry.ts
+++ b/scripts/benchmark-size/runner/local-registry.ts
@@ -17,7 +17,6 @@ export const localPublishChangedPackages = async (): Promise<string> => {
   console.info(`the package versions will be the actual version up with a patch version and preid "ci".`);
   await exec("yarn", ["local-publish"], {
     cwd: PROJECT_ROOT,
-    stdio: "inherit",
   });
   console.info(`published ${readdirSync(join(PROJECT_ROOT, "verdaccio", "storage", "@aws-sdk")).length} packages`);
   return join(PROJECT_ROOT, "verdaccio", "config.yaml");


### PR DESCRIPTION
after confirming that the test:size script is working, we don't need this output anymore