### PR TITLE
docs: add missing extract:docs commands

### DIFF
--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -9,6 +9,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "extract:docs": "api-extractor run --local",
     "test": "yarn g:vitest run",
     "test:integration": "yarn g:vitest run -c vitest.config.integ.ts",
     "test:watch": "yarn g:vitest watch",

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -9,6 +9,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "extract:docs": "api-extractor run --local",
     "test": "yarn g:vitest run",
     "test:integration": "yarn g:vitest run -c vitest.config.integ.ts",
     "test:watch": "yarn g:vitest watch",


### PR DESCRIPTION
adds `extract:docs` scripts to packages that recently had api-extractor.json configuration added