### PR TITLE
chore(middleware-flexible-checksums): add requestAlgorithmMemberHttpHeader

### DIFF
--- a/clients/client-s3/src/commands/DeleteObjectsCommand.ts
+++ b/clients/client-s3/src/commands/DeleteObjectsCommand.ts
@@ -322,6 +322,7 @@ export class DeleteObjectsCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutBucketAccelerateConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketAccelerateConfigurationCommand.ts
@@ -124,6 +124,7 @@ export class PutBucketAccelerateConfigurationCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: false,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketAclCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketAclCommand.ts
@@ -315,6 +315,7 @@ export class PutBucketAclCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketCorsCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketCorsCommand.ts
@@ -199,6 +199,7 @@ export class PutBucketCorsCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketEncryptionCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketEncryptionCommand.ts
@@ -214,6 +214,7 @@ export class PutBucketEncryptionCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketLifecycleConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketLifecycleConfigurationCommand.ts
@@ -300,6 +300,7 @@ export class PutBucketLifecycleConfigurationCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutBucketLoggingCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketLoggingCommand.ts
@@ -215,6 +215,7 @@ export class PutBucketLoggingCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketPolicyCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketPolicyCommand.ts
@@ -167,6 +167,7 @@ export class PutBucketPolicyCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketReplicationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketReplicationCommand.ts
@@ -239,6 +239,7 @@ export class PutBucketReplicationCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketRequestPaymentCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketRequestPaymentCommand.ts
@@ -115,6 +115,7 @@ export class PutBucketRequestPaymentCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketTaggingCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketTaggingCommand.ts
@@ -169,6 +169,7 @@ export class PutBucketTaggingCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketVersioningCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketVersioningCommand.ts
@@ -149,6 +149,7 @@ export class PutBucketVersioningCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketWebsiteCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketWebsiteCommand.ts
@@ -250,6 +250,7 @@ export class PutBucketWebsiteCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutObjectAclCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectAclCommand.ts
@@ -314,6 +314,7 @@ export class PutObjectAclCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutObjectCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectCommand.ts
@@ -463,6 +463,7 @@ export class PutObjectCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: false,
       }),
       getCheckContentLengthHeaderPlugin(config),

--- a/clients/client-s3/src/commands/PutObjectLegalHoldCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectLegalHoldCommand.ts
@@ -92,6 +92,7 @@ export class PutObjectLegalHoldCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutObjectLockConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectLockConfigurationCommand.ts
@@ -115,6 +115,7 @@ export class PutObjectLockConfigurationCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutObjectRetentionCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectRetentionCommand.ts
@@ -95,6 +95,7 @@ export class PutObjectRetentionCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutObjectTaggingCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectTaggingCommand.ts
@@ -175,6 +175,7 @@ export class PutObjectTaggingCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutPublicAccessBlockCommand.ts
+++ b/clients/client-s3/src/commands/PutPublicAccessBlockCommand.ts
@@ -123,6 +123,7 @@ export class PutPublicAccessBlockCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/RestoreObjectCommand.ts
+++ b/clients/client-s3/src/commands/RestoreObjectCommand.ts
@@ -389,6 +389,7 @@ export class RestoreObjectCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: false,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/UploadPartCommand.ts
+++ b/clients/client-s3/src/commands/UploadPartCommand.ts
@@ -321,6 +321,7 @@ export class UploadPartCommand extends $Command
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
         requestAlgorithmMember: "ChecksumAlgorithm",
+        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
         requestChecksumRequired: false,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.aws.traits.HttpChecksumTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -203,13 +204,14 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
         params.put("requestChecksumRequired", httpChecksumTrait.isRequestChecksumRequired());
         httpChecksumTrait.getRequestAlgorithmMember().ifPresent(requestAlgorithmMember -> {
             params.put("requestAlgorithmMember", requestAlgorithmMember);
-            operation.getInput().ifPresent(inputShapeId -> {
-                StructureShape inputShape = model.expectShape(inputShapeId, StructureShape.class);
-                inputShape.getMember(requestAlgorithmMember).ifPresent(requestAlgorithmMemberShape -> {
-                    requestAlgorithmMemberShape.getTrait(HttpHeaderTrait.class).ifPresent(httpHeaderTrait -> {
-                        params.put("requestAlgorithmMemberHttpHeader", httpHeaderTrait.getValue());
-                    });
-                });
+
+            // We know that input shape is structure, and contains requestAlgorithmMember.
+            StructureShape inputShape =  model.expectShape(operation.getInput().get(), StructureShape.class);
+            MemberShape requestAlgorithmMemberShape = inputShape.getAllMembers().get(requestAlgorithmMember);
+
+            // Set requestAlgorithmMemberHttpHeader if HttpHeaderTrait is present.
+            requestAlgorithmMemberShape.getTrait(HttpHeaderTrait.class).ifPresent(httpHeaderTrait -> {
+                params.put("requestAlgorithmMemberHttpHeader", httpHeaderTrait.getValue());
             });
         });
         httpChecksumTrait.getRequestValidationModeMember().ifPresent(requestValidationModeMember -> {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
@@ -30,6 +30,8 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.HttpHeaderTrait;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
@@ -201,6 +203,14 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
         params.put("requestChecksumRequired", httpChecksumTrait.isRequestChecksumRequired());
         httpChecksumTrait.getRequestAlgorithmMember().ifPresent(requestAlgorithmMember -> {
             params.put("requestAlgorithmMember", requestAlgorithmMember);
+            operation.getInput().ifPresent(inputShapeId -> {
+                StructureShape inputShape = model.expectShape(inputShapeId, StructureShape.class);
+                inputShape.getMember(requestAlgorithmMember).ifPresent(requestAlgorithmMemberShape -> {
+                    requestAlgorithmMemberShape.getTrait(HttpHeaderTrait.class).ifPresent(httpHeaderTrait -> {
+                        params.put("requestAlgorithmMemberHttpHeader", httpHeaderTrait.getValue());
+                    });
+                });
+            });
         });
         httpChecksumTrait.getRequestValidationModeMember().ifPresent(requestValidationModeMember -> {
             params.put("requestValidationModeMember", requestValidationModeMember);

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -30,6 +30,12 @@ export interface FlexibleChecksumsRequestMiddlewareConfig {
    * Defines a top-level operation input member that is used to configure request checksum behavior.
    */
   requestAlgorithmMember?: string;
+
+  /**
+   * The {@link httpHeader} value for {@link requestAlgorithmMember}, if present.
+   * {@link https://smithy.io/2.0/spec/http-bindings.html#httpheader-trait httpHeader}
+   */
+  requestAlgorithmMemberHttpHeader?: string;
 }
 
 export const flexibleChecksumsMiddlewareOptions: BuildHandlerOptions = {


### PR DESCRIPTION
### Issue
* Internal JS-5396
* Will be consumed in https://github.com/aws/aws-sdk-js-v3/pull/6492

### Description
Creates and sets [httpHeader](https://smithy.io/2.0/spec/http-bindings.html#httpheader-trait) value for [requestAlgorithmMember](https://smithy.io/2.0/aws/aws-core.html#aws-protocols-httpchecksum-trait), if present. 

### Testing
CI, as this PR just populates the middleware config.
The value will be consumed, and tested in https://github.com/aws/aws-sdk-js-v3/pull/6492

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
