### PR TITLE
fix(crc64-nvme-crt): return checksum for empty string if called without data

### DIFF
--- a/packages/crc64-nvme-crt/src/CrtCrc64Nvme.spec.ts
+++ b/packages/crc64-nvme-crt/src/CrtCrc64Nvme.spec.ts
@@ -4,9 +4,10 @@ import { describe, expect, it } from "vitest";
 import { CrtCrc64Nvme } from "./CrtCrc64Nvme";
 
 describe(CrtCrc64Nvme.name, () => {
-  it("should throw an error if digest is called before update", async () => {
+  it("should return checksum for empty string if digest is called before update", async () => {
     const crc64 = new CrtCrc64Nvme();
-    await expect(crc64.digest()).rejects.toThrowError("No data provided to checksum");
+    const digest = await crc64.digest();
+    expect(toBase64(digest)).toEqual("AAAAAAAAAAA=");
   });
 
   it.each([

--- a/packages/crc64-nvme-crt/src/CrtCrc64Nvme.ts
+++ b/packages/crc64-nvme-crt/src/CrtCrc64Nvme.ts
@@ -3,20 +3,17 @@ import { Checksum } from "@smithy/types";
 import { toUint8Array } from "@smithy/util-utf8";
 
 export class CrtCrc64Nvme implements Checksum {
-  private previous: DataView | undefined;
+  private checksum: DataView = new DataView(new ArrayBuffer(8));
 
-  update(chunk: Uint8Array) {
-    this.previous = checksums.crc64nvme(chunk, this.previous);
+  update(data: Uint8Array) {
+    this.checksum = checksums.crc64nvme(data, this.checksum);
   }
 
   async digest() {
-    if (!this.previous) {
-      throw new Error("No data provided to checksum");
-    }
-    return toUint8Array(this.previous);
+    return toUint8Array(this.checksum);
   }
 
   reset() {
-    this.previous = undefined;
+    this.checksum = new DataView(new ArrayBuffer(8));
   }
 }


### PR DESCRIPTION
### Issue
Internal JS-5674

### Description
Returns checksum for empty string if called without data

### Testing

Verified using internal test code that CRC64VME checksum if `"AAAAAAAAAAA="` when called for empty string.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
