### PR TITLE
chore(middleware-flexible-checksums): change default algorithm to CRC32

### DIFF
--- a/packages/middleware-flexible-checksums/src/constants.ts
+++ b/packages/middleware-flexible-checksums/src/constants.ts
@@ -52,6 +52,9 @@ export const DEFAULT_RESPONSE_CHECKSUM_VALIDATION = RequestChecksumCalculation.W
  * Checksum Algorithms supported by the SDK.
  */
 export enum ChecksumAlgorithm {
+  /**
+   * @deprecated Use {@link ChecksumAlgorithm.CRC32} instead.
+   */
   MD5 = "MD5",
   CRC32 = "CRC32",
   CRC32C = "CRC32C",
@@ -70,9 +73,4 @@ export enum ChecksumLocation {
 /**
  * @internal
  */
-export const DEFAULT_CHECKSUM_ALGORITHM = ChecksumAlgorithm.MD5;
-
-/**
- * @internal
- */
-export const S3_EXPRESS_DEFAULT_CHECKSUM_ALGORITHM = ChecksumAlgorithm.CRC32;
+export const DEFAULT_CHECKSUM_ALGORITHM = ChecksumAlgorithm.CRC32;

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -74,14 +74,10 @@ export const flexibleChecksumsMiddleware =
     const { base64Encoder, streamHasher } = config;
     const { requestChecksumRequired, requestAlgorithmMember } = middlewareConfig;
 
-    const checksumAlgorithm = getChecksumAlgorithmForRequest(
-      input,
-      {
-        requestChecksumRequired,
-        requestAlgorithmMember: requestAlgorithmMember?.name,
-      },
-      !!context.isS3ExpressBucket
-    );
+    const checksumAlgorithm = getChecksumAlgorithmForRequest(input, {
+      requestChecksumRequired,
+      requestAlgorithmMember: requestAlgorithmMember?.name,
+    });
     let updatedBody = requestBody;
     let updatedHeaders = headers;
 

--- a/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.spec.ts
+++ b/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test as it } from "vitest";
 
-import { ChecksumAlgorithm } from "./constants";
+import { ChecksumAlgorithm, DEFAULT_CHECKSUM_ALGORITHM } from "./constants";
 import { getChecksumAlgorithmForRequest } from "./getChecksumAlgorithmForRequest";
 import { CLIENT_SUPPORTED_ALGORITHMS } from "./types";
 
@@ -8,8 +8,8 @@ describe(getChecksumAlgorithmForRequest.name, () => {
   const mockRequestAlgorithmMember = "mockRequestAlgorithmMember";
 
   describe("when requestAlgorithmMember is not provided", () => {
-    it("returns MD5 if requestChecksumRequired is set", () => {
-      expect(getChecksumAlgorithmForRequest({}, { requestChecksumRequired: true })).toEqual(ChecksumAlgorithm.MD5);
+    it(`returns ${DEFAULT_CHECKSUM_ALGORITHM} if requestChecksumRequired is set`, () => {
+      expect(getChecksumAlgorithmForRequest({}, { requestChecksumRequired: true })).toEqual(DEFAULT_CHECKSUM_ALGORITHM);
     });
 
     it("returns undefined if requestChecksumRequired is false", () => {
@@ -20,9 +20,9 @@ describe(getChecksumAlgorithmForRequest.name, () => {
   describe("when requestAlgorithmMember is not set in input", () => {
     const mockOptions = { requestAlgorithmMember: mockRequestAlgorithmMember };
 
-    it("returns MD5 if requestChecksumRequired is set", () => {
+    it(`returns ${DEFAULT_CHECKSUM_ALGORITHM} if requestChecksumRequired is set`, () => {
       expect(getChecksumAlgorithmForRequest({}, { ...mockOptions, requestChecksumRequired: true })).toEqual(
-        ChecksumAlgorithm.MD5
+        DEFAULT_CHECKSUM_ALGORITHM
       );
     });
 

--- a/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.ts
+++ b/packages/middleware-flexible-checksums/src/getChecksumAlgorithmForRequest.ts
@@ -1,4 +1,4 @@
-import { ChecksumAlgorithm, DEFAULT_CHECKSUM_ALGORITHM, S3_EXPRESS_DEFAULT_CHECKSUM_ALGORITHM } from "./constants";
+import { ChecksumAlgorithm, DEFAULT_CHECKSUM_ALGORITHM } from "./constants";
 import { CLIENT_SUPPORTED_ALGORITHMS } from "./types";
 
 export interface GetChecksumAlgorithmForRequestOptions {
@@ -20,16 +20,13 @@ export interface GetChecksumAlgorithmForRequestOptions {
  */
 export const getChecksumAlgorithmForRequest = (
   input: any,
-  { requestChecksumRequired, requestAlgorithmMember }: GetChecksumAlgorithmForRequestOptions,
-  isS3Express?: boolean
+  { requestChecksumRequired, requestAlgorithmMember }: GetChecksumAlgorithmForRequestOptions
 ): ChecksumAlgorithm | undefined => {
-  const defaultAlgorithm = isS3Express ? S3_EXPRESS_DEFAULT_CHECKSUM_ALGORITHM : DEFAULT_CHECKSUM_ALGORITHM;
-
   // Either the Operation input member that is used to configure request checksum behavior is not set, or
   // the value for input member to configure flexible checksum is not set.
   if (!requestAlgorithmMember || !input[requestAlgorithmMember]) {
     // Select an algorithm only if request checksum is required.
-    return requestChecksumRequired ? defaultAlgorithm : undefined;
+    return requestChecksumRequired ? DEFAULT_CHECKSUM_ALGORITHM : undefined;
   }
 
   const checksumAlgorithm = input[requestAlgorithmMember];

--- a/private/aws-middleware-test/src/middleware-serde.spec.ts
+++ b/private/aws-middleware-test/src/middleware-serde.spec.ts
@@ -27,7 +27,7 @@ describe("middleware-serde", () => {
           "x-amz-acl": "private",
           "content-length": "509",
           Expect: "100-continue",
-          "content-md5": "qpwmS0vhCISEXes008aoXA==",
+          "x-amz-checksum-crc32": "XnKFaw==",
           host: "s3.us-west-2.amazonaws.com",
           "x-amz-content-sha256": "c0a89780e1aac5dfa17604e9e25616e7babba0b655db189be49b4c352543bb22",
         },


### PR DESCRIPTION
### Issue
* Internal JS-5396
* Split from https://github.com/aws/aws-sdk-js-v3/pull/6492

### Description
Changes default checksum algorithm to CRC32, and deprecates MD5.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
