### PR TITLE
chore(scripts): yarn install with --no-immutable to allow lockfile modification

### DIFF
--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -142,7 +142,7 @@ const {
     }
 
     require("./customizations/workspaces-thin-client")();
-    await spawnProcess("yarn", [], { cwd: REPO_ROOT, stdio: "inherit", env: { ...process.env, CI: "" } });
+    await spawnProcess("yarn", ["install", "--no-immutable"], { cwd: REPO_ROOT, stdio: "inherit", env: { ...process.env, CI: "" } });
     require("../runtime-dependency-version-check/runtime-dep-version-check");
   } catch (e) {
     console.log(e);


### PR DESCRIPTION
### Issue
Internal JS-5573

disable the `--immutable` flag (https://github.com/yarnpkg/berry/discussions/3486) to allow for lockfile modifications. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
