### PR TITLE
fix(credential-providers): supply backup credentials to fromTemporaryCredentials

### DIFF
--- a/packages/credential-providers/src/fromTemporaryCredentials.browser.ts
+++ b/packages/credential-providers/src/fromTemporaryCredentials.browser.ts
@@ -1,0 +1,75 @@
+import type { AssumeRoleCommandInput, STSClient, STSClientConfig } from "@aws-sdk/nested-clients/sts";
+import type {
+  AwsIdentityProperties,
+  CredentialProviderOptions,
+  RuntimeConfigAwsCredentialIdentityProvider,
+} from "@aws-sdk/types";
+import { CredentialsProviderError } from "@smithy/property-provider";
+import { AwsCredentialIdentity, AwsCredentialIdentityProvider, Pluggable } from "@smithy/types";
+
+export interface FromTemporaryCredentialsOptions extends CredentialProviderOptions {
+  params: Omit<AssumeRoleCommandInput, "RoleSessionName"> & { RoleSessionName?: string };
+  masterCredentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
+  clientConfig?: STSClientConfig;
+  clientPlugins?: Pluggable<any, any>[];
+  mfaCodeProvider?: (mfaSerial: string) => Promise<string>;
+}
+
+export const fromTemporaryCredentials = (
+  options: FromTemporaryCredentialsOptions,
+  credentialDefaultProvider?: () => AwsCredentialIdentityProvider
+): RuntimeConfigAwsCredentialIdentityProvider => {
+  let stsClient: STSClient;
+  return async (awsIdentityProperties: AwsIdentityProperties = {}): Promise<AwsCredentialIdentity> => {
+    options.logger?.debug("@aws-sdk/credential-providers - fromTemporaryCredentials (STS)");
+    const params = { ...options.params, RoleSessionName: options.params.RoleSessionName ?? "aws-sdk-js-" + Date.now() };
+    if (params?.SerialNumber) {
+      if (!options.mfaCodeProvider) {
+        throw new CredentialsProviderError(
+          `Temporary credential requires multi-factor authentication,` + ` but no MFA code callback was provided.`,
+          {
+            tryNextLink: false,
+            logger: options.logger,
+          }
+        );
+      }
+      params.TokenCode = await options.mfaCodeProvider(params?.SerialNumber);
+    }
+
+    const { AssumeRoleCommand, STSClient } = await import("./loadSts");
+
+    if (!stsClient) {
+      const defaultCredentialsOrError =
+        typeof credentialDefaultProvider === "function" ? credentialDefaultProvider() : undefined;
+
+      const { callerClientConfig } = awsIdentityProperties;
+      stsClient = new STSClient({
+        ...options.clientConfig,
+        credentials:
+          options.masterCredentials ??
+          options.clientConfig?.credentials ??
+          callerClientConfig?.credentialDefaultProvider?.() ??
+          defaultCredentialsOrError,
+      });
+    }
+    if (options.clientPlugins) {
+      for (const plugin of options.clientPlugins) {
+        stsClient.middlewareStack.use(plugin);
+      }
+    }
+    const { Credentials } = await stsClient.send(new AssumeRoleCommand(params));
+    if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
+      throw new CredentialsProviderError(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`, {
+        logger: options.logger,
+      });
+    }
+    return {
+      accessKeyId: Credentials.AccessKeyId,
+      secretAccessKey: Credentials.SecretAccessKey,
+      sessionToken: Credentials.SessionToken,
+      expiration: Credentials.Expiration,
+      // TODO(credentialScope): access normally when shape is updated.
+      credentialScope: (Credentials as any).CredentialScope,
+    };
+  };
+};

--- a/packages/credential-providers/src/fromTemporaryCredentials.ts
+++ b/packages/credential-providers/src/fromTemporaryCredentials.ts
@@ -1,15 +1,13 @@
-import type { AssumeRoleCommandInput, STSClient, STSClientConfig } from "@aws-sdk/nested-clients/sts";
-import type { CredentialProviderOptions } from "@aws-sdk/types";
-import { CredentialsProviderError } from "@smithy/property-provider";
-import { AwsCredentialIdentity, AwsCredentialIdentityProvider, Pluggable } from "@smithy/types";
+import type { RuntimeConfigAwsCredentialIdentityProvider } from "@aws-sdk/types";
 
-export interface FromTemporaryCredentialsOptions extends CredentialProviderOptions {
-  params: Omit<AssumeRoleCommandInput, "RoleSessionName"> & { RoleSessionName?: string };
-  masterCredentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
-  clientConfig?: STSClientConfig;
-  clientPlugins?: Pluggable<any, any>[];
-  mfaCodeProvider?: (mfaSerial: string) => Promise<string>;
-}
+import { fromNodeProviderChain } from "./fromNodeProviderChain";
+import type { FromTemporaryCredentialsOptions } from "./fromTemporaryCredentials.browser";
+import { fromTemporaryCredentials as fromTemporaryCredentialsBase } from "./fromTemporaryCredentials.browser";
+
+/**
+ * @public
+ */
+export { FromTemporaryCredentialsOptions };
 
 /**
  * Creates a credential provider function that retrieves temporary credentials from STS AssumeRole API.
@@ -53,45 +51,8 @@ export interface FromTemporaryCredentialsOptions extends CredentialProviderOptio
  *
  * @public
  */
-export const fromTemporaryCredentials = (options: FromTemporaryCredentialsOptions): AwsCredentialIdentityProvider => {
-  let stsClient: STSClient;
-  return async (): Promise<AwsCredentialIdentity> => {
-    options.logger?.debug("@aws-sdk/credential-providers - fromTemporaryCredentials (STS)");
-    const params = { ...options.params, RoleSessionName: options.params.RoleSessionName ?? "aws-sdk-js-" + Date.now() };
-    if (params?.SerialNumber) {
-      if (!options.mfaCodeProvider) {
-        throw new CredentialsProviderError(
-          `Temporary credential requires multi-factor authentication,` + ` but no MFA code callback was provided.`,
-          {
-            tryNextLink: false,
-            logger: options.logger,
-          }
-        );
-      }
-      params.TokenCode = await options.mfaCodeProvider(params?.SerialNumber);
-    }
-
-    const { AssumeRoleCommand, STSClient } = await import("./loadSts");
-
-    if (!stsClient) stsClient = new STSClient({ ...options.clientConfig, credentials: options.masterCredentials });
-    if (options.clientPlugins) {
-      for (const plugin of options.clientPlugins) {
-        stsClient.middlewareStack.use(plugin);
-      }
-    }
-    const { Credentials } = await stsClient.send(new AssumeRoleCommand(params));
-    if (!Credentials || !Credentials.AccessKeyId || !Credentials.SecretAccessKey) {
-      throw new CredentialsProviderError(`Invalid response from STS.assumeRole call with role ${params.RoleArn}`, {
-        logger: options.logger,
-      });
-    }
-    return {
-      accessKeyId: Credentials.AccessKeyId,
-      secretAccessKey: Credentials.SecretAccessKey,
-      sessionToken: Credentials.SessionToken,
-      expiration: Credentials.Expiration,
-      // TODO(credentialScope): access normally when shape is updated.
-      credentialScope: (Credentials as any).CredentialScope,
-    };
-  };
+export const fromTemporaryCredentials = (
+  options: FromTemporaryCredentialsOptions
+): RuntimeConfigAwsCredentialIdentityProvider => {
+  return fromTemporaryCredentialsBase(options, fromNodeProviderChain);
 };

--- a/packages/credential-providers/src/index.browser.ts
+++ b/packages/credential-providers/src/index.browser.ts
@@ -2,5 +2,5 @@ export * from "./fromCognitoIdentity";
 export * from "./fromCognitoIdentityPool";
 export { fromHttp } from "@aws-sdk/credential-provider-http";
 export type { FromHttpOptions, HttpProviderCredentials } from "@aws-sdk/credential-provider-http";
-export * from "./fromTemporaryCredentials";
+export * from "./fromTemporaryCredentials.browser";
 export * from "./fromWebToken";

--- a/packages/nested-clients/package.json
+++ b/packages/nested-clients/package.json
@@ -86,8 +86,8 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-es/nested-sso-oidc/runtimeConfig": "./dist-es/nested-sso-oidc/runtimeConfig.browser",
-    "./dist-es/nested-sts/runtimeConfig": "./dist-es/nested-sts/runtimeConfig.browser"
+    "./dist-es/submodules/sts/runtimeConfig": "./dist-es/submodules/sts/runtimeConfig.browser",
+    "./dist-es/submodules/sso-oidc/runtimeConfig": "./dist-es/submodules/sso-oidc/runtimeConfig.browser"
   },
   "react-native": {},
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/nested-clients",

--- a/packages/types/src/identity/AwsCredentialIdentity.ts
+++ b/packages/types/src/identity/AwsCredentialIdentity.ts
@@ -1,4 +1,4 @@
-import type { AwsCredentialIdentity } from "@smithy/types";
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types";
 
 import type { AwsSdkCredentialsFeatures } from "../feature-ids";
 
@@ -11,6 +11,11 @@ export interface AwsIdentityProperties {
   callerClientConfig?: {
     region(): Promise<string>;
     profile?: string;
+    /**
+     * @internal
+     * @deprecated
+     */
+    credentialDefaultProvider?: (input?: any) => AwsCredentialIdentityProvider;
   };
 }
 


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6816

### Description
This provides backup credentials to the `fromTemporaryCredentials()` provider.
Also fixes browser bundling for the nested clients.

### Testing
- [ ] ~~needs new integration test~~
- [x] added new unit tests, the fromTemporaryCredentials provider is not part of the default chain and has no associated integration test
