### PR TITLE
chore(ci): add closed-issue-message GitHub action

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -1,0 +1,17 @@
+name: Closed Issue Message
+on:
+    issues:
+       types: [closed]
+jobs:
+    auto_comment:
+        runs-on: ubuntu-latest
+        permissions:
+          issues: write
+        steps:
+        - uses: aws-actions/closed-issue-message@v1
+          with:
+            # These inputs are both required
+            repo-token: "${{ secrets.GITHUB_TOKEN }}"
+            message: |
+                     This issue is now closed. Comments on closed issues are hard for our team to see. 
+                     If you need more assistance, please open a new issue that references this one.


### PR DESCRIPTION
### Description

Add Github action that sets a default message to be commented on all issues or pull requests when they get closed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
