### PR TITLE
fix(cloudfront-signer): parse date using Date constructor

### DIFF
--- a/packages/cloudfront-signer/README.md
+++ b/packages/cloudfront-signer/README.md
@@ -17,7 +17,7 @@ const s3ObjectKey = "private-content/private.jpeg";
 const url = `${cloudfrontDistributionDomain}/${s3ObjectKey}`;
 const privateKey = "CONTENTS-OF-PRIVATE-KEY";
 const keyPairId = "PUBLIC-KEY-ID-OF-CLOUDFRONT-KEY-PAIR";
-const dateLessThan = "2022-01-01"; //  accepts string (Date constructor compatible), number (milliseconds since epoch)
+const dateLessThan = "2022-01-01"; // any Date constructor compatible
 
 const signedUrl = getSignedUrl({
   url,

--- a/packages/cloudfront-signer/README.md
+++ b/packages/cloudfront-signer/README.md
@@ -17,7 +17,7 @@ const s3ObjectKey = "private-content/private.jpeg";
 const url = `${cloudfrontDistributionDomain}/${s3ObjectKey}`;
 const privateKey = "CONTENTS-OF-PRIVATE-KEY";
 const keyPairId = "PUBLIC-KEY-ID-OF-CLOUDFRONT-KEY-PAIR";
-const dateLessThan = "2022-01-01"; // any Date constructor compatible
+const dateLessThan = "2022-01-01"; //  accepts string (Date constructor compatible), number (milliseconds since epoch)
 
 const signedUrl = getSignedUrl({
   url,

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -607,8 +607,11 @@ describe("getSignedCookies", () => {
 
 describe("getSignedUrl- when signing a URL with a date range", () => {
   const dateString = "2024-05-17T12:30:45.000Z";
+  const dateGreaterThanString = "2024-05-16T12:30:45.000Z";
   const dateNumber = 1125674245900;
+  const dateGreaterThanNumber = 1716034245000;
   const dateObject = new Date(dateString);
+  const dateGreaterThanObject = new Date(dateGreaterThanString);
   it("allows string input compatible with Date constructor", () => {
     const epochDateLessThan = Math.round(new Date(dateString).getTime() / 1000);
     const resultUrl = getSignedUrl({
@@ -669,5 +672,99 @@ describe("getSignedUrl- when signing a URL with a date range", () => {
 
     expect(resultUrl).toContain(`Expires=${epochDateLessThan}`);
     expect(resultCookies["CloudFront-Expires"]).toBe(epochDateLessThan);
+  });
+  it("allows string input for date range", () => {
+    const result = getSignedUrl({
+      url,
+      keyPairId,
+      dateLessThan: dateString,
+      dateGreaterThan: dateGreaterThanString,
+      privateKey,
+      passphrase,
+    });
+
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: url,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": Math.round(new Date(dateString).getTime() / 1000),
+            },
+            DateGreaterThan: {
+              "AWS:EpochTime": Math.round(new Date(dateGreaterThanString).getTime() / 1000),
+            },
+          },
+        },
+      ],
+    });
+
+    const parsedUrl = parseUrl(result);
+    expect(parsedUrl).toBeDefined();
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
+  });
+
+  it("allows number input for date range", () => {
+    const result = getSignedUrl({
+      url,
+      keyPairId,
+      dateLessThan: dateNumber as unknown as string,
+      dateGreaterThan: dateGreaterThanNumber as unknown as string,
+      privateKey,
+      passphrase,
+    });
+
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: url,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": Math.round(dateNumber / 1000),
+            },
+            DateGreaterThan: {
+              "AWS:EpochTime": Math.round(dateGreaterThanNumber / 1000),
+            },
+          },
+        },
+      ],
+    });
+
+    const parsedUrl = parseUrl(result);
+    expect(parsedUrl).toBeDefined();
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
+  });
+  it("allows Date object input for date range", () => {
+    const result = getSignedUrl({
+      url,
+      keyPairId,
+      dateLessThan: dateObject as unknown as string,
+      dateGreaterThan: dateGreaterThanObject as unknown as string,
+      privateKey,
+      passphrase,
+    });
+
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: url,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": Math.round(dateObject.getTime() / 1000),
+            },
+            DateGreaterThan: {
+              "AWS:EpochTime": Math.round(dateGreaterThanObject.getTime() / 1000),
+            },
+          },
+        },
+      ],
+    });
+
+    const parsedUrl = parseUrl(result);
+    expect(parsedUrl).toBeDefined();
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
   });
 });

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -634,14 +634,14 @@ describe("getSignedUrl- when signing a URL with a date range", () => {
     const resultUrl = getSignedUrl({
       url,
       keyPairId,
-      dateLessThan: dateNumber,
+      dateLessThan: dateNumber as unknown as string,
       privateKey,
       passphrase,
     });
     const resultCookies = getSignedCookies({
       url,
       keyPairId,
-      dateLessThan: dateNumber,
+      dateLessThan: dateNumber as unknown as string,
       privateKey,
       passphrase,
     });

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -606,8 +606,9 @@ describe("getSignedCookies", () => {
 });
 
 describe("getSignedUrl- when signing a URL with a date range", () => {
-  const dateString = "2024-05-17";
+  const dateString = "2024-05-17T12:30:45.000Z";
   const dateNumber = 1125674245900;
+  const dateObject = new Date(dateString);
   it("allows string input compatible with Date constructor", () => {
     const epochDateLessThan = Math.round(new Date(dateString).getTime() / 1000);
     const resultUrl = getSignedUrl({
@@ -642,6 +643,26 @@ describe("getSignedUrl- when signing a URL with a date range", () => {
       url,
       keyPairId,
       dateLessThan: dateNumber as unknown as string,
+      privateKey,
+      passphrase,
+    });
+
+    expect(resultUrl).toContain(`Expires=${epochDateLessThan}`);
+    expect(resultCookies["CloudFront-Expires"]).toBe(epochDateLessThan);
+  });
+  it("allows Date object input", () => {
+    const epochDateLessThan = Math.round(dateObject.getTime() / 1000);
+    const resultUrl = getSignedUrl({
+      url,
+      keyPairId,
+      dateLessThan: dateObject as unknown as string,
+      privateKey,
+      passphrase,
+    });
+    const resultCookies = getSignedCookies({
+      url,
+      keyPairId,
+      dateLessThan: dateObject as unknown as string,
       privateKey,
       passphrase,
     });

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -638,14 +638,14 @@ describe("getSignedUrl- when signing a URL with a date range", () => {
     const resultUrl = getSignedUrl({
       url,
       keyPairId,
-      dateLessThan: dateNumber as unknown as string,
+      dateLessThan: dateNumber,
       privateKey,
       passphrase,
     });
     const resultCookies = getSignedCookies({
       url,
       keyPairId,
-      dateLessThan: dateNumber as unknown as string,
+      dateLessThan: dateNumber,
       privateKey,
       passphrase,
     });
@@ -658,14 +658,14 @@ describe("getSignedUrl- when signing a URL with a date range", () => {
     const resultUrl = getSignedUrl({
       url,
       keyPairId,
-      dateLessThan: dateObject as unknown as string,
+      dateLessThan: dateObject,
       privateKey,
       passphrase,
     });
     const resultCookies = getSignedCookies({
       url,
       keyPairId,
-      dateLessThan: dateObject as unknown as string,
+      dateLessThan: dateObject,
       privateKey,
       passphrase,
     });
@@ -709,8 +709,8 @@ describe("getSignedUrl- when signing a URL with a date range", () => {
     const result = getSignedUrl({
       url,
       keyPairId,
-      dateLessThan: dateNumber as unknown as string,
-      dateGreaterThan: dateGreaterThanNumber as unknown as string,
+      dateLessThan: dateNumber,
+      dateGreaterThan: dateGreaterThanNumber,
       privateKey,
       passphrase,
     });
@@ -740,8 +740,8 @@ describe("getSignedUrl- when signing a URL with a date range", () => {
     const result = getSignedUrl({
       url,
       keyPairId,
-      dateLessThan: dateObject as unknown as string,
-      dateGreaterThan: dateGreaterThanObject as unknown as string,
+      dateLessThan: dateObject,
+      dateGreaterThan: dateGreaterThanObject,
       privateKey,
       passphrase,
     });

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -604,3 +604,49 @@ describe("getSignedCookies", () => {
     expect(verifySignature(denormalizeBase64(result["CloudFront-Signature"]), policy)).toBeTruthy();
   });
 });
+
+describe("getSignedUrl- when signing a URL with a date range", () => {
+  const dateString = "2024-05-17";
+  const dateNumber = 1125674245900;
+  it("allows string input compatible with Date constructor", () => {
+    const epochDateLessThan = Math.round(new Date(dateString).getTime() / 1000);
+    const resultUrl = getSignedUrl({
+      url,
+      keyPairId,
+      dateLessThan: dateString,
+      privateKey,
+      passphrase,
+    });
+    const resultCookies = getSignedCookies({
+      url,
+      keyPairId,
+      dateLessThan: dateString,
+      privateKey,
+      passphrase,
+    });
+
+    expect(resultUrl).toContain(`Expires=${epochDateLessThan}`);
+    expect(resultCookies["CloudFront-Expires"]).toBe(epochDateLessThan);
+  });
+
+  it("allows number input in milliseconds compatible with Date constructor", () => {
+    const epochDateLessThan = Math.round(new Date(dateNumber).getTime() / 1000);
+    const resultUrl = getSignedUrl({
+      url,
+      keyPairId,
+      dateLessThan: dateNumber,
+      privateKey,
+      passphrase,
+    });
+    const resultCookies = getSignedCookies({
+      url,
+      keyPairId,
+      dateLessThan: dateNumber,
+      privateKey,
+      passphrase,
+    });
+
+    expect(resultUrl).toContain(`Expires=${epochDateLessThan}`);
+    expect(resultCookies["CloudFront-Expires"]).toBe(epochDateLessThan);
+  });
+});

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -359,12 +359,12 @@ class CloudfrontSignBuilder {
     return Math.round(date.getTime() / 1000);
   }
 
-  private parseDate(date?: string): number | undefined {
+  private parseDate(date?: string | number | Date): number | undefined {
     if (!date) {
       return undefined;
     }
-    const parsedDate = Date.parse(date);
-    return isNaN(parsedDate) ? undefined : this.epochTime(new Date(parsedDate));
+    const parsedDate = new Date(date);
+    return isNaN(parsedDate.getTime()) ? undefined : this.epochTime(parsedDate);
   }
 
   private parseDateWindow(expiration: string, start?: string): PolicyDates {

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -370,7 +370,7 @@ class CloudfrontSignBuilder {
   private parseDateWindow(expiration: string | number | Date, start?: string | number | Date): PolicyDates {
     const dateLessThan = this.parseDate(expiration);
     if (!dateLessThan) {
-      throw new Error("dateLessThan is invalid. Ensure the date string is compatible with the Date constructor.");
+      throw new Error("dateLessThan is invalid. Ensure the date value is compatible with the Date constructor.");
     }
     return {
       dateLessThan,

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -25,9 +25,9 @@ export type CloudfrontSignInputWithParameters = CloudfrontSignerCredentials & {
   /** The URL string to sign. */
   url: string;
   /** The date string for when the signed URL or cookie can no longer be accessed */
-  dateLessThan: string;
+  dateLessThan: string | number | Date;
   /** The date string for when the signed URL or cookie can start to be accessed. */
-  dateGreaterThan?: string;
+  dateGreaterThan?: string | number | Date;
   /** The IP address string to restrict signed URL access to. */
   ipAddress?: string;
   /**
@@ -367,7 +367,7 @@ class CloudfrontSignBuilder {
     return isNaN(parsedDate.getTime()) ? undefined : this.epochTime(parsedDate);
   }
 
-  private parseDateWindow(expiration: string, start?: string): PolicyDates {
+  private parseDateWindow(expiration: string | number | Date, start?: string | number | Date): PolicyDates {
     const dateLessThan = this.parseDate(expiration);
     if (!dateLessThan) {
       throw new Error("dateLessThan is invalid. Ensure the date string is compatible with the Date constructor.");
@@ -400,8 +400,8 @@ class CloudfrontSignBuilder {
     ipAddress,
   }: {
     url?: string;
-    dateLessThan?: string;
-    dateGreaterThan?: string;
+    dateLessThan?: string | number | Date;
+    dateGreaterThan?: string | number | Date;
     ipAddress?: string;
   }) {
     if (!url || !dateLessThan) {


### PR DESCRIPTION
### Issue
#6403

### Description
This PR adds changes in the parseDate function to use date constructor instead of Date.parse() to support timestamps in milliseconds.


### Testing
Locally by testing it with milliseconds and date format string inputs.

 ``` RUN  v2.1.9 /local/home/smilkuri/aws-sdk-js-v3/packages/cloudfront-signer

 ✓ src/sign.spec.ts (25)
   ✓ getSignedUrl (11)
     ✓ should maintain query params after signing a URL
     ✓ should include url path in policy of signed URL
     ✓ should sign a URL with a canned policy
     ✓ should sign a URL with a custom policy containing a start date
     ✓ should sign a URL with a custom policy containing an ip address
     ✓ should sign a URL with a custom policy containing a start date and ip address
     ✓ should allow an ip address with and without a mask
     ✓ should throw an error when the ip address is invalid
     ✓ should sign a RTMP URL
     ✓ should sign a URL with a policy provided by the user
     ✓ should sign a URL automatically extracted from a policy provided by the user
   ✓ getSignedCookies (8)
     ✓ should allow an ip address with and without a mask
     ✓ should throw an error when the ip address is invalid
     ✓ should be able sign cookies that contain a URL with wildcards
     ✓ should sign cookies with a canned policy
     ✓ should sign cookies with a custom policy containing a start date
     ✓ should sign cookies with a custom policy containing an ip address
     ✓ should sign cookies with a custom policy containing a start date and ip address
     ✓ should sign cookies with a policy provided by the user without a url
   ✓ getSignedUrl- when signing a URL with a date range (6)
     ✓ allows string input compatible with Date constructor
     ✓ allows number input in milliseconds compatible with Date constructor
     ✓ allows Date object input
     ✓ allows string input for date range
     ✓ allows number input for date range
     ✓ allows Date object input for date range

 Test Files  1 passed (1)
      Tests  25 passed (25)
   Start at  14:58:42
   Duration  507ms (transform 133ms, setup 0ms, collect 135ms, tests 96ms, environment 0ms, prepare 87ms)

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
