### PR TITLE
test(lib-storage): pass requestChecksumCalculation as WHEN_REQUIRED

### DIFF
--- a/lib/lib-storage/src/lib-storage.e2e.spec.ts
+++ b/lib/lib-storage/src/lib-storage.e2e.spec.ts
@@ -27,6 +27,8 @@ describe("@aws-sdk/lib-storage", () => {
 
     client = new S3({
       region,
+      // ToDo(JS-5678): Remove this when default checksum is supported by Upload.
+      requestChecksumCalculation: "WHEN_REQUIRED",
     });
   });
 


### PR DESCRIPTION
### Issue
Internal JS-5678

### Description

Temporarily passes requestChecksumCalculation as WHEN_REQUIRED in E2E tests for Upload

### Testing

#### Before

```console
$ lib-storage> yarn test:e2e
...
 ❯ src/lib-storage.e2e.spec.ts (4) 2144ms
   ❯ @aws-sdk/lib-storage (4) 2143ms
     ❯ Upload (4) 1223ms
       × should upload in parts for input type bytes
       × should upload in parts for input type string 544ms
       × should upload in parts for input type Readable
...
 FAIL  src/lib-storage.e2e.spec.ts > @aws-sdk/lib-storage > Upload > should upload in parts for input type bytes
 FAIL  src/lib-storage.e2e.spec.ts > @aws-sdk/lib-storage > Upload > should upload in parts for input type string
 FAIL  src/lib-storage.e2e.spec.ts > @aws-sdk/lib-storage > Upload > should upload in parts for input type Readable
InvalidPart: One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.
...
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

#### After

```console
$ lib-storage> yarn test:e2e
...
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
