### PR TITLE
fix(lib-dynamodb): input types conflicts with client-dynamodb

### DIFF
--- a/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
@@ -18,7 +18,7 @@ export { DynamoDBDocumentClientCommand, $Command };
 export type BatchExecuteStatementCommandInput = Omit<__BatchExecuteStatementCommandInput, "Statements"> & {
   Statements:
     | (Omit<BatchStatementRequest, "Parameters"> & {
-        Parameters?: NativeAttributeValue[];
+        Parameters?: NativeAttributeValue[] | undefined;
       })[]
     | undefined;
 };

--- a/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
@@ -20,12 +20,16 @@ export type BatchWriteCommandInput = Omit<__BatchWriteItemCommandInput, "Request
     | Record<
         string,
         (Omit<WriteRequest, "PutRequest" | "DeleteRequest"> & {
-          PutRequest?: Omit<PutRequest, "Item"> & {
-            Item: Record<string, NativeAttributeValue> | undefined;
-          };
-          DeleteRequest?: Omit<DeleteRequest, "Key"> & {
-            Key: Record<string, NativeAttributeValue> | undefined;
-          };
+          PutRequest?:
+            | (Omit<PutRequest, "Item"> & {
+                Item: Record<string, NativeAttributeValue> | undefined;
+              })
+            | undefined;
+          DeleteRequest?:
+            | (Omit<DeleteRequest, "Key"> & {
+                Key: Record<string, NativeAttributeValue> | undefined;
+              })
+            | undefined;
         })[]
       >
     | undefined;

--- a/lib/lib-dynamodb/src/commands/DeleteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/DeleteCommand.ts
@@ -17,14 +17,16 @@ export { DynamoDBDocumentClientCommand, $Command };
  */
 export type DeleteCommandInput = Omit<__DeleteItemCommandInput, "Key" | "Expected" | "ExpressionAttributeValues"> & {
   Key: Record<string, NativeAttributeValue> | undefined;
-  Expected?: Record<
-    string,
-    Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
-      Value?: NativeAttributeValue;
-      AttributeValueList?: NativeAttributeValue[];
-    }
-  >;
-  ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
+  Expected?:
+    | Record<
+        string,
+        | Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
+            Value?: NativeAttributeValue;
+            AttributeValueList?: NativeAttributeValue[] | undefined;
+          }
+      >
+    | undefined;
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
@@ -16,7 +16,7 @@ export { DynamoDBDocumentClientCommand, $Command };
  * @public
  */
 export type ExecuteStatementCommandInput = Omit<__ExecuteStatementCommandInput, "Parameters"> & {
-  Parameters?: NativeAttributeValue[];
+  Parameters?: NativeAttributeValue[] | undefined;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
@@ -18,7 +18,7 @@ export { DynamoDBDocumentClientCommand, $Command };
 export type ExecuteTransactionCommandInput = Omit<__ExecuteTransactionCommandInput, "TransactStatements"> & {
   TransactStatements:
     | (Omit<ParameterizedStatement, "Parameters"> & {
-        Parameters?: NativeAttributeValue[];
+        Parameters?: NativeAttributeValue[] | undefined;
       })[]
     | undefined;
 };

--- a/lib/lib-dynamodb/src/commands/PutCommand.ts
+++ b/lib/lib-dynamodb/src/commands/PutCommand.ts
@@ -17,14 +17,16 @@ export { DynamoDBDocumentClientCommand, $Command };
  */
 export type PutCommandInput = Omit<__PutItemCommandInput, "Item" | "Expected" | "ExpressionAttributeValues"> & {
   Item: Record<string, NativeAttributeValue> | undefined;
-  Expected?: Record<
-    string,
-    Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
-      Value?: NativeAttributeValue;
-      AttributeValueList?: NativeAttributeValue[];
-    }
-  >;
-  ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
+  Expected?:
+    | Record<
+        string,
+        Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
+          Value?: NativeAttributeValue | undefined;
+          AttributeValueList?: NativeAttributeValue[] | undefined;
+        }
+      >
+    | undefined;
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/QueryCommand.ts
+++ b/lib/lib-dynamodb/src/commands/QueryCommand.ts
@@ -19,20 +19,24 @@ export type QueryCommandInput = Omit<
   __QueryCommandInput,
   "KeyConditions" | "QueryFilter" | "ExclusiveStartKey" | "ExpressionAttributeValues"
 > & {
-  KeyConditions?: Record<
-    string,
-    Omit<Condition, "AttributeValueList"> & {
-      AttributeValueList?: NativeAttributeValue[];
-    }
-  >;
-  QueryFilter?: Record<
-    string,
-    Omit<Condition, "AttributeValueList"> & {
-      AttributeValueList?: NativeAttributeValue[];
-    }
-  >;
-  ExclusiveStartKey?: Record<string, NativeAttributeValue>;
-  ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
+  KeyConditions?:
+    | Record<
+        string,
+        Omit<Condition, "AttributeValueList"> & {
+          AttributeValueList?: NativeAttributeValue[] | undefined;
+        }
+      >
+    | undefined;
+  QueryFilter?:
+    | Record<
+        string,
+        Omit<Condition, "AttributeValueList"> & {
+          AttributeValueList?: NativeAttributeValue[] | undefined;
+        }
+      >
+    | undefined;
+  ExclusiveStartKey?: Record<string, NativeAttributeValue> | undefined;
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/ScanCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ScanCommand.ts
@@ -19,14 +19,16 @@ export type ScanCommandInput = Omit<
   __ScanCommandInput,
   "ScanFilter" | "ExclusiveStartKey" | "ExpressionAttributeValues"
 > & {
-  ScanFilter?: Record<
-    string,
-    Omit<Condition, "AttributeValueList"> & {
-      AttributeValueList?: NativeAttributeValue[];
-    }
-  >;
-  ExclusiveStartKey?: Record<string, NativeAttributeValue>;
-  ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
+  ScanFilter?:
+    | Record<
+        string,
+        Omit<Condition, "AttributeValueList"> & {
+          AttributeValueList?: NativeAttributeValue[] | undefined;
+        }
+      >
+    | undefined;
+  ExclusiveStartKey?: Record<string, NativeAttributeValue> | undefined;
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
@@ -18,22 +18,30 @@ export { DynamoDBDocumentClientCommand, $Command };
 export type TransactWriteCommandInput = Omit<__TransactWriteItemsCommandInput, "TransactItems"> & {
   TransactItems:
     | (Omit<TransactWriteItem, "ConditionCheck" | "Put" | "Delete" | "Update"> & {
-        ConditionCheck?: Omit<ConditionCheck, "Key" | "ExpressionAttributeValues"> & {
-          Key: Record<string, NativeAttributeValue> | undefined;
-          ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
-        };
-        Put?: Omit<Put, "Item" | "ExpressionAttributeValues"> & {
-          Item: Record<string, NativeAttributeValue> | undefined;
-          ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
-        };
-        Delete?: Omit<Delete, "Key" | "ExpressionAttributeValues"> & {
-          Key: Record<string, NativeAttributeValue> | undefined;
-          ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
-        };
-        Update?: Omit<Update, "Key" | "ExpressionAttributeValues"> & {
-          Key: Record<string, NativeAttributeValue> | undefined;
-          ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
-        };
+        ConditionCheck?:
+          | (Omit<ConditionCheck, "Key" | "ExpressionAttributeValues"> & {
+              Key: Record<string, NativeAttributeValue> | undefined;
+              ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
+            })
+          | undefined;
+        Put?:
+          | (Omit<Put, "Item" | "ExpressionAttributeValues"> & {
+              Item: Record<string, NativeAttributeValue> | undefined;
+              ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
+            })
+          | undefined;
+        Delete?:
+          | (Omit<Delete, "Key" | "ExpressionAttributeValues"> & {
+              Key: Record<string, NativeAttributeValue> | undefined;
+              ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
+            })
+          | undefined;
+        Update?:
+          | (Omit<Update, "Key" | "ExpressionAttributeValues"> & {
+              Key: Record<string, NativeAttributeValue> | undefined;
+              ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
+            })
+          | undefined;
       })[]
     | undefined;
 };

--- a/lib/lib-dynamodb/src/commands/UpdateCommand.ts
+++ b/lib/lib-dynamodb/src/commands/UpdateCommand.ts
@@ -20,20 +20,24 @@ export type UpdateCommandInput = Omit<
   "Key" | "AttributeUpdates" | "Expected" | "ExpressionAttributeValues"
 > & {
   Key: Record<string, NativeAttributeValue> | undefined;
-  AttributeUpdates?: Record<
-    string,
-    Omit<AttributeValueUpdate, "Value"> & {
-      Value?: NativeAttributeValue;
-    }
-  >;
-  Expected?: Record<
-    string,
-    Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
-      Value?: NativeAttributeValue;
-      AttributeValueList?: NativeAttributeValue[];
-    }
-  >;
-  ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
+  AttributeUpdates?:
+    | Record<
+        string,
+        Omit<AttributeValueUpdate, "Value"> & {
+          Value?: NativeAttributeValue;
+        }
+      >
+    | undefined;
+  Expected?:
+    | Record<
+        string,
+        Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
+          Value?: NativeAttributeValue;
+          AttributeValueList?: NativeAttributeValue[] | undefined;
+        }
+      >
+    | undefined;
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
 };
 
 /**


### PR DESCRIPTION
### Issue
Fixes #6668

### Description
#6654 added `| undefined` to optional model props, but the types in lib-dynamodb wasn't updated to reflect that change. This leaves consumers using `exactOptionalPropertyTypes: true` with ts errors when trying to use almost any of the commands in lib-dynamodb.
E.g.: 
```ts
import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";

const dyndbClient = new DynamoDBClient({});

const dyndbDocClient = DynamoDBDocumentClient.from(dyndbClient);

dyndbDocClient.send(new ScanCommand({ TableName: "my-table" }));

```
causes
```
Argument of type 'ScanCommand' is not assignable to parameter of type 'Command<ServiceInputTypes, ScanCommandInput, ServiceOutputTypes, ScanCommandOutput | ScanCommandOutput, SmithyResolvedConfiguration<...>>'.
  The types of 'middlewareStack.addRelativeTo' are incompatible between these types.
    Type '(middleware: MiddlewareType<ScanCommandInput | ScanCommandInput, ScanCommandOutput | ScanCommandOutput>, options: RelativeMiddlewareOptions) => void' is not assignable to type '(middleware: MiddlewareType<ScanCommandInput, ScanCommandOutput | ScanCommandOutput>, options: RelativeMiddlewareOptions) => void'.
      Types of parameters 'middleware' and 'middleware' are incompatible.
        Type 'MiddlewareType<ScanCommandInput, ScanCommandOutput | ScanCommandOutput>' is not assignable to type 'MiddlewareType<ScanCommandInput | ScanCommandInput, ScanCommandOutput | ScanCommandOutput>'.
          Type 'InitializeMiddleware<ScanCommandInput, ScanCommandOutput | ScanCommandOutput>' is not assignable to type 'MiddlewareType<ScanCommandInput | ScanCommandInput, ScanCommandOutput | ScanCommandOutput>'.
            Type 'InitializeMiddleware<ScanCommandInput, ScanCommandOutput | ScanCommandOutput>' is not assignable to type 'InitializeMiddleware<ScanCommandInput | ScanCommandInput, ScanCommandOutput | ScanCommandOutput>'.
              Type 'InitializeHandler<ScanCommandInput, ScanCommandOutput | ScanCommandOutput>' is not assignable to type 'InitializeHandler<ScanCommandInput | ScanCommandInput, ScanCommandOutput | ScanCommandOutput>'.
                Type 'ScanCommandInput | ScanCommandInput' is not assignable to type 'ScanCommandInput' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
                  Type 'import("/aws-sdk-error-repro/node_modules/@aws-sdk/client-dynamodb/dist-types/commands/ScanCommand").ScanCommandInput' is not assignable to type 'import("/aws-sdk-error-repro/node_modules/@aws-sdk/lib-dynamodb/dist-types/commands/ScanCommand").ScanCommandInput' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
                    Type 'ScanCommandInput' is not assignable to type '{ ScanFilter?: Record<string, Omit<Condition, "AttributeValueList"> & { AttributeValueList?: any[]; }>; ExclusiveStartKey?: Record<string, any>; ExpressionAttributeValues?: Record<...>; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
                      Types of property 'ScanFilter' are incompatible.
                        Type 'Record<string, Condition> | undefined' is not assignable to type 'Record<string, Omit<Condition, "AttributeValueList"> & { AttributeValueList?: any[]; }>'.
                          Type 'undefined' is not assignable to type 'Record<string, Omit<Condition, "AttributeValueList"> & { AttributeValueList?: any[]; }>'.
```

### Testing
Enabled `exactOptionalPropertyTypes` in the aws-sdk repo while working on the issues, to ensure they got fixed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
