### PR TITLE
fix(codegen): handle case when sample operation not found

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
@@ -106,10 +106,14 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
             OperationShape sampleOperation =
                 getPreferredExampleOperation(topDownIndex.getContainedOperations(service), model);
 
-            String operationName = sampleOperation.getId().getName(service);
+            String operationName =
+                sampleOperation == null
+                ? "Example"
+                : sampleOperation.getId().getName(service);
+
             resource = resource.replaceAll(Pattern.quote("${commandName}"), operationName);
             resource = resource.replaceAll(Pattern.quote("${operationName}"),
-                    operationName.substring(0, 1).toLowerCase() + operationName.substring(1));
+                operationName.substring(0, 1).toLowerCase() + operationName.substring(1));
 
             writer.write(resource.replaceAll(Pattern.quote("$"), Matcher.quoteReplacement("$$")));
             writeOperationList(writer, model, settings);


### PR DESCRIPTION
Handles the case where the service model has no operation shapes.

Of course, a service is not going to be very successful right now if it has no operations, but we do not want the preview build to fail. Some features are opened and run builds before the models get loaded into the feature. 