### PR TITLE
chore(codegen): bump smithy-gradle-version to 1.2.0

### DIFF
--- a/codegen/generic-client-test-codegen/build.gradle.kts
+++ b/codegen/generic-client-test-codegen/build.gradle.kts
@@ -30,8 +30,8 @@ buildscript {
 }
 
 plugins {
-    val smithyGradleVersion: String by project
-    id("software.amazon.smithy").version(smithyGradleVersion)
+    val smithyPluginVersion: String by project
+    id("software.amazon.smithy").version(smithyPluginVersion)
 }
 
 dependencies {

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
 smithyVersion=1.53.0
-smithyGradleVersion=0.6.0
+smithyGradleVersion=1.2.0

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,3 @@
 smithyVersion=1.53.0
 smithyGradleVersion=1.2.0
+smithyPluginVersion=0.6.0

--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -30,8 +30,8 @@ buildscript {
 }
 
 plugins {
-    val smithyGradleVersion: String by project
-    id("software.amazon.smithy").version(smithyGradleVersion)
+    val smithyPluginVersion: String by project
+    id("software.amazon.smithy").version(smithyPluginVersion)
 }
 
 dependencies {

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -38,8 +38,8 @@ buildscript {
 }
 
 plugins {
-    val smithyGradleVersion: String by project
-    id("software.amazon.smithy").version(smithyGradleVersion)
+    val smithyPluginVersion: String by project
+    id("software.amazon.smithy").version(smithyPluginVersion)
 }
 
 dependencies {

--- a/codegen/settings.gradle.kts
+++ b/codegen/settings.gradle.kts
@@ -35,3 +35,17 @@ file(
             .filter { it.isDirectory }
             .forEach { includeBuild(it.absolutePath) }
     }
+
+pluginManagement {
+    val smithyGradleVersion: String by settings
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-jar").version(smithyGradleVersion)
+        id("software.amazon.smithy.gradle.smithy-base").version(smithyGradleVersion)
+    }
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/pull/1499

### Description
* Bumps smithy-gradle-version to `1.2.0`
* Introduces smithyPluginVersion property, and pins it to `0.6.0`

### Testing
* CI
* Verified that generated clients were not updated

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
