### PR TITLE
test(client-s3): disable checksum calculation and validation in legacy tests

### DIFF
--- a/features/s3/step_definitions/buckets.js
+++ b/features/s3/step_definitions/buckets.js
@@ -21,6 +21,8 @@ After({ tags: "@buckets" }, function (callback) {
 Given("I am using the S3 {string} region", function (region, callback) {
   this.s3 = new this.S3({
     region: region,
+    requestChecksumCalculation: "WHEN_REQUIRED",
+    responseChecksumValidation: "WHEN_REQUIRED",
   });
   callback();
 });
@@ -235,6 +237,8 @@ When("I create a bucket with a DNS compatible name that contains a dot", functio
 Given("I force path style requests", function (callback) {
   this.s3 = new this.S3({
     forcePathStyle: true,
+    requestChecksumCalculation: "WHEN_REQUIRED",
+    responseChecksumValidation: "WHEN_REQUIRED",
   });
   callback();
 });

--- a/features/s3/step_definitions/hooks.js
+++ b/features/s3/step_definitions/hooks.js
@@ -4,6 +4,8 @@ Before({ tags: "@s3" }, function (scenario, callback) {
   const { S3 } = require("../../../clients/client-s3");
   this.service = this.s3 = new S3({
     maxRetries: 100,
+    requestChecksumCalculation: "WHEN_REQUIRED",
+    responseChecksumValidation: "WHEN_REQUIRED",
   });
   callback();
 });

--- a/features/s3/step_definitions/objects.js
+++ b/features/s3/step_definitions/objects.js
@@ -95,7 +95,7 @@ Then("the object {string} should contain {string}", function (key, contents, nex
 });
 
 Then("the HTTP response should have a content length of {int}", function (contentLength, next) {
-  this.assert.equal(this.data.Body.headers["content-length"], contentLength);
+  this.assert.equal(this.data.ContentLength, contentLength);
   next();
 });
 


### PR DESCRIPTION
### Issue
Missed in https://github.com/aws/aws-sdk-js-v3/pull/6750

### Description
Disables checksum calculation and validation in legacy tests

### Testing

#### Before

```console
$ ./node_modules/.bin/cucumber-js --fail-fast -t "@s3"
This Node.js version (v22.11.0) has not been tested with this version of Cucumber; it should work normally, but please raise an issue if you see anything unexpected.
.........................................................................F--.-------------------------------------------------------------------------------------------------------------------------------------------------------

Failures:

1) Scenario: Operating on a bucket using path style # features/s3/buckets.feature:56
   ✔ Before # features/extra/hooks.js:15
   ✔ Before # features/s3/step_definitions/buckets.js:3
   ✔ Before # features/s3/step_definitions/hooks.js:3
   ✔ Before # features/s3/step_definitions/proxy.js:5
   ✔ Given I force path style requests # features/s3/step_definitions/buckets.js:235
   ✔ And I create a bucket # features/extra/hooks.js:38
   ✔ When I put "abc" to the key "hello" in the bucket # features/s3/step_definitions/buckets.js:254
   ✔ And I get the key "hello" in the bucket # features/s3/step_definitions/buckets.js:263
   ✖ Then the bucket name should be in the request path # features/s3/step_definitions/buckets.js:242
       TypeError: Cannot read properties of undefined (reading 'path')
           at Object.<anonymous> (/local/home/trivikr/workspace/aws-sdk-js-v3/features/s3/step_definitions/buckets.js:243:35)
   - And the bucket name should not be in the request host # features/s3/step_definitions/buckets.js:248
   - Then I delete the object "hello" from the bucket # features/s3/step_definitions/buckets.js:271
   ✔ After # features/s3/step_definitions/buckets.js:8

23 scenarios (1 failed, 15 skipped, 7 passed)
128 steps (1 failed, 93 skipped, 34 passed)
0m07.069s (executing steps: 0m06.990s)
```

#### After

```console
$ ./node_modules/.bin/cucumber-js --fail-fast -t "@s3"
...
23 scenarios (23 passed)
128 steps (128 passed)
0m09.966s (executing steps: 0m09.409s)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
