### PR TITLE
chore(codegen): bump smithy-typescript-codegen to 0.26.0

### DIFF
--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "de3a850552111a7018df855f808258074a90ab62",
+  SMITHY_TS_COMMIT: "fbe3c04b5627a8aea693b5bfc1598adbac0213d5",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/pull/1510

### Description
Bumps smithy-typescript-codegen to 0.26.0

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
