### PR TITLE
fix(core): use credentials provided by extensions when instantiating sigv4 signer

### DIFF
--- a/clients/client-accessanalyzer/src/AccessAnalyzerClient.ts
+++ b/clients/client-accessanalyzer/src/AccessAnalyzerClient.ts
@@ -460,7 +460,7 @@ export class AccessAnalyzerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-accessanalyzer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-accessanalyzer/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-account/src/AccountClient.ts
+++ b/clients/client-account/src/AccountClient.ts
@@ -344,7 +344,7 @@ export class AccountClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-account/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-account/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-acm-pca/src/ACMPCAClient.ts
+++ b/clients/client-acm-pca/src/ACMPCAClient.ts
@@ -410,7 +410,7 @@ export class ACMPCAClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-acm-pca/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-acm-pca/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-acm/src/ACMClient.ts
+++ b/clients/client-acm/src/ACMClient.ts
@@ -358,7 +358,7 @@ export class ACMClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-acm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-acm/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-amp/src/AmpClient.ts
+++ b/clients/client-amp/src/AmpClient.ts
@@ -433,7 +433,7 @@ export class AmpClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-amp/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amp/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-amplify/src/AmplifyClient.ts
+++ b/clients/client-amplify/src/AmplifyClient.ts
@@ -433,7 +433,7 @@ export class AmplifyClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-amplify/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amplify/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-amplifybackend/src/AmplifyBackendClient.ts
+++ b/clients/client-amplifybackend/src/AmplifyBackendClient.ts
@@ -407,7 +407,7 @@ export class AmplifyBackendClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-amplifybackend/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amplifybackend/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-amplifyuibuilder/src/AmplifyUIBuilderClient.ts
+++ b/clients/client-amplifyuibuilder/src/AmplifyUIBuilderClient.ts
@@ -385,7 +385,7 @@ export class AmplifyUIBuilderClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-amplifyuibuilder/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amplifyuibuilder/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-api-gateway/src/APIGatewayClient.ts
+++ b/clients/client-api-gateway/src/APIGatewayClient.ts
@@ -781,7 +781,7 @@ export class APIGatewayClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-api-gateway/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-api-gateway/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-apigatewaymanagementapi/src/ApiGatewayManagementApiClient.ts
+++ b/clients/client-apigatewaymanagementapi/src/ApiGatewayManagementApiClient.ts
@@ -293,7 +293,7 @@ export class ApiGatewayManagementApiClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-apigatewaymanagementapi/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-apigatewaymanagementapi/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-apigatewayv2/src/ApiGatewayV2Client.ts
+++ b/clients/client-apigatewayv2/src/ApiGatewayV2Client.ts
@@ -542,7 +542,7 @@ export class ApiGatewayV2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-apigatewayv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-apigatewayv2/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-app-mesh/src/AppMeshClient.ts
+++ b/clients/client-app-mesh/src/AppMeshClient.ts
@@ -466,7 +466,7 @@ export class AppMeshClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-app-mesh/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-app-mesh/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-appconfig/src/AppConfigClient.ts
+++ b/clients/client-appconfig/src/AppConfigClient.ts
@@ -637,7 +637,7 @@ export class AppConfigClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-appconfig/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appconfig/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-appconfigdata/src/AppConfigDataClient.ts
+++ b/clients/client-appconfigdata/src/AppConfigDataClient.ts
@@ -353,7 +353,7 @@ export class AppConfigDataClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-appconfigdata/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appconfigdata/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-appfabric/src/AppFabricClient.ts
+++ b/clients/client-appfabric/src/AppFabricClient.ts
@@ -415,7 +415,7 @@ export class AppFabricClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-appfabric/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appfabric/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-appflow/src/AppflowClient.ts
+++ b/clients/client-appflow/src/AppflowClient.ts
@@ -432,7 +432,7 @@ export class AppflowClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-appflow/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appflow/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-appintegrations/src/AppIntegrationsClient.ts
+++ b/clients/client-appintegrations/src/AppIntegrationsClient.ts
@@ -434,7 +434,7 @@ export class AppIntegrationsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-appintegrations/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appintegrations/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-application-auto-scaling/src/ApplicationAutoScalingClient.ts
+++ b/clients/client-application-auto-scaling/src/ApplicationAutoScalingClient.ts
@@ -438,7 +438,7 @@ export class ApplicationAutoScalingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-application-auto-scaling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-auto-scaling/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-application-discovery-service/src/ApplicationDiscoveryServiceClient.ts
+++ b/clients/client-application-discovery-service/src/ApplicationDiscoveryServiceClient.ts
@@ -528,7 +528,7 @@ export class ApplicationDiscoveryServiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-application-discovery-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-discovery-service/src/auth/httpAuthSchemeProvider.ts
@@ -134,10 +134,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-application-insights/src/ApplicationInsightsClient.ts
+++ b/clients/client-application-insights/src/ApplicationInsightsClient.ts
@@ -421,7 +421,7 @@ export class ApplicationInsightsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-application-insights/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-insights/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-application-signals/src/ApplicationSignalsClient.ts
+++ b/clients/client-application-signals/src/ApplicationSignalsClient.ts
@@ -392,7 +392,7 @@ export class ApplicationSignalsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-application-signals/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-signals/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-applicationcostprofiler/src/ApplicationCostProfilerClient.ts
+++ b/clients/client-applicationcostprofiler/src/ApplicationCostProfilerClient.ts
@@ -328,7 +328,7 @@ export class ApplicationCostProfilerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-applicationcostprofiler/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-applicationcostprofiler/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-apprunner/src/AppRunnerClient.ts
+++ b/clients/client-apprunner/src/AppRunnerClient.ts
@@ -474,7 +474,7 @@ export class AppRunnerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-apprunner/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-apprunner/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-appstream/src/AppStreamClient.ts
+++ b/clients/client-appstream/src/AppStreamClient.ts
@@ -661,7 +661,7 @@ export class AppStreamClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-appstream/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appstream/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-appsync/src/AppSyncClient.ts
+++ b/clients/client-appsync/src/AppSyncClient.ts
@@ -579,7 +579,7 @@ export class AppSyncClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-appsync/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appsync/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-apptest/src/AppTestClient.ts
+++ b/clients/client-apptest/src/AppTestClient.ts
@@ -380,7 +380,7 @@ export class AppTestClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-apptest/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-apptest/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-arc-zonal-shift/src/ARCZonalShiftClient.ts
+++ b/clients/client-arc-zonal-shift/src/ARCZonalShiftClient.ts
@@ -380,7 +380,7 @@ export class ARCZonalShiftClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-arc-zonal-shift/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-arc-zonal-shift/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-artifact/src/ArtifactClient.ts
+++ b/clients/client-artifact/src/ArtifactClient.ts
@@ -311,7 +311,7 @@ export class ArtifactClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-artifact/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-artifact/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-athena/src/AthenaClient.ts
+++ b/clients/client-athena/src/AthenaClient.ts
@@ -594,7 +594,7 @@ export class AthenaClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-athena/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-athena/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-auditmanager/src/AuditManagerClient.ts
+++ b/clients/client-auditmanager/src/AuditManagerClient.ts
@@ -622,7 +622,7 @@ export class AuditManagerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-auditmanager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-auditmanager/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-auto-scaling-plans/src/AutoScalingPlansClient.ts
+++ b/clients/client-auto-scaling-plans/src/AutoScalingPlansClient.ts
@@ -348,7 +348,7 @@ export class AutoScalingPlansClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-auto-scaling-plans/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-auto-scaling-plans/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-auto-scaling/src/AutoScalingClient.ts
+++ b/clients/client-auto-scaling/src/AutoScalingClient.ts
@@ -623,7 +623,7 @@ export class AutoScalingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-auto-scaling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-auto-scaling/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-b2bi/src/B2biClient.ts
+++ b/clients/client-b2bi/src/B2biClient.ts
@@ -396,7 +396,7 @@ export class B2biClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-b2bi/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-b2bi/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-backup-gateway/src/BackupGatewayClient.ts
+++ b/clients/client-backup-gateway/src/BackupGatewayClient.ts
@@ -412,7 +412,7 @@ export class BackupGatewayClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-backup-gateway/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-backup-gateway/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-backup/src/BackupClient.ts
+++ b/clients/client-backup/src/BackupClient.ts
@@ -738,7 +738,7 @@ export class BackupClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-backup/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-backup/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-backupsearch/src/BackupSearchClient.ts
+++ b/clients/client-backupsearch/src/BackupSearchClient.ts
@@ -356,7 +356,7 @@ export class BackupSearchClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-backupsearch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-backupsearch/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-batch/src/BatchClient.ts
+++ b/clients/client-batch/src/BatchClient.ts
@@ -450,7 +450,7 @@ export class BatchClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-batch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-batch/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-bcm-data-exports/src/BCMDataExportsClient.ts
+++ b/clients/client-bcm-data-exports/src/BCMDataExportsClient.ts
@@ -333,7 +333,7 @@ export class BCMDataExportsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-bcm-data-exports/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bcm-data-exports/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-bcm-pricing-calculator/src/BCMPricingCalculatorClient.ts
+++ b/clients/client-bcm-pricing-calculator/src/BCMPricingCalculatorClient.ts
@@ -472,7 +472,7 @@ export class BCMPricingCalculatorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-bcm-pricing-calculator/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bcm-pricing-calculator/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-bedrock-agent-runtime/src/BedrockAgentRuntimeClient.ts
+++ b/clients/client-bedrock-agent-runtime/src/BedrockAgentRuntimeClient.ts
@@ -388,7 +388,7 @@ export class BedrockAgentRuntimeClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveRuntimeExtensions(_config_8, configuration?.extensions || []);
     super(_config_9);
     this.config = _config_9;

--- a/clients/client-bedrock-agent-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-agent-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-bedrock-agent/src/BedrockAgentClient.ts
+++ b/clients/client-bedrock-agent/src/BedrockAgentClient.ts
@@ -578,7 +578,7 @@ export class BedrockAgentClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-bedrock-agent/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-agent/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-bedrock-data-automation-runtime/src/BedrockDataAutomationRuntimeClient.ts
+++ b/clients/client-bedrock-data-automation-runtime/src/BedrockDataAutomationRuntimeClient.ts
@@ -312,7 +312,7 @@ export class BedrockDataAutomationRuntimeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-bedrock-data-automation-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-data-automation-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -134,10 +134,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-bedrock-data-automation/src/BedrockDataAutomationClient.ts
+++ b/clients/client-bedrock-data-automation/src/BedrockDataAutomationClient.ts
@@ -350,7 +350,7 @@ export class BedrockDataAutomationClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-bedrock-data-automation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-data-automation/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-bedrock-runtime/src/BedrockRuntimeClient.ts
+++ b/clients/client-bedrock-runtime/src/BedrockRuntimeClient.ts
@@ -328,7 +328,7 @@ export class BedrockRuntimeClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveRuntimeExtensions(_config_8, configuration?.extensions || []);
     super(_config_9);
     this.config = _config_9;

--- a/clients/client-bedrock-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-bedrock/src/BedrockClient.ts
+++ b/clients/client-bedrock/src/BedrockClient.ts
@@ -569,7 +569,7 @@ export class BedrockClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-bedrock/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-billing/src/BillingClient.ts
+++ b/clients/client-billing/src/BillingClient.ts
@@ -329,7 +329,7 @@ export class BillingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-billing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-billing/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-billingconductor/src/BillingconductorClient.ts
+++ b/clients/client-billingconductor/src/BillingconductorClient.ts
@@ -446,7 +446,7 @@ export class BillingconductorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-billingconductor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-billingconductor/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-braket/src/BraketClient.ts
+++ b/clients/client-braket/src/BraketClient.ts
@@ -338,7 +338,7 @@ export class BraketClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-braket/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-braket/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-budgets/src/BudgetsClient.ts
+++ b/clients/client-budgets/src/BudgetsClient.ts
@@ -437,7 +437,7 @@ export class BudgetsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-budgets/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-budgets/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-chatbot/src/ChatbotClient.ts
+++ b/clients/client-chatbot/src/ChatbotClient.ts
@@ -490,7 +490,7 @@ export class ChatbotClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-chatbot/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chatbot/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-chime-sdk-identity/src/ChimeSDKIdentityClient.ts
+++ b/clients/client-chime-sdk-identity/src/ChimeSDKIdentityClient.ts
@@ -452,7 +452,7 @@ export class ChimeSDKIdentityClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-chime-sdk-identity/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-identity/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-chime-sdk-media-pipelines/src/ChimeSDKMediaPipelinesClient.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/ChimeSDKMediaPipelinesClient.ts
@@ -462,7 +462,7 @@ export class ChimeSDKMediaPipelinesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-chime-sdk-media-pipelines/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-chime-sdk-meetings/src/ChimeSDKMeetingsClient.ts
+++ b/clients/client-chime-sdk-meetings/src/ChimeSDKMeetingsClient.ts
@@ -358,7 +358,7 @@ export class ChimeSDKMeetingsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-chime-sdk-meetings/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-meetings/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-chime-sdk-messaging/src/ChimeSDKMessagingClient.ts
+++ b/clients/client-chime-sdk-messaging/src/ChimeSDKMessagingClient.ts
@@ -539,7 +539,7 @@ export class ChimeSDKMessagingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-chime-sdk-messaging/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-messaging/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-chime-sdk-voice/src/ChimeSDKVoiceClient.ts
+++ b/clients/client-chime-sdk-voice/src/ChimeSDKVoiceClient.ts
@@ -792,7 +792,7 @@ export class ChimeSDKVoiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-chime-sdk-voice/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-voice/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-chime/src/ChimeClient.ts
+++ b/clients/client-chime/src/ChimeClient.ts
@@ -601,7 +601,7 @@ export class ChimeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-chime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cleanrooms/src/CleanRoomsClient.ts
+++ b/clients/client-cleanrooms/src/CleanRoomsClient.ts
@@ -733,7 +733,7 @@ export class CleanRoomsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cleanrooms/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cleanrooms/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cleanroomsml/src/CleanRoomsMLClient.ts
+++ b/clients/client-cleanroomsml/src/CleanRoomsMLClient.ts
@@ -604,7 +604,7 @@ export class CleanRoomsMLClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cleanroomsml/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cleanroomsml/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloud9/src/Cloud9Client.ts
+++ b/clients/client-cloud9/src/Cloud9Client.ts
@@ -422,7 +422,7 @@ export class Cloud9Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloud9/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloud9/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudcontrol/src/CloudControlClient.ts
+++ b/clients/client-cloudcontrol/src/CloudControlClient.ts
@@ -321,7 +321,7 @@ export class CloudControlClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudcontrol/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudcontrol/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-clouddirectory/src/CloudDirectoryClient.ts
+++ b/clients/client-clouddirectory/src/CloudDirectoryClient.ts
@@ -568,7 +568,7 @@ export class CloudDirectoryClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-clouddirectory/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-clouddirectory/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudformation/src/CloudFormationClient.ts
+++ b/clients/client-cloudformation/src/CloudFormationClient.ts
@@ -698,7 +698,7 @@ export class CloudFormationClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudformation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudformation/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudfront-keyvaluestore/src/CloudFrontKeyValueStoreClient.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/CloudFrontKeyValueStoreClient.ts
@@ -308,7 +308,7 @@ export class CloudFrontKeyValueStoreClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudfront-keyvaluestore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/auth/httpAuthSchemeProvider.ts
@@ -335,10 +335,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   const config_1 = resolveAwsSdkSigV4AConfig(config_0);
   return {
     ...config_1,

--- a/clients/client-cloudfront/src/CloudFrontClient.ts
+++ b/clients/client-cloudfront/src/CloudFrontClient.ts
@@ -888,7 +888,7 @@ export class CloudFrontClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudfront/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudfront/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudhsm-v2/src/CloudHSMV2Client.ts
+++ b/clients/client-cloudhsm-v2/src/CloudHSMV2Client.ts
@@ -348,7 +348,7 @@ export class CloudHSMV2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudhsm-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudhsm-v2/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudhsm/src/CloudHSMClient.ts
+++ b/clients/client-cloudhsm/src/CloudHSMClient.ts
@@ -363,7 +363,7 @@ export class CloudHSMClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudhsm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudhsm/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudsearch-domain/src/CloudSearchDomainClient.ts
+++ b/clients/client-cloudsearch-domain/src/CloudSearchDomainClient.ts
@@ -293,7 +293,7 @@ export class CloudSearchDomainClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudsearch-domain/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudsearch-domain/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudsearch/src/CloudSearchClient.ts
+++ b/clients/client-cloudsearch/src/CloudSearchClient.ts
@@ -410,7 +410,7 @@ export class CloudSearchClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudsearch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudsearch/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudtrail-data/src/CloudTrailDataClient.ts
+++ b/clients/client-cloudtrail-data/src/CloudTrailDataClient.ts
@@ -293,7 +293,7 @@ export class CloudTrailDataClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudtrail-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudtrail-data/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudtrail/src/CloudTrailClient.ts
+++ b/clients/client-cloudtrail/src/CloudTrailClient.ts
@@ -518,7 +518,7 @@ export class CloudTrailClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudtrail/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudtrail/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudwatch-events/src/CloudWatchEventsClient.ts
+++ b/clients/client-cloudwatch-events/src/CloudWatchEventsClient.ts
@@ -508,7 +508,7 @@ export class CloudWatchEventsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cloudwatch-events/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudwatch-events/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudwatch-logs/src/CloudWatchLogsClient.ts
+++ b/clients/client-cloudwatch-logs/src/CloudWatchLogsClient.ts
@@ -713,7 +713,7 @@ export class CloudWatchLogsClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveRuntimeExtensions(_config_8, configuration?.extensions || []);
     super(_config_9);
     this.config = _config_9;

--- a/clients/client-cloudwatch-logs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudwatch-logs/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cloudwatch/src/CloudWatchClient.ts
+++ b/clients/client-cloudwatch/src/CloudWatchClient.ts
@@ -459,7 +459,7 @@ export class CloudWatchClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveCompressionConfig(_config_7);
     const _config_9 = resolveRuntimeExtensions(_config_8, configuration?.extensions || []);
     super(_config_9);

--- a/clients/client-cloudwatch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudwatch/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codeartifact/src/CodeartifactClient.ts
+++ b/clients/client-codeartifact/src/CodeartifactClient.ts
@@ -871,7 +871,7 @@ export class CodeartifactClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codeartifact/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeartifact/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codebuild/src/CodeBuildClient.ts
+++ b/clients/client-codebuild/src/CodeBuildClient.ts
@@ -492,7 +492,7 @@ export class CodeBuildClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codebuild/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codebuild/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codecatalyst/src/CodeCatalystClient.ts
+++ b/clients/client-codecatalyst/src/CodeCatalystClient.ts
@@ -612,7 +612,7 @@ export class CodeCatalystClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codecatalyst/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codecatalyst/src/auth/httpAuthSchemeProvider.ts
@@ -132,8 +132,9 @@ export interface HttpAuthSchemeResolvedConfig {
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
   const token = memoizeIdentityProvider(config.token, isIdentityExpired, doesIdentityRequireRefresh);
   return {

--- a/clients/client-codecommit/src/CodeCommitClient.ts
+++ b/clients/client-codecommit/src/CodeCommitClient.ts
@@ -1059,7 +1059,7 @@ export class CodeCommitClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codecommit/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codecommit/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codeconnections/src/CodeConnectionsClient.ts
+++ b/clients/client-codeconnections/src/CodeConnectionsClient.ts
@@ -488,7 +488,7 @@ export class CodeConnectionsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codeconnections/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeconnections/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codedeploy/src/CodeDeployClient.ts
+++ b/clients/client-codedeploy/src/CodeDeployClient.ts
@@ -622,7 +622,7 @@ export class CodeDeployClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codedeploy/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codedeploy/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codeguru-reviewer/src/CodeGuruReviewerClient.ts
+++ b/clients/client-codeguru-reviewer/src/CodeGuruReviewerClient.ts
@@ -370,7 +370,7 @@ export class CodeGuruReviewerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codeguru-reviewer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeguru-reviewer/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codeguru-security/src/CodeGuruSecurityClient.ts
+++ b/clients/client-codeguru-security/src/CodeGuruSecurityClient.ts
@@ -348,7 +348,7 @@ export class CodeGuruSecurityClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codeguru-security/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeguru-security/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codeguruprofiler/src/CodeGuruProfilerClient.ts
+++ b/clients/client-codeguruprofiler/src/CodeGuruProfilerClient.ts
@@ -414,7 +414,7 @@ export class CodeGuruProfilerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codeguruprofiler/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeguruprofiler/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codepipeline/src/CodePipelineClient.ts
+++ b/clients/client-codepipeline/src/CodePipelineClient.ts
@@ -675,7 +675,7 @@ export class CodePipelineClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codepipeline/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codepipeline/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codestar-connections/src/CodeStarConnectionsClient.ts
+++ b/clients/client-codestar-connections/src/CodeStarConnectionsClient.ts
@@ -489,7 +489,7 @@ export class CodeStarConnectionsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codestar-connections/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codestar-connections/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-codestar-notifications/src/CodestarNotificationsClient.ts
+++ b/clients/client-codestar-notifications/src/CodestarNotificationsClient.ts
@@ -421,7 +421,7 @@ export class CodestarNotificationsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-codestar-notifications/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codestar-notifications/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cognito-identity-provider/src/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/src/CognitoIdentityProviderClient.ts
@@ -857,7 +857,7 @@ export class CognitoIdentityProviderClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cognito-identity-provider/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cognito-identity-provider/src/auth/httpAuthSchemeProvider.ts
@@ -267,10 +267,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cognito-identity/src/CognitoIdentityClient.ts
+++ b/clients/client-cognito-identity/src/CognitoIdentityClient.ts
@@ -403,7 +403,7 @@ export class CognitoIdentityClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cognito-identity/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cognito-identity/src/auth/httpAuthSchemeProvider.ts
@@ -150,10 +150,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cognito-sync/src/CognitoSyncClient.ts
+++ b/clients/client-cognito-sync/src/CognitoSyncClient.ts
@@ -371,7 +371,7 @@ export class CognitoSyncClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cognito-sync/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cognito-sync/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-comprehend/src/ComprehendClient.ts
+++ b/clients/client-comprehend/src/ComprehendClient.ts
@@ -725,7 +725,7 @@ export class ComprehendClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-comprehend/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-comprehend/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-comprehendmedical/src/ComprehendMedicalClient.ts
+++ b/clients/client-comprehendmedical/src/ComprehendMedicalClient.ts
@@ -425,7 +425,7 @@ export class ComprehendMedicalClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-comprehendmedical/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-comprehendmedical/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-compute-optimizer/src/ComputeOptimizerClient.ts
+++ b/clients/client-compute-optimizer/src/ComputeOptimizerClient.ts
@@ -466,7 +466,7 @@ export class ComputeOptimizerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-compute-optimizer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-compute-optimizer/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-config-service/src/ConfigServiceClient.ts
+++ b/clients/client-config-service/src/ConfigServiceClient.ts
@@ -853,7 +853,7 @@ export class ConfigServiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-config-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-config-service/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-connect-contact-lens/src/ConnectContactLensClient.ts
+++ b/clients/client-connect-contact-lens/src/ConnectContactLensClient.ts
@@ -310,7 +310,7 @@ export class ConnectContactLensClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-connect-contact-lens/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connect-contact-lens/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-connect/src/ConnectClient.ts
+++ b/clients/client-connect/src/ConnectClient.ts
@@ -1678,7 +1678,7 @@ export class ConnectClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-connect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connect/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-connectcampaigns/src/ConnectCampaignsClient.ts
+++ b/clients/client-connectcampaigns/src/ConnectCampaignsClient.ts
@@ -383,7 +383,7 @@ export class ConnectCampaignsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-connectcampaigns/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectcampaigns/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-connectcampaignsv2/src/ConnectCampaignsV2Client.ts
+++ b/clients/client-connectcampaignsv2/src/ConnectCampaignsV2Client.ts
@@ -449,7 +449,7 @@ export class ConnectCampaignsV2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-connectcampaignsv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectcampaignsv2/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-connectcases/src/ConnectCasesClient.ts
+++ b/clients/client-connectcases/src/ConnectCasesClient.ts
@@ -437,7 +437,7 @@ export class ConnectCasesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-connectcases/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectcases/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-connectparticipant/src/ConnectParticipantClient.ts
+++ b/clients/client-connectparticipant/src/ConnectParticipantClient.ts
@@ -364,7 +364,7 @@ export class ConnectParticipantClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-connectparticipant/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectparticipant/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-controlcatalog/src/ControlCatalogClient.ts
+++ b/clients/client-controlcatalog/src/ControlCatalogClient.ts
@@ -329,7 +329,7 @@ export class ControlCatalogClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-controlcatalog/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-controlcatalog/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-controltower/src/ControlTowerClient.ts
+++ b/clients/client-controltower/src/ControlTowerClient.ts
@@ -791,7 +791,7 @@ export class ControlTowerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-controltower/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-controltower/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cost-and-usage-report-service/src/CostAndUsageReportServiceClient.ts
+++ b/clients/client-cost-and-usage-report-service/src/CostAndUsageReportServiceClient.ts
@@ -340,7 +340,7 @@ export class CostAndUsageReportServiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cost-and-usage-report-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cost-and-usage-report-service/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cost-explorer/src/CostExplorerClient.ts
+++ b/clients/client-cost-explorer/src/CostExplorerClient.ts
@@ -536,7 +536,7 @@ export class CostExplorerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cost-explorer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cost-explorer/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-cost-optimization-hub/src/CostOptimizationHubClient.ts
+++ b/clients/client-cost-optimization-hub/src/CostOptimizationHubClient.ts
@@ -327,7 +327,7 @@ export class CostOptimizationHubClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-cost-optimization-hub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cost-optimization-hub/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-customer-profiles/src/CustomerProfilesClient.ts
+++ b/clients/client-customer-profiles/src/CustomerProfilesClient.ts
@@ -611,7 +611,7 @@ export class CustomerProfilesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-customer-profiles/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-customer-profiles/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-data-pipeline/src/DataPipelineClient.ts
+++ b/clients/client-data-pipeline/src/DataPipelineClient.ts
@@ -372,7 +372,7 @@ export class DataPipelineClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-data-pipeline/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-data-pipeline/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-database-migration-service/src/DatabaseMigrationServiceClient.ts
+++ b/clients/client-database-migration-service/src/DatabaseMigrationServiceClient.ts
@@ -909,7 +909,7 @@ export class DatabaseMigrationServiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-database-migration-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-database-migration-service/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-databrew/src/DataBrewClient.ts
+++ b/clients/client-databrew/src/DataBrewClient.ts
@@ -443,7 +443,7 @@ export class DataBrewClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-databrew/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-databrew/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-dataexchange/src/DataExchangeClient.ts
+++ b/clients/client-dataexchange/src/DataExchangeClient.ts
@@ -430,7 +430,7 @@ export class DataExchangeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-dataexchange/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dataexchange/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-datasync/src/DataSyncClient.ts
+++ b/clients/client-datasync/src/DataSyncClient.ts
@@ -592,7 +592,7 @@ export class DataSyncClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-datasync/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-datasync/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-datazone/src/DataZoneClient.ts
+++ b/clients/client-datazone/src/DataZoneClient.ts
@@ -948,7 +948,7 @@ export class DataZoneClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-datazone/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-datazone/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-dax/src/DAXClient.ts
+++ b/clients/client-dax/src/DAXClient.ts
@@ -379,7 +379,7 @@ export class DAXClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-dax/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dax/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-deadline/src/DeadlineClient.ts
+++ b/clients/client-deadline/src/DeadlineClient.ts
@@ -774,7 +774,7 @@ export class DeadlineClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-deadline/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-deadline/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-detective/src/DetectiveClient.ts
+++ b/clients/client-detective/src/DetectiveClient.ts
@@ -488,7 +488,7 @@ export class DetectiveClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-detective/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-detective/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-device-farm/src/DeviceFarmClient.ts
+++ b/clients/client-device-farm/src/DeviceFarmClient.ts
@@ -628,7 +628,7 @@ export class DeviceFarmClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-device-farm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-device-farm/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-devops-guru/src/DevOpsGuruClient.ts
+++ b/clients/client-devops-guru/src/DevOpsGuruClient.ts
@@ -457,7 +457,7 @@ export class DevOpsGuruClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-devops-guru/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-devops-guru/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-direct-connect/src/DirectConnectClient.ts
+++ b/clients/client-direct-connect/src/DirectConnectClient.ts
@@ -616,7 +616,7 @@ export class DirectConnectClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-direct-connect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-direct-connect/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-directory-service-data/src/DirectoryServiceDataClient.ts
+++ b/clients/client-directory-service-data/src/DirectoryServiceDataClient.ts
@@ -391,7 +391,7 @@ export class DirectoryServiceDataClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-directory-service-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-directory-service-data/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-directory-service/src/DirectoryServiceClient.ts
+++ b/clients/client-directory-service/src/DirectoryServiceClient.ts
@@ -609,7 +609,7 @@ export class DirectoryServiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-directory-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-directory-service/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-dlm/src/DLMClient.ts
+++ b/clients/client-dlm/src/DLMClient.ts
@@ -332,7 +332,7 @@ export class DLMClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-dlm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dlm/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-docdb-elastic/src/DocDBElasticClient.ts
+++ b/clients/client-docdb-elastic/src/DocDBElasticClient.ts
@@ -385,7 +385,7 @@ export class DocDBElasticClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-docdb-elastic/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-docdb-elastic/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-docdb/src/DocDBClient.ts
+++ b/clients/client-docdb/src/DocDBClient.ts
@@ -580,7 +580,7 @@ export class DocDBClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-docdb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-docdb/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-drs/src/DrsClient.ts
+++ b/clients/client-drs/src/DrsClient.ts
@@ -545,7 +545,7 @@ export class DrsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-drs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-drs/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-dsql/src/DSQLClient.ts
+++ b/clients/client-dsql/src/DSQLClient.ts
@@ -335,7 +335,7 @@ export class DSQLClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-dsql/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dsql/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-dynamodb-streams/src/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/src/DynamoDBStreamsClient.ts
@@ -303,7 +303,7 @@ export class DynamoDBStreamsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-dynamodb-streams/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dynamodb-streams/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-dynamodb/src/DynamoDBClient.ts
+++ b/clients/client-dynamodb/src/DynamoDBClient.ts
@@ -563,7 +563,7 @@ export class DynamoDBClient extends __Client<
     const _config_5 = resolveRegionConfig(_config_4);
     const _config_6 = resolveHostHeaderConfig(_config_5);
     const _config_7 = resolveEndpointConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveEndpointDiscoveryConfig(_config_8, {
       endpointDiscoveryCommandCtor: DescribeEndpointsCommand,
     });

--- a/clients/client-dynamodb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dynamodb/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ebs/src/EBSClient.ts
+++ b/clients/client-ebs/src/EBSClient.ts
@@ -328,7 +328,7 @@ export class EBSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ebs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ebs/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ec2-instance-connect/src/EC2InstanceConnectClient.ts
+++ b/clients/client-ec2-instance-connect/src/EC2InstanceConnectClient.ts
@@ -301,7 +301,7 @@ export class EC2InstanceConnectClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ec2-instance-connect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ec2-instance-connect/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ec2/src/EC2Client.ts
+++ b/clients/client-ec2/src/EC2Client.ts
@@ -3853,7 +3853,7 @@ export class EC2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ec2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ec2/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ecr-public/src/ECRPUBLICClient.ts
+++ b/clients/client-ecr-public/src/ECRPUBLICClient.ts
@@ -401,7 +401,7 @@ export class ECRPUBLICClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ecr-public/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ecr-public/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ecr/src/ECRClient.ts
+++ b/clients/client-ecr/src/ECRClient.ts
@@ -535,7 +535,7 @@ export class ECRClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ecr/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ecr/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ecs/src/ECSClient.ts
+++ b/clients/client-ecs/src/ECSClient.ts
@@ -572,7 +572,7 @@ export class ECSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ecs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ecs/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-efs/src/EFSClient.ts
+++ b/clients/client-efs/src/EFSClient.ts
@@ -438,7 +438,7 @@ export class EFSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-efs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-efs/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-eks-auth/src/EKSAuthClient.ts
+++ b/clients/client-eks-auth/src/EKSAuthClient.ts
@@ -292,7 +292,7 @@ export class EKSAuthClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-eks-auth/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-eks-auth/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-eks/src/EKSClient.ts
+++ b/clients/client-eks/src/EKSClient.ts
@@ -560,7 +560,7 @@ export class EKSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-eks/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-eks/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-elastic-beanstalk/src/ElasticBeanstalkClient.ts
+++ b/clients/client-elastic-beanstalk/src/ElasticBeanstalkClient.ts
@@ -557,7 +557,7 @@ export class ElasticBeanstalkClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-elastic-beanstalk/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elastic-beanstalk/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-elastic-load-balancing-v2/src/ElasticLoadBalancingV2Client.ts
+++ b/clients/client-elastic-load-balancing-v2/src/ElasticLoadBalancingV2Client.ts
@@ -540,7 +540,7 @@ export class ElasticLoadBalancingV2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-elastic-load-balancing-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elastic-load-balancing-v2/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-elastic-load-balancing/src/ElasticLoadBalancingClient.ts
+++ b/clients/client-elastic-load-balancing/src/ElasticLoadBalancingClient.ts
@@ -466,7 +466,7 @@ export class ElasticLoadBalancingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-elastic-load-balancing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elastic-load-balancing/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-elastic-transcoder/src/ElasticTranscoderClient.ts
+++ b/clients/client-elastic-transcoder/src/ElasticTranscoderClient.ts
@@ -345,7 +345,7 @@ export class ElasticTranscoderClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-elastic-transcoder/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elastic-transcoder/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-elasticache/src/ElastiCacheClient.ts
+++ b/clients/client-elasticache/src/ElastiCacheClient.ts
@@ -680,7 +680,7 @@ export class ElastiCacheClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-elasticache/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elasticache/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-elasticsearch-service/src/ElasticsearchServiceClient.ts
+++ b/clients/client-elasticsearch-service/src/ElasticsearchServiceClient.ts
@@ -551,7 +551,7 @@ export class ElasticsearchServiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-elasticsearch-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elasticsearch-service/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-emr-containers/src/EMRContainersClient.ts
+++ b/clients/client-emr-containers/src/EMRContainersClient.ts
@@ -421,7 +421,7 @@ export class EMRContainersClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-emr-containers/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-emr-containers/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-emr-serverless/src/EMRServerlessClient.ts
+++ b/clients/client-emr-serverless/src/EMRServerlessClient.ts
@@ -361,7 +361,7 @@ export class EMRServerlessClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-emr-serverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-emr-serverless/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-emr/src/EMRClient.ts
+++ b/clients/client-emr/src/EMRClient.ts
@@ -556,7 +556,7 @@ export class EMRClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-emr/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-emr/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-entityresolution/src/EntityResolutionClient.ts
+++ b/clients/client-entityresolution/src/EntityResolutionClient.ts
@@ -459,7 +459,7 @@ export class EntityResolutionClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-entityresolution/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-entityresolution/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-eventbridge/src/EventBridgeClient.ts
+++ b/clients/client-eventbridge/src/EventBridgeClient.ts
@@ -526,7 +526,7 @@ export class EventBridgeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-eventbridge/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-eventbridge/src/auth/httpAuthSchemeProvider.ts
@@ -317,10 +317,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   const config_1 = resolveAwsSdkSigV4AConfig(config_0);
   return {
     ...config_1,

--- a/clients/client-evidently/src/EvidentlyClient.ts
+++ b/clients/client-evidently/src/EvidentlyClient.ts
@@ -425,7 +425,7 @@ export class EvidentlyClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-evidently/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-evidently/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-finspace-data/src/FinspaceDataClient.ts
+++ b/clients/client-finspace-data/src/FinspaceDataClient.ts
@@ -410,7 +410,7 @@ export class FinspaceDataClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-finspace-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-finspace-data/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-finspace/src/FinspaceClient.ts
+++ b/clients/client-finspace/src/FinspaceClient.ts
@@ -473,7 +473,7 @@ export class FinspaceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-finspace/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-finspace/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-firehose/src/FirehoseClient.ts
+++ b/clients/client-firehose/src/FirehoseClient.ts
@@ -353,7 +353,7 @@ export class FirehoseClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-firehose/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-firehose/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-fis/src/FisClient.ts
+++ b/clients/client-fis/src/FisClient.ts
@@ -417,7 +417,7 @@ export class FisClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-fis/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-fis/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-fms/src/FMSClient.ts
+++ b/clients/client-fms/src/FMSClient.ts
@@ -482,7 +482,7 @@ export class FMSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-fms/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-fms/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-forecast/src/ForecastClient.ts
+++ b/clients/client-forecast/src/ForecastClient.ts
@@ -584,7 +584,7 @@ export class ForecastClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-forecast/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-forecast/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-forecastquery/src/ForecastqueryClient.ts
+++ b/clients/client-forecastquery/src/ForecastqueryClient.ts
@@ -292,7 +292,7 @@ export class ForecastqueryClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-forecastquery/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-forecastquery/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-frauddetector/src/FraudDetectorClient.ts
+++ b/clients/client-frauddetector/src/FraudDetectorClient.ts
@@ -584,7 +584,7 @@ export class FraudDetectorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-frauddetector/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-frauddetector/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-freetier/src/FreeTierClient.ts
+++ b/clients/client-freetier/src/FreeTierClient.ts
@@ -298,7 +298,7 @@ export class FreeTierClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-freetier/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-freetier/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-fsx/src/FSxClient.ts
+++ b/clients/client-fsx/src/FSxClient.ts
@@ -495,7 +495,7 @@ export class FSxClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-fsx/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-fsx/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-gamelift/src/GameLiftClient.ts
+++ b/clients/client-gamelift/src/GameLiftClient.ts
@@ -914,7 +914,7 @@ export class GameLiftClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-gamelift/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-gamelift/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-gameliftstreams/src/GameLiftStreamsClient.ts
+++ b/clients/client-gameliftstreams/src/GameLiftStreamsClient.ts
@@ -392,7 +392,7 @@ export class GameLiftStreamsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-gameliftstreams/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-gameliftstreams/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-geo-maps/src/GeoMapsClient.ts
+++ b/clients/client-geo-maps/src/GeoMapsClient.ts
@@ -330,7 +330,7 @@ export class GeoMapsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-geo-maps/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-geo-maps/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-geo-places/src/GeoPlacesClient.ts
+++ b/clients/client-geo-places/src/GeoPlacesClient.ts
@@ -344,7 +344,7 @@ export class GeoPlacesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-geo-places/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-geo-places/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-geo-routes/src/GeoRoutesClient.ts
+++ b/clients/client-geo-routes/src/GeoRoutesClient.ts
@@ -327,7 +327,7 @@ export class GeoRoutesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-geo-routes/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-geo-routes/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-glacier/src/GlacierClient.ts
+++ b/clients/client-glacier/src/GlacierClient.ts
@@ -489,7 +489,7 @@ export class GlacierClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-glacier/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-glacier/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-global-accelerator/src/GlobalAcceleratorClient.ts
+++ b/clients/client-global-accelerator/src/GlobalAcceleratorClient.ts
@@ -616,7 +616,7 @@ export class GlobalAcceleratorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-global-accelerator/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-global-accelerator/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-glue/src/GlueClient.ts
+++ b/clients/client-glue/src/GlueClient.ts
@@ -1365,7 +1365,7 @@ export class GlueClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-glue/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-glue/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-grafana/src/GrafanaClient.ts
+++ b/clients/client-grafana/src/GrafanaClient.ts
@@ -412,7 +412,7 @@ export class GrafanaClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-grafana/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-grafana/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-greengrass/src/GreengrassClient.ts
+++ b/clients/client-greengrass/src/GreengrassClient.ts
@@ -791,7 +791,7 @@ export class GreengrassClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-greengrass/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-greengrass/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-greengrassv2/src/GreengrassV2Client.ts
+++ b/clients/client-greengrassv2/src/GreengrassV2Client.ts
@@ -429,7 +429,7 @@ export class GreengrassV2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-greengrassv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-greengrassv2/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-groundstation/src/GroundStationClient.ts
+++ b/clients/client-groundstation/src/GroundStationClient.ts
@@ -419,7 +419,7 @@ export class GroundStationClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-groundstation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-groundstation/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-guardduty/src/GuardDutyClient.ts
+++ b/clients/client-guardduty/src/GuardDutyClient.ts
@@ -642,7 +642,7 @@ export class GuardDutyClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-guardduty/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-guardduty/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-health/src/HealthClient.ts
+++ b/clients/client-health/src/HealthClient.ts
@@ -407,7 +407,7 @@ export class HealthClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-health/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-health/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-healthlake/src/HealthLakeClient.ts
+++ b/clients/client-healthlake/src/HealthLakeClient.ts
@@ -345,7 +345,7 @@ export class HealthLakeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-healthlake/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-healthlake/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iam/src/IAMClient.ts
+++ b/clients/client-iam/src/IAMClient.ts
@@ -1023,7 +1023,7 @@ export class IAMClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iam/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iam/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-identitystore/src/IdentitystoreClient.ts
+++ b/clients/client-identitystore/src/IdentitystoreClient.ts
@@ -369,7 +369,7 @@ export class IdentitystoreClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-identitystore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-identitystore/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-imagebuilder/src/ImagebuilderClient.ts
+++ b/clients/client-imagebuilder/src/ImagebuilderClient.ts
@@ -650,7 +650,7 @@ export class ImagebuilderClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-imagebuilder/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-imagebuilder/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-inspector-scan/src/InspectorScanClient.ts
+++ b/clients/client-inspector-scan/src/InspectorScanClient.ts
@@ -288,7 +288,7 @@ export class InspectorScanClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-inspector-scan/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-inspector-scan/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-inspector/src/InspectorClient.ts
+++ b/clients/client-inspector/src/InspectorClient.ts
@@ -479,7 +479,7 @@ export class InspectorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-inspector/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-inspector/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-inspector2/src/Inspector2Client.ts
+++ b/clients/client-inspector2/src/Inspector2Client.ts
@@ -567,7 +567,7 @@ export class Inspector2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-inspector2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-inspector2/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-internetmonitor/src/InternetMonitorClient.ts
+++ b/clients/client-internetmonitor/src/InternetMonitorClient.ts
@@ -353,7 +353,7 @@ export class InternetMonitorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-internetmonitor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-internetmonitor/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-invoicing/src/InvoicingClient.ts
+++ b/clients/client-invoicing/src/InvoicingClient.ts
@@ -336,7 +336,7 @@ export class InvoicingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-invoicing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-invoicing/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iot-data-plane/src/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/src/IoTDataPlaneClient.ts
@@ -324,7 +324,7 @@ export class IoTDataPlaneClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iot-data-plane/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-data-plane/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iot-events-data/src/IoTEventsDataClient.ts
+++ b/clients/client-iot-events-data/src/IoTEventsDataClient.ts
@@ -336,7 +336,7 @@ export class IoTEventsDataClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iot-events-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-events-data/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iot-events/src/IoTEventsClient.ts
+++ b/clients/client-iot-events/src/IoTEventsClient.ts
@@ -400,7 +400,7 @@ export class IoTEventsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iot-events/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-events/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iot-jobs-data-plane/src/IoTJobsDataPlaneClient.ts
+++ b/clients/client-iot-jobs-data-plane/src/IoTJobsDataPlaneClient.ts
@@ -334,7 +334,7 @@ export class IoTJobsDataPlaneClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iot-jobs-data-plane/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-jobs-data-plane/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iot-managed-integrations/src/IoTManagedIntegrationsClient.ts
+++ b/clients/client-iot-managed-integrations/src/IoTManagedIntegrationsClient.ts
@@ -572,7 +572,7 @@ export class IoTManagedIntegrationsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iot-managed-integrations/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-managed-integrations/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iot-wireless/src/IoTWirelessClient.ts
+++ b/clients/client-iot-wireless/src/IoTWirelessClient.ts
@@ -896,7 +896,7 @@ export class IoTWirelessClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iot-wireless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-wireless/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iot/src/IoTClient.ts
+++ b/clients/client-iot/src/IoTClient.ts
@@ -1589,7 +1589,7 @@ export class IoTClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iot/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iotanalytics/src/IoTAnalyticsClient.ts
+++ b/clients/client-iotanalytics/src/IoTAnalyticsClient.ts
@@ -429,7 +429,7 @@ export class IoTAnalyticsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iotanalytics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotanalytics/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iotdeviceadvisor/src/IotDeviceAdvisorClient.ts
+++ b/clients/client-iotdeviceadvisor/src/IotDeviceAdvisorClient.ts
@@ -352,7 +352,7 @@ export class IotDeviceAdvisorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iotdeviceadvisor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotdeviceadvisor/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iotfleethub/src/IoTFleetHubClient.ts
+++ b/clients/client-iotfleethub/src/IoTFleetHubClient.ts
@@ -317,7 +317,7 @@ export class IoTFleetHubClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iotfleethub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotfleethub/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iotfleetwise/src/IoTFleetWiseClient.ts
+++ b/clients/client-iotfleetwise/src/IoTFleetWiseClient.ts
@@ -548,7 +548,7 @@ export class IoTFleetWiseClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iotfleetwise/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotfleetwise/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iotsecuretunneling/src/IoTSecureTunnelingClient.ts
+++ b/clients/client-iotsecuretunneling/src/IoTSecureTunnelingClient.ts
@@ -321,7 +321,7 @@ export class IoTSecureTunnelingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iotsecuretunneling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotsecuretunneling/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iotsitewise/src/IoTSiteWiseClient.ts
+++ b/clients/client-iotsitewise/src/IoTSiteWiseClient.ts
@@ -680,7 +680,7 @@ export class IoTSiteWiseClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveRuntimeExtensions(_config_8, configuration?.extensions || []);
     super(_config_9);
     this.config = _config_9;

--- a/clients/client-iotsitewise/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotsitewise/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iotthingsgraph/src/IoTThingsGraphClient.ts
+++ b/clients/client-iotthingsgraph/src/IoTThingsGraphClient.ts
@@ -460,7 +460,7 @@ export class IoTThingsGraphClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iotthingsgraph/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotthingsgraph/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-iottwinmaker/src/IoTTwinMakerClient.ts
+++ b/clients/client-iottwinmaker/src/IoTTwinMakerClient.ts
@@ -442,7 +442,7 @@ export class IoTTwinMakerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-iottwinmaker/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iottwinmaker/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ivs-realtime/src/IVSRealTimeClient.ts
+++ b/clients/client-ivs-realtime/src/IVSRealTimeClient.ts
@@ -500,7 +500,7 @@ export class IVSRealTimeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ivs-realtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ivs-realtime/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ivs/src/IvsClient.ts
+++ b/clients/client-ivs/src/IvsClient.ts
@@ -567,7 +567,7 @@ export class IvsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ivs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ivs/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ivschat/src/IvschatClient.ts
+++ b/clients/client-ivschat/src/IvschatClient.ts
@@ -461,7 +461,7 @@ export class IvschatClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ivschat/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ivschat/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kafka/src/KafkaClient.ts
+++ b/clients/client-kafka/src/KafkaClient.ts
@@ -518,7 +518,7 @@ export class KafkaClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kafka/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kafka/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kafkaconnect/src/KafkaConnectClient.ts
+++ b/clients/client-kafkaconnect/src/KafkaConnectClient.ts
@@ -365,7 +365,7 @@ export class KafkaConnectClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kafkaconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kafkaconnect/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kendra-ranking/src/KendraRankingClient.ts
+++ b/clients/client-kendra-ranking/src/KendraRankingClient.ts
@@ -334,7 +334,7 @@ export class KendraRankingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kendra-ranking/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kendra-ranking/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kendra/src/KendraClient.ts
+++ b/clients/client-kendra/src/KendraClient.ts
@@ -587,7 +587,7 @@ export class KendraClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kendra/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kendra/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-keyspaces/src/KeyspacesClient.ts
+++ b/clients/client-keyspaces/src/KeyspacesClient.ts
@@ -363,7 +363,7 @@ export class KeyspacesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-keyspaces/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-keyspaces/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kinesis-analytics-v2/src/KinesisAnalyticsV2Client.ts
+++ b/clients/client-kinesis-analytics-v2/src/KinesisAnalyticsV2Client.ts
@@ -466,7 +466,7 @@ export class KinesisAnalyticsV2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kinesis-analytics-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-analytics-v2/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kinesis-analytics/src/KinesisAnalyticsClient.ts
+++ b/clients/client-kinesis-analytics/src/KinesisAnalyticsClient.ts
@@ -392,7 +392,7 @@ export class KinesisAnalyticsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kinesis-analytics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-analytics/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kinesis-video-archived-media/src/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/src/KinesisVideoArchivedMediaClient.ts
@@ -322,7 +322,7 @@ export class KinesisVideoArchivedMediaClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kinesis-video-archived-media/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-archived-media/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kinesis-video-media/src/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/src/KinesisVideoMediaClient.ts
@@ -295,7 +295,7 @@ export class KinesisVideoMediaClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kinesis-video-media/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-media/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kinesis-video-signaling/src/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/src/KinesisVideoSignalingClient.ts
@@ -300,7 +300,7 @@ export class KinesisVideoSignalingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kinesis-video-signaling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-signaling/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kinesis-video-webrtc-storage/src/KinesisVideoWebRTCStorageClient.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/KinesisVideoWebRTCStorageClient.ts
@@ -295,7 +295,7 @@ export class KinesisVideoWebRTCStorageClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kinesis-video-webrtc-storage/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kinesis-video/src/KinesisVideoClient.ts
+++ b/clients/client-kinesis-video/src/KinesisVideoClient.ts
@@ -434,7 +434,7 @@ export class KinesisVideoClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kinesis-video/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kinesis/src/KinesisClient.ts
+++ b/clients/client-kinesis/src/KinesisClient.ts
@@ -438,7 +438,7 @@ export class KinesisClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveRuntimeExtensions(_config_8, configuration?.extensions || []);
     super(_config_9);
     this.config = _config_9;

--- a/clients/client-kinesis/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-kms/src/KMSClient.ts
+++ b/clients/client-kms/src/KMSClient.ts
@@ -588,7 +588,7 @@ export class KMSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-kms/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kms/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-lakeformation/src/LakeFormationClient.ts
+++ b/clients/client-lakeformation/src/LakeFormationClient.ts
@@ -571,7 +571,7 @@ export class LakeFormationClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-lakeformation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lakeformation/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-lambda/src/LambdaClient.ts
+++ b/clients/client-lambda/src/LambdaClient.ts
@@ -701,7 +701,7 @@ export class LambdaClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveRuntimeExtensions(_config_8, configuration?.extensions || []);
     super(_config_9);
     this.config = _config_9;

--- a/clients/client-lambda/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lambda/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-launch-wizard/src/LaunchWizardClient.ts
+++ b/clients/client-launch-wizard/src/LaunchWizardClient.ts
@@ -338,7 +338,7 @@ export class LaunchWizardClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-launch-wizard/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-launch-wizard/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-lex-model-building-service/src/LexModelBuildingServiceClient.ts
+++ b/clients/client-lex-model-building-service/src/LexModelBuildingServiceClient.ts
@@ -446,7 +446,7 @@ export class LexModelBuildingServiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-lex-model-building-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-model-building-service/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-lex-models-v2/src/LexModelsV2Client.ts
+++ b/clients/client-lex-models-v2/src/LexModelsV2Client.ts
@@ -707,7 +707,7 @@ export class LexModelsV2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-lex-models-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-models-v2/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-lex-runtime-service/src/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/src/LexRuntimeServiceClient.ts
@@ -320,7 +320,7 @@ export class LexRuntimeServiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-lex-runtime-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-runtime-service/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-lex-runtime-v2/src/LexRuntimeV2Client.ts
+++ b/clients/client-lex-runtime-v2/src/LexRuntimeV2Client.ts
@@ -340,7 +340,7 @@ export class LexRuntimeV2Client extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveEventStreamConfig(_config_8);
     const _config_10 = resolveRuntimeExtensions(_config_9, configuration?.extensions || []);
     super(_config_10);

--- a/clients/client-lex-runtime-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-runtime-v2/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-license-manager-linux-subscriptions/src/LicenseManagerLinuxSubscriptionsClient.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/LicenseManagerLinuxSubscriptionsClient.ts
@@ -348,7 +348,7 @@ export class LicenseManagerLinuxSubscriptionsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-license-manager-linux-subscriptions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/auth/httpAuthSchemeProvider.ts
@@ -134,10 +134,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-license-manager-user-subscriptions/src/LicenseManagerUserSubscriptionsClient.ts
+++ b/clients/client-license-manager-user-subscriptions/src/LicenseManagerUserSubscriptionsClient.ts
@@ -377,7 +377,7 @@ export class LicenseManagerUserSubscriptionsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-license-manager-user-subscriptions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-license-manager-user-subscriptions/src/auth/httpAuthSchemeProvider.ts
@@ -134,10 +134,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-license-manager/src/LicenseManagerClient.ts
+++ b/clients/client-license-manager/src/LicenseManagerClient.ts
@@ -525,7 +525,7 @@ export class LicenseManagerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-license-manager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-license-manager/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-lightsail/src/LightsailClient.ts
+++ b/clients/client-lightsail/src/LightsailClient.ts
@@ -1017,7 +1017,7 @@ export class LightsailClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-lightsail/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lightsail/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-location/src/LocationClient.ts
+++ b/clients/client-location/src/LocationClient.ts
@@ -551,7 +551,7 @@ export class LocationClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-location/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-location/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-lookoutequipment/src/LookoutEquipmentClient.ts
+++ b/clients/client-lookoutequipment/src/LookoutEquipmentClient.ts
@@ -510,7 +510,7 @@ export class LookoutEquipmentClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-lookoutequipment/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lookoutequipment/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-lookoutmetrics/src/LookoutMetricsClient.ts
+++ b/clients/client-lookoutmetrics/src/LookoutMetricsClient.ts
@@ -424,7 +424,7 @@ export class LookoutMetricsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-lookoutmetrics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lookoutmetrics/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-lookoutvision/src/LookoutVisionClient.ts
+++ b/clients/client-lookoutvision/src/LookoutVisionClient.ts
@@ -374,7 +374,7 @@ export class LookoutVisionClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-lookoutvision/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lookoutvision/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-m2/src/M2Client.ts
+++ b/clients/client-m2/src/M2Client.ts
@@ -432,7 +432,7 @@ export class M2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-m2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-m2/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-machine-learning/src/MachineLearningClient.ts
+++ b/clients/client-machine-learning/src/MachineLearningClient.ts
@@ -405,7 +405,7 @@ export class MachineLearningClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-machine-learning/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-machine-learning/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-macie2/src/Macie2Client.ts
+++ b/clients/client-macie2/src/Macie2Client.ts
@@ -683,7 +683,7 @@ export class Macie2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-macie2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-macie2/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mailmanager/src/MailManagerClient.ts
+++ b/clients/client-mailmanager/src/MailManagerClient.ts
@@ -542,7 +542,7 @@ export class MailManagerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mailmanager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mailmanager/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-managedblockchain-query/src/ManagedBlockchainQueryClient.ts
+++ b/clients/client-managedblockchain-query/src/ManagedBlockchainQueryClient.ts
@@ -329,7 +329,7 @@ export class ManagedBlockchainQueryClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-managedblockchain-query/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-managedblockchain-query/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-managedblockchain/src/ManagedBlockchainClient.ts
+++ b/clients/client-managedblockchain/src/ManagedBlockchainClient.ts
@@ -374,7 +374,7 @@ export class ManagedBlockchainClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-managedblockchain/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-managedblockchain/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-marketplace-agreement/src/MarketplaceAgreementClient.ts
+++ b/clients/client-marketplace-agreement/src/MarketplaceAgreementClient.ts
@@ -316,7 +316,7 @@ export class MarketplaceAgreementClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-marketplace-agreement/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-agreement/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-marketplace-catalog/src/MarketplaceCatalogClient.ts
+++ b/clients/client-marketplace-catalog/src/MarketplaceCatalogClient.ts
@@ -340,7 +340,7 @@ export class MarketplaceCatalogClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-marketplace-catalog/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-catalog/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-marketplace-commerce-analytics/src/MarketplaceCommerceAnalyticsClient.ts
+++ b/clients/client-marketplace-commerce-analytics/src/MarketplaceCommerceAnalyticsClient.ts
@@ -293,7 +293,7 @@ export class MarketplaceCommerceAnalyticsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-marketplace-commerce-analytics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-commerce-analytics/src/auth/httpAuthSchemeProvider.ts
@@ -134,10 +134,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-marketplace-deployment/src/MarketplaceDeploymentClient.ts
+++ b/clients/client-marketplace-deployment/src/MarketplaceDeploymentClient.ts
@@ -305,7 +305,7 @@ export class MarketplaceDeploymentClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-marketplace-deployment/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-deployment/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-marketplace-entitlement-service/src/MarketplaceEntitlementServiceClient.ts
+++ b/clients/client-marketplace-entitlement-service/src/MarketplaceEntitlementServiceClient.ts
@@ -306,7 +306,7 @@ export class MarketplaceEntitlementServiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-marketplace-entitlement-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-entitlement-service/src/auth/httpAuthSchemeProvider.ts
@@ -134,10 +134,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-marketplace-metering/src/MarketplaceMeteringClient.ts
+++ b/clients/client-marketplace-metering/src/MarketplaceMeteringClient.ts
@@ -361,7 +361,7 @@ export class MarketplaceMeteringClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-marketplace-metering/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-metering/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-marketplace-reporting/src/MarketplaceReportingClient.ts
+++ b/clients/client-marketplace-reporting/src/MarketplaceReportingClient.ts
@@ -343,7 +343,7 @@ export class MarketplaceReportingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-marketplace-reporting/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-reporting/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mediaconnect/src/MediaConnectClient.ts
+++ b/clients/client-mediaconnect/src/MediaConnectClient.ts
@@ -516,7 +516,7 @@ export class MediaConnectClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mediaconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediaconnect/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mediaconvert/src/MediaConvertClient.ts
+++ b/clients/client-mediaconvert/src/MediaConvertClient.ts
@@ -389,7 +389,7 @@ export class MediaConvertClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mediaconvert/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediaconvert/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-medialive/src/MediaLiveClient.ts
+++ b/clients/client-medialive/src/MediaLiveClient.ts
@@ -798,7 +798,7 @@ export class MediaLiveClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-medialive/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-medialive/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mediapackage-vod/src/MediaPackageVodClient.ts
+++ b/clients/client-mediapackage-vod/src/MediaPackageVodClient.ts
@@ -368,7 +368,7 @@ export class MediaPackageVodClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mediapackage-vod/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediapackage-vod/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mediapackage/src/MediaPackageClient.ts
+++ b/clients/client-mediapackage/src/MediaPackageClient.ts
@@ -368,7 +368,7 @@ export class MediaPackageClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mediapackage/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediapackage/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mediapackagev2/src/MediaPackageV2Client.ts
+++ b/clients/client-mediapackagev2/src/MediaPackageV2Client.ts
@@ -418,7 +418,7 @@ export class MediaPackageV2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mediapackagev2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediapackagev2/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mediastore-data/src/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/src/MediaStoreDataClient.ts
@@ -311,7 +311,7 @@ export class MediaStoreDataClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mediastore-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediastore-data/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mediastore/src/MediaStoreClient.ts
+++ b/clients/client-mediastore/src/MediaStoreClient.ts
@@ -360,7 +360,7 @@ export class MediaStoreClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mediastore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediastore/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mediatailor/src/MediaTailorClient.ts
+++ b/clients/client-mediatailor/src/MediaTailorClient.ts
@@ -471,7 +471,7 @@ export class MediaTailorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mediatailor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediatailor/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-medical-imaging/src/MedicalImagingClient.ts
+++ b/clients/client-medical-imaging/src/MedicalImagingClient.ts
@@ -509,7 +509,7 @@ export class MedicalImagingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-medical-imaging/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-medical-imaging/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-memorydb/src/MemoryDBClient.ts
+++ b/clients/client-memorydb/src/MemoryDBClient.ts
@@ -469,7 +469,7 @@ export class MemoryDBClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-memorydb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-memorydb/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mgn/src/MgnClient.ts
+++ b/clients/client-mgn/src/MgnClient.ts
@@ -596,7 +596,7 @@ export class MgnClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mgn/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mgn/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-migration-hub-refactor-spaces/src/MigrationHubRefactorSpacesClient.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/MigrationHubRefactorSpacesClient.ts
@@ -376,7 +376,7 @@ export class MigrationHubRefactorSpacesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-migration-hub-refactor-spaces/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/auth/httpAuthSchemeProvider.ts
@@ -134,10 +134,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-migration-hub/src/MigrationHubClient.ts
+++ b/clients/client-migration-hub/src/MigrationHubClient.ts
@@ -415,7 +415,7 @@ export class MigrationHubClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-migration-hub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migration-hub/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-migrationhub-config/src/MigrationHubConfigClient.ts
+++ b/clients/client-migrationhub-config/src/MigrationHubConfigClient.ts
@@ -331,7 +331,7 @@ export class MigrationHubConfigClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-migrationhub-config/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migrationhub-config/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-migrationhuborchestrator/src/MigrationHubOrchestratorClient.ts
+++ b/clients/client-migrationhuborchestrator/src/MigrationHubOrchestratorClient.ts
@@ -409,7 +409,7 @@ export class MigrationHubOrchestratorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-migrationhuborchestrator/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migrationhuborchestrator/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-migrationhubstrategy/src/MigrationHubStrategyClient.ts
+++ b/clients/client-migrationhubstrategy/src/MigrationHubStrategyClient.ts
@@ -397,7 +397,7 @@ export class MigrationHubStrategyClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-migrationhubstrategy/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migrationhubstrategy/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mq/src/MqClient.ts
+++ b/clients/client-mq/src/MqClient.ts
@@ -377,7 +377,7 @@ export class MqClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mq/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mq/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mturk/src/MTurkClient.ts
+++ b/clients/client-mturk/src/MTurkClient.ts
@@ -467,7 +467,7 @@ export class MTurkClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mturk/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mturk/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-mwaa/src/MWAAClient.ts
+++ b/clients/client-mwaa/src/MWAAClient.ts
@@ -406,7 +406,7 @@ export class MWAAClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-mwaa/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mwaa/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-neptune-graph/src/NeptuneGraphClient.ts
+++ b/clients/client-neptune-graph/src/NeptuneGraphClient.ts
@@ -419,7 +419,7 @@ export class NeptuneGraphClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-neptune-graph/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-neptune-graph/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-neptune/src/NeptuneClient.ts
+++ b/clients/client-neptune/src/NeptuneClient.ts
@@ -675,7 +675,7 @@ export class NeptuneClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-neptune/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-neptune/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-neptunedata/src/NeptunedataClient.ts
+++ b/clients/client-neptunedata/src/NeptunedataClient.ts
@@ -508,7 +508,7 @@ export class NeptunedataClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-neptunedata/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-neptunedata/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-network-firewall/src/NetworkFirewallClient.ts
+++ b/clients/client-network-firewall/src/NetworkFirewallClient.ts
@@ -566,7 +566,7 @@ export class NetworkFirewallClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-network-firewall/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-network-firewall/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-networkflowmonitor/src/NetworkFlowMonitorClient.ts
+++ b/clients/client-networkflowmonitor/src/NetworkFlowMonitorClient.ts
@@ -413,7 +413,7 @@ export class NetworkFlowMonitorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-networkflowmonitor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-networkflowmonitor/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-networkmanager/src/NetworkManagerClient.ts
+++ b/clients/client-networkmanager/src/NetworkManagerClient.ts
@@ -692,7 +692,7 @@ export class NetworkManagerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-networkmanager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-networkmanager/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-networkmonitor/src/NetworkMonitorClient.ts
+++ b/clients/client-networkmonitor/src/NetworkMonitorClient.ts
@@ -337,7 +337,7 @@ export class NetworkMonitorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-networkmonitor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-networkmonitor/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-notifications/src/NotificationsClient.ts
+++ b/clients/client-notifications/src/NotificationsClient.ts
@@ -477,7 +477,7 @@ export class NotificationsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-notifications/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-notifications/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-notificationscontacts/src/NotificationsContactsClient.ts
+++ b/clients/client-notificationscontacts/src/NotificationsContactsClient.ts
@@ -320,7 +320,7 @@ export class NotificationsContactsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-notificationscontacts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-notificationscontacts/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-oam/src/OAMClient.ts
+++ b/clients/client-oam/src/OAMClient.ts
@@ -349,7 +349,7 @@ export class OAMClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-oam/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-oam/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-observabilityadmin/src/ObservabilityAdminClient.ts
+++ b/clients/client-observabilityadmin/src/ObservabilityAdminClient.ts
@@ -338,7 +338,7 @@ export class ObservabilityAdminClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-observabilityadmin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-observabilityadmin/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-omics/src/OmicsClient.ts
+++ b/clients/client-omics/src/OmicsClient.ts
@@ -697,7 +697,7 @@ export class OmicsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-omics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-omics/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-opensearch/src/OpenSearchClient.ts
+++ b/clients/client-opensearch/src/OpenSearchClient.ts
@@ -639,7 +639,7 @@ export class OpenSearchClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-opensearch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-opensearch/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-opensearchserverless/src/OpenSearchServerlessClient.ts
+++ b/clients/client-opensearchserverless/src/OpenSearchServerlessClient.ts
@@ -458,7 +458,7 @@ export class OpenSearchServerlessClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-opensearchserverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-opensearchserverless/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-opsworks/src/OpsWorksClient.ts
+++ b/clients/client-opsworks/src/OpsWorksClient.ts
@@ -699,7 +699,7 @@ export class OpsWorksClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-opsworks/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-opsworks/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-opsworkscm/src/OpsWorksCMClient.ts
+++ b/clients/client-opsworkscm/src/OpsWorksCMClient.ts
@@ -446,7 +446,7 @@ export class OpsWorksCMClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-opsworkscm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-opsworkscm/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-organizations/src/OrganizationsClient.ts
+++ b/clients/client-organizations/src/OrganizationsClient.ts
@@ -604,7 +604,7 @@ export class OrganizationsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-organizations/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-organizations/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-osis/src/OSISClient.ts
+++ b/clients/client-osis/src/OSISClient.ts
@@ -343,7 +343,7 @@ export class OSISClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-osis/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-osis/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-outposts/src/OutpostsClient.ts
+++ b/clients/client-outposts/src/OutpostsClient.ts
@@ -405,7 +405,7 @@ export class OutpostsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-outposts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-outposts/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-panorama/src/PanoramaClient.ts
+++ b/clients/client-panorama/src/PanoramaClient.ts
@@ -454,7 +454,7 @@ export class PanoramaClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-panorama/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-panorama/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-partnercentral-selling/src/PartnerCentralSellingClient.ts
+++ b/clients/client-partnercentral-selling/src/PartnerCentralSellingClient.ts
@@ -539,7 +539,7 @@ export class PartnerCentralSellingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-partnercentral-selling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-partnercentral-selling/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-payment-cryptography-data/src/PaymentCryptographyDataClient.ts
+++ b/clients/client-payment-cryptography-data/src/PaymentCryptographyDataClient.ts
@@ -336,7 +336,7 @@ export class PaymentCryptographyDataClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-payment-cryptography-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-payment-cryptography-data/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-payment-cryptography/src/PaymentCryptographyClient.ts
+++ b/clients/client-payment-cryptography/src/PaymentCryptographyClient.ts
@@ -363,7 +363,7 @@ export class PaymentCryptographyClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-payment-cryptography/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-payment-cryptography/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-pca-connector-ad/src/PcaConnectorAdClient.ts
+++ b/clients/client-pca-connector-ad/src/PcaConnectorAdClient.ts
@@ -406,7 +406,7 @@ export class PcaConnectorAdClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-pca-connector-ad/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pca-connector-ad/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-pca-connector-scep/src/PcaConnectorScepClient.ts
+++ b/clients/client-pca-connector-scep/src/PcaConnectorScepClient.ts
@@ -335,7 +335,7 @@ export class PcaConnectorScepClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-pca-connector-scep/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pca-connector-scep/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-pcs/src/PCSClient.ts
+++ b/clients/client-pcs/src/PCSClient.ts
@@ -379,7 +379,7 @@ export class PCSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-pcs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pcs/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-personalize-events/src/PersonalizeEventsClient.ts
+++ b/clients/client-personalize-events/src/PersonalizeEventsClient.ts
@@ -307,7 +307,7 @@ export class PersonalizeEventsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-personalize-events/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-personalize-events/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-personalize-runtime/src/PersonalizeRuntimeClient.ts
+++ b/clients/client-personalize-runtime/src/PersonalizeRuntimeClient.ts
@@ -302,7 +302,7 @@ export class PersonalizeRuntimeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-personalize-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-personalize-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-personalize/src/PersonalizeClient.ts
+++ b/clients/client-personalize/src/PersonalizeClient.ts
@@ -591,7 +591,7 @@ export class PersonalizeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-personalize/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-personalize/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-pi/src/PIClient.ts
+++ b/clients/client-pi/src/PIClient.ts
@@ -380,7 +380,7 @@ export class PIClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-pi/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pi/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-pinpoint-email/src/PinpointEmailClient.ts
+++ b/clients/client-pinpoint-email/src/PinpointEmailClient.ts
@@ -546,7 +546,7 @@ export class PinpointEmailClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-pinpoint-email/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint-email/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-pinpoint-sms-voice-v2/src/PinpointSMSVoiceV2Client.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/PinpointSMSVoiceV2Client.ts
@@ -775,7 +775,7 @@ export class PinpointSMSVoiceV2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-pinpoint-sms-voice-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-pinpoint-sms-voice/src/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/src/PinpointSMSVoiceClient.ts
@@ -332,7 +332,7 @@ export class PinpointSMSVoiceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-pinpoint-sms-voice/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint-sms-voice/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-pinpoint/src/PinpointClient.ts
+++ b/clients/client-pinpoint/src/PinpointClient.ts
@@ -776,7 +776,7 @@ export class PinpointClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-pinpoint/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-pipes/src/PipesClient.ts
+++ b/clients/client-pipes/src/PipesClient.ts
@@ -325,7 +325,7 @@ export class PipesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-pipes/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pipes/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-polly/src/PollyClient.ts
+++ b/clients/client-polly/src/PollyClient.ts
@@ -335,7 +335,7 @@ export class PollyClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-polly/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-polly/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-pricing/src/PricingClient.ts
+++ b/clients/client-pricing/src/PricingClient.ts
@@ -333,7 +333,7 @@ export class PricingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-pricing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pricing/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-privatenetworks/src/PrivateNetworksClient.ts
+++ b/clients/client-privatenetworks/src/PrivateNetworksClient.ts
@@ -401,7 +401,7 @@ export class PrivateNetworksClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-privatenetworks/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-privatenetworks/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-proton/src/ProtonClient.ts
+++ b/clients/client-proton/src/ProtonClient.ts
@@ -856,7 +856,7 @@ export class ProtonClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-proton/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-proton/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-qapps/src/QAppsClient.ts
+++ b/clients/client-qapps/src/QAppsClient.ts
@@ -449,7 +449,7 @@ export class QAppsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-qapps/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qapps/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-qbusiness/src/QBusinessClient.ts
+++ b/clients/client-qbusiness/src/QBusinessClient.ts
@@ -626,7 +626,7 @@ export class QBusinessClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveEventStreamConfig(_config_8);
     const _config_10 = resolveRuntimeExtensions(_config_9, configuration?.extensions || []);
     super(_config_10);

--- a/clients/client-qbusiness/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qbusiness/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-qconnect/src/QConnectClient.ts
+++ b/clients/client-qconnect/src/QConnectClient.ts
@@ -719,7 +719,7 @@ export class QConnectClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-qconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qconnect/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-qldb-session/src/QLDBSessionClient.ts
+++ b/clients/client-qldb-session/src/QLDBSessionClient.ts
@@ -308,7 +308,7 @@ export class QLDBSessionClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-qldb-session/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qldb-session/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-qldb/src/QLDBClient.ts
+++ b/clients/client-qldb/src/QLDBClient.ts
@@ -374,7 +374,7 @@ export class QLDBClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-qldb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qldb/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-quicksight/src/QuickSightClient.ts
+++ b/clients/client-quicksight/src/QuickSightClient.ts
@@ -1293,7 +1293,7 @@ export class QuickSightClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-quicksight/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-quicksight/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ram/src/RAMClient.ts
+++ b/clients/client-ram/src/RAMClient.ts
@@ -480,7 +480,7 @@ export class RAMClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ram/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ram/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-rbin/src/RbinClient.ts
+++ b/clients/client-rbin/src/RbinClient.ts
@@ -331,7 +331,7 @@ export class RbinClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-rbin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rbin/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-rds-data/src/RDSDataClient.ts
+++ b/clients/client-rds-data/src/RDSDataClient.ts
@@ -325,7 +325,7 @@ export class RDSDataClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-rds-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rds-data/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-rds/src/RDSClient.ts
+++ b/clients/client-rds/src/RDSClient.ts
@@ -1179,7 +1179,7 @@ export class RDSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-rds/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rds/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-redshift-data/src/RedshiftDataClient.ts
+++ b/clients/client-redshift-data/src/RedshiftDataClient.ts
@@ -330,7 +330,7 @@ export class RedshiftDataClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-redshift-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-redshift-data/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-redshift-serverless/src/RedshiftServerlessClient.ts
+++ b/clients/client-redshift-serverless/src/RedshiftServerlessClient.ts
@@ -547,7 +547,7 @@ export class RedshiftServerlessClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-redshift-serverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-redshift-serverless/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-redshift/src/RedshiftClient.ts
+++ b/clients/client-redshift/src/RedshiftClient.ts
@@ -1042,7 +1042,7 @@ export class RedshiftClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-redshift/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-redshift/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-rekognition/src/RekognitionClient.ts
+++ b/clients/client-rekognition/src/RekognitionClient.ts
@@ -981,7 +981,7 @@ export class RekognitionClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-rekognition/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rekognition/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-rekognitionstreaming/src/RekognitionStreamingClient.ts
+++ b/clients/client-rekognitionstreaming/src/RekognitionStreamingClient.ts
@@ -343,7 +343,7 @@ export class RekognitionStreamingClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveEventStreamConfig(_config_8);
     const _config_10 = resolveWebSocketConfig(_config_9);
     const _config_11 = resolveRuntimeExtensions(_config_10, configuration?.extensions || []);

--- a/clients/client-rekognitionstreaming/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rekognitionstreaming/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-repostspace/src/RepostspaceClient.ts
+++ b/clients/client-repostspace/src/RepostspaceClient.ts
@@ -329,7 +329,7 @@ export class RepostspaceClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-repostspace/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-repostspace/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-resiliencehub/src/ResiliencehubClient.ts
+++ b/clients/client-resiliencehub/src/ResiliencehubClient.ts
@@ -624,7 +624,7 @@ export class ResiliencehubClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-resiliencehub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resiliencehub/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-resource-explorer-2/src/ResourceExplorer2Client.ts
+++ b/clients/client-resource-explorer-2/src/ResourceExplorer2Client.ts
@@ -397,7 +397,7 @@ export class ResourceExplorer2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-resource-explorer-2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resource-explorer-2/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-resource-groups-tagging-api/src/ResourceGroupsTaggingAPIClient.ts
+++ b/clients/client-resource-groups-tagging-api/src/ResourceGroupsTaggingAPIClient.ts
@@ -321,7 +321,7 @@ export class ResourceGroupsTaggingAPIClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-resource-groups-tagging-api/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resource-groups-tagging-api/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-resource-groups/src/ResourceGroupsClient.ts
+++ b/clients/client-resource-groups/src/ResourceGroupsClient.ts
@@ -401,7 +401,7 @@ export class ResourceGroupsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-resource-groups/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resource-groups/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-robomaker/src/RoboMakerClient.ts
+++ b/clients/client-robomaker/src/RoboMakerClient.ts
@@ -572,7 +572,7 @@ export class RoboMakerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-robomaker/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-robomaker/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-rolesanywhere/src/RolesAnywhereClient.ts
+++ b/clients/client-rolesanywhere/src/RolesAnywhereClient.ts
@@ -406,7 +406,7 @@ export class RolesAnywhereClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-rolesanywhere/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rolesanywhere/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-route-53-domains/src/Route53DomainsClient.ts
+++ b/clients/client-route-53-domains/src/Route53DomainsClient.ts
@@ -456,7 +456,7 @@ export class Route53DomainsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-route-53-domains/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route-53-domains/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-route-53/src/Route53Client.ts
+++ b/clients/client-route-53/src/Route53Client.ts
@@ -660,7 +660,7 @@ export class Route53Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-route-53/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route-53/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-route53-recovery-cluster/src/Route53RecoveryClusterClient.ts
+++ b/clients/client-route53-recovery-cluster/src/Route53RecoveryClusterClient.ts
@@ -350,7 +350,7 @@ export class Route53RecoveryClusterClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-route53-recovery-cluster/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53-recovery-cluster/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-route53-recovery-control-config/src/Route53RecoveryControlConfigClient.ts
+++ b/clients/client-route53-recovery-control-config/src/Route53RecoveryControlConfigClient.ts
@@ -384,7 +384,7 @@ export class Route53RecoveryControlConfigClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-route53-recovery-control-config/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53-recovery-control-config/src/auth/httpAuthSchemeProvider.ts
@@ -134,10 +134,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-route53-recovery-readiness/src/Route53RecoveryReadinessClient.ts
+++ b/clients/client-route53-recovery-readiness/src/Route53RecoveryReadinessClient.ts
@@ -432,7 +432,7 @@ export class Route53RecoveryReadinessClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-route53-recovery-readiness/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53-recovery-readiness/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-route53profiles/src/Route53ProfilesClient.ts
+++ b/clients/client-route53profiles/src/Route53ProfilesClient.ts
@@ -364,7 +364,7 @@ export class Route53ProfilesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-route53profiles/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53profiles/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-route53resolver/src/Route53ResolverClient.ts
+++ b/clients/client-route53resolver/src/Route53ResolverClient.ts
@@ -679,7 +679,7 @@ export class Route53ResolverClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-route53resolver/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53resolver/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-rum/src/RUMClient.ts
+++ b/clients/client-rum/src/RUMClient.ts
@@ -381,7 +381,7 @@ export class RUMClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-rum/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rum/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-s3-control/src/S3ControlClient.ts
+++ b/clients/client-s3-control/src/S3ControlClient.ts
@@ -790,7 +790,7 @@ export class S3ControlClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveS3ControlConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveRuntimeExtensions(_config_8, configuration?.extensions || []);
     super(_config_9);
     this.config = _config_9;

--- a/clients/client-s3-control/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3-control/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-s3/src/S3Client.ts
+++ b/clients/client-s3/src/S3Client.ts
@@ -835,7 +835,7 @@ export class S3Client extends __Client<
     const _config_6 = resolveHostHeaderConfig(_config_5);
     const _config_7 = resolveEndpointConfig(_config_6);
     const _config_8 = resolveEventStreamSerdeConfig(_config_7);
-    const _config_9 = resolveHttpAuthSchemeConfig(_config_8);
+    const _config_9 = resolveHttpAuthSchemeConfig(_config_8, { client: () => this });
     const _config_10 = resolveS3Config(_config_9, { session: [() => this, CreateSessionCommand] });
     const _config_11 = resolveRuntimeExtensions(_config_10, configuration?.extensions || []);
     super(_config_11);

--- a/clients/client-s3/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3/src/auth/httpAuthSchemeProvider.ts
@@ -319,10 +319,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   const config_1 = resolveAwsSdkSigV4AConfig(config_0);
   return {
     ...config_1,

--- a/clients/client-s3outposts/src/S3OutpostsClient.ts
+++ b/clients/client-s3outposts/src/S3OutpostsClient.ts
@@ -305,7 +305,7 @@ export class S3OutpostsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-s3outposts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3outposts/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-s3tables/src/S3TablesClient.ts
+++ b/clients/client-s3tables/src/S3TablesClient.ts
@@ -395,7 +395,7 @@ export class S3TablesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-s3tables/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3tables/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sagemaker-a2i-runtime/src/SageMakerA2IRuntimeClient.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/SageMakerA2IRuntimeClient.ts
@@ -327,7 +327,7 @@ export class SageMakerA2IRuntimeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sagemaker-a2i-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sagemaker-edge/src/SagemakerEdgeClient.ts
+++ b/clients/client-sagemaker-edge/src/SagemakerEdgeClient.ts
@@ -299,7 +299,7 @@ export class SagemakerEdgeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sagemaker-edge/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-edge/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sagemaker-featurestore-runtime/src/SageMakerFeatureStoreRuntimeClient.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/SageMakerFeatureStoreRuntimeClient.ts
@@ -326,7 +326,7 @@ export class SageMakerFeatureStoreRuntimeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sagemaker-featurestore-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -134,10 +134,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sagemaker-geospatial/src/SageMakerGeospatialClient.ts
+++ b/clients/client-sagemaker-geospatial/src/SageMakerGeospatialClient.ts
@@ -399,7 +399,7 @@ export class SageMakerGeospatialClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sagemaker-geospatial/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-geospatial/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sagemaker-metrics/src/SageMakerMetricsClient.ts
+++ b/clients/client-sagemaker-metrics/src/SageMakerMetricsClient.ts
@@ -297,7 +297,7 @@ export class SageMakerMetricsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sagemaker-metrics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-metrics/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sagemaker-runtime/src/SageMakerRuntimeClient.ts
+++ b/clients/client-sagemaker-runtime/src/SageMakerRuntimeClient.ts
@@ -316,7 +316,7 @@ export class SageMakerRuntimeClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveRuntimeExtensions(_config_8, configuration?.extensions || []);
     super(_config_9);
     this.config = _config_9;

--- a/clients/client-sagemaker-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sagemaker/src/SageMakerClient.ts
+++ b/clients/client-sagemaker/src/SageMakerClient.ts
@@ -1946,7 +1946,7 @@ export class SageMakerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sagemaker/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-savingsplans/src/SavingsplansClient.ts
+++ b/clients/client-savingsplans/src/SavingsplansClient.ts
@@ -338,7 +338,7 @@ export class SavingsplansClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-savingsplans/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-savingsplans/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-scheduler/src/SchedulerClient.ts
+++ b/clients/client-scheduler/src/SchedulerClient.ts
@@ -336,7 +336,7 @@ export class SchedulerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-scheduler/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-scheduler/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-schemas/src/SchemasClient.ts
+++ b/clients/client-schemas/src/SchemasClient.ts
@@ -398,7 +398,7 @@ export class SchemasClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-schemas/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-schemas/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-secrets-manager/src/SecretsManagerClient.ts
+++ b/clients/client-secrets-manager/src/SecretsManagerClient.ts
@@ -405,7 +405,7 @@ export class SecretsManagerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-secrets-manager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-secrets-manager/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-security-ir/src/SecurityIRClient.ts
+++ b/clients/client-security-ir/src/SecurityIRClient.ts
@@ -365,7 +365,7 @@ export class SecurityIRClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-security-ir/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-security-ir/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-securityhub/src/SecurityHubClient.ts
+++ b/clients/client-securityhub/src/SecurityHubClient.ts
@@ -748,7 +748,7 @@ export class SecurityHubClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-securityhub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-securityhub/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-securitylake/src/SecurityLakeClient.ts
+++ b/clients/client-securitylake/src/SecurityLakeClient.ts
@@ -453,7 +453,7 @@ export class SecurityLakeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-securitylake/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-securitylake/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-serverlessapplicationrepository/src/ServerlessApplicationRepositoryClient.ts
+++ b/clients/client-serverlessapplicationrepository/src/ServerlessApplicationRepositoryClient.ts
@@ -374,7 +374,7 @@ export class ServerlessApplicationRepositoryClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-serverlessapplicationrepository/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-serverlessapplicationrepository/src/auth/httpAuthSchemeProvider.ts
@@ -134,10 +134,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-service-catalog-appregistry/src/ServiceCatalogAppRegistryClient.ts
+++ b/clients/client-service-catalog-appregistry/src/ServiceCatalogAppRegistryClient.ts
@@ -396,7 +396,7 @@ export class ServiceCatalogAppRegistryClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-service-catalog-appregistry/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-service-catalog-appregistry/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-service-catalog/src/ServiceCatalogClient.ts
+++ b/clients/client-service-catalog/src/ServiceCatalogClient.ts
@@ -758,7 +758,7 @@ export class ServiceCatalogClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-service-catalog/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-service-catalog/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-service-quotas/src/ServiceQuotasClient.ts
+++ b/clients/client-service-quotas/src/ServiceQuotasClient.ts
@@ -388,7 +388,7 @@ export class ServiceQuotasClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-service-quotas/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-service-quotas/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-servicediscovery/src/ServiceDiscoveryClient.ts
+++ b/clients/client-servicediscovery/src/ServiceDiscoveryClient.ts
@@ -421,7 +421,7 @@ export class ServiceDiscoveryClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-servicediscovery/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-servicediscovery/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ses/src/SESClient.ts
+++ b/clients/client-ses/src/SESClient.ts
@@ -683,7 +683,7 @@ export class SESClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ses/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ses/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sesv2/src/SESv2Client.ts
+++ b/clients/client-sesv2/src/SESv2Client.ts
@@ -782,7 +782,7 @@ export class SESv2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sesv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sesv2/src/auth/httpAuthSchemeProvider.ts
@@ -316,10 +316,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   const config_1 = resolveAwsSdkSigV4AConfig(config_0);
   return {
     ...config_1,

--- a/clients/client-sfn/src/SFNClient.ts
+++ b/clients/client-sfn/src/SFNClient.ts
@@ -455,7 +455,7 @@ export class SFNClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sfn/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sfn/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-shield/src/ShieldClient.ts
+++ b/clients/client-shield/src/ShieldClient.ts
@@ -467,7 +467,7 @@ export class ShieldClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-shield/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-shield/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-signer/src/SignerClient.ts
+++ b/clients/client-signer/src/SignerClient.ts
@@ -388,7 +388,7 @@ export class SignerClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-signer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-signer/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-simspaceweaver/src/SimSpaceWeaverClient.ts
+++ b/clients/client-simspaceweaver/src/SimSpaceWeaverClient.ts
@@ -348,7 +348,7 @@ export class SimSpaceWeaverClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-simspaceweaver/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-simspaceweaver/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sms/src/SMSClient.ts
+++ b/clients/client-sms/src/SMSClient.ts
@@ -478,7 +478,7 @@ export class SMSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sms/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sms/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-snow-device-management/src/SnowDeviceManagementClient.ts
+++ b/clients/client-snow-device-management/src/SnowDeviceManagementClient.ts
@@ -335,7 +335,7 @@ export class SnowDeviceManagementClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-snow-device-management/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-snow-device-management/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-snowball/src/SnowballClient.ts
+++ b/clients/client-snowball/src/SnowballClient.ts
@@ -400,7 +400,7 @@ export class SnowballClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-snowball/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-snowball/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sns/src/SNSClient.ts
+++ b/clients/client-sns/src/SNSClient.ts
@@ -497,7 +497,7 @@ export class SNSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sns/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sns/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-socialmessaging/src/SocialMessagingClient.ts
+++ b/clients/client-socialmessaging/src/SocialMessagingClient.ts
@@ -384,7 +384,7 @@ export class SocialMessagingClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-socialmessaging/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-socialmessaging/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sqs/src/SQSClient.ts
+++ b/clients/client-sqs/src/SQSClient.ts
@@ -462,7 +462,7 @@ export class SQSClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveQueueUrlConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveRuntimeExtensions(_config_8, configuration?.extensions || []);
     super(_config_9);
     this.config = _config_9;

--- a/clients/client-sqs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sqs/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ssm-contacts/src/SSMContactsClient.ts
+++ b/clients/client-ssm-contacts/src/SSMContactsClient.ts
@@ -453,7 +453,7 @@ export class SSMContactsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ssm-contacts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-contacts/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ssm-incidents/src/SSMIncidentsClient.ts
+++ b/clients/client-ssm-incidents/src/SSMIncidentsClient.ts
@@ -435,7 +435,7 @@ export class SSMIncidentsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ssm-incidents/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-incidents/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ssm-quicksetup/src/SSMQuickSetupClient.ts
+++ b/clients/client-ssm-quicksetup/src/SSMQuickSetupClient.ts
@@ -358,7 +358,7 @@ export class SSMQuickSetupClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ssm-quicksetup/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-quicksetup/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ssm-sap/src/SsmSapClient.ts
+++ b/clients/client-ssm-sap/src/SsmSapClient.ts
@@ -379,7 +379,7 @@ export class SsmSapClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ssm-sap/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-sap/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-ssm/src/SSMClient.ts
+++ b/clients/client-ssm/src/SSMClient.ts
@@ -1040,7 +1040,7 @@ export class SSMClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-ssm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sso-admin/src/SSOAdminClient.ts
+++ b/clients/client-sso-admin/src/SSOAdminClient.ts
@@ -712,7 +712,7 @@ export class SSOAdminClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sso-admin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sso-admin/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sso-oidc/src/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/src/SSOOIDCClient.ts
@@ -340,7 +340,7 @@ export class SSOOIDCClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sso-oidc/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sso-oidc/src/auth/httpAuthSchemeProvider.ts
@@ -145,10 +145,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sso/src/SSOClient.ts
+++ b/clients/client-sso/src/SSOClient.ts
@@ -306,7 +306,7 @@ export class SSOClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sso/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sso/src/auth/httpAuthSchemeProvider.ts
@@ -149,10 +149,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-storage-gateway/src/StorageGatewayClient.ts
+++ b/clients/client-storage-gateway/src/StorageGatewayClient.ts
@@ -797,7 +797,7 @@ export class StorageGatewayClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-storage-gateway/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-storage-gateway/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-sts/src/STSClient.ts
+++ b/clients/client-sts/src/STSClient.ts
@@ -323,7 +323,7 @@ export class STSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-sts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sts/src/auth/httpAuthSchemeProvider.ts
@@ -157,11 +157,12 @@ export interface HttpAuthSchemeResolvedConfig extends StsAuthResolvedConfig, Aws
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
   const config_0 = resolveStsAuthConfig(config);
-  const config_1 = resolveAwsSdkSigV4Config(config_0);
+  const config_1 = resolveAwsSdkSigV4Config(config_0, client);
   return {
     ...config_1,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-supplychain/src/SupplyChainClient.ts
+++ b/clients/client-supplychain/src/SupplyChainClient.ts
@@ -395,7 +395,7 @@ export class SupplyChainClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-supplychain/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-supplychain/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-support-app/src/SupportAppClient.ts
+++ b/clients/client-support-app/src/SupportAppClient.ts
@@ -391,7 +391,7 @@ export class SupportAppClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-support-app/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-support-app/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-support/src/SupportClient.ts
+++ b/clients/client-support/src/SupportClient.ts
@@ -411,7 +411,7 @@ export class SupportClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-support/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-support/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-swf/src/SWFClient.ts
+++ b/clients/client-swf/src/SWFClient.ts
@@ -500,7 +500,7 @@ export class SWFClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-swf/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-swf/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-synthetics/src/SyntheticsClient.ts
+++ b/clients/client-synthetics/src/SyntheticsClient.ts
@@ -379,7 +379,7 @@ export class SyntheticsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-synthetics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-synthetics/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-taxsettings/src/TaxSettingsClient.ts
+++ b/clients/client-taxsettings/src/TaxSettingsClient.ts
@@ -376,7 +376,7 @@ export class TaxSettingsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-taxsettings/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-taxsettings/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-textract/src/TextractClient.ts
+++ b/clients/client-textract/src/TextractClient.ts
@@ -397,7 +397,7 @@ export class TextractClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-textract/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-textract/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-timestream-influxdb/src/TimestreamInfluxDBClient.ts
+++ b/clients/client-timestream-influxdb/src/TimestreamInfluxDBClient.ts
@@ -354,7 +354,7 @@ export class TimestreamInfluxDBClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-timestream-influxdb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-timestream-influxdb/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-timestream-query/src/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/src/TimestreamQueryClient.ts
@@ -379,7 +379,7 @@ export class TimestreamQueryClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveEndpointDiscoveryConfig(_config_7, {
       endpointDiscoveryCommandCtor: DescribeEndpointsCommand,
     });

--- a/clients/client-timestream-query/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-timestream-query/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-timestream-write/src/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/src/TimestreamWriteClient.ts
@@ -386,7 +386,7 @@ export class TimestreamWriteClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveEndpointDiscoveryConfig(_config_7, {
       endpointDiscoveryCommandCtor: DescribeEndpointsCommand,
     });

--- a/clients/client-timestream-write/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-timestream-write/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-tnb/src/TnbClient.ts
+++ b/clients/client-tnb/src/TnbClient.ts
@@ -483,7 +483,7 @@ export class TnbClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-tnb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-tnb/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-transcribe-streaming/src/TranscribeStreamingClient.ts
+++ b/clients/client-transcribe-streaming/src/TranscribeStreamingClient.ts
@@ -377,7 +377,7 @@ export class TranscribeStreamingClient extends __Client<
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
     const _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    const _config_8 = resolveHttpAuthSchemeConfig(_config_7);
+    const _config_8 = resolveHttpAuthSchemeConfig(_config_7, { client: () => this });
     const _config_9 = resolveEventStreamConfig(_config_8);
     const _config_10 = resolveWebSocketConfig(_config_9);
     const _config_11 = resolveRuntimeExtensions(_config_10, configuration?.extensions || []);

--- a/clients/client-transcribe-streaming/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-transcribe-streaming/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-transcribe/src/TranscribeClient.ts
+++ b/clients/client-transcribe/src/TranscribeClient.ts
@@ -542,7 +542,7 @@ export class TranscribeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-transcribe/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-transcribe/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-transfer/src/TransferClient.ts
+++ b/clients/client-transfer/src/TransferClient.ts
@@ -536,7 +536,7 @@ export class TransferClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-transfer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-transfer/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-translate/src/TranslateClient.ts
+++ b/clients/client-translate/src/TranslateClient.ts
@@ -359,7 +359,7 @@ export class TranslateClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-translate/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-translate/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-trustedadvisor/src/TrustedAdvisorClient.ts
+++ b/clients/client-trustedadvisor/src/TrustedAdvisorClient.ts
@@ -347,7 +347,7 @@ export class TrustedAdvisorClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-trustedadvisor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-trustedadvisor/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-verifiedpermissions/src/VerifiedPermissionsClient.ts
+++ b/clients/client-verifiedpermissions/src/VerifiedPermissionsClient.ts
@@ -462,7 +462,7 @@ export class VerifiedPermissionsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-verifiedpermissions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-verifiedpermissions/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-voice-id/src/VoiceIDClient.ts
+++ b/clients/client-voice-id/src/VoiceIDClient.ts
@@ -399,7 +399,7 @@ export class VoiceIDClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-voice-id/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-voice-id/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-vpc-lattice/src/VPCLatticeClient.ts
+++ b/clients/client-vpc-lattice/src/VPCLatticeClient.ts
@@ -606,7 +606,7 @@ export class VPCLatticeClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-vpc-lattice/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-vpc-lattice/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-waf-regional/src/WAFRegionalClient.ts
+++ b/clients/client-waf-regional/src/WAFRegionalClient.ts
@@ -645,7 +645,7 @@ export class WAFRegionalClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-waf-regional/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-waf-regional/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-waf/src/WAFClient.ts
+++ b/clients/client-waf/src/WAFClient.ts
@@ -627,7 +627,7 @@ export class WAFClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-waf/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-waf/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-wafv2/src/WAFV2Client.ts
+++ b/clients/client-wafv2/src/WAFV2Client.ts
@@ -565,7 +565,7 @@ export class WAFV2Client extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-wafv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wafv2/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-wellarchitected/src/WellArchitectedClient.ts
+++ b/clients/client-wellarchitected/src/WellArchitectedClient.ts
@@ -586,7 +586,7 @@ export class WellArchitectedClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-wellarchitected/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wellarchitected/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-wisdom/src/WisdomClient.ts
+++ b/clients/client-wisdom/src/WisdomClient.ts
@@ -455,7 +455,7 @@ export class WisdomClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-wisdom/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wisdom/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-workdocs/src/WorkDocsClient.ts
+++ b/clients/client-workdocs/src/WorkDocsClient.ts
@@ -531,7 +531,7 @@ export class WorkDocsClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-workdocs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workdocs/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-workmail/src/WorkMailClient.ts
+++ b/clients/client-workmail/src/WorkMailClient.ts
@@ -775,7 +775,7 @@ export class WorkMailClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-workmail/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workmail/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-workmailmessageflow/src/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/src/WorkMailMessageFlowClient.ts
@@ -306,7 +306,7 @@ export class WorkMailMessageFlowClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-workmailmessageflow/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workmailmessageflow/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-workspaces-thin-client/src/WorkSpacesThinClientClient.ts
+++ b/clients/client-workspaces-thin-client/src/WorkSpacesThinClientClient.ts
@@ -349,7 +349,7 @@ export class WorkSpacesThinClientClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-workspaces-thin-client/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces-thin-client/src/auth/httpAuthSchemeProvider.ts
@@ -135,10 +135,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-workspaces-web/src/WorkSpacesWebClient.ts
+++ b/clients/client-workspaces-web/src/WorkSpacesWebClient.ts
@@ -635,7 +635,7 @@ export class WorkSpacesWebClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-workspaces-web/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces-web/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-workspaces/src/WorkSpacesClient.ts
+++ b/clients/client-workspaces/src/WorkSpacesClient.ts
@@ -768,7 +768,7 @@ export class WorkSpacesClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-workspaces/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/clients/client-xray/src/XRayClient.ts
+++ b/clients/client-xray/src/XRayClient.ts
@@ -450,7 +450,7 @@ export class XRayClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/clients/client-xray/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-xray/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
@@ -185,6 +185,7 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                         .namespace(AwsDependency.AWS_SDK_CORE.getPackageName(), "/")
                         .addDependency(AwsDependency.AWS_SDK_CORE)
                         .build())
+                    .addArgs(List.of("client"))
                     .inputConfig(Symbol.builder()
                         .name("AwsSdkSigV4AuthInputConfig")
                         .namespace(AwsDependency.AWS_SDK_CORE.getPackageName(), "/")

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
@@ -102,7 +102,10 @@ export interface AwsSdkSigV4AuthResolvedConfig {
  * @internal
  */
 export const resolveAwsSdkSigV4Config = <T>(
-  config: T & AwsSdkSigV4AuthInputConfig & AwsSdkSigV4PreviouslyResolved
+  config: T & AwsSdkSigV4AuthInputConfig & AwsSdkSigV4PreviouslyResolved,
+  client?: () => {
+    config: AwsSdkSigV4AuthResolvedConfig;
+  }
 ): T & AwsSdkSigV4AuthResolvedConfig => {
   let isUserSupplied = false;
   // Normalize credentials
@@ -208,7 +211,7 @@ export const resolveAwsSdkSigV4Config = <T>(
 
       const params: SignatureV4Init & SignatureV4CryptoInit = {
         ...config,
-        credentials: boundCredentialsProvider,
+        credentials: client?.().config.credentials ?? boundCredentialsProvider,
         region: config.signingRegion,
         service: config.signingName,
         sha256,

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
@@ -104,7 +104,7 @@ export interface AwsSdkSigV4AuthResolvedConfig {
 export const resolveAwsSdkSigV4Config = <T>(
   config: T & AwsSdkSigV4AuthInputConfig & AwsSdkSigV4PreviouslyResolved,
   client?: () => {
-    config: AwsSdkSigV4AuthResolvedConfig;
+    config: Pick<AwsSdkSigV4AuthInputConfig, "credentials">;
   }
 ): T & AwsSdkSigV4AuthResolvedConfig => {
   let isUserSupplied = false;

--- a/packages/nested-clients/src/submodules/sso-oidc/SSOOIDCClient.ts
+++ b/packages/nested-clients/src/submodules/sso-oidc/SSOOIDCClient.ts
@@ -318,7 +318,7 @@ export class SSOOIDCClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/packages/nested-clients/src/submodules/sso-oidc/auth/httpAuthSchemeProvider.ts
+++ b/packages/nested-clients/src/submodules/sso-oidc/auth/httpAuthSchemeProvider.ts
@@ -137,10 +137,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/packages/nested-clients/src/submodules/sts/STSClient.ts
+++ b/packages/nested-clients/src/submodules/sts/STSClient.ts
@@ -295,7 +295,7 @@ export class STSClient extends __Client<
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);
-    const _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    const _config_7 = resolveHttpAuthSchemeConfig(_config_6, { client: () => this });
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);
     this.config = _config_8;

--- a/packages/nested-clients/src/submodules/sts/auth/httpAuthSchemeProvider.ts
+++ b/packages/nested-clients/src/submodules/sts/auth/httpAuthSchemeProvider.ts
@@ -153,11 +153,12 @@ export interface HttpAuthSchemeResolvedConfig extends StsAuthResolvedConfig, Aws
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
   const config_0 = resolveStsAuthConfig(config);
-  const config_1 = resolveAwsSdkSigV4Config(config_0);
+  const config_1 = resolveAwsSdkSigV4Config(config_0, client);
   return {
     ...config_1,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/private/aws-echo-service/src/EchoServiceClient.ts
+++ b/private/aws-echo-service/src/EchoServiceClient.ts
@@ -244,7 +244,7 @@ export class EchoServiceClient extends __Client<
     let _config_2 = resolveCustomEndpointsConfig(_config_1);
     let _config_3 = resolveRetryConfig(_config_2);
     let _config_4 = resolveHostHeaderConfig(_config_3);
-    let _config_5 = resolveHttpAuthSchemeConfig(_config_4);
+    let _config_5 = resolveHttpAuthSchemeConfig(_config_4, { client: () => this });
     let _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
     super(_config_6);
     this.config = _config_6;

--- a/private/aws-echo-service/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-echo-service/src/auth/httpAuthSchemeProvider.ts
@@ -101,8 +101,9 @@ export interface HttpAuthSchemeResolvedConfig {
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
   return {
     ...config,

--- a/private/aws-protocoltests-ec2/src/EC2ProtocolClient.ts
+++ b/private/aws-protocoltests-ec2/src/EC2ProtocolClient.ts
@@ -389,7 +389,7 @@ export class EC2ProtocolClient extends __Client<
     const _config_3 = resolveRegionConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveEndpointsConfig(_config_4);
-    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5, { client: () => this });
     const _config_7 = resolveCompressionConfig(_config_6);
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);

--- a/private/aws-protocoltests-ec2/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-ec2/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/private/aws-protocoltests-json-10/src/JSONRPC10Client.ts
+++ b/private/aws-protocoltests-json-10/src/JSONRPC10Client.ts
@@ -367,7 +367,7 @@ export class JSONRPC10Client extends __Client<
     const _config_3 = resolveRegionConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveEndpointsConfig(_config_4);
-    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5, { client: () => this });
     const _config_7 = resolveCompressionConfig(_config_6);
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);

--- a/private/aws-protocoltests-json-10/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-10/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/private/aws-protocoltests-json-machinelearning/src/MachineLearningClient.ts
+++ b/private/aws-protocoltests-json-machinelearning/src/MachineLearningClient.ts
@@ -286,7 +286,7 @@ export class MachineLearningClient extends __Client<
     const _config_3 = resolveRegionConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveEndpointsConfig(_config_4);
-    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5, { client: () => this });
     const _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
     super(_config_7);
     this.config = _config_7;

--- a/private/aws-protocoltests-json-machinelearning/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-machinelearning/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/private/aws-protocoltests-json/src/JsonProtocolClient.ts
+++ b/private/aws-protocoltests-json/src/JsonProtocolClient.ts
@@ -373,7 +373,7 @@ export class JsonProtocolClient extends __Client<
     const _config_3 = resolveRegionConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveEndpointsConfig(_config_4);
-    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5, { client: () => this });
     const _config_7 = resolveCompressionConfig(_config_6);
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);

--- a/private/aws-protocoltests-json/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/private/aws-protocoltests-query/src/QueryProtocolClient.ts
+++ b/private/aws-protocoltests-query/src/QueryProtocolClient.ts
@@ -419,7 +419,7 @@ export class QueryProtocolClient extends __Client<
     const _config_3 = resolveRegionConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveEndpointsConfig(_config_4);
-    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5, { client: () => this });
     const _config_7 = resolveCompressionConfig(_config_6);
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);

--- a/private/aws-protocoltests-query/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-query/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/private/aws-protocoltests-restjson-apigateway/src/APIGatewayClient.ts
+++ b/private/aws-protocoltests-restjson-apigateway/src/APIGatewayClient.ts
@@ -287,7 +287,7 @@ export class APIGatewayClient extends __Client<
     const _config_3 = resolveRegionConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveEndpointsConfig(_config_4);
-    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5, { client: () => this });
     const _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
     super(_config_7);
     this.config = _config_7;

--- a/private/aws-protocoltests-restjson-apigateway/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-apigateway/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/private/aws-protocoltests-restjson-glacier/src/GlacierClient.ts
+++ b/private/aws-protocoltests-restjson-glacier/src/GlacierClient.ts
@@ -301,7 +301,7 @@ export class GlacierClient extends __Client<
     const _config_3 = resolveRegionConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveEndpointsConfig(_config_4);
-    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5, { client: () => this });
     const _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
     super(_config_7);
     this.config = _config_7;

--- a/private/aws-protocoltests-restjson-glacier/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-glacier/src/auth/httpAuthSchemeProvider.ts
@@ -127,10 +127,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
+++ b/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
@@ -812,7 +812,7 @@ export class RestJsonProtocolClient extends __Client<
     const _config_3 = resolveRegionConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveEndpointsConfig(_config_4);
-    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5, { client: () => this });
     const _config_7 = resolveCompressionConfig(_config_6);
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);

--- a/private/aws-protocoltests-restjson/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson/src/auth/httpAuthSchemeProvider.ts
@@ -130,10 +130,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/private/aws-protocoltests-restxml/src/RestXmlProtocolClient.ts
+++ b/private/aws-protocoltests-restxml/src/RestXmlProtocolClient.ts
@@ -581,7 +581,7 @@ export class RestXmlProtocolClient extends __Client<
     const _config_3 = resolveRegionConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
     const _config_5 = resolveEndpointsConfig(_config_4);
-    const _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    const _config_6 = resolveHttpAuthSchemeConfig(_config_5, { client: () => this });
     const _config_7 = resolveCompressionConfig(_config_6);
     const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
     super(_config_8);

--- a/private/aws-protocoltests-restxml/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restxml/src/auth/httpAuthSchemeProvider.ts
@@ -128,10 +128,11 @@ export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedCon
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_0 = resolveAwsSdkSigV4Config(config, client);
   return {
     ...config_0,
   } as T & HttpAuthSchemeResolvedConfig;

--- a/private/aws-protocoltests-smithy-rpcv2-cbor/src/RpcV2ProtocolClient.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor/src/RpcV2ProtocolClient.ts
@@ -297,7 +297,7 @@ export class RpcV2ProtocolClient extends __Client<
     const _config_2 = resolveCustomEndpointsConfig(_config_1);
     const _config_3 = resolveRetryConfig(_config_2);
     const _config_4 = resolveHostHeaderConfig(_config_3);
-    const _config_5 = resolveHttpAuthSchemeConfig(_config_4);
+    const _config_5 = resolveHttpAuthSchemeConfig(_config_4, { client: () => this });
     const _config_6 = resolveRuntimeExtensions(_config_5, configuration?.extensions || []);
     super(_config_6);
     this.config = _config_6;

--- a/private/aws-protocoltests-smithy-rpcv2-cbor/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor/src/auth/httpAuthSchemeProvider.ts
@@ -102,8 +102,9 @@ export interface HttpAuthSchemeResolvedConfig {
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
   return {
     ...config,

--- a/private/weather-legacy-auth/src/middleware/HttpApiKeyAuth/index.ts
+++ b/private/weather-legacy-auth/src/middleware/HttpApiKeyAuth/index.ts
@@ -1,6 +1,6 @@
 // smithy-typescript generated code
 // Please do not touch this file. It's generated from a template in:
-// https://github.com/awslabs/smithy-typescript/blob/main/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/integration/http-api-key-auth.ts
+// https://github.com/smithy-lang/smithy-typescript/blob/main/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/integration/http-api-key-auth.ts
 // derived from https://github.com/aws/aws-sdk-js-v3/blob/e35f78c97fa6710ff9c444351893f0f06755e771/packages/middleware-endpoint-discovery/src/endpointDiscoveryMiddleware.ts
 
 import { HttpRequest } from "@smithy/protocol-http";

--- a/private/weather/src/WeatherClient.ts
+++ b/private/weather/src/WeatherClient.ts
@@ -310,7 +310,7 @@ export class WeatherClient extends __Client<
     let _config_3 = resolveRetryConfig(_config_2);
     let _config_4 = resolveRegionConfig(_config_3);
     let _config_5 = resolveHostHeaderConfig(_config_4);
-    let _config_6 = resolveHttpAuthSchemeConfig(_config_5);
+    let _config_6 = resolveHttpAuthSchemeConfig(_config_5, { client: () => this });
     let _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
     super(_config_7);
     this.config = _config_7;

--- a/private/weather/src/auth/httpAuthSchemeProvider.ts
+++ b/private/weather/src/auth/httpAuthSchemeProvider.ts
@@ -236,8 +236,9 @@ export interface HttpAuthSchemeResolvedConfig {
 /**
  * @internal
  */
-export const resolveHttpAuthSchemeConfig = <T>(
-  config: T & HttpAuthSchemeInputConfig
+export const resolveHttpAuthSchemeConfig = <T, R extends object>(
+  config: T & HttpAuthSchemeInputConfig,
+  { client }: { client: () => { config: R } }
 ): T & HttpAuthSchemeResolvedConfig => {
   const apiKey = memoizeIdentityProvider(config.apiKey, isIdentityExpired, doesIdentityRequireRefresh);
   const credentials = memoizeIdentityProvider(config.credentials, isIdentityExpired, doesIdentityRequireRefresh);

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "9ffe82d60dd45787a4279eb9723290edb39d0e10",
+  SMITHY_TS_COMMIT: "6e6e5722397bd95b20ff09154db54a7c67e947d6",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "6e6e5722397bd95b20ff09154db54a7c67e947d6",
+  SMITHY_TS_COMMIT: "234b491f667101e08fab524b7d88c67bfed64c46",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
addresses https://github.com/aws/aws-sdk-js-v3/issues/6954

requires https://github.com/smithy-lang/smithy-typescript/pull/1548

allow the sigV4ConfigResolver to access the client and its resolved credentialsProvider when instantiating request signers

- [x] smithy hash update
- [x] needs full codegen 