### PR TITLE
credential-providers README - fix missing quote in fromSSO

### DIFF
--- a/packages/credential-providers/README.md
+++ b/packages/credential-providers/README.md
@@ -521,7 +521,7 @@ function. You can either load the SSO config from shared INI credential files, o
 
 ```javascript
 import { fromSSO } from "@aws-sdk/credential-providers"; // ES6 import
-// const { fromSSO } = require(@aws-sdk/credential-providers") // CommonJS import
+// const { fromSSO } = require("@aws-sdk/credential-providers") // CommonJS import
 
 const client = new FooClient({
   credentials: fromSSO({


### PR DESCRIPTION
fix missing quote in fromSSO example code

### Issue
Issue number, if available, prefixed with "#"

### Description
The CommonJS "require" code in the example is missing a quote

### Testing

```js
const { fromSSO } = require("@aws-sdk/credential-providers") // CommonJS import
```

### Checklist
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
