### PR TITLE
fix(middleware-recursion-detection): make the x-ray trace header check case-insensitive

### DIFF
--- a/packages/middleware-recursion-detection/src/index.spec.ts
+++ b/packages/middleware-recursion-detection/src/index.spec.ts
@@ -70,6 +70,27 @@ describe(recursionDetectionMiddleware.name, () => {
     expect(request.headers[TRACE_ID_HEADER_NAME]).toBe("some-real-trace-id");
   });
 
+  it(`should NOT set ${TRACE_ID_HEADER_NAME} header when the header is already set in all lowercase`, async () => {
+    process.env = {
+      AWS_LAMBDA_FUNCTION_NAME: "some-function",
+      _X_AMZN_TRACE_ID: "some-trace-id",
+    };
+    const handler = recursionDetectionMiddleware({ runtime: "node" })(mockNextHandler, {} as any);
+    await handler({
+      input: {},
+      request: new HttpRequest({
+        headers: {
+          [TRACE_ID_HEADER_NAME.toLowerCase()]: "some-real-trace-id",
+        },
+      }),
+    });
+
+    const { calls } = (mockNextHandler as any).mock;
+    expect(calls.length).toBe(1);
+    const { request } = mockNextHandler.mock.calls[0][0];
+    expect(request.headers[TRACE_ID_HEADER_NAME.toLowerCase()]).toBe("some-real-trace-id");
+  });
+
   it("has no effect for browser runtime", async () => {
     process.env = {
       AWS_LAMBDA_FUNCTION_NAME: "some-function",

--- a/packages/middleware-recursion-detection/src/index.ts
+++ b/packages/middleware-recursion-detection/src/index.ts
@@ -30,7 +30,9 @@ export const recursionDetectionMiddleware =
     if (
       !HttpRequest.isInstance(request) ||
       options.runtime !== "node" ||
-      request.headers.hasOwnProperty(TRACE_ID_HEADER_NAME)
+      Object.keys(request.headers).some(
+        (key) => key.toLowerCase() === TRACE_ID_HEADER_NAME.toLowerCase()
+      )
     ) {
       return next(args);
     }


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6937

### Description

`middleware-recursion-detection` performs a request header check that is case-sensitive.
This PR changes this check to be case-insensitive.

### Testing

Added unit tests.

Also:
1. Have LambdaX and LambdaY, LambdaX invokes LambdaY via Lambda invoke from @aws-sdk/client-lambda, add permissions to LambdaX to use invoke.
2. Modified `middleware-recursion-detection` in node_modules of the LambdaX to make the trace header check case-insensitive
3. Enable Lambda service traces in both LambdaX and LambdaY
4. Enable Application Signals in LambdaX both LambdaX and LambdaY
5. Invoke LambdaX function.
6. Observed that `middleware-recursion-detection` will correctly not inject the trace header when calling `lambdaClient's invoke`, because the `x-amzn-trace-id` header already exists due to step (4)

### Additional context
Add any other context about the PR here.

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
