### PR TITLE
chore(middleware-flexible-checksums): use switch for selecting checksum algorithm function

### DIFF
--- a/packages/middleware-flexible-checksums/src/selectChecksumAlgorithmFunction.ts
+++ b/packages/middleware-flexible-checksums/src/selectChecksumAlgorithmFunction.ts
@@ -11,11 +11,19 @@ import { getCrc32ChecksumAlgorithmFunction } from "./getCrc32ChecksumAlgorithmFu
 export const selectChecksumAlgorithmFunction = (
   checksumAlgorithm: ChecksumAlgorithm,
   config: PreviouslyResolved
-): ChecksumConstructor | HashConstructor =>
-  ({
-    [ChecksumAlgorithm.MD5]: config.md5,
-    [ChecksumAlgorithm.CRC32]: getCrc32ChecksumAlgorithmFunction(),
-    [ChecksumAlgorithm.CRC32C]: AwsCrc32c,
-    [ChecksumAlgorithm.SHA1]: config.sha1,
-    [ChecksumAlgorithm.SHA256]: config.sha256,
-  }[checksumAlgorithm]);
+): ChecksumConstructor | HashConstructor => {
+  switch (checksumAlgorithm) {
+    case ChecksumAlgorithm.MD5:
+      return config.md5;
+    case ChecksumAlgorithm.CRC32:
+      return getCrc32ChecksumAlgorithmFunction();
+    case ChecksumAlgorithm.CRC32C:
+      return AwsCrc32c;
+    case ChecksumAlgorithm.SHA1:
+      return config.sha1;
+    case ChecksumAlgorithm.SHA256:
+      return config.sha256;
+    default:
+      throw new Error(`Unsupported checksum algorithm: ${checksumAlgorithm}`);
+  }
+};


### PR DESCRIPTION
### Issue
* Internal JS-5396
* Switch is better since:
  * In the past, we'd to decide whether to switch between different CRC32 implementations https://github.com/aws/aws-sdk-js-v3/pull/6641
  * In near future, CRC64-NVME implementation will come from optional dependency https://github.com/aws/aws-sdk-js-v3/pull/6736, and we'll throw error if the optional dependency is not present.

### Description
Uses switch for selecting checksum algorithm function

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
