### PR TITLE
chore(ci): skip enabling corepack

### DIFF
--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: set up Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/6757, after which we switched to using globally installed yarn classic from GitHub runners to use local binary of yarn modern.

### Description
Skips enabling corepack in pre-commit-hooks.

### Testing

Verified that `pre-commit-hooks` uses yarn@4.5.1

```console
Run yarn install --frozen-lockfile
...
➤ YN0000: · Yarn 4.5.1
```

Job: https://github.com/aws/aws-sdk-js-v3/actions/runs/12508374958/job/34896397427?pr=6760

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
