### PR TITLE
feat(credential-providers): make credential providers aware of caller client region

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "copy-models": "node ./scripts/copy-models",
     "extract:docs": "node ./scripts/extract-docs/index.js",
     "g:vitest": "cd $INIT_CWD && vitest",
+    "g:jest": "cd $INIT_CWD && jest",
     "generate-clients": "node ./scripts/generate-clients",
     "generate:clients:generic": "node ./scripts/generate-clients/generic",
     "generate:defaults-mode-provider": "./scripts/generate-defaults-mode-provider/index.js",

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
@@ -129,8 +129,8 @@ export const resolveAwsSdkSigV4Config = <T>(
     }
   }
 
-  const contextBoundCredentialsProvider = async () => {
-    return credentialsProvider!({ contextClientConfig: config });
+  const boundCredentialsProvider = async () => {
+    return credentialsProvider!({ callerClientConfig: config });
   };
 
   // Populate sigv4 arguments
@@ -174,7 +174,7 @@ export const resolveAwsSdkSigV4Config = <T>(
 
           const params: SignatureV4Init & SignatureV4CryptoInit = {
             ...config,
-            credentials: contextBoundCredentialsProvider,
+            credentials: boundCredentialsProvider,
             region: config.signingRegion,
             service: config.signingName,
             sha256,
@@ -210,7 +210,7 @@ export const resolveAwsSdkSigV4Config = <T>(
 
       const params: SignatureV4Init & SignatureV4CryptoInit = {
         ...config,
-        credentials: contextBoundCredentialsProvider,
+        credentials: boundCredentialsProvider,
         region: config.signingRegion,
         service: config.signingName,
         sha256,
@@ -228,10 +228,10 @@ export const resolveAwsSdkSigV4Config = <T>(
     signingEscapePath,
     credentials: isUserSupplied
       ? async () =>
-          contextBoundCredentialsProvider!().then((creds: AttributedAwsCredentialIdentity) =>
+          boundCredentialsProvider!().then((creds: AttributedAwsCredentialIdentity) =>
             setCredentialFeature(creds, "CREDENTIALS_CODE", "e")
           )
-      : contextBoundCredentialsProvider!,
+      : boundCredentialsProvider!,
     signer,
   };
 };

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
@@ -129,9 +129,7 @@ export const resolveAwsSdkSigV4Config = <T>(
     }
   }
 
-  const boundCredentialsProvider = async () => {
-    return credentialsProvider!({ callerClientConfig: config });
-  };
+  const boundCredentialsProvider = async () => credentialsProvider!({ callerClientConfig: config });
 
   // Populate sigv4 arguments
   const {

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -47,7 +47,7 @@ export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): 
           region:
             parameters.clientConfig?.region ??
             parameters.parentClientConfig?.region ??
-            awsIdentityProperties?.contextClientConfig?.region,
+            awsIdentityProperties?.callerClientConfig?.region,
         })
       )
     ).send(

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -1,6 +1,6 @@
-import type { CredentialProviderOptions } from "@aws-sdk/types";
+import type { AwsIdentityProperties, CredentialProviderOptions, RegionalIdentityProvider } from "@aws-sdk/types";
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { AwsCredentialIdentity, Logger, Provider } from "@smithy/types";
+import type { AwsCredentialIdentity, Logger } from "@smithy/types";
 
 import { CognitoProviderParameters } from "./CognitoProviderParameters";
 import { resolveLogins } from "./resolveLogins";
@@ -18,7 +18,7 @@ export interface CognitoIdentityCredentials extends AwsCredentialIdentity {
 /**
  * @internal
  */
-export type CognitoIdentityCredentialProvider = Provider<CognitoIdentityCredentials>;
+export type CognitoIdentityCredentialProvider = RegionalIdentityProvider<CognitoIdentityCredentials>;
 
 /**
  * @internal
@@ -29,7 +29,7 @@ export type CognitoIdentityCredentialProvider = Provider<CognitoIdentityCredenti
  * Results from this function call are not cached internally.
  */
 export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): CognitoIdentityCredentialProvider {
-  return async (): Promise<CognitoIdentityCredentials> => {
+  return async (awsIdentityProperties?: AwsIdentityProperties): Promise<CognitoIdentityCredentials> => {
     parameters.logger?.debug("@aws-sdk/credential-provider-cognito-identity - fromCognitoIdentity");
     const { GetCredentialsForIdentityCommand, CognitoIdentityClient } = await import("./loadCognitoIdentity");
 
@@ -44,7 +44,10 @@ export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): 
       parameters.client ??
       new CognitoIdentityClient(
         Object.assign({}, parameters.clientConfig ?? {}, {
-          region: parameters.clientConfig?.region ?? parameters.parentClientConfig?.region,
+          region:
+            parameters.clientConfig?.region ??
+            parameters.parentClientConfig?.region ??
+            awsIdentityProperties?.contextClientConfig?.region,
         })
       )
     ).send(

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -1,4 +1,4 @@
-import type { AwsIdentityProperties, CredentialProviderOptions, RegionalIdentityProvider } from "@aws-sdk/types";
+import type { AwsIdentityProperties, CredentialProviderOptions, RuntimeConfigIdentityProvider } from "@aws-sdk/types";
 import { CredentialsProviderError } from "@smithy/property-provider";
 import type { AwsCredentialIdentity, Logger } from "@smithy/types";
 
@@ -18,7 +18,7 @@ export interface CognitoIdentityCredentials extends AwsCredentialIdentity {
 /**
  * @internal
  */
-export type CognitoIdentityCredentialProvider = RegionalIdentityProvider<CognitoIdentityCredentials>;
+export type CognitoIdentityCredentialProvider = RuntimeConfigIdentityProvider<CognitoIdentityCredentials>;
 
 /**
  * @internal

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
@@ -68,11 +68,11 @@ export function fromCognitoIdentityPool({
       identityId,
     });
 
-    return provider();
+    return provider(awsIdentityProperties);
   };
 
-  return () =>
-    provider().catch(async (err) => {
+  return (awsIdentityProperties?: AwsIdentityProperties) =>
+    provider(awsIdentityProperties).catch(async (err) => {
       if (cacheKey) {
         Promise.resolve(cache.removeItem(cacheKey)).catch(() => {});
       }

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
@@ -1,4 +1,4 @@
-import type { CredentialProviderOptions } from "@aws-sdk/types";
+import type { AwsIdentityProperties, CredentialProviderOptions } from "@aws-sdk/types";
 import { CredentialsProviderError } from "@smithy/property-provider";
 import { Logger } from "@smithy/types";
 
@@ -35,12 +35,15 @@ export function fromCognitoIdentityPool({
     ? `aws:cognito-identity-credentials:${identityPoolId}:${userIdentifier}`
     : undefined;
 
-  let provider: CognitoIdentityCredentialProvider = async () => {
+  let provider: CognitoIdentityCredentialProvider = async (awsIdentityProperties?: AwsIdentityProperties) => {
     const { GetIdCommand, CognitoIdentityClient } = await import("./loadCognitoIdentity");
     const _client =
       client ??
       new CognitoIdentityClient(
-        Object.assign({}, clientConfig ?? {}, { region: clientConfig?.region ?? parentClientConfig?.region })
+        Object.assign({}, clientConfig ?? {}, {
+          region:
+            clientConfig?.region ?? parentClientConfig?.region ?? awsIdentityProperties?.contextClientConfig?.region,
+        })
       );
 
     let identityId: string | undefined = (cacheKey && (await cache.getItem(cacheKey))) as string | undefined;

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
@@ -42,7 +42,7 @@ export function fromCognitoIdentityPool({
       new CognitoIdentityClient(
         Object.assign({}, clientConfig ?? {}, {
           region:
-            clientConfig?.region ?? parentClientConfig?.region ?? awsIdentityProperties?.contextClientConfig?.region,
+            clientConfig?.region ?? parentClientConfig?.region ?? awsIdentityProperties?.callerClientConfig?.region,
         })
       );
 

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -13,7 +13,9 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "yarn g:vitest run",
-    "test:watch": "yarn g:vitest watch"
+    "test:watch": "yarn g:vitest watch",
+    "test:integration": "yarn g:vitest run -c vitest.config.integ.ts",
+    "test:integration:watch": "yarn g:vitest watch -c vitest.config.integ.ts"
   },
   "keywords": [
     "aws",

--- a/packages/credential-provider-ini/src/fromIni.integ.spec.ts
+++ b/packages/credential-provider-ini/src/fromIni.integ.spec.ts
@@ -1,0 +1,242 @@
+import { STS } from "@aws-sdk/client-sts";
+import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
+import { SourceProfileInit } from "@smithy/shared-ini-file-loader";
+import type { NodeHttpHandlerOptions, ParsedIniData } from "@smithy/types";
+import { PassThrough } from "node:stream";
+import { beforeEach, describe, expect, test as it, vi } from "vitest";
+
+import { fromIni } from "./fromIni";
+
+let iniProfileData: ParsedIniData = null as any;
+vi.mock("@smithy/shared-ini-file-loader", async () => {
+  const actual: any = await vi.importActual("@smithy/shared-ini-file-loader");
+  const pkg = {
+    ...actual,
+    async loadSsoSessionData() {
+      return Object.entries(iniProfileData)
+        .filter(([key]) => key.startsWith("sso-session."))
+        .reduce(
+          (acc, [key, value]) => ({
+            ...acc,
+            [key.split("sso-session.")[1]]: value,
+          }),
+          {}
+        );
+    },
+    async parseKnownFiles(init: SourceProfileInit): Promise<ParsedIniData> {
+      return iniProfileData;
+    },
+    async getSSOTokenFromFile() {
+      return {
+        accessToken: "mock_sso_token",
+        expiresAt: "3000-01-01T00:00:00.000Z",
+      };
+    },
+  };
+  return {
+    ...pkg,
+    default: pkg,
+  };
+});
+
+class MockNodeHttpHandler {
+  static create(instanceOrOptions?: any) {
+    if (typeof instanceOrOptions?.handle === "function") {
+      return instanceOrOptions;
+    }
+    return new MockNodeHttpHandler();
+  }
+  async handle(request: HttpRequest) {
+    const body = new PassThrough({});
+
+    const region = (request.hostname.match(/sts\.(.*?)\./) || [, "unknown"])[1];
+
+    if (request.headers.Authorization === "container-authorization") {
+      body.write(
+        JSON.stringify({
+          AccessKeyId: "CONTAINER_ACCESS_KEY",
+          SecretAccessKey: "CONTAINER_SECRET_ACCESS_KEY",
+          Token: "CONTAINER_TOKEN",
+          Expiration: "3000-01-01T00:00:00.000Z",
+        })
+      );
+    } else if (request.path?.includes("/federation/credentials")) {
+      body.write(
+        JSON.stringify({
+          roleCredentials: {
+            accessKeyId: "SSO_ACCESS_KEY_ID",
+            secretAccessKey: "SSO_SECRET_ACCESS_KEY",
+            sessionToken: "SSO_SESSION_TOKEN",
+            expiration: "3000-01-01T00:00:00.000Z",
+          },
+        })
+      );
+    } else if (request.body?.includes("Action=AssumeRoleWithWebIdentity")) {
+      body.write(`
+<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<AssumeRoleWithWebIdentityResult>
+<Credentials>
+  <AccessKeyId>STS_ARWI_ACCESS_KEY_ID</AccessKeyId>
+  <SecretAccessKey>STS_ARWI_SECRET_ACCESS_KEY</SecretAccessKey>
+  <SessionToken>STS_ARWI_SESSION_TOKEN_${region}</SessionToken>
+  <Expiration>3000-01-01T00:00:00.000Z</Expiration>
+</Credentials>
+</AssumeRoleWithWebIdentityResult>
+<ResponseMetadata>
+<RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>`);
+    } else if (request.body?.includes("Action=AssumeRole")) {
+      body.write(`
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<AssumeRoleResult>
+<Credentials>
+  <AccessKeyId>STS_AR_ACCESS_KEY_ID</AccessKeyId>
+  <SecretAccessKey>STS_AR_SECRET_ACCESS_KEY</SecretAccessKey>
+  <SessionToken>STS_AR_SESSION_TOKEN_${region}</SessionToken>
+  <Expiration>3000-01-01T00:00:00.000Z</Expiration>
+</Credentials>
+</AssumeRoleResult>
+<ResponseMetadata>
+<RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ResponseMetadata>
+</AssumeRoleResponse>`);
+    } else if (request.body.includes("Action=GetCallerIdentity")) {
+      body.write(`
+<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<GetCallerIdentityResult>
+<Arn>arn:aws:iam::123456789012:user/Alice</Arn>
+<UserId>AIDACKCEVSQ6C2EXAMPLE</UserId>
+<Account>123456789012</Account>
+</GetCallerIdentityResult>
+<ResponseMetadata>
+<RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ResponseMetadata>
+</GetCallerIdentityResponse>`);
+    } else {
+      throw new Error("request not supported.");
+    }
+    body.end();
+    return {
+      response: new HttpResponse({
+        statusCode: 200,
+        body,
+        headers: {},
+      }),
+    };
+  }
+  updateHttpClientConfig(key: keyof NodeHttpHandlerOptions, value: NodeHttpHandlerOptions[typeof key]): void {}
+  httpHandlerConfigs(): NodeHttpHandlerOptions {
+    return null as any;
+  }
+}
+
+describe("fromIni region search order", () => {
+  beforeEach(() => {
+    iniProfileData = {
+      default: {
+        region: "us-west-2",
+        output: "json",
+      },
+    };
+    iniProfileData.assume = {
+      region: "us-stsar-1",
+      aws_access_key_id: "ASSUME_STATIC_ACCESS_KEY",
+      aws_secret_access_key: "ASSUME_STATIC_SECRET_KEY",
+    };
+    Object.assign(iniProfileData.default, {
+      region: "us-stsar-1",
+      role_arn: "ROLE_ARN",
+      role_session_name: "ROLE_SESSION_NAME",
+      external_id: "EXTERNAL_ID",
+      source_profile: "assume",
+    });
+  });
+
+  it("should use 1st priority for the clientConfig given to the provider factory", async () => {
+    const sts = new STS({
+      requestHandler: new MockNodeHttpHandler(),
+      region: "ap-northeast-2",
+      credentials: fromIni({
+        clientConfig: {
+          requestHandler: new MockNodeHttpHandler(),
+          region: "ap-northeast-1",
+        },
+      }),
+    });
+
+    await sts.getCallerIdentity({});
+    const credentials = await sts.config.credentials();
+    expect(credentials).toContain({
+      accessKeyId: "STS_AR_ACCESS_KEY_ID",
+      secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
+      sessionToken: "STS_AR_SESSION_TOKEN_ap-northeast-1",
+    });
+  });
+
+  it("should use 2nd priority for the context client", async () => {
+    const sts = new STS({
+      requestHandler: new MockNodeHttpHandler(),
+      region: "ap-northeast-2",
+      credentials: fromIni({
+        clientConfig: {
+          requestHandler: new MockNodeHttpHandler(),
+        },
+      }),
+    });
+
+    await sts.getCallerIdentity({});
+    const credentials = await sts.config.credentials();
+    expect(credentials).toContain({
+      accessKeyId: "STS_AR_ACCESS_KEY_ID",
+      secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
+      sessionToken: "STS_AR_SESSION_TOKEN_ap-northeast-2",
+    });
+  });
+
+  it("should use 3rd priority for the profile region if not used in the context of a client with a region", async () => {
+    const credentialsData = await fromIni({
+      clientConfig: {
+        requestHandler: new MockNodeHttpHandler(),
+      },
+    })();
+
+    const sts = new STS({
+      requestHandler: new MockNodeHttpHandler(),
+      region: "ap-northeast-2",
+      credentials: credentialsData,
+    });
+
+    await sts.getCallerIdentity({});
+    const credentials = await sts.config.credentials();
+    expect(credentials).toContain({
+      accessKeyId: "STS_AR_ACCESS_KEY_ID",
+      secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
+      sessionToken: "STS_AR_SESSION_TOKEN_us-stsar-1",
+    });
+  });
+
+  it("should use 4th priority for the default partition's default region", async () => {
+    delete iniProfileData.default.region;
+
+    const credentialsData = await fromIni({
+      clientConfig: {
+        requestHandler: new MockNodeHttpHandler(),
+      },
+    })();
+
+    const sts = new STS({
+      requestHandler: new MockNodeHttpHandler(),
+      region: "ap-northeast-2",
+      credentials: credentialsData,
+    });
+
+    await sts.getCallerIdentity({});
+    const credentials = await sts.config.credentials();
+    expect(credentials).toContain({
+      accessKeyId: "STS_AR_ACCESS_KEY_ID",
+      secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
+      sessionToken: "STS_AR_SESSION_TOKEN_us-east-1",
+    });
+  });
+});

--- a/packages/credential-provider-ini/src/fromIni.integ.spec.ts
+++ b/packages/credential-provider-ini/src/fromIni.integ.spec.ts
@@ -174,7 +174,29 @@ describe("fromIni region search order", () => {
     });
   });
 
-  it("should use 2nd priority for the context client", async () => {
+  it("should use 2nd priority for the profile region", async () => {
+    const sts = new STS({
+      requestHandler: new MockNodeHttpHandler(),
+      region: "ap-northeast-2",
+      credentials: fromIni({
+        clientConfig: {
+          requestHandler: new MockNodeHttpHandler(),
+        },
+      }),
+    });
+
+    await sts.getCallerIdentity({});
+    const credentials = await sts.config.credentials();
+    expect(credentials).toContain({
+      accessKeyId: "STS_AR_ACCESS_KEY_ID",
+      secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
+      sessionToken: "STS_AR_SESSION_TOKEN_us-stsar-1",
+    });
+  });
+
+  it("should use 3rd priority for the caller client", async () => {
+    delete iniProfileData.default.region;
+
     const sts = new STS({
       requestHandler: new MockNodeHttpHandler(),
       region: "ap-northeast-2",
@@ -191,28 +213,6 @@ describe("fromIni region search order", () => {
       accessKeyId: "STS_AR_ACCESS_KEY_ID",
       secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
       sessionToken: "STS_AR_SESSION_TOKEN_ap-northeast-2",
-    });
-  });
-
-  it("should use 3rd priority for the profile region if not used in the context of a client with a region", async () => {
-    const credentialsData = await fromIni({
-      clientConfig: {
-        requestHandler: new MockNodeHttpHandler(),
-      },
-    })();
-
-    const sts = new STS({
-      requestHandler: new MockNodeHttpHandler(),
-      region: "ap-northeast-2",
-      credentials: credentialsData,
-    });
-
-    await sts.getCallerIdentity({});
-    const credentials = await sts.config.credentials();
-    expect(credentials).toContain({
-      accessKeyId: "STS_AR_ACCESS_KEY_ID",
-      secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
-      sessionToken: "STS_AR_SESSION_TOKEN_us-stsar-1",
     });
   });
 

--- a/packages/credential-provider-ini/src/fromIni.ts
+++ b/packages/credential-provider-ini/src/fromIni.ts
@@ -57,13 +57,13 @@ export interface FromIniInit extends SourceProfileInit, CredentialProviderOption
  */
 export const fromIni =
   (_init: FromIniInit = {}): RegionalAwsCredentialIdentityProvider =>
-  async ({ contextClientConfig } = {}) => {
+  async ({ callerClientConfig } = {}) => {
     const init: FromIniInit = {
       ..._init,
     };
-    if (contextClientConfig?.region) {
+    if (callerClientConfig?.region) {
       init.parentClientConfig = {
-        region: contextClientConfig.region,
+        region: callerClientConfig.region,
         ..._init.parentClientConfig,
       };
     }

--- a/packages/credential-provider-ini/src/fromIni.ts
+++ b/packages/credential-provider-ini/src/fromIni.ts
@@ -1,6 +1,6 @@
 import type { AssumeRoleWithWebIdentityParams } from "@aws-sdk/credential-provider-web-identity";
 import type { CredentialProviderOptions } from "@aws-sdk/types";
-import type { RegionalAwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type { RuntimeConfigAwsCredentialIdentityProvider } from "@aws-sdk/types";
 import { getProfileName, parseKnownFiles, SourceProfileInit } from "@smithy/shared-ini-file-loader";
 import type { AwsCredentialIdentity, Pluggable } from "@smithy/types";
 
@@ -56,7 +56,7 @@ export interface FromIniInit extends SourceProfileInit, CredentialProviderOption
  * role assumption and multi-factor authentication.
  */
 export const fromIni =
-  (_init: FromIniInit = {}): RegionalAwsCredentialIdentityProvider =>
+  (_init: FromIniInit = {}): RuntimeConfigAwsCredentialIdentityProvider =>
   async ({ callerClientConfig } = {}) => {
     const init: FromIniInit = {
       ..._init,

--- a/packages/credential-provider-ini/src/fromIni.ts
+++ b/packages/credential-provider-ini/src/fromIni.ts
@@ -60,11 +60,13 @@ export const fromIni =
   async (props = {}) => {
     const init: FromIniInit = {
       ..._init,
-      parentClientConfig: {
-        region: props.contextClientConfig?.region,
-        ..._init.parentClientConfig,
-      },
     };
+    if (props.contextClientConfig?.region) {
+      init.parentClientConfig = {
+        region: props.contextClientConfig.region,
+        ..._init.parentClientConfig,
+      };
+    }
     init.logger?.debug("@aws-sdk/credential-provider-ini - fromIni");
     const profiles = await parseKnownFiles(init);
     return resolveProfileData(getProfileName(init), profiles, init);

--- a/packages/credential-provider-ini/src/fromIni.ts
+++ b/packages/credential-provider-ini/src/fromIni.ts
@@ -57,13 +57,13 @@ export interface FromIniInit extends SourceProfileInit, CredentialProviderOption
  */
 export const fromIni =
   (_init: FromIniInit = {}): RegionalAwsCredentialIdentityProvider =>
-  async (props = {}) => {
+  async ({ contextClientConfig } = {}) => {
     const init: FromIniInit = {
       ..._init,
     };
-    if (props.contextClientConfig?.region) {
+    if (contextClientConfig?.region) {
       init.parentClientConfig = {
-        region: props.contextClientConfig.region,
+        region: contextClientConfig.region,
         ..._init.parentClientConfig,
       };
     }

--- a/packages/credential-provider-ini/src/fromIni.ts
+++ b/packages/credential-provider-ini/src/fromIni.ts
@@ -1,7 +1,8 @@
 import type { AssumeRoleWithWebIdentityParams } from "@aws-sdk/credential-provider-web-identity";
 import type { CredentialProviderOptions } from "@aws-sdk/types";
+import type { RegionalAwsCredentialIdentityProvider } from "@aws-sdk/types";
 import { getProfileName, parseKnownFiles, SourceProfileInit } from "@smithy/shared-ini-file-loader";
-import type { AwsCredentialIdentity, AwsCredentialIdentityProvider, Pluggable } from "@smithy/types";
+import type { AwsCredentialIdentity, Pluggable } from "@smithy/types";
 
 import { AssumeRoleParams } from "./resolveAssumeRoleCredentials";
 import { resolveProfileData } from "./resolveProfileData";
@@ -55,8 +56,15 @@ export interface FromIniInit extends SourceProfileInit, CredentialProviderOption
  * role assumption and multi-factor authentication.
  */
 export const fromIni =
-  (init: FromIniInit = {}): AwsCredentialIdentityProvider =>
-  async () => {
+  (_init: FromIniInit = {}): RegionalAwsCredentialIdentityProvider =>
+  async (props = {}) => {
+    const init: FromIniInit = {
+      ..._init,
+      parentClientConfig: {
+        region: props.contextClientConfig?.region,
+        ..._init.parentClientConfig,
+      },
+    };
     init.logger?.debug("@aws-sdk/credential-provider-ini - fromIni");
     const profiles = await parseKnownFiles(init);
     return resolveProfileData(getProfileName(init), profiles, init);

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -119,10 +119,7 @@ export const resolveAssumeRoleCredentials = async (
         credentialProviderLogger: options.logger,
         parentClientConfig: {
           ...options?.parentClientConfig,
-          // The profile region is the last fallback, and only applies
-          // if the clientConfig.region is not defined by the user
-          // and no contextual outer client configuration region can be found.
-          region: options?.parentClientConfig?.region ?? region,
+          region: region ?? options?.parentClientConfig?.region,
         },
       },
       options.clientPlugins

--- a/packages/credential-provider-ini/vitest.config.integ.ts
+++ b/packages/credential-provider-ini/vitest.config.integ.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.integ.spec.ts"],
+    environment: "node",
+  },
+});

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -16,7 +16,7 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "yarn g:vitest run",
-    "test:integration": "jest -c jest.config.integ.js",
+    "test:integration": "yarn g:jest -c jest.config.integ.js",
     "test:watch": "yarn g:vitest watch"
   },
   "keywords": [

--- a/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
+++ b/packages/credential-provider-node/src/credential-provider-node.integ.spec.ts
@@ -398,7 +398,7 @@ describe("credential-provider-node integration test", () => {
       expect(credentials).toEqual({
         accessKeyId: "STS_AR_ACCESS_KEY_ID",
         secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
-        sessionToken: "STS_AR_SESSION_TOKEN_us-west-2",
+        sessionToken: "STS_AR_SESSION_TOKEN_us-stsar-1",
         expiration: new Date("3000-01-01T00:00:00.000Z"),
         $source: {
           CREDENTIALS_PROFILE_SOURCE_PROFILE: "o",
@@ -805,7 +805,7 @@ describe("credential-provider-node integration test", () => {
   });
 
   describe("Region resolution for code-level providers given to a client", () => {
-    it("fromCognitoIdentity provider should use context client region", async () => {
+    it("fromCognitoIdentity provider should use caller client region", async () => {
       sts = new STS({
         region: "ap-northeast-1",
         credentials: fromCognitoIdentity({
@@ -824,7 +824,7 @@ describe("credential-provider-node integration test", () => {
       });
     });
 
-    it("fromCognitoIdentityPool provider should use context client region", async () => {
+    it("fromCognitoIdentityPool provider should use caller client region", async () => {
       sts = new STS({
         region: "ap-northeast-1",
         credentials: fromCognitoIdentityPool({
@@ -843,7 +843,7 @@ describe("credential-provider-node integration test", () => {
       });
     });
 
-    it("fromIni assumeRole provider should use the context client's region for STS", async () => {
+    it("fromIni assumeRole provider should use the caller client's region for STS", async () => {
       sts = new STS({
         region: "eu-west-1",
         credentials: fromIni(),
@@ -875,7 +875,7 @@ describe("credential-provider-node integration test", () => {
       });
     });
 
-    it("fromWebToken provider should use context client region", async () => {
+    it("fromWebToken provider should use caller client region", async () => {
       sts = new STS({
         region: "ap-northeast-1",
         credentials: fromWebToken({
@@ -899,7 +899,7 @@ describe("credential-provider-node integration test", () => {
 
     it.skip(
       "fromSSO (SSO) provider is excluded from testing because the SSO_REGION is a required parameter and is used " +
-        "instead of any fallback to the context client region",
+        "instead of any fallback to the caller client region",
       async () => {}
     );
 

--- a/packages/credential-provider-web-identity/src/fromWebToken.ts
+++ b/packages/credential-provider-web-identity/src/fromWebToken.ts
@@ -1,7 +1,7 @@
 import type {
   AwsIdentityProperties,
   CredentialProviderOptions,
-  RegionalAwsCredentialIdentityProvider,
+  RuntimeConfigAwsCredentialIdentityProvider,
 } from "@aws-sdk/types";
 import type { AwsCredentialIdentity, Pluggable } from "@smithy/types";
 
@@ -155,7 +155,7 @@ export interface FromWebTokenInit
  * @internal
  */
 export const fromWebToken =
-  (init: FromWebTokenInit): RegionalAwsCredentialIdentityProvider =>
+  (init: FromWebTokenInit): RuntimeConfigAwsCredentialIdentityProvider =>
   async (awsIdentityProperties?: AwsIdentityProperties) => {
     init.logger?.debug("@aws-sdk/credential-provider-web-identity - fromWebToken");
     const { roleArn, roleSessionName, webIdentityToken, providerId, policyArns, policy, durationSeconds } = init;

--- a/packages/credential-provider-web-identity/src/fromWebToken.ts
+++ b/packages/credential-provider-web-identity/src/fromWebToken.ts
@@ -169,10 +169,14 @@ export const fromWebToken =
         {
           ...init.clientConfig,
           credentialProviderLogger: init.logger,
-          parentClientConfig: {
-            region: awsIdentityProperties?.contextClientConfig?.region,
-            ...init.parentClientConfig,
-          },
+          ...(awsIdentityProperties?.contextClientConfig?.region
+            ? {
+                parentClientConfig: {
+                  region: awsIdentityProperties?.contextClientConfig?.region,
+                  ...init.parentClientConfig,
+                },
+              }
+            : {}),
         },
         init.clientPlugins
       );

--- a/packages/credential-provider-web-identity/src/fromWebToken.ts
+++ b/packages/credential-provider-web-identity/src/fromWebToken.ts
@@ -169,10 +169,10 @@ export const fromWebToken =
         {
           ...init.clientConfig,
           credentialProviderLogger: init.logger,
-          ...(awsIdentityProperties?.contextClientConfig?.region || init.parentClientConfig
+          ...(awsIdentityProperties?.callerClientConfig?.region || init.parentClientConfig
             ? {
                 parentClientConfig: {
-                  region: awsIdentityProperties?.contextClientConfig?.region,
+                  region: awsIdentityProperties?.callerClientConfig?.region,
                   ...init.parentClientConfig,
                 },
               }

--- a/packages/credential-provider-web-identity/src/fromWebToken.ts
+++ b/packages/credential-provider-web-identity/src/fromWebToken.ts
@@ -1,6 +1,9 @@
-import { setCredentialFeature } from "@aws-sdk/core/client";
-import type { CredentialProviderOptions } from "@aws-sdk/types";
-import type { AwsCredentialIdentity, AwsCredentialIdentityProvider, Pluggable } from "@smithy/types";
+import type {
+  AwsIdentityProperties,
+  CredentialProviderOptions,
+  RegionalAwsCredentialIdentityProvider,
+} from "@aws-sdk/types";
+import type { AwsCredentialIdentity, Pluggable } from "@smithy/types";
 
 /**
  * @public
@@ -152,8 +155,8 @@ export interface FromWebTokenInit
  * @internal
  */
 export const fromWebToken =
-  (init: FromWebTokenInit): AwsCredentialIdentityProvider =>
-  async () => {
+  (init: FromWebTokenInit): RegionalAwsCredentialIdentityProvider =>
+  async (awsIdentityProperties?: AwsIdentityProperties) => {
     init.logger?.debug("@aws-sdk/credential-provider-web-identity - fromWebToken");
     const { roleArn, roleSessionName, webIdentityToken, providerId, policyArns, policy, durationSeconds } = init;
 
@@ -166,7 +169,10 @@ export const fromWebToken =
         {
           ...init.clientConfig,
           credentialProviderLogger: init.logger,
-          parentClientConfig: init.parentClientConfig,
+          parentClientConfig: {
+            region: awsIdentityProperties?.contextClientConfig?.region,
+            ...init.parentClientConfig,
+          },
         },
         init.clientPlugins
       );

--- a/packages/credential-provider-web-identity/src/fromWebToken.ts
+++ b/packages/credential-provider-web-identity/src/fromWebToken.ts
@@ -169,7 +169,7 @@ export const fromWebToken =
         {
           ...init.clientConfig,
           credentialProviderLogger: init.logger,
-          ...(awsIdentityProperties?.contextClientConfig?.region
+          ...(awsIdentityProperties?.contextClientConfig?.region || init.parentClientConfig
             ? {
                 parentClientConfig: {
                   region: awsIdentityProperties?.contextClientConfig?.region,

--- a/packages/credential-providers/src/createCredentialChain.spec.ts
+++ b/packages/credential-providers/src/createCredentialChain.spec.ts
@@ -1,4 +1,4 @@
-import { RegionalAwsCredentialIdentityProvider } from "@aws-sdk/types";
+import { RuntimeConfigAwsCredentialIdentityProvider } from "@aws-sdk/types";
 import { ProviderError } from "@smithy/property-provider";
 import { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
@@ -82,7 +82,7 @@ describe(createCredentialChain.name, () => {
   });
 
   it("is compatible with contextual-region-aware credential providers", async () => {
-    const provider: RegionalAwsCredentialIdentityProvider = async ({ callerClientConfig } = {}) => {
+    const provider: RuntimeConfigAwsCredentialIdentityProvider = async ({ callerClientConfig } = {}) => {
       return {
         accessKeyId: "",
         secretAccessKey: "",

--- a/packages/credential-providers/src/createCredentialChain.spec.ts
+++ b/packages/credential-providers/src/createCredentialChain.spec.ts
@@ -82,11 +82,11 @@ describe(createCredentialChain.name, () => {
   });
 
   it("is compatible with contextual-region-aware credential providers", async () => {
-    const provider: RegionalAwsCredentialIdentityProvider = async ({ contextClientConfig } = {}) => {
+    const provider: RegionalAwsCredentialIdentityProvider = async ({ callerClientConfig } = {}) => {
       return {
         accessKeyId: "",
         secretAccessKey: "",
-        sessionToken: (await contextClientConfig?.region()) ?? "wrong_region",
+        sessionToken: (await callerClientConfig?.region()) ?? "wrong_region",
       };
     };
     const errorProvider = async () => {
@@ -97,7 +97,7 @@ describe(createCredentialChain.name, () => {
 
     expect(
       await chain({
-        contextClientConfig: {
+        callerClientConfig: {
           async region() {
             return "ap-northeast-1";
           },

--- a/packages/credential-providers/src/createCredentialChain.ts
+++ b/packages/credential-providers/src/createCredentialChain.ts
@@ -1,7 +1,7 @@
 import type {
   AwsIdentityProperties,
-  RegionalAwsCredentialIdentityProvider,
-  RegionalIdentityProvider,
+  RuntimeConfigAwsCredentialIdentityProvider,
+  RuntimeConfigIdentityProvider,
 } from "@aws-sdk/types";
 import { ProviderError } from "@smithy/property-provider";
 import type { AwsCredentialIdentityProvider } from "@smithy/types";
@@ -57,8 +57,8 @@ type Mutable<Type> = {
  * providers in sequence until one succeeds or all fail.
  */
 export const createCredentialChain = (
-  ...credentialProviders: RegionalAwsCredentialIdentityProvider[]
-): RegionalAwsCredentialIdentityProvider & CustomCredentialChainOptions => {
+  ...credentialProviders: RuntimeConfigAwsCredentialIdentityProvider[]
+): RuntimeConfigAwsCredentialIdentityProvider & CustomCredentialChainOptions => {
   let expireAfter = -1;
   const baseFunction = async (awsIdentityProperties?: AwsIdentityProperties) => {
     const credentials = await propertyProviderChain(...credentialProviders)(awsIdentityProperties);
@@ -85,7 +85,7 @@ export const createCredentialChain = (
  * @internal
  */
 export const propertyProviderChain =
-  <T>(...providers: Array<RegionalIdentityProvider<T>>): RegionalIdentityProvider<T> =>
+  <T>(...providers: Array<RuntimeConfigIdentityProvider<T>>): RuntimeConfigIdentityProvider<T> =>
   async (awsIdentityProperties?: AwsIdentityProperties) => {
     if (providers.length === 0) {
       throw new ProviderError("No providers in chain");

--- a/packages/credential-providers/src/fromIni.ts
+++ b/packages/credential-providers/src/fromIni.ts
@@ -1,5 +1,5 @@
 import { fromIni as _fromIni, FromIniInit } from "@aws-sdk/credential-provider-ini";
-import type { RegionalAwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type { RuntimeConfigAwsCredentialIdentityProvider } from "@aws-sdk/types";
 
 /**
  * Creates a credential provider function that reads from a shared credentials file at `~/.aws/credentials` and a
@@ -40,7 +40,7 @@ import type { RegionalAwsCredentialIdentityProvider } from "@aws-sdk/types";
  * });
  * ```
  */
-export const fromIni = (init: FromIniInit = {}): RegionalAwsCredentialIdentityProvider =>
+export const fromIni = (init: FromIniInit = {}): RuntimeConfigAwsCredentialIdentityProvider =>
   _fromIni({
     ...init,
   });

--- a/packages/credential-providers/src/fromIni.ts
+++ b/packages/credential-providers/src/fromIni.ts
@@ -1,5 +1,5 @@
 import { fromIni as _fromIni, FromIniInit } from "@aws-sdk/credential-provider-ini";
-import { AwsCredentialIdentityProvider } from "@smithy/types";
+import type { RegionalAwsCredentialIdentityProvider } from "@aws-sdk/types";
 
 /**
  * Creates a credential provider function that reads from a shared credentials file at `~/.aws/credentials` and a
@@ -40,7 +40,7 @@ import { AwsCredentialIdentityProvider } from "@smithy/types";
  * });
  * ```
  */
-export const fromIni = (init: FromIniInit = {}): AwsCredentialIdentityProvider =>
+export const fromIni = (init: FromIniInit = {}): RegionalAwsCredentialIdentityProvider =>
   _fromIni({
     ...init,
   });

--- a/packages/middleware-signing/README.md
+++ b/packages/middleware-signing/README.md
@@ -2,3 +2,6 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-signing/latest.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-signing)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-signing.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-signing)
+
+This package is deprecated. It is only used in "legacy auth", and no longer used in the
+AWS SDK as of the Smithy Reference Architecture implementation of identity and auth.

--- a/packages/middleware-signing/src/awsAuthConfiguration.ts
+++ b/packages/middleware-signing/src/awsAuthConfiguration.ts
@@ -1,4 +1,4 @@
-import type { AwsCredentialIdentityProvider, RegionalAwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type { AwsCredentialIdentityProvider, RuntimeConfigAwsCredentialIdentityProvider } from "@aws-sdk/types";
 import { memoize } from "@smithy/property-provider";
 import { SignatureV4, SignatureV4CryptoInit, SignatureV4Init } from "@smithy/signature-v4";
 import {
@@ -293,7 +293,7 @@ export const resolveSigV4AuthConfig = <T>(
  * @deprecated only used in legacy auth.
  */
 const normalizeCredentialProvider = (
-  credentials: AwsCredentialIdentity | Provider<AwsCredentialIdentity> | RegionalAwsCredentialIdentityProvider
+  credentials: AwsCredentialIdentity | Provider<AwsCredentialIdentity> | RuntimeConfigAwsCredentialIdentityProvider
 ): MemoizedProvider<AwsCredentialIdentity> => {
   if (typeof credentials === "function") {
     return memoize(
@@ -315,7 +315,7 @@ const normalizeCredentialProvider = (
  * a binding to the config itself.
  */
 const createConfigBoundCredentialProvider = (input: {
-  credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider | RegionalAwsCredentialIdentityProvider;
+  credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider | RuntimeConfigAwsCredentialIdentityProvider;
   credentialDefaultProvider: PreviouslyResolved["credentialDefaultProvider"];
   region: PreviouslyResolved["region"];
 }): AwsCredentialIdentityProvider => {
@@ -327,7 +327,7 @@ const createConfigBoundCredentialProvider = (input: {
         })
       );
   const normalizedCreds = async () =>
-    (normalizedCredentialsProvider as RegionalAwsCredentialIdentityProvider)({
+    (normalizedCredentialsProvider as RuntimeConfigAwsCredentialIdentityProvider)({
       callerClientConfig: {
         region: normalizeProvider(input.region),
       },

--- a/packages/middleware-signing/src/awsAuthConfiguration.ts
+++ b/packages/middleware-signing/src/awsAuthConfiguration.ts
@@ -1,3 +1,4 @@
+import type { AwsCredentialIdentityProvider, RegionalAwsCredentialIdentityProvider } from "@aws-sdk/types";
 import { memoize } from "@smithy/property-provider";
 import { SignatureV4, SignatureV4CryptoInit, SignatureV4Init } from "@smithy/signature-v4";
 import {
@@ -23,6 +24,7 @@ const CREDENTIAL_EXPIRE_WINDOW = 300000;
 
 /**
  * @public
+ * @deprecated only used in legacy auth.
  */
 export interface AwsAuthInputConfig {
   /**
@@ -62,6 +64,7 @@ export interface AwsAuthInputConfig {
 
 /**
  * @public
+ * @deprecated only used in legacy auth.
  */
 export interface SigV4AuthInputConfig {
   /**
@@ -85,6 +88,10 @@ export interface SigV4AuthInputConfig {
   systemClockOffset?: number;
 }
 
+/**
+ * @internal
+ * @deprecated only used in legacy auth.
+ */
 interface PreviouslyResolved {
   credentialDefaultProvider: (input: any) => MemoizedProvider<AwsCredentialIdentity>;
   region: string | Provider<string>;
@@ -97,6 +104,10 @@ interface PreviouslyResolved {
   useDualstackEndpoint: Provider<boolean>;
 }
 
+/**
+ * @internal
+ * @deprecated only used in legacy auth.
+ */
 interface SigV4PreviouslyResolved {
   credentialDefaultProvider: (input: any) => MemoizedProvider<AwsCredentialIdentity>;
   region: string | Provider<string>;
@@ -105,6 +116,10 @@ interface SigV4PreviouslyResolved {
   logger?: Logger;
 }
 
+/**
+ * @internal
+ * @deprecated only used in legacy auth.
+ */
 export interface AwsAuthResolvedConfig {
   /**
    * Resolved value for input config {@link AwsAuthInputConfig.credentials}
@@ -126,18 +141,21 @@ export interface AwsAuthResolvedConfig {
   systemClockOffset: number;
 }
 
+/**
+ * @internal
+ * @deprecated only used in legacy auth.
+ */
 export interface SigV4AuthResolvedConfig extends AwsAuthResolvedConfig {}
 
+/**
+ * @internal
+ * @deprecated only used in legacy auth.
+ */
 export const resolveAwsAuthConfig = <T>(
   input: T & AwsAuthInputConfig & PreviouslyResolved
 ): T & AwsAuthResolvedConfig => {
-  const normalizedCreds = input.credentials
-    ? normalizeCredentialProvider(input.credentials)
-    : input.credentialDefaultProvider(
-        Object.assign({}, input, {
-          parentClientConfig: input,
-        })
-      );
+  const normalizedCreds = createConfigBoundCredentialProvider(input);
+
   const { signingEscapePath = true, systemClockOffset = input.systemClockOffset || 0, sha256 } = input;
   let signer: (authScheme?: AuthScheme) => Promise<RequestSigner>;
   if (input.signer) {
@@ -237,17 +255,14 @@ export const resolveAwsAuthConfig = <T>(
   };
 };
 
-// TODO: reduce code duplication
+/**
+ * @internal
+ * @deprecated only used in legacy auth.
+ */
 export const resolveSigV4AuthConfig = <T>(
   input: T & SigV4AuthInputConfig & SigV4PreviouslyResolved
 ): T & SigV4AuthResolvedConfig => {
-  const normalizedCreds = input.credentials
-    ? normalizeCredentialProvider(input.credentials)
-    : input.credentialDefaultProvider(
-        Object.assign({}, input, {
-          parentClientConfig: input,
-        })
-      );
+  const normalizedCreds = createConfigBoundCredentialProvider(input);
   const { signingEscapePath = true, systemClockOffset = input.systemClockOffset || 0, sha256 } = input;
   let signer: Provider<RequestSigner>;
   if (input.signer) {
@@ -273,8 +288,12 @@ export const resolveSigV4AuthConfig = <T>(
   };
 };
 
+/**
+ * @internal
+ * @deprecated only used in legacy auth.
+ */
 const normalizeCredentialProvider = (
-  credentials: AwsCredentialIdentity | Provider<AwsCredentialIdentity>
+  credentials: AwsCredentialIdentity | Provider<AwsCredentialIdentity> | RegionalAwsCredentialIdentityProvider
 ): MemoizedProvider<AwsCredentialIdentity> => {
   if (typeof credentials === "function") {
     return memoize(
@@ -286,4 +305,32 @@ const normalizeCredentialProvider = (
     );
   }
   return normalizeProvider(credentials);
+};
+
+/**
+ * @internal
+ * @deprecated only used in legacy auth.
+ *
+ * normalizes the credentials from the input config into a provider that has
+ * a binding to the config itself.
+ */
+const createConfigBoundCredentialProvider = (input: {
+  credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider | RegionalAwsCredentialIdentityProvider;
+  credentialDefaultProvider: PreviouslyResolved["credentialDefaultProvider"];
+  region: PreviouslyResolved["region"];
+}): AwsCredentialIdentityProvider => {
+  const normalizedCredentialsProvider = input.credentials
+    ? normalizeCredentialProvider(input.credentials)
+    : input.credentialDefaultProvider(
+        Object.assign({}, input, {
+          parentClientConfig: input,
+        })
+      );
+  const normalizedCreds = async () =>
+    (normalizedCredentialsProvider as RegionalAwsCredentialIdentityProvider)({
+      contextClientConfig: {
+        region: normalizeProvider(input.region),
+      },
+    });
+  return normalizedCreds;
 };

--- a/packages/middleware-signing/src/awsAuthConfiguration.ts
+++ b/packages/middleware-signing/src/awsAuthConfiguration.ts
@@ -328,7 +328,7 @@ const createConfigBoundCredentialProvider = (input: {
       );
   const normalizedCreds = async () =>
     (normalizedCredentialsProvider as RegionalAwsCredentialIdentityProvider)({
-      contextClientConfig: {
+      callerClientConfig: {
         region: normalizeProvider(input.region),
       },
     });

--- a/packages/middleware-signing/src/awsAuthMiddleware.ts
+++ b/packages/middleware-signing/src/awsAuthMiddleware.ts
@@ -17,6 +17,9 @@ import { AwsAuthResolvedConfig } from "./awsAuthConfiguration";
 import { getSkewCorrectedDate } from "./utils/getSkewCorrectedDate";
 import { getUpdatedSystemClockOffset } from "./utils/getUpdatedSystemClockOffset";
 
+/**
+ * @deprecated only used in legacy auth.
+ */
 export const awsAuthMiddleware =
   <Input extends object, Output extends object>(
     options: AwsAuthResolvedConfig
@@ -111,6 +114,9 @@ export const awsAuthMiddleware =
 const getDateHeader = (response: unknown): string | undefined =>
   HttpResponse.isInstance(response) ? response.headers?.date ?? response.headers?.Date : undefined;
 
+/**
+ * @deprecated only used in legacy auth.
+ */
 export const awsAuthMiddlewareOptions: RelativeMiddlewareOptions = {
   name: "awsAuthMiddleware",
   tags: ["SIGNATURE", "AWSAUTH"],
@@ -119,10 +125,16 @@ export const awsAuthMiddlewareOptions: RelativeMiddlewareOptions = {
   override: true,
 };
 
+/**
+ * @deprecated only used in legacy auth.
+ */
 export const getAwsAuthPlugin = (options: AwsAuthResolvedConfig): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
     clientStack.addRelativeTo(awsAuthMiddleware(options), awsAuthMiddlewareOptions);
   },
 });
 
+/**
+ * @deprecated only used in legacy auth.
+ */
 export const getSigV4AuthPlugin = getAwsAuthPlugin;

--- a/packages/middleware-websocket/package.json
+++ b/packages/middleware-websocket/package.json
@@ -23,7 +23,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/middleware-signing": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-format-url": "*",
     "@smithy/eventstream-codec": "^3.1.10",

--- a/packages/token-providers/src/fromSso.ts
+++ b/packages/token-providers/src/fromSso.ts
@@ -40,10 +40,14 @@ export const fromSso =
   async (awsIdentityProperties?: AwsIdentityProperties) => {
     const init: FromSsoInit = {
       ..._init,
-      parentClientConfig: {
-        region: awsIdentityProperties?.contextClientConfig?.region,
-        ..._init.parentClientConfig,
-      },
+      ...(awsIdentityProperties?.contextClientConfig?.region
+        ? {
+            parentClientConfig: {
+              region: awsIdentityProperties?.contextClientConfig?.region,
+              ..._init.parentClientConfig,
+            },
+          }
+        : {}),
     };
     init.logger?.debug("@aws-sdk/token-providers - fromSso");
 

--- a/packages/token-providers/src/fromSso.ts
+++ b/packages/token-providers/src/fromSso.ts
@@ -1,4 +1,9 @@
-import { CredentialProviderOptions, TokenIdentity, TokenIdentityProvider } from "@aws-sdk/types";
+import {
+  AwsIdentityProperties,
+  CredentialProviderOptions,
+  RegionalIdentityProvider,
+  TokenIdentity,
+} from "@aws-sdk/types";
 import { TokenProviderError } from "@smithy/property-provider";
 import {
   getProfileName,
@@ -31,8 +36,15 @@ export interface FromSsoInit extends SourceProfileInit, CredentialProviderOption
  * Creates a token provider that will read from SSO token cache or ssoOidc.createToken() call.
  */
 export const fromSso =
-  (init: FromSsoInit = {}): TokenIdentityProvider =>
-  async () => {
+  (_init: FromSsoInit = {}): RegionalIdentityProvider<TokenIdentity> =>
+  async (awsIdentityProperties?: AwsIdentityProperties) => {
+    const init: FromSsoInit = {
+      ..._init,
+      parentClientConfig: {
+        region: awsIdentityProperties?.contextClientConfig?.region,
+        ..._init.parentClientConfig,
+      },
+    };
     init.logger?.debug("@aws-sdk/token-providers - fromSso");
 
     const profiles = await parseKnownFiles(init);

--- a/packages/token-providers/src/fromSso.ts
+++ b/packages/token-providers/src/fromSso.ts
@@ -1,7 +1,7 @@
 import {
   AwsIdentityProperties,
   CredentialProviderOptions,
-  RegionalIdentityProvider,
+  RuntimeConfigIdentityProvider,
   TokenIdentity,
 } from "@aws-sdk/types";
 import { TokenProviderError } from "@smithy/property-provider";
@@ -36,7 +36,7 @@ export interface FromSsoInit extends SourceProfileInit, CredentialProviderOption
  * Creates a token provider that will read from SSO token cache or ssoOidc.createToken() call.
  */
 export const fromSso =
-  (_init: FromSsoInit = {}): RegionalIdentityProvider<TokenIdentity> =>
+  (_init: FromSsoInit = {}): RuntimeConfigIdentityProvider<TokenIdentity> =>
   async (awsIdentityProperties?: AwsIdentityProperties) => {
     const init: FromSsoInit = {
       ..._init,

--- a/packages/token-providers/src/fromSso.ts
+++ b/packages/token-providers/src/fromSso.ts
@@ -40,10 +40,10 @@ export const fromSso =
   async (awsIdentityProperties?: AwsIdentityProperties) => {
     const init: FromSsoInit = {
       ..._init,
-      ...(awsIdentityProperties?.contextClientConfig?.region
+      ...(awsIdentityProperties?.callerClientConfig?.region
         ? {
             parentClientConfig: {
-              region: awsIdentityProperties?.contextClientConfig?.region,
+              region: awsIdentityProperties?.callerClientConfig?.region,
               ..._init.parentClientConfig,
             },
           }

--- a/packages/types/src/identity/AwsCredentialIdentity.ts
+++ b/packages/types/src/identity/AwsCredentialIdentity.ts
@@ -17,23 +17,25 @@ export interface AwsIdentityProperties {
  * @public
  *
  * Variation of {@link IdentityProvider} which accepts a contextual
- * client configuration that includes an AWS region.
+ * client configuration that includes an AWS region and potentially other
+ * configurable fields.
  *
- * Used to link a credential provider to a client region if it is being called
+ * Used to link a credential provider to a client if it is being called
  * in the context of a client.
  */
-export type RegionalIdentityProvider<T> = (awsIdentityProperties?: AwsIdentityProperties) => Promise<T>;
+export type RuntimeConfigIdentityProvider<T> = (awsIdentityProperties?: AwsIdentityProperties) => Promise<T>;
 
 /**
  * @public
  *
  * Variation of {@link AwsCredentialIdentityProvider} which accepts a contextual
- * client configuration that includes an AWS region.
+ * client configuration that includes an AWS region and potentially other
+ * configurable fields.
  *
- * Used to link a credential provider to a client region if it is being called
+ * Used to link a credential provider to a client if it is being called
  * in the context of a client.
  */
-export type RegionalAwsCredentialIdentityProvider = RegionalIdentityProvider<AwsCredentialIdentity>;
+export type RuntimeConfigAwsCredentialIdentityProvider = RuntimeConfigIdentityProvider<AwsCredentialIdentity>;
 
 /**
  * @public

--- a/packages/types/src/identity/AwsCredentialIdentity.ts
+++ b/packages/types/src/identity/AwsCredentialIdentity.ts
@@ -8,7 +8,7 @@ export { AwsCredentialIdentity, AwsCredentialIdentityProvider, IdentityProvider 
  * @public
  */
 export interface AwsIdentityProperties {
-  contextClientConfig?: {
+  callerClientConfig?: {
     region(): Promise<string>;
   };
 }

--- a/packages/types/src/identity/AwsCredentialIdentity.ts
+++ b/packages/types/src/identity/AwsCredentialIdentity.ts
@@ -2,8 +2,44 @@ import type { AwsCredentialIdentity } from "@smithy/types";
 
 import type { AwsSdkCredentialsFeatures } from "../feature-ids";
 
-export { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types";
+export { AwsCredentialIdentity, AwsCredentialIdentityProvider, IdentityProvider } from "@smithy/types";
 
+/**
+ * @public
+ */
+export interface AwsIdentityProperties {
+  contextClientConfig?: {
+    region(): Promise<string>;
+  };
+}
+
+/**
+ * @public
+ *
+ * Variation of {@link IdentityProvider} which accepts a contextual
+ * client configuration that includes an AWS region.
+ *
+ * Used to link a credential provider to a client region if it is being called
+ * in the context of a client.
+ */
+export type RegionalIdentityProvider<T> = (awsIdentityProperties?: AwsIdentityProperties) => Promise<T>;
+
+/**
+ * @public
+ *
+ * Variation of {@link AwsCredentialIdentityProvider} which accepts a contextual
+ * client configuration that includes an AWS region.
+ *
+ * Used to link a credential provider to a client region if it is being called
+ * in the context of a client.
+ */
+export type RegionalAwsCredentialIdentityProvider = RegionalIdentityProvider<AwsCredentialIdentity>;
+
+/**
+ * @public
+ *
+ * AwsCredentialIdentity with source attribution metadata.
+ */
 export type AttributedAwsCredentialIdentity = AwsCredentialIdentity & {
   $source?: AwsSdkCredentialsFeatures;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -24042,7 +24042,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk/middleware-websocket@workspace:packages/middleware-websocket"
   dependencies:
-    "@aws-sdk/middleware-signing": "npm:*"
     "@aws-sdk/types": "npm:*"
     "@aws-sdk/util-format-url": "npm:*"
     "@smithy/eventstream-codec": "npm:^3.1.10"


### PR DESCRIPTION
We [previously](https://github.com/aws/aws-sdk-js-v3/pull/5758) introduced the concept of a "parentClientConfig" for credential providers that create another (inner) SDK client such as STS. 

One problem was that if the provider was initialized outside of a client, this connection could not be made. This PR makes AWS credential providers accept a contextual client config, making them region aware at call time. The result is improved intuitiveness of default behavior, as shown below.

### currently

⚠️ when using a CODE level credential configuration, any potential spawning of an inner client such as STS for AssumeRole must be passed the region in a redundant manner. This is because `fromIni` is a standalone function that can resolve credentials without the context of an SDK client.

```js
import { DynamoDB } from "@aws-sdk/client-dynamodb";
import { fromIni } from "@aws-sdk/credential-providers";

const ddb = new DynamoDB({
  region: "eu-west-1",
  credentials: fromIni({
    clientConfig: { region: "eu-west-1" }, // required, but often forgotten
  }),
});
```

### in this PR

Improved intuitiveness of credentials region resolution.

```js
import { DynamoDB } from "@aws-sdk/client-dynamodb";
import { fromIni } from "@aws-sdk/credential-providers";

const ddb = new DynamoDB({
  region: "eu-west-1",
  // will default to the client's region instead of the commercial partition default (us-east-1)
  credentials: fromIni({}), 
});

// initialized outside a client
const credentialsProvider = fromIni();

// uses global default of us-east-1 as before, when invoked outside of a client.
const credentials = await credentialsProvider();

const ddb = new DynamoDB({
  region: "eu-west-1",
  credentials, // will default to the client's region if supplied to a client
});
```