### PR TITLE
fix(lib-storage): set default ChecksumAlgorithm when calling CreateMPU

### DIFF
--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -1,5 +1,6 @@
 import {
   AbortMultipartUploadCommand,
+  ChecksumAlgorithm,
   CompletedPart,
   CompleteMultipartUploadCommand,
   CompleteMultipartUploadCommandOutput,
@@ -200,7 +201,11 @@ export class Upload extends EventEmitter {
 
   private async __createMultipartUpload(): Promise<CreateMultipartUploadCommandOutput> {
     if (!this.createMultiPartPromise) {
-      const createCommandParams = { ...this.params, Body: undefined };
+      const createCommandParams = {
+        ChecksumAlgorithm: ChecksumAlgorithm.CRC32,
+        ...this.params,
+        Body: undefined,
+      };
       this.createMultiPartPromise = this.client
         .send(new CreateMultipartUploadCommand(createCommandParams))
         .then((createMpuResponse) => {

--- a/lib/lib-storage/src/lib-storage.e2e.spec.ts
+++ b/lib/lib-storage/src/lib-storage.e2e.spec.ts
@@ -27,8 +27,6 @@ describe("@aws-sdk/lib-storage", () => {
 
     client = new S3({
       region,
-      // ToDo(JS-5678): Remove this when default checksum is supported by Upload.
-      requestChecksumCalculation: "WHEN_REQUIRED",
     });
   });
 


### PR DESCRIPTION
### Issue

* Missed in https://github.com/aws/aws-sdk-js-v3/pull/6750
* Reverts https://github.com/aws/aws-sdk-js-v3/pull/6800

### Description

Sets default ChecksumAlgorithm when calling CreateMPU

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
