### PR TITLE
docs(middleware-flexible-checksums): add api annotations

### DIFF
--- a/packages/middleware-flexible-checksums/api-extractor.json
+++ b/packages/middleware-flexible-checksums/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -9,6 +9,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "extract:docs": "api-extractor run --local",
     "test": "yarn g:vitest run",
     "test:watch": "yarn g:vitest watch",
     "test:integration": "yarn g:vitest run -c vitest.config.integ.ts",

--- a/packages/middleware-flexible-checksums/src/NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS.ts
+++ b/packages/middleware-flexible-checksums/src/NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS.ts
@@ -3,9 +3,19 @@ import { LoadedConfigSelectors } from "@smithy/node-config-provider";
 import { DEFAULT_REQUEST_CHECKSUM_CALCULATION, RequestChecksumCalculation } from "./constants";
 import { SelectorType, stringUnionSelector } from "./stringUnionSelector";
 
+/**
+ * @internal
+ */
 export const ENV_REQUEST_CHECKSUM_CALCULATION = "AWS_REQUEST_CHECKSUM_CALCULATION";
+
+/**
+ * @internal
+ */
 export const CONFIG_REQUEST_CHECKSUM_CALCULATION = "request_checksum_calculation";
 
+/**
+ * @internal
+ */
 export const NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS: LoadedConfigSelectors<RequestChecksumCalculation> = {
   environmentVariableSelector: (env) =>
     stringUnionSelector(env, ENV_REQUEST_CHECKSUM_CALCULATION, RequestChecksumCalculation, SelectorType.ENV),

--- a/packages/middleware-flexible-checksums/src/NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS.ts
+++ b/packages/middleware-flexible-checksums/src/NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS.ts
@@ -3,9 +3,19 @@ import { LoadedConfigSelectors } from "@smithy/node-config-provider";
 import { DEFAULT_RESPONSE_CHECKSUM_VALIDATION, ResponseChecksumValidation } from "./constants";
 import { SelectorType, stringUnionSelector } from "./stringUnionSelector";
 
+/**
+ * @internal
+ */
 export const ENV_RESPONSE_CHECKSUM_VALIDATION = "AWS_RESPONSE_CHECKSUM_VALIDATION";
+
+/**
+ * @internal
+ */
 export const CONFIG_RESPONSE_CHECKSUM_VALIDATION = "response_checksum_validation";
 
+/**
+ * @internal
+ */
 export const NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS: LoadedConfigSelectors<ResponseChecksumValidation> = {
   environmentVariableSelector: (env) =>
     stringUnionSelector(env, ENV_RESPONSE_CHECKSUM_VALIDATION, ResponseChecksumValidation, SelectorType.ENV),

--- a/packages/middleware-flexible-checksums/src/configuration.ts
+++ b/packages/middleware-flexible-checksums/src/configuration.ts
@@ -11,6 +11,9 @@ import {
 
 import { RequestChecksumCalculation, ResponseChecksumValidation } from "./constants";
 
+/**
+ * @internal
+ */
 export interface PreviouslyResolved {
   /**
    * The function that will be used to convert binary data to a base64-encoded string.

--- a/packages/middleware-flexible-checksums/src/constants.ts
+++ b/packages/middleware-flexible-checksums/src/constants.ts
@@ -1,5 +1,6 @@
 /**
  * Determines when a checksum will be calculated for request payloads.
+ * @public
  */
 export const RequestChecksumCalculation = {
   /**
@@ -19,12 +20,19 @@ export const RequestChecksumCalculation = {
   WHEN_REQUIRED: "WHEN_REQUIRED",
 } as const;
 
+/**
+ * @public
+ */
 export type RequestChecksumCalculation = (typeof RequestChecksumCalculation)[keyof typeof RequestChecksumCalculation];
 
+/**
+ * @internal
+ */
 export const DEFAULT_REQUEST_CHECKSUM_CALCULATION = RequestChecksumCalculation.WHEN_SUPPORTED;
 
 /**
  * Determines when checksum validation will be performed on response payloads.
+ * @public
  */
 export const ResponseChecksumValidation = {
   /**
@@ -44,12 +52,19 @@ export const ResponseChecksumValidation = {
   WHEN_REQUIRED: "WHEN_REQUIRED",
 } as const;
 
+/**
+ * @public
+ */
 export type ResponseChecksumValidation = (typeof ResponseChecksumValidation)[keyof typeof ResponseChecksumValidation];
 
+/**
+ * @internal
+ */
 export const DEFAULT_RESPONSE_CHECKSUM_VALIDATION = RequestChecksumCalculation.WHEN_SUPPORTED;
 
 /**
  * Checksum Algorithms supported by the SDK.
+ * @public
  */
 export enum ChecksumAlgorithm {
   /**
@@ -65,6 +80,7 @@ export enum ChecksumAlgorithm {
 
 /**
  * Location when the checksum is stored in the request body.
+ * @internal
  */
 export enum ChecksumLocation {
   HEADER = "header",

--- a/packages/middleware-flexible-checksums/src/crc64-nvme-crt-container.ts
+++ b/packages/middleware-flexible-checksums/src/crc64-nvme-crt-container.ts
@@ -1,7 +1,7 @@
 import { ChecksumConstructor } from "@smithy/types";
 
 /**
- * @public
+ * @internal
  *
  * \@aws-sdk/crc64-nvme-crt will install the constructor in this
  * container if it is installed.

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsInputMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsInputMiddleware.ts
@@ -12,6 +12,9 @@ import {
 import { PreviouslyResolved } from "./configuration";
 import { RequestChecksumCalculation, ResponseChecksumValidation } from "./constants";
 
+/**
+ * @internal
+ */
 export interface FlexibleChecksumsInputMiddlewareConfig {
   /**
    * Defines a top-level operation input member used to opt-in to best-effort validation

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -21,8 +21,10 @@ import { isStreaming } from "./isStreaming";
 import { selectChecksumAlgorithmFunction } from "./selectChecksumAlgorithmFunction";
 import { stringHasher } from "./stringHasher";
 
+/**
+ * @internal
+ */
 export interface FlexibleChecksumsRequestMiddlewareConfig {
-  /**
   /**
    * Indicates an operation requires a checksum in its HTTP request.
    */
@@ -45,6 +47,9 @@ export interface FlexibleChecksumsRequestMiddlewareConfig {
   };
 }
 
+/**
+ * @internal
+ */
 export const flexibleChecksumsMiddlewareOptions: BuildHandlerOptions = {
   name: "flexibleChecksumsMiddleware",
   step: "build",

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsResponseMiddleware.ts
@@ -16,6 +16,9 @@ import { getChecksumLocationName } from "./getChecksumLocationName";
 import { isChecksumWithPartNumber } from "./isChecksumWithPartNumber";
 import { validateChecksumFromResponse } from "./validateChecksumFromResponse";
 
+/**
+ * @internal
+ */
 export interface FlexibleChecksumsResponseMiddlewareConfig {
   /**
    * Defines a top-level operation input member used to opt-in to best-effort validation

--- a/packages/middleware-flexible-checksums/src/getFlexibleChecksumsPlugin.ts
+++ b/packages/middleware-flexible-checksums/src/getFlexibleChecksumsPlugin.ts
@@ -17,11 +17,17 @@ import {
   flexibleChecksumsResponseMiddlewareOptions,
 } from "./flexibleChecksumsResponseMiddleware";
 
+/**
+ * @internal
+ */
 export interface FlexibleChecksumsMiddlewareConfig
   extends FlexibleChecksumsRequestMiddlewareConfig,
     FlexibleChecksumsInputMiddlewareConfig,
     FlexibleChecksumsResponseMiddlewareConfig {}
 
+/**
+ * @internal
+ */
 export const getFlexibleChecksumsPlugin = (
   config: PreviouslyResolved,
   middlewareConfig: FlexibleChecksumsMiddlewareConfig

--- a/packages/middleware-flexible-checksums/src/resolveFlexibleChecksumsConfig.ts
+++ b/packages/middleware-flexible-checksums/src/resolveFlexibleChecksumsConfig.ts
@@ -8,6 +8,9 @@ import {
   ResponseChecksumValidation,
 } from "./constants";
 
+/**
+ * @public
+ */
 export interface FlexibleChecksumsInputConfig {
   /**
    * Determines when a checksum will be calculated for request payloads.
@@ -37,12 +40,18 @@ export interface FlexibleChecksumsInputConfig {
   requestStreamBufferSize?: number | false;
 }
 
+/**
+ * @internal
+ */
 export interface FlexibleChecksumsResolvedConfig {
   requestChecksumCalculation: Provider<RequestChecksumCalculation>;
   responseChecksumValidation: Provider<ResponseChecksumValidation>;
   requestStreamBufferSize: number;
 }
 
+/**
+ * @internal
+ */
 export const resolveFlexibleChecksumsConfig = <T>(
   input: T & FlexibleChecksumsInputConfig
 ): T & FlexibleChecksumsResolvedConfig => ({


### PR DESCRIPTION
adds missing api extractor configs and api annotation to the flexible checksums package