### PR TITLE
fix(middleware-flexible-checksums): use input from args and not middleware config

### DIFF
--- a/clients/client-s3/src/commands/DeleteObjectsCommand.ts
+++ b/clients/client-s3/src/commands/DeleteObjectsCommand.ts
@@ -307,7 +307,6 @@ export class DeleteObjectsCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/GetObjectCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectCommand.ts
@@ -360,7 +360,6 @@ export class GetObjectCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestChecksumRequired: false,
         requestValidationModeMember: "ChecksumMode",
         responseAlgorithms: ["CRC32", "CRC32C", "SHA256", "SHA1"],

--- a/clients/client-s3/src/commands/PutBucketAccelerateConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketAccelerateConfigurationCommand.ts
@@ -123,7 +123,6 @@ export class PutBucketAccelerateConfigurationCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: false,
       }),

--- a/clients/client-s3/src/commands/PutBucketAclCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketAclCommand.ts
@@ -314,7 +314,6 @@ export class PutBucketAclCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutBucketCorsCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketCorsCommand.ts
@@ -198,7 +198,6 @@ export class PutBucketCorsCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutBucketEncryptionCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketEncryptionCommand.ts
@@ -198,7 +198,6 @@ export class PutBucketEncryptionCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutBucketLifecycleConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketLifecycleConfigurationCommand.ts
@@ -260,7 +260,6 @@ export class PutBucketLifecycleConfigurationCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutBucketLoggingCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketLoggingCommand.ts
@@ -214,7 +214,6 @@ export class PutBucketLoggingCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutBucketOwnershipControlsCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketOwnershipControlsCommand.ts
@@ -104,7 +104,6 @@ export class PutBucketOwnershipControlsCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketPolicyCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketPolicyCommand.ts
@@ -157,7 +157,6 @@ export class PutBucketPolicyCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutBucketReplicationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketReplicationCommand.ts
@@ -239,7 +239,6 @@ export class PutBucketReplicationCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutBucketRequestPaymentCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketRequestPaymentCommand.ts
@@ -114,7 +114,6 @@ export class PutBucketRequestPaymentCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutBucketTaggingCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketTaggingCommand.ts
@@ -168,7 +168,6 @@ export class PutBucketTaggingCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutBucketVersioningCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketVersioningCommand.ts
@@ -149,7 +149,6 @@ export class PutBucketVersioningCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutBucketWebsiteCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketWebsiteCommand.ts
@@ -249,7 +249,6 @@ export class PutBucketWebsiteCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutObjectAclCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectAclCommand.ts
@@ -313,7 +313,6 @@ export class PutObjectAclCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutObjectCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectCommand.ts
@@ -413,7 +413,6 @@ export class PutObjectCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: false,
       }),

--- a/clients/client-s3/src/commands/PutObjectLegalHoldCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectLegalHoldCommand.ts
@@ -91,7 +91,6 @@ export class PutObjectLegalHoldCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutObjectLockConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectLockConfigurationCommand.ts
@@ -114,7 +114,6 @@ export class PutObjectLockConfigurationCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutObjectRetentionCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectRetentionCommand.ts
@@ -94,7 +94,6 @@ export class PutObjectRetentionCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutObjectTaggingCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectTaggingCommand.ts
@@ -174,7 +174,6 @@ export class PutObjectTaggingCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/PutPublicAccessBlockCommand.ts
+++ b/clients/client-s3/src/commands/PutPublicAccessBlockCommand.ts
@@ -122,7 +122,6 @@ export class PutPublicAccessBlockCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: true,
       }),

--- a/clients/client-s3/src/commands/RestoreObjectCommand.ts
+++ b/clients/client-s3/src/commands/RestoreObjectCommand.ts
@@ -388,7 +388,6 @@ export class RestoreObjectCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: false,
       }),

--- a/clients/client-s3/src/commands/UploadPartCommand.ts
+++ b/clients/client-s3/src/commands/UploadPartCommand.ts
@@ -309,7 +309,6 @@ export class UploadPartCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        input: this.input,
         requestAlgorithmMember: "ChecksumAlgorithm",
         requestChecksumRequired: false,
       }),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 import software.amazon.smithy.aws.traits.HttpChecksumTrait;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
@@ -197,7 +197,6 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
         OperationShape operation
     ) {
         Map<String, Object> params = new TreeMap<String, Object>();
-        params.put("input", Symbol.builder().name("this.input").build());
 
         HttpChecksumTrait httpChecksumTrait = operation.expectTrait(HttpChecksumTrait.class);
         params.put("requestChecksumRequired", httpChecksumTrait.isRequestChecksumRequired());

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.spec.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.spec.ts
@@ -29,12 +29,12 @@ describe(flexibleChecksumsMiddleware.name, () => {
 
   const mockInput = {};
   const mockConfig = {} as PreviouslyResolved;
-  const mockMiddlewareConfig = { input: mockInput, requestChecksumRequired: false };
+  const mockMiddlewareConfig = { requestChecksumRequired: false };
 
   const mockBody = { body: "mockRequestBody" };
   const mockHeaders = { "content-length": 100, "content-encoding": "gzip" };
   const mockRequest = { body: mockBody, headers: mockHeaders };
-  const mockArgs = { request: mockRequest } as BuildHandlerArguments<any>;
+  const mockArgs = { input: mockInput, request: mockRequest } as BuildHandlerArguments<any>;
   const mockResult = { response: { body: "mockResponsebody" } };
 
   beforeEach(() => {

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -21,10 +21,6 @@ import { stringHasher } from "./stringHasher";
 
 export interface FlexibleChecksumsRequestMiddlewareConfig {
   /**
-   * The input object for the operation.
-   */
-  input: Object;
-
   /**
    * Indicates an operation requires a checksum in its HTTP request.
    */
@@ -57,10 +53,10 @@ export const flexibleChecksumsMiddleware =
       return next(args);
     }
 
-    const { request } = args;
+    const { request, input } = args;
     const { body: requestBody, headers } = request;
     const { base64Encoder, streamHasher } = config;
-    const { input, requestChecksumRequired, requestAlgorithmMember } = middlewareConfig;
+    const { requestChecksumRequired, requestAlgorithmMember } = middlewareConfig;
 
     const checksumAlgorithm = getChecksumAlgorithmForRequest(
       input,


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/6492#issuecomment-2486389365

### Description

Use input from args and not middleware config in flexible checksums middleware.

This is because args.input will have updated values, while middlewareConfig.input will have initial values.
We're updating value in `input[requestAlgorithmMember]` in https://github.com/aws/aws-sdk-js-v3/pull/6492

### Testing
CI

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";
import { NodeHttpHandler } from "@smithy/node-http-handler";
import { equal } from "assert";

// Prints checksum headers for request and response.
class CustomHandler extends NodeHttpHandler {
  constructor() {
    super();
  }

  printChecksumHeaders(prefix, headers) {
    for (const [header, value] of Object.entries(headers)) {
      if (header.startsWith("x-amz-checksum-") || header.startsWith("x-amz-sdk-checksum-")) {
        console.log(`${prefix}['${header}']: '${value}'`);
      }
    }
  }

  async handle(request, options) {
    this.printChecksumHeaders("request", request.headers);
    const response = await super.handle(request, options);
    this.printChecksumHeaders("response", response.response.headers);
    return response;
  }
}

const client = new S3({ requestHandler: new CustomHandler() });
const Bucket = "test-flexible-checksums-v2"; // Replace with your test bucket name.
const Key = "hello-world.txt";
const Body = "Hello World"; // Replace with the content you want to test.

console.log("Put Object");
await client.putObject({ Bucket, Key, Body, ChecksumAlgorithm: "CRC32" });

console.log("\nGet Object");
const response = await client.getObject({ Bucket, Key, ChecksumMode: "ENABLED" });

equal(Body, await response.Body.transformToString());
```

Checksum headers are set when ChecksumAlgorithm and ChecksumMode are set.
```console
Put Object
request['x-amz-sdk-checksum-algorithm']: 'CRC32'
request['x-amz-checksum-crc32']: 'ShexVg=='
response['x-amz-checksum-crc32']: 'ShexVg=='

Get Object
request['x-amz-checksum-mode']: 'ENABLED'
response['x-amz-checksum-crc32']: 'ShexVg=='
```

Checksum headers are not set when ChecksumAlgorithm and ChecksumMode are not set.
```console
Put Object

Get Object
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
