### PR TITLE
chore(supplemental-docs): md5 fallback for DeleteObjects update

### DIFF
--- a/supplemental-docs/MD5_FALLBACK.md
+++ b/supplemental-docs/MD5_FALLBACK.md
@@ -2,14 +2,15 @@
 
 ## Background
 
-In AWS SDK for JavaScript [v3.729.0](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.729.0),
-we shipped a feature that [changed default object integrity in
-S3](https://github.com/aws/aws-sdk-js-v3/issues/6810). The SDKs now default to using more modern
-checksums (like CRC32) to ensure object integrity, whereas previously MD5 checksums were being used.
-Some third-party S3-compatible services currently do not support these checksums and require MD5 checksums. Furthermore, the `DeleteObjects` operation in S3 [requires a `Content-MD5` request header](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) in which case too, you should use the MD5 fallback as noted below.
-
+In AWS SDK for JavaScript v3.729.0, we
+shipped a feature that changed default object integrity in S3.
+The SDKs now default to using more modern checksums (like CRC32) to ensure object integrity, whereas
+previously MD5 checksums were being used. Some third-party S3-compatible services currently do not
+support these checksums and require MD5 checksums. Furthermore, the [DeleteObjects operation in S3
+requires a Content-MD5 request header](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html)
+in which case too, you should use the MD5 fallback as noted below.
 If you wish to fallback to the old behavior of sending MD5 checksums, for operations like
-`DeleteObjectsCommand` this is how you can do it in AWS SDK for JavaScript v3:
+DeleteObjectsCommand this is how you can do it in AWS SDK for JavaScript v3:
 
 ## MD5 fallback
 

--- a/supplemental-docs/MD5_FALLBACK.md
+++ b/supplemental-docs/MD5_FALLBACK.md
@@ -6,8 +6,7 @@ In AWS SDK for JavaScript [v3.729.0](https://github.com/aws/aws-sdk-js-v3/releas
 we shipped a feature that [changed default object integrity in
 S3](https://github.com/aws/aws-sdk-js-v3/issues/6810). The SDKs now default to using more modern
 checksums (like CRC32) to ensure object integrity, whereas previously MD5 checksums were being used.
-Some third-party S3-compatible services currently do not support these checksums. To our knowledge,
-this affects only the S3 `DeleteObjects` operation.
+Some third-party S3-compatible services currently do not support these checksums and require MD5 checksums. Furthermore, the `DeleteObjects` operation in S3 [requires a `Content-MD5` request header](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) in which case too, you should use the MD5 fallback as noted below.
 
 If you wish to fallback to the old behavior of sending MD5 checksums, for operations like
 `DeleteObjectsCommand` this is how you can do it in AWS SDK for JavaScript v3:

--- a/supplemental-docs/MD5_FALLBACK.md
+++ b/supplemental-docs/MD5_FALLBACK.md
@@ -2,8 +2,8 @@
 
 ## Background
 
-In AWS SDK for JavaScript v3.729.0, we
-shipped a feature that changed default object integrity in S3.
+In AWS SDK for JavaScript [v3.729.0](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.729.0), we
+shipped a feature that [changed default object integrity in S3](https://github.com/aws/aws-sdk-js-v3/issues/6810).
 The SDKs now default to using more modern checksums (like CRC32) to ensure object integrity, whereas
 previously MD5 checksums were being used. Some third-party S3-compatible services currently do not
 support these checksums and require MD5 checksums. Furthermore, the [DeleteObjects operation in S3

--- a/supplemental-docs/MD5_FALLBACK.md
+++ b/supplemental-docs/MD5_FALLBACK.md
@@ -10,7 +10,7 @@ support these checksums and require MD5 checksums. Furthermore, the [DeleteObjec
 requires a Content-MD5 request header](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html)
 in which case too, you should use the MD5 fallback as noted below.
 If you wish to fallback to the old behavior of sending MD5 checksums, for operations like
-DeleteObjectsCommand this is how you can do it in AWS SDK for JavaScript v3:
+`DeleteObjectsCommand` this is how you can do it in AWS SDK for JavaScript v3:
 
 ## MD5 fallback
 


### PR DESCRIPTION
### Description
clarification regarding [`DeleteObjects`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) requiring Content-MD5 header.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
