### PR TITLE
test(client-s3): use chunk size of 8 KB

### DIFF
--- a/clients/client-s3/test/e2e/S3.e2e.spec.ts
+++ b/clients/client-s3/test/e2e/S3.e2e.spec.ts
@@ -35,8 +35,8 @@ describe("@aws-sdk/client-s3", () => {
       await client.deleteObject({ Bucket, Key });
     });
     it("should succeed with Node.js readable stream body", async () => {
-      const length = 10 * 1000; // 10KB
-      const chunkSize = 10;
+      const length = 100 * 1024; // 100KB
+      const chunkSize = 8 * 1024; // 8KB
       const { Readable } = require("stream");
       let sizeLeft = length;
       const inputStream = new Readable({


### PR DESCRIPTION
### Issue
Internal JS-5678

### Description

Changes chunk size in E2E tests to 8 KB.

From [S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html)
> The chunk size must be at least 8 KB. We recommend a chunk size of a least 64 KB for better performance. This chunk size applies to all chunks except the last one. The last chunk you send can be smaller than 8 KB. If your payload is small and can fit into one chunk, then it can be smaller than the 8 KB.

### Testing

#### Before

```console
$ client-s3> yarn test:e2e
...
 ❯ test/e2e/S3.e2e.spec.ts (8) 1905ms
   ❯ @aws-sdk/client-s3 (8) 1904ms
     ❯ PutObject (1)
       × should succeed with Node.js readable stream body
...
 FAIL  test/e2e/S3.e2e.spec.ts > @aws-sdk/client-s3 > PutObject > should succeed with Node.js readable stream body
InvalidChunkSizeError: Only the last chunk is allowed to have a size less than 8192 bytes
...
Test Files  1 failed (1)
     Tests  1 failed | 7 passed (8)
```

#### After

```console
$ client-s3> yarn test:e2e
...
 Test Files  1 passed (1)
      Tests  8 passed (8)
```


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
