### PR TITLE
chore(codegen): bump codegen version to 0.27.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,13 +1,21 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.27.0 (2025-03-04)
+
+## Features
+- Upgraded to smithy-typescript 0.27.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0270-2025-03-04))
+- Upgraded to smithy 1.54.0 ([#6913](https://github.com/aws/aws-sdk-js-v3/pull/6913))
+- Upgraded to smithy 1.53.0 ([#6906](https://github.com/aws/aws-sdk-js-v3/pull/6906))
+
+### Bug Fixes
+- Fixed union member serialization in JSON ([#6892](https://github.com/aws/aws-sdk-js-v3/pull/6892))
+
 ## 0.26.0 (2025-01-22)
 
 ### Features
 - Upgraded to 0.26.0 of smithy-typescript ([Release Notes](https://github.com/kuhe/smithy-typescript/blob/main/CHANGELOG.md#0260-2025-01-22))
 - Enabled profile configuration for clients ([#6728](https://github.com/aws/aws-sdk-js-v3/pull/6728))
 - Created nested clients for internal use ([#6791](https://github.com/aws/aws-sdk-js-v3/pull/6791))
-
-### Bug Fixes
 
 ## 0.25.0 (2024-11-18)
 

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.26.0"
+    version = "0.27.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.26.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.27.0")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "ee3ec22a19cd4d7e5cb1721e0848d6afa98ab6fb",
+  SMITHY_TS_COMMIT: "9ffe82d60dd45787a4279eb9723290edb39d0e10",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Internal JS-5739

### Description
Bumps codegen version to 0.27.0

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
