### PR TITLE
AwsCliv2CredentialProvider

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -3,7 +3,8 @@
   "description": "AWS SDK for JavaScript Accessanalyzer Client for Node.js, Browser and React Native",
   "version": "3.741.0",
   "scripts": {
-    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build": "concurrently 'yarn generate:version' 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types' ",
+    "build:webpack": "webpack",
     "build:cjs": "node ../../scripts/compilation/inline client-accessanalyzer",
     "build:es": "tsc -p tsconfig.es.json",
     "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
@@ -11,7 +12,8 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "extract:docs": "api-extractor run --local",
-    "generate:client": "node ../../scripts/generate-clients/single-service --solo accessanalyzer"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo accessanalyzer",
+    "generate:version": "node src/scripts/generate-version.js"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",
@@ -63,10 +65,23 @@
   "devDependencies": {
     "@tsconfig/node18": "18.2.4",
     "@types/node": "^18.19.69",
+    "@types/path-browserify": "^1",
+    "@types/webpack-bundle-analyzer": "^4",
+    "assert": "^2.1.0",
+    "browserify-zlib": "^0.2.0",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
+    "http2-wrapper": "^2.2.1",
+    "https-browserify": "^1.0.0",
+    "os-browserify": "^0.3.0",
+    "path-browserify": "^1.0.1",
     "rimraf": "3.0.2",
-    "typescript": "~5.2.2"
+    "stream-http": "^3.2.0",
+    "typescript": "~5.2.2",
+    "url": "^0.11.4",
+    "webpack": "^5.97.1",
+    "webpack-bundle-analyzer": "^4.10.2",
+    "webpack-cli": "^6.0.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/clients/client-accessanalyzer/src/index.ts
+++ b/clients/client-accessanalyzer/src/index.ts
@@ -1,5 +1,6 @@
 // smithy-typescript generated code
 /* eslint-disable */
+import { version } from "../version.json";
 /**
  * <p>Identity and Access Management Access Analyzer helps you to set, verify, and refine your IAM policies by providing
  *          a suite of capabilities. Its features include findings for external and unused access,
@@ -28,6 +29,8 @@
  *
  * @packageDocumentation
  */
+
+export const VERSION = version;
 export * from "./AccessAnalyzerClient";
 export * from "./AccessAnalyzer";
 export { ClientInputEndpointParameters } from "./endpoint/EndpointParameters";

--- a/clients/client-accessanalyzer/src/runtimeConfig.browser.ts
+++ b/clients/client-accessanalyzer/src/runtimeConfig.browser.ts
@@ -1,6 +1,6 @@
 // smithy-typescript generated code
 // @ts-ignore: package.json will be imported from dist folders
-import packageInfo from "../package.json"; // eslint-disable-line
+import packageInfo from "../version.json"; // eslint-disable-line
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { createDefaultUserAgentProvider } from "@aws-sdk/util-user-agent-browser";

--- a/clients/client-accessanalyzer/src/runtimeConfig.ts
+++ b/clients/client-accessanalyzer/src/runtimeConfig.ts
@@ -1,6 +1,6 @@
 // smithy-typescript generated code
 // @ts-ignore: package.json will be imported from dist folders
-import packageInfo from "../package.json"; // eslint-disable-line
+import packageInfo from "../version.json"; // eslint-disable-line
 
 import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";

--- a/packages/credential-providers/src/fromAwsCliV2CompatibleProviderChain.ts
+++ b/packages/credential-providers/src/fromAwsCliV2CompatibleProviderChain.ts
@@ -1,0 +1,59 @@
+import { fromEnv } from "@aws-sdk/credential-provider-env";
+import { fromIni } from "@aws-sdk/credential-provider-ini";
+import { defaultProvider } from "@aws-sdk/credential-provider-node";
+import type { CredentialProviderOptions, Provider } from "@aws-sdk/types";
+import { chain, memoize } from "@smithy/property-provider";
+import type { AwsCredentialIdentity } from "@smithy/types";
+
+interface AwsCliV2CompatibleProviderOptions extends CredentialProviderOptions {
+  profile?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+}
+
+/**
+ * AWS CLI V2 Compatible Credential Provider Chain
+ * If profile is explicitly provided, uses fromIni with that profile.
+ * Otherwise, uses a chain of fromEnv and fromNodeProviderChain.
+ */
+export const fromAwsCliV2CompatibleProviderChain = (
+  options: AwsCliV2CompatibleProviderOptions = {}
+): Provider<AwsCredentialIdentity> => {
+  const { profile, accessKeyId, secretAccessKey, sessionToken } = options;
+
+  return memoize(
+    async (): Promise<AwsCredentialIdentity> => {
+      // If explicit credentials are provided in the constructor, use them.
+      if (accessKeyId && secretAccessKey) {
+        return {
+          accessKeyId,
+          secretAccessKey,
+          sessionToken, // Optional
+        };
+      }
+      // If profile is explicitly provided, use fromIni directly
+      if (profile) {
+        return fromIni({ profile })();
+      }
+
+      // Otherwise, use the chain of providers
+      const credentials = await chain(fromEnv(), async () => {
+        return defaultProvider()();
+      })();
+
+      if (!credentials) {
+        throw new Error("Failed to retrieve valid AWS credentials");
+      }
+
+      return credentials;
+    },
+    credentialsTreatedAsExpired,
+    credentialsWillNeedRefresh
+  );
+};
+
+export const credentialsTreatedAsExpired = (credentials: AwsCredentialIdentity) =>
+  credentials?.expiration !== undefined && credentials.expiration.getTime() - Date.now() < 300000;
+
+export const credentialsWillNeedRefresh = (credentials: AwsCredentialIdentity) => credentials?.expiration !== undefined;

--- a/packages/credential-providers/src/resolveAwsCliV2Region.ts
+++ b/packages/credential-providers/src/resolveAwsCliV2Region.ts
@@ -1,0 +1,51 @@
+import { MetadataService } from "@aws-sdk/ec2-metadata-service";
+import { logger } from "@aws-sdk/smithy-client/dist-types";
+import { loadSharedConfigFiles } from "@smithy/shared-ini-file-loader";
+
+/**
+ * Resolves the AWS region following AWS CLI V2 precedence order.
+ */
+export const resolveAwsCliV2Region = async (defaultRegion?: string, maybeProfile?: string): Promise<string> => {
+  const profile = maybeProfile ?? process.env.AWS_PROFILE ?? process.env.AWS_DEFAULT_PROFILE ?? "default";
+
+  const region =
+    process.env.AWS_REGION ||
+    process.env.AWS_DEFAULT_REGION ||
+    (await getRegionFromIni(profile)) ||
+    (await regionFromMetadataService());
+
+  if (!region) {
+    const usedProfile = !profile ? "" : ` (profile: "${profile}")`;
+    if (defaultRegion) {
+      logger.warn(
+        `Unable to determine AWS region from environment or AWS configuration${usedProfile}, defaulting to '${defaultRegion}'`
+      );
+      return defaultRegion;
+    }
+    throw new Error(
+      `Unable to determine AWS region from environment or AWS configuration${usedProfile}. Please specify a region.`
+    );
+  }
+  return region;
+};
+
+/**
+ * Fetches the region from the AWS shared config files.
+ */
+export async function getRegionFromIni(profile: string): Promise<string | undefined> {
+  const sharedFiles = await loadSharedConfigFiles({ ignoreCache: true });
+  return sharedFiles.configFile?.[profile]?.region || sharedFiles.credentialsFile?.[profile]?.region;
+}
+
+/**
+ * Retrieves the AWS region from the EC2 Instance Metadata Service (IMDS).
+ */
+export async function regionFromMetadataService(): Promise<string | undefined> {
+  try {
+    const metadataService = new MetadataService();
+    const document = await metadataService.request("/latest/dynamic/instance-identity/document", {});
+    return JSON.parse(document).region;
+  } catch (e) {
+    return undefined;
+  }
+}


### PR DESCRIPTION
- **feat(client-route-53): Amazon Route 53 now supports the Asia Pacific (Thailand) Region (ap-southeast-7) for latency records, geoproximity records, and private DNS for Amazon VPCs in that region**
- **docs(client-rds): Updates Amazon RDS documentation to clarify the RestoreDBClusterToPointInTime description.**
- **feat(client-sagemaker): Adds support for IPv6 for SageMaker HyperPod cluster nodes.**
- **feat(clients): update client endpoints as of 2025-01-08**
- **Publish v3.725.0**
- **test: update vitest to 2.1.8 (#6780)**
- **chore(codegen): update template typescript version (#6784)**
- **chore(models): update API models**
- **chore(endpoints): update endpoints model**
- **chore(util-endpoints): update aws partitions.json**
- **feat(client-compute-optimizer): This release expands AWS Compute Optimizer rightsizing recommendation support for Amazon EC2 Auto Scaling groups to include those with scaling policies and multiple instance types.**
- **feat(client-codebuild): AWS CodeBuild Now Supports BuildBatch in Reserved Capacity and Lambda**
- **feat(client-fms): AWS Firewall Manager now lets you combine multiple resource tags using the logical AND operator or the logical OR operator.**
- **Publish v3.726.0**
- **fix(codegen): handle case when sample operation not found (#6788)**
- **docs(client-redshift): Additions to the PubliclyAccessible and Encrypted parameters clarifying what the defaults are.**
- **docs(client-sts): Fixed typos in the descriptions.**
- **docs(client-securitylake): Doc only update for ServiceName that fixes several customer-reported issues**
- **feat(clients): update client endpoints as of 2025-01-10**
- **Publish v3.726.1**
- **chore(ci): add closed-issue-message GitHub action (#6794)**
- **feat(client-bedrock): With this release, Bedrock Evaluation will now support latency-optimized inference for foundation models.**
- **feat(client-transcribe): This update provides tagging support for Transcribe's Call Analytics Jobs and Call Analytics Categories.**
- **feat(client-ec2): Add support for DisconnectOnSessionTimeout flag in CreateClientVpnEndpoint and ModifyClientVpnEndpoint requests and DescribeClientVpnEndpoints responses**
- **feat(client-artifact): Support resolving regional API calls to partition's leader region endpoint.**
- **feat(client-kafkaconnect): Support updating connector configuration via UpdateConnector API. Release Operations API to monitor the status of the connector operation.**
- **feat(clients): update client endpoints as of 2025-01-13**
- **Publish v3.727.0**
- **feat(client-route-53): Amazon Route 53 now supports the Mexico (Central) Region (mx-central-1) for latency records, geoproximity records, and private DNS for Amazon VPCs in that region**
- **feat(client-gamelift): Amazon GameLift releases a new game session placement feature: PriorityConfigurationOverride. You can now override how a game session queue prioritizes placement locations for a single StartGameSessionPlacement request.**
- **feat(clients): update client endpoints as of 2025-01-14**
- **Publish v3.728.0**
- **chore(middleware-flexible-checksums): change default algorithm to CRC32 (#6749)**
- **chore(middleware-flexible-checksums): perform checksum calculation and validation by default (#6750)**
- **test(client-s3): use chunk size of 8 KB (#6799)**
- **test(lib-storage): pass requestChecksumCalculation as WHEN_REQUIRED (#6800)**
- **test(client-s3): skip putObject blob body in browser (#6801)**
- **fix(crc64-nvme-crt): return checksum for empty string if called without data (#6798)**
- **test(client-s3): disable checksum calculation and validation in legacy tests (#6804)**
- **fix(lib-storage): set ChecksumAlgorithm when calling CreateMPU (#6802)**
- **chore(deps): bump nanoid from 3.3.7 to 3.3.8 (#6722)**
- **Merge customizations for S3**
- **feat(client-cognito-identity): corrects the dual-stack endpoint configuration**
- **feat(client-sesv2): This release introduces a new recommendation in Virtual Deliverability Manager Advisor, which detects elevated complaint rates for customer sending identities.**
- **feat(client-workspaces): Added GeneralPurpose.4xlarge & GeneralPurpose.8xlarge ComputeTypes.**
- **feat(client-workspaces-thin-client): Mark type in MaintenanceWindow as required.**
- **docs(client-api-gateway): Documentation updates for Amazon API Gateway**
- **feat(client-partnercentral-selling): Add Tagging support for ResourceSnapshotJob resources**
- **feat(client-security-ir): Increase minimum length of Threat Actor IP 'userAgent' to 1.**
- **feat(client-s3): This change enhances integrity protections for new SDK requests to S3. S3 SDKs now support the CRC64NVME checksum algorithm, full object checksums for multipart S3 objects, and new default integrity protections for S3 requests.**
- **feat(client-bedrock-agent-runtime): Now supports streaming for inline agents.**
- **feat(clients): update client endpoints as of 2025-01-15**
- **Publish v3.729.0**
- **docs(client-s3): update changelog for default data integrity protections (#6807)**
- **fix(nested-clients): create nested clients for internal use (#6791)**
- **chore(codegen): move nested client generation to end (#6812)**
- **chore(codegen): generate nested clients only if no glob provided (#6813)**
- **chore(models): update API models**
- **chore(endpoints): update endpoints model**
- **chore(util-endpoints): update aws partitions.json**
- **docs(client-ecs): The release addresses Amazon ECS documentation tickets.**
- **feat(client-sagemaker): Added support for ml.trn1.32xlarge instance type in Reserved Capacity Offering**
- **Publish v3.730.0**
- **fix(credential-providers): supply backup credentials to fromTemporaryCredentials (#6817)**
- **fix(nested-clients): fix inliner build script (#6820)**
- **fix: fix key ordering for code generation build (#6821)**
- **feat(client-ec2): Release u7i-6tb.112xlarge, u7i-8tb.112xlarge, u7inh-32tb.480xlarge, p5e.48xlarge, p5en.48xlarge, f2.12xlarge, f2.48xlarge, trn2.48xlarge instance types.**
- **feat(client-bedrock-runtime): Allow hyphens in tool name for Converse and ConverseStream APIs**
- **docs(client-detective): Doc only update for Detective documentation.**
- **feat(client-notifications): Added support for Managed Notifications, integration with AWS Organization and added aggregation summaries for Aggregate Notifications**
- **docs(client-sagemaker): Correction of docs for  "Added support for ml.trn1.32xlarge instance type in Reserved Capacity Offering"**
- **feat(clients): update client endpoints as of 2025-01-17**
- **Publish v3.731.0**
- **chore: bump turbo to 2.3.3 (#6824)**
- **chore(credential-providers): minor code cleanup (#6825)**
- **chore(nested-clients): no-op change to publish new version (#6826)**
- **Publish v3.731.1**
- **fix(middleware-flexible-checksums): skip checksum validation if CRC64NVME dependency is absent (#6835)**
- **feat(client-cognito-identity-provider): corrects the dual-stack endpoint configuration for cognitoidp**
- **feat(client-connect): Added DeleteContactFlowVersion API and the CAMPAIGN flow type**
- **feat(client-iotsitewise): AWS IoT SiteWise now supports ingestion and querying of Null (all data types) and NaN (double type) values of bad or uncertain data quality. New partial error handling prevents data loss during ingestion. Enabled by default for new customers; existing customers can opt-in.**
- **docs(client-cloudwatch-logs): Documentation-only update to address doc errors**
- **docs(client-batch): Documentation-only update: clarified the description of the shareDecaySeconds parameter of the FairsharePolicy data type, clarified the description of the priority parameter of the JobQueueDetail data type.**
- **feat(client-quicksight): Added `DigitGroupingStyle` in ThousandsSeparator to allow grouping by `LAKH`( Indian Grouping system ) currency. Support LAKH and `CRORE` currency types in Column Formatting.**
- **docs(client-sns): This release adds support for the topic attribute FifoThroughputScope for SNS FIFO topics. For details, see the documentation history in the Amazon Simple Notification Service Developer Guide.**
- **feat(client-emr-serverless): Increasing entryPoint in SparkSubmit to accept longer script paths. New limit is 4kb.**
- **feat(clients): update client endpoints as of 2025-01-21**
- **Publish v3.732.0**
- **chore(credential-providers): move base fromTempCreds impl to non-browser file (#6836)**
- **test(packages): await promise assertions, cleanup test logging (#6839)**
- **feat(client-bedrock-agent-runtime): Adds multi-turn input support for an Agent node in an Amazon Bedrock Flow**
- **docs(client-glue): Docs Update for timeout changes**
- **docs(client-workspaces-thin-client): Rename WorkSpaces Web to WorkSpaces Secure Browser**
- **feat(client-medialive): AWS Elemental MediaLive adds a new feature, ID3 segment tagging, in CMAF Ingest output groups. It allows customers to insert ID3 tags into every output segment, controlled by a newly added channel schedule action Id3SegmentTagging.**
- **feat(clients): update client endpoints as of 2025-01-22**
- **Publish v3.733.0**
- **feat(credential-providers): pass caller client options to fromTemporaryCredentials inner STSClient (#6838)**
- **chore(codegen): bump smithy-typescript-codegen to 0.26.0 (#6843)**
- **chore(codegen): bump codegen version to 0.26.0 (#6844)**
- **feat(client-ec2): Added "future" allocation type for future dated capacity reservation**
- **Publish v3.734.0**
- **fix(middleware-flexible-checksum): remove stream collection code (#6846)**
- **feat(client-cloudtrail): This release introduces the SearchSampleQueries API that allows users to search for CloudTrail Lake sample queries.**
- **docs(client-sso-oidc): Fixed typos in the descriptions.**
- **feat(client-transfer): Added CustomDirectories as a new directory option for storing inbound AS2 messages, MDN files and Status files.**
- **docs(client-ssm): Systems Manager doc-only update for January, 2025.**
- **feat(client-eks): Adds support for UpdateStrategies in EKS Managed Node Groups.**
- **feat(client-healthlake): Added new authorization strategy value 'SMART_ON_FHIR' for CreateFHIRDatastore API to support Smart App 2.0**
- **Publish v3.735.0**
- **feat(client-bedrock-agent): Add support for the prompt caching feature for Bedrock Prompt Management**
- **feat(client-mediaconvert): This release adds support for dynamic audio configuration and the ability to disable the deblocking filter for h265 encodes.**
- **feat(client-s3-control): Minor fix to ARN validation for Lambda functions passed to S3 Batch Operations**
- **feat(client-iot): Raised the documentParameters size limit to 30 KB for AWS IoT Device Management - Jobs.**
- **feat(clients): update client endpoints as of 2025-01-27**
- **Publish v3.736.0**
- **feat(client-firehose): For AppendOnly streams, Firehose will automatically scale to match your throughput.**
- **feat(client-appsync): Add stash and outErrors to EvaluateCode/EvaluateMappingTemplate response**
- **feat(client-deadline): feature: Deadline: Add support for limiting the concurrent usage of external resources, like floating licenses, using limits and the ability to constrain the maximum number of workers that work on a job**
- **feat(client-datasync): AWS DataSync now supports the Kerberos authentication protocol for SMB locations.**
- **feat(client-timestream-influxdb): Adds 'allocatedStorage' parameter to UpdateDbInstance API that allows increasing the database instance storage size and 'dbStorageType' parameter to UpdateDbInstance API that allows changing the storage type of the database instance**
- **feat(client-ec2): This release changes the CreateFleet CLI and SDK's such that if you do not specify a client token, a randomly generated token is used for the request to ensure idempotency.**
- **Publish v3.737.0**
- **fix(credential-provider-node): handle string value `AWS_EC2_METADATA_DISABLED=false` (#6823)**
- **chore(build): set cache read/write based on build type (#6852)**
- **feat(client-transcribe-streaming): This release adds support for AWS HealthScribe Streaming APIs within Amazon Transcribe.**
- **feat(client-ecr): Add support for Dualstack and Dualstack-with-FIPS Endpoints**
- **feat(client-s3): Change the type of MpuObjectSize in CompleteMultipartUploadRequest from int to long.**
- **feat(client-ecr-public): Add support for Dualstack Endpoints**
- **feat(client-bcm-pricing-calculator): Added ConflictException error type in DeleteBillScenario, BatchDeleteBillScenarioCommitmentModification, BatchDeleteBillScenarioUsageModification, BatchUpdateBillScenarioUsageModification, and BatchUpdateBillScenarioCommitmentModification API operations.**
- **feat(client-mailmanager): This release includes a new feature for Amazon SES Mail Manager which allows customers to specify known addresses and domains and make use of those in traffic policies and rules actions to distinguish between known and unknown entries.**
- **Publish v3.738.0**
- **feat(client-qbusiness): Added APIs to manage QBusiness user subscriptions**
- **feat(client-appstream): Add support for managing admin consent requirement on selected domains for OneDrive Storage Connectors in AppStream2.0.**
- **feat(client-ecr): Temporarily updating dualstack endpoint support**
- **feat(client-verifiedpermissions): Adds Cedar JSON format support for entities and context data in authorization requests**
- **feat(client-mediatailor): Adds options for configuring how MediaTailor conditions ads before inserting them into the content stream. Based on the new settings, MediaTailor will either transcode ads to match the content stream as it has in the past, or it will insert ads without first transcoding them.**
- **feat(client-s3tables): You can now use the CreateTable API operation to create tables with schemas by adding an optional metadata argument.**
- **feat(client-bedrock-agent-runtime): Add a 'reason' field to InternalServerException**
- **feat(client-ecr-public): Temporarily updating dualstack endpoint support**
- **feat(clients): update client endpoints as of 2025-01-30**
- **Publish v3.739.0**
- **chore(middleware-sdk-s3): unset SessionMode default value (#6860)**
- **feat(client-amp): Add support for sending metrics to cross account and CMCK AMP workspaces through RoleConfiguration on Create/Update Scraper.**
- **feat(client-codebuild): Added support for CodeBuild self-hosted Buildkite runner builds**
- **feat(client-sagemaker): This release introduces a new valid value in InstanceType parameter: p5en.48xlarge, in ProductionVariant.**
- **docs(client-rds): Updates to Aurora MySQL and Aurora PostgreSQL API pages with instance log type in the create and modify DB Cluster.**
- **feat(client-geo-routes): The OptimizeWaypoints API now supports 50 waypoints per request (20 with constraints like AccessHours or AppointmentTime). It adds waypoint clustering via Clustering and ClusteringIndex for better optimization. Also, total distance validation is removed for greater flexibility.**
- **feat(client-bedrock-agent-runtime): This change is to deprecate the existing citation field under RetrieveAndGenerateStream API response in lieu of GeneratedResponsePart and RetrievedReferences**
- **Publish v3.740.0**
- **feat(credential-provider-ini): add ignoreCache option (#6856)**
- **feat(client-mediatailor): Add support for CloudWatch Vended Logs which allows for delivery of customer logs to CloudWatch Logs, S3, or Firehose.**
- **Publish v3.741.0**
- **cliv2 compatible provider**

### Issue
Issue number, if available, prefixed with "#"

### Description
What does this implement/fix? Explain your changes.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
