### PR TITLE
fix(credential-provider-node): handle string value `AWS_EC2_METADATA_DISABLED=false`

### DIFF
--- a/packages/credential-provider-node/src/remoteProvider.ts
+++ b/packages/credential-provider-node/src/remoteProvider.ts
@@ -24,7 +24,7 @@ export const remoteProvider = async (
     return chain(fromHttp(init), fromContainerMetadata(init));
   }
 
-  if (process.env[ENV_IMDS_DISABLED]) {
+  if (process.env[ENV_IMDS_DISABLED] && process.env[ENV_IMDS_DISABLED] !== "false") {
     return async () => {
       throw new CredentialsProviderError("EC2 Instance Metadata Service access disabled", { logger: init.logger });
     };


### PR DESCRIPTION
Setting the environment variable `AWS_EC2_METADATA_DISABLED` to "false" causes the condition to evaluate as `true`, which disables the IMDS credentials check.
