### PR TITLE
chore(chodegen): bump codegen version to 0.26.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.26.0 (2025-01-22)
+
+### Features
+- Upgraded to 0.26.0 of smithy-typescript ([Release Notes](https://github.com/kuhe/smithy-typescript/blob/main/CHANGELOG.md#0260-2025-01-22))
+- Enabled profile configuration for clients ([#6728](https://github.com/aws/aws-sdk-js-v3/pull/6728))
+- Created nested clients for internal use ([#6791](https://github.com/aws/aws-sdk-js-v3/pull/6791))
+
+### Bug Fixes
+
 ## 0.25.0 (2024-11-18)
 
 ### Features


### PR DESCRIPTION
### Issue
Internal JS-5673

### Description
Adds CHANGELOG for 0.26.0
The version was bumped in https://github.com/aws/aws-sdk-js-v3/pull/6843

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
