### PR TITLE
chore(middleware-flexible-checksums): use object for requestAlgorithmMember

### DIFF
--- a/clients/client-s3/src/commands/CreateBucketMetadataTableConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/CreateBucketMetadataTableConfigurationCommand.ts
@@ -143,8 +143,7 @@ export class CreateBucketMetadataTableConfigurationCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/DeleteObjectsCommand.ts
+++ b/clients/client-s3/src/commands/DeleteObjectsCommand.ts
@@ -322,8 +322,7 @@ export class DeleteObjectsCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutBucketAccelerateConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketAccelerateConfigurationCommand.ts
@@ -123,8 +123,7 @@ export class PutBucketAccelerateConfigurationCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: false,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketAclCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketAclCommand.ts
@@ -314,8 +314,7 @@ export class PutBucketAclCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketCorsCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketCorsCommand.ts
@@ -198,8 +198,7 @@ export class PutBucketCorsCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketEncryptionCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketEncryptionCommand.ts
@@ -214,8 +214,7 @@ export class PutBucketEncryptionCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketLifecycleConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketLifecycleConfigurationCommand.ts
@@ -304,8 +304,7 @@ export class PutBucketLifecycleConfigurationCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutBucketLoggingCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketLoggingCommand.ts
@@ -214,8 +214,7 @@ export class PutBucketLoggingCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketPolicyCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketPolicyCommand.ts
@@ -167,8 +167,7 @@ export class PutBucketPolicyCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketReplicationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketReplicationCommand.ts
@@ -238,8 +238,7 @@ export class PutBucketReplicationCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketRequestPaymentCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketRequestPaymentCommand.ts
@@ -114,8 +114,7 @@ export class PutBucketRequestPaymentCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketTaggingCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketTaggingCommand.ts
@@ -168,8 +168,7 @@ export class PutBucketTaggingCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketVersioningCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketVersioningCommand.ts
@@ -148,8 +148,7 @@ export class PutBucketVersioningCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutBucketWebsiteCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketWebsiteCommand.ts
@@ -249,8 +249,7 @@ export class PutBucketWebsiteCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/PutObjectAclCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectAclCommand.ts
@@ -313,8 +313,7 @@ export class PutObjectAclCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutObjectCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectCommand.ts
@@ -463,8 +463,7 @@ export class PutObjectCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: false,
       }),
       getCheckContentLengthHeaderPlugin(config),

--- a/clients/client-s3/src/commands/PutObjectLegalHoldCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectLegalHoldCommand.ts
@@ -91,8 +91,7 @@ export class PutObjectLegalHoldCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutObjectLockConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectLockConfigurationCommand.ts
@@ -114,8 +114,7 @@ export class PutObjectLockConfigurationCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutObjectRetentionCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectRetentionCommand.ts
@@ -94,8 +94,7 @@ export class PutObjectRetentionCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutObjectTaggingCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectTaggingCommand.ts
@@ -174,8 +174,7 @@ export class PutObjectTaggingCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/PutPublicAccessBlockCommand.ts
+++ b/clients/client-s3/src/commands/PutPublicAccessBlockCommand.ts
@@ -122,8 +122,7 @@ export class PutPublicAccessBlockCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: true,
       }),
     ];

--- a/clients/client-s3/src/commands/RestoreObjectCommand.ts
+++ b/clients/client-s3/src/commands/RestoreObjectCommand.ts
@@ -388,8 +388,7 @@ export class RestoreObjectCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: false,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/clients/client-s3/src/commands/UploadPartCommand.ts
+++ b/clients/client-s3/src/commands/UploadPartCommand.ts
@@ -321,8 +321,7 @@ export class UploadPartCommand extends $Command
       getSerdePlugin(config, this.serialize, this.deserialize),
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
       getFlexibleChecksumsPlugin(config, {
-        requestAlgorithmMember: "ChecksumAlgorithm",
-        requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+        requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
         requestChecksumRequired: false,
       }),
       getThrow200ExceptionsPlugin(config),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
@@ -203,7 +203,8 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
         HttpChecksumTrait httpChecksumTrait = operation.expectTrait(HttpChecksumTrait.class);
         params.put("requestChecksumRequired", httpChecksumTrait.isRequestChecksumRequired());
         httpChecksumTrait.getRequestAlgorithmMember().ifPresent(requestAlgorithmMember -> {
-            params.put("requestAlgorithmMember", requestAlgorithmMember);
+            Map<String, String> requestAlgorithmMemberMap = new TreeMap<String, String>();
+            requestAlgorithmMemberMap.put("name", requestAlgorithmMember);
 
             // We know that input shape is structure, and contains requestAlgorithmMember.
             StructureShape inputShape =  model.expectShape(operation.getInput().get(), StructureShape.class);
@@ -211,8 +212,10 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
 
             // Set requestAlgorithmMemberHttpHeader if HttpHeaderTrait is present.
             requestAlgorithmMemberShape.getTrait(HttpHeaderTrait.class).ifPresent(httpHeaderTrait -> {
-                params.put("requestAlgorithmMemberHttpHeader", httpHeaderTrait.getValue());
+                requestAlgorithmMemberMap.put("httpHeader", httpHeaderTrait.getValue());
             });
+
+            params.put("requestAlgorithmMember", requestAlgorithmMemberMap);
         });
         httpChecksumTrait.getRequestValidationModeMember().ifPresent(requestValidationModeMember -> {
             params.put("requestValidationModeMember", requestValidationModeMember);

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -27,15 +27,20 @@ export interface FlexibleChecksumsRequestMiddlewareConfig {
   requestChecksumRequired: boolean;
 
   /**
-   * Defines a top-level operation input member that is used to configure request checksum behavior.
+   * Member that is used to configure request checksum behavior.
    */
-  requestAlgorithmMember?: string;
+  requestAlgorithmMember?: {
+    /**
+     * Defines a top-level operation input member that is used to configure request checksum behavior.
+     */
+    name: string;
 
-  /**
-   * The {@link httpHeader} value for {@link requestAlgorithmMember}, if present.
-   * {@link https://smithy.io/2.0/spec/http-bindings.html#httpheader-trait httpHeader}
-   */
-  requestAlgorithmMemberHttpHeader?: string;
+    /**
+     * The {@link httpHeader} value, if present.
+     * {@link https://smithy.io/2.0/spec/http-bindings.html#httpheader-trait httpHeader}
+     */
+    httpHeader?: string;
+  };
 }
 
 export const flexibleChecksumsMiddlewareOptions: BuildHandlerOptions = {
@@ -68,7 +73,7 @@ export const flexibleChecksumsMiddleware =
       input,
       {
         requestChecksumRequired,
-        requestAlgorithmMember,
+        requestAlgorithmMember: requestAlgorithmMember?.name,
       },
       !!context.isS3ExpressBucket
     );


### PR DESCRIPTION
### Issue
* Internal JS-5396
* Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/6694

### Description
Switches to using object for requestAlgorithmMember to avoid future confusion that requestAlgorithmMember and requestAlgorithmMemberHttpHeader can exist independently of each other

### Testing
CI, as this PR just populates the middleware config.
The value in `httpHeader` will be consumed, and tested in https://github.com/aws/aws-sdk-js-v3/pull/6492

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
