### PR TITLE
fix: pass through credentials parameters when wrapping the provider

### DIFF
--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
@@ -129,7 +129,7 @@ export const resolveAwsSdkSigV4Config = <T>(
     }
   }
 
-  const boundCredentialsProvider = async () => credentialsProvider!({ callerClientConfig: config });
+  const boundCredentialsProvider = async (options: Record<string, any> | undefined) => credentialsProvider!({ ...options, callerClientConfig: config });
 
   // Populate sigv4 arguments
   const {
@@ -225,8 +225,8 @@ export const resolveAwsSdkSigV4Config = <T>(
     systemClockOffset,
     signingEscapePath,
     credentials: isUserSupplied
-      ? async () =>
-          boundCredentialsProvider!().then((creds: AttributedAwsCredentialIdentity) =>
+      ? async (options: Record<string, any> | undefined) =>
+          boundCredentialsProvider!(options).then((creds: AttributedAwsCredentialIdentity) =>
             setCredentialFeature(creds, "CREDENTIALS_CODE", "e")
           )
       : boundCredentialsProvider!,


### PR DESCRIPTION
### Issue
#6960


### Description

Passes through credentials parameter object when wrapping the credential provider

### Testing
Minimal reproduction example in linked issue

### Additional context
Fixes inadvertent behaviour change. Issue recently rolled out into bundled Lambda runtime.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
