### PR TITLE
feat(credential-provider-ini): add ignoreCache option

### DIFF
--- a/packages/credential-provider-ini/src/fromIni.spec.ts
+++ b/packages/credential-provider-ini/src/fromIni.spec.ts
@@ -72,4 +72,55 @@ describe(fromIni.name, () => {
       mockInitWithParentClientConfig
     );
   });
+
+  describe("ignoreCache option", () => {
+    it("passes ignoreCache option to parseKnownFiles when true", async () => {
+      const initWithIgnoreCache = { ...mockInit, ignoreCache: true };
+      const expectedInitWithParentClientConfig = {
+        ...mockInitWithParentClientConfig,
+        ignoreCache: true,
+      };
+
+      await fromIni(initWithIgnoreCache)();
+
+      expect(parseKnownFiles).toHaveBeenCalledWith(expectedInitWithParentClientConfig);
+    });
+
+    it("passes ignoreCache option to parseKnownFiles when false", async () => {
+      const initWithIgnoreCache = { ...mockInit, ignoreCache: false };
+      const expectedInitWithParentClientConfig = {
+        ...mockInitWithParentClientConfig,
+        ignoreCache: false,
+      };
+
+      await fromIni(initWithIgnoreCache)();
+
+      expect(parseKnownFiles).toHaveBeenCalledWith(expectedInitWithParentClientConfig);
+    });
+
+    it("does not pass ignoreCache when option is undefined", async () => {
+      await fromIni(mockInit)();
+
+      expect(parseKnownFiles).toHaveBeenCalledWith(mockInitWithParentClientConfig);
+      expect(mockInitWithParentClientConfig).not.toHaveProperty("ignoreCache");
+    });
+
+    it("preserves ignoreCache when merging with callerClientConfig", async () => {
+      const initWithIgnoreCache = { ...mockInit, ignoreCache: true };
+      const callerConfig = {
+        profile: "otherProfile",
+        region: async () => "us-east-1",
+      };
+
+      await fromIni(initWithIgnoreCache)({ callerClientConfig: callerConfig });
+
+      expect(parseKnownFiles).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ignoreCache: true,
+          profile: mockProfileName,
+          parentClientConfig: expect.objectContaining(callerConfig),
+        })
+      );
+    });
+  });
 });

--- a/packages/credential-provider-ini/src/fromIni.ts
+++ b/packages/credential-provider-ini/src/fromIni.ts
@@ -47,6 +47,12 @@ export interface FromIniInit extends SourceProfileInit, CredentialProviderOption
   clientConfig?: any;
 
   clientPlugins?: Pluggable<any, any>[];
+
+  /**
+   * When true, always reload credentials from the file system instead of using cached values.
+   * This is useful when you need to detect changes to the credentials file.
+   */
+  ignoreCache?: boolean;
 }
 
 /**

--- a/supplemental-docs/CLIENTS.md
+++ b/supplemental-docs/CLIENTS.md
@@ -165,18 +165,19 @@ import { fromIni } from "@aws-sdk/credential-provider-ini";
 
 // Create client with credentials that will reload from file
 const client = new S3Client({
-  credentials: fromIni({ ignoreCache: true })
- });
- ```
+  credentials: fromIni({ ignoreCache: true }),
+});
+```
 
 Refreshing credentials for an existing client:
+
 ```typescript
 import { S3Client } from "@aws-sdk/client-s3";
 import { fromIni } from "@aws-sdk/credential-provider-ini";
 
 // Initial client setup
 const client = new S3Client({
-  credentials: fromIni({ ignoreCache: true })
+  credentials: fromIni({ ignoreCache: true }),
 });
 
 // To refresh credentials later:
@@ -189,21 +190,21 @@ async function refreshClientCredentials() {
 ```
 
 For temporary credentials:
+
 ```typescript
-import { fromTemporaryCredentials } from "@aws-sdk/credential-provider";
+import { fromTemporaryCredentials } from "@aws-sdk/credential-providers";
 
 // Better approach for temporary credentials that need regular refreshing
 const client = new S3Client({
   credentials: fromTemporaryCredentials({
-  // your temporary credentials config
-    })
-  });
+    // your temporary credentials config
+  }),
+});
 ```
 
 - When using with AWS clients, the credential provider function is handled automatically.
 - For temporary credentials that need regular refreshing, `fromTemporaryCredentials` is recommended over manual refresh with `ignoreCache`.
 - Creating a new client instance ensures fresh credentials.
-
 
 ### AWS Profile `profile`
 

--- a/supplemental-docs/CLIENTS.md
+++ b/supplemental-docs/CLIENTS.md
@@ -169,26 +169,6 @@ const client = new S3Client({
 });
 ```
 
-Refreshing credentials for an existing client:
-
-```typescript
-import { S3Client } from "@aws-sdk/client-s3";
-import { fromIni } from "@aws-sdk/credential-providers";
-
-// Initial client setup
-const client = new S3Client({
-  credentials: fromIni({ ignoreCache: true }),
-});
-
-// To refresh credentials later:
-async function refreshClientCredentials() {
-  const credProvider = fromIni({ ignoreCache: true });
-  // Get fresh credentials and update the client
-  const freshCredentials = await credProvider();
-  client.config.credentials = freshCredentials;
-}
-```
-
 For temporary credentials:
 
 You can use the `fromTemporaryCredentials` provider that creates a credential provider function that retrieves temporary credentials from STS AssumeRole API.

--- a/supplemental-docs/CLIENTS.md
+++ b/supplemental-docs/CLIENTS.md
@@ -171,7 +171,7 @@ const client = new S3Client({
 
 For temporary credentials:
 
-You can use the `fromTemporaryCredentials` provider that creates a credential provider function that retrieves temporary credentials from STS AssumeRole API.
+You can use the `fromTemporaryCredentials` provider that creates a credential provider function that retrieves temporary credentials from STS AssumeRole API. Depending on your use-case, this might be the preferred way to use temporary credentials, as compared to having a `.ini` file with `ignoreCache` (that will utilize filesystem operations) set to true.
 
 ```typescript
 import { fromTemporaryCredentials } from "@aws-sdk/credential-providers";

--- a/supplemental-docs/CLIENTS.md
+++ b/supplemental-docs/CLIENTS.md
@@ -161,7 +161,7 @@ Using ignoreCache with an S3 client:
 
 ```typescript
 import { S3Client } from "@aws-sdk/client-s3";
-import { fromIni } from "@aws-sdk/credential-provider-ini";
+import { fromIni } from "@aws-sdk/credential-providers";
 
 // Create client with credentials that will reload from file
 const client = new S3Client({
@@ -173,7 +173,7 @@ Refreshing credentials for an existing client:
 
 ```typescript
 import { S3Client } from "@aws-sdk/client-s3";
-import { fromIni } from "@aws-sdk/credential-provider-ini";
+import { fromIni } from "@aws-sdk/credential-providers";
 
 // Initial client setup
 const client = new S3Client({
@@ -190,6 +190,8 @@ async function refreshClientCredentials() {
 ```
 
 For temporary credentials:
+
+You can use the `fromTemporaryCredentials` provider that creates a credential provider function that retrieves temporary credentials from STS AssumeRole API.
 
 ```typescript
 import { fromTemporaryCredentials } from "@aws-sdk/credential-providers";

--- a/supplemental-docs/CLIENTS.md
+++ b/supplemental-docs/CLIENTS.md
@@ -153,7 +153,7 @@ const client = new S3Client({
 
 #### Enabling uncached/refreshed credentials in `fromIni` credential provider
 
-`fromIni` credential provider accepts a boolean `ignoreCache` value which when true, always reloads credentials from the file system instead of using cached values. This is useful when you need to detect changes to the credentials file.
+`fromIni` credential provider accepts a boolean `ignoreCache` option which when true, always reloads credentials from the file system instead of using cached values. This is useful when you need to detect changes to the credentials file.
 
 Note: For temporary credentials that need regular refreshing, consider using `fromTemporaryCredentials` instead.
 
@@ -190,7 +190,7 @@ async function refreshClientCredentials() {
 
 For temporary credentials:
 ```typescript
-import { fromTemporaryCredentials } from "@aws-sdk/credential-provider-ini";
+import { fromTemporaryCredentials } from "@aws-sdk/credential-provider";
 
 // Better approach for temporary credentials that need regular refreshing
 const client = new S3Client({

--- a/supplemental-docs/CLIENTS.md
+++ b/supplemental-docs/CLIENTS.md
@@ -151,6 +151,60 @@ const client = new S3Client({
 });
 ```
 
+#### Enabling uncached/refreshed credentials in `fromIni` credential provider
+
+`fromIni` credential provider accepts a boolean `ignoreCache` value which when true, always reloads credentials from the file system instead of using cached values. This is useful when you need to detect changes to the credentials file.
+
+Note: For temporary credentials that need regular refreshing, consider using `fromTemporaryCredentials` instead.
+
+Using ignoreCache with an S3 client:
+
+```typescript
+import { S3Client } from "@aws-sdk/client-s3";
+import { fromIni } from "@aws-sdk/credential-provider-ini";
+
+// Create client with credentials that will reload from file
+const client = new S3Client({
+  credentials: fromIni({ ignoreCache: true })
+ });
+ ```
+
+Refreshing credentials for an existing client:
+```typescript
+import { S3Client } from "@aws-sdk/client-s3";
+import { fromIni } from "@aws-sdk/credential-provider-ini";
+
+// Initial client setup
+const client = new S3Client({
+  credentials: fromIni({ ignoreCache: true })
+});
+
+// To refresh credentials later:
+async function refreshClientCredentials() {
+  const credProvider = fromIni({ ignoreCache: true });
+  // Get fresh credentials and update the client
+  const freshCredentials = await credProvider();
+  client.config.credentials = freshCredentials;
+}
+```
+
+For temporary credentials:
+```typescript
+import { fromTemporaryCredentials } from "@aws-sdk/credential-provider-ini";
+
+// Better approach for temporary credentials that need regular refreshing
+const client = new S3Client({
+  credentials: fromTemporaryCredentials({
+  // your temporary credentials config
+    })
+  });
+```
+
+- When using with AWS clients, the credential provider function is handled automatically.
+- For temporary credentials that need regular refreshing, `fromTemporaryCredentials` is recommended over manual refresh with `ignoreCache`.
+- Creating a new client instance ensures fresh credentials.
+
+
 ### AWS Profile `profile`
 
 Available since [v3.714.0](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.714.0).


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/3396

### Description
Exposes the `ignoreCache` option for `fromIni` credential provider. 

To note, if you run a test script using the `fromIni` credential provider (loading credentials from the `~/.aws/credentials` file) separately each time, the Node.js process starts fresh each time, so there's no cached state between runs. But, if you modify the credentials file within the same running process, we can see the caching in effect - the credentials wouldn't update even after waiting for a while.

The exposed option `ignoreCache` will allow uncached/refreshed credentials from the credentials file to be used, even if the credentials file is modified within the same running process. 

### Testing
`credential-provider-ini` package updated tests

```console
✓ src/fromIni.spec.ts (7)
 ✓ src/resolveAssumeRoleCredentials.spec.ts (23)
 ✓ src/resolveCredentialSource.spec.ts (4)
 ✓ src/resolveProcessCredentials.spec.ts (14)
 ✓ src/resolveProfileData.spec.ts (7)
 ✓ src/resolveSsoCredentials.spec.ts (9)
 ✓ src/resolveStaticCredentials.spec.ts (16)
 ✓ src/resolveWebIdentityCredentials.spec.ts (16)

 Test Files  8 passed (8)
      Tests  96 passed (96)
.
.
```

### Additional context
Short test script to see this option in action:
```typescript
import { fromIni } from "@aws-sdk/credential-provider-ini";
import { writeFileSync } from "fs";
import { homedir } from "os";
import { resolve } from "path";

const AWS_CREDENTIALS = resolve(`${homedir}/.aws/credentials`);

const getCredentials = async (ignoreCache = false) => {
  const credentials = await fromIni({ ignoreCache })();
  console.log(new Date().toISOString(), credentials);
};

// Test with caching (default behavior)
console.log("With caching:");
await getCredentials(false);

// Modify credentials file
const newCredentials = `
[default]
aws_access_key_id = hello
aws_secret_access_key = hi
`;

console.log("\nModifying credentials file...");
writeFileSync(AWS_CREDENTIALS, newCredentials);

// Test immediate read with caching
console.log("\nImmediate read with caching:");
await getCredentials(false);

// Test immediate read without caching
console.log("\nImmediate read without caching:");
await getCredentials(true);

```

Output:
```console
% node creds-uncached.mjs
With caching:
2025-01-30T18:29:05.766Z {
  accessKeyId: 'foo',
  secretAccessKey: 'bar',
  sessionToken: undefined,
  '$source': { CREDENTIALS_PROFILE: 'n' }
}

Modifying credentials file...

Immediate read with caching:
2025-01-30T18:29:05.768Z {
  accessKeyId: 'foo',
  secretAccessKey: 'bar',
  sessionToken: undefined,
  '$source': { CREDENTIALS_PROFILE: 'n' }
}

Immediate read without caching:
2025-01-30T18:29:05.768Z {
  accessKeyId: 'hello',
  secretAccessKey: 'hi',
  sessionToken: undefined,
  '$source': { CREDENTIALS_PROFILE: 'n' }
}
```


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
