### PR TITLE
fix(middleware-recursion-detection): Fix case-insensitive trace ID header detection in middleware

### DIFF
--- a/packages/middleware-recursion-detection/src/index.spec.ts
+++ b/packages/middleware-recursion-detection/src/index.spec.ts
@@ -70,6 +70,27 @@ describe(recursionDetectionMiddleware.name, () => {
     expect(request.headers[TRACE_ID_HEADER_NAME]).toBe("some-real-trace-id");
   });
 
+  it(`should NOT set ${TRACE_ID_HEADER_NAME} header when the header is already set in all lowercase`, async () => {
+    process.env = {
+      AWS_LAMBDA_FUNCTION_NAME: "some-function",
+      _X_AMZN_TRACE_ID: "some-trace-id",
+    };
+    const handler = recursionDetectionMiddleware({ runtime: "node" })(mockNextHandler, {} as any);
+    await handler({
+      input: {},
+      request: new HttpRequest({
+        headers: {
+          [TRACE_ID_HEADER_NAME.toLowerCase()]: "some-real-trace-id",
+        },
+      }),
+    });
+
+    const { calls } = (mockNextHandler as any).mock;
+    expect(calls.length).toBe(1);
+    const { request } = mockNextHandler.mock.calls[0][0];
+    expect(request.headers[TRACE_ID_HEADER_NAME.toLowerCase()]).toBe("some-real-trace-id");
+  });
+
   it("has no effect for browser runtime", async () => {
     process.env = {
       AWS_LAMBDA_FUNCTION_NAME: "some-function",


### PR DESCRIPTION
### Issue
#6937 

### Description
Updates the recursion detection middleware to properly handle case insensitive matching of the X-Amzn-Trace-Id header. 

### Testing
How was this change tested?
Locally by adding unit test.
 ```
RUN  v2.1.9 /local/home/smilkuri/aws-sdk-js-v3/packages/middleware-recursion-detection

 ✓ src/index.spec.ts (5)
   ✓ recursionDetectionMiddleware (5)
     ✓ sets X-Amzn-Trace-Id header when function name and trace id environmental variables are set
     ✓ should NOT set X-Amzn-Trace-Id header when function name environmental variable is NOT set
     ✓ should NOT set X-Amzn-Trace-Id header when the header is already set
     ✓ should NOT set X-Amzn-Trace-Id header when the header is already set in all lowercase
     ✓ has no effect for browser runtime

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  16:05:33
   Duration  315ms (transform 49ms, setup 0ms, collect 44ms, tests 4ms, environment 0ms, prepare 93ms)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
