### PR TITLE
fix(core/httpAuthSchemes): fix type declaration of resolved credentials

### DIFF
--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
@@ -1,5 +1,5 @@
 import { setCredentialFeature } from "@aws-sdk/core/client";
-import { AttributedAwsCredentialIdentity } from "@aws-sdk/types";
+import type { AttributedAwsCredentialIdentity, MergeFunctions } from "@aws-sdk/types";
 import {
   doesIdentityRequireRefresh,
   isIdentityExpired,
@@ -81,9 +81,8 @@ export interface AwsSdkSigV4AuthResolvedConfig {
   /**
    * Resolved value for input config {@link AwsSdkSigV4AuthInputConfig.credentials}
    * This provider MAY memoize the loaded credentials for certain period.
-   * See {@link MemoizedProvider} for more information.
    */
-  credentials: AwsCredentialIdentityProvider;
+  credentials: MergeFunctions<AwsCredentialIdentityProvider, MemoizedProvider<AwsCredentialIdentity>>;
   /**
    * Resolved value for input config {@link AwsSdkSigV4AuthInputConfig.signer}
    */

--- a/packages/nested-clients/package.json
+++ b/packages/nested-clients/package.json
@@ -98,18 +98,18 @@
   },
   "exports": {
     "./sso-oidc": {
+      "types": "./dist-types/submodules/sso-oidc/index.d.ts",
       "module": "./dist-es/submodules/sso-oidc/index.js",
       "node": "./dist-cjs/submodules/sso-oidc/index.js",
       "import": "./dist-es/submodules/sso-oidc/index.js",
-      "require": "./dist-cjs/submodules/sso-oidc/index.js",
-      "types": "./dist-types/submodules/sso-oidc/index.d.ts"
+      "require": "./dist-cjs/submodules/sso-oidc/index.js"
     },
     "./sts": {
+      "types": "./dist-types/submodules/sts/index.d.ts",
       "module": "./dist-es/submodules/sts/index.js",
       "node": "./dist-cjs/submodules/sts/index.js",
       "import": "./dist-es/submodules/sts/index.js",
-      "require": "./dist-cjs/submodules/sts/index.js",
-      "types": "./dist-types/submodules/sts/index.d.ts"
+      "require": "./dist-cjs/submodules/sts/index.js"
     }
   }
 }

--- a/packages/polly-request-presigner/src/getSignedUrls.ts
+++ b/packages/polly-request-presigner/src/getSignedUrls.ts
@@ -1,4 +1,5 @@
 import { PollyClient, SynthesizeSpeechCommand } from "@aws-sdk/client-polly";
+import type { AwsCredentialIdentity, Provider } from "@aws-sdk/types";
 import { formatUrl } from "@aws-sdk/util-format-url";
 import { HttpRequest } from "@smithy/protocol-http";
 import { SignatureV4 } from "@smithy/signature-v4";
@@ -8,10 +9,13 @@ export const getSignedUrl = async (
   command: SynthesizeSpeechCommand,
   options: any = {}
 ): Promise<string> => {
+  const { credentials } = client.config;
+
   const signer = new SignatureV4({
     service: options.service || "polly",
     uriEscapePath: options.uriEscapePath || false,
     ...client.config,
+    credentials: credentials as Provider<AwsCredentialIdentity>,
   });
 
   const presignInterceptMiddleware = (next: any, context: any) => async (args: any) => {

--- a/packages/types/src/function.spec.ts
+++ b/packages/types/src/function.spec.ts
@@ -1,0 +1,32 @@
+import { Exact } from "@smithy/types";
+
+import type { MergeFunctions } from "./function";
+
+{
+  const function1 = ({ a }: { a: boolean }) => ({ a: a });
+  const function2 = ({ b }: { b: boolean }) => ({ b: b });
+
+  const function3: MergeFunctions<typeof function1, typeof function2> = null as any;
+
+  // it should merge the first arg and return value objects of function1 and function2
+  // into function3.
+
+  type assert0 = Exact<typeof function3, ({ a, b }?: { a: boolean; b: boolean }) => { a: boolean; b: boolean }>;
+  const assert0: assert0 = true as const;
+}
+
+{
+  const function1 = ({ a }: { a: boolean }) => Promise.resolve({ a: a });
+  const function2 = ({ b }: { b: boolean }) => Promise.resolve({ b: b });
+
+  const function3: MergeFunctions<typeof function1, typeof function2> = null as any;
+
+  // it should merge the first arg and return value objects of function1 and function2
+  // into function3 while ignoring the async Promise wrapper.
+
+  type assert1 = Exact<
+    typeof function3,
+    ({ a, b }?: { a: boolean; b: boolean }) => Promise<{ a: boolean; b: boolean }>
+  >;
+  const assert1: assert1 = true as const;
+}

--- a/packages/types/src/function.ts
+++ b/packages/types/src/function.ts
@@ -1,0 +1,13 @@
+/**
+ * Resolves a function that accepts both the object argument fields of F1 and F2.
+ * The function returns an intersection of what F1 and F2 return.
+ *
+ * @public
+ */
+export type MergeFunctions<F1, F2> = F1 extends (arg: infer A1) => infer R1
+  ? F2 extends (arg: infer A2) => infer R2
+    ? R1 extends Promise<unknown>
+      ? (arg?: A1 & A2) => Promise<Awaited<R1> & Awaited<R2>>
+      : (arg?: A1 & A2) => R1 & R2
+    : never
+  : never;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,6 +13,7 @@ export * from "./endpoint";
 export * from "./eventStream";
 export * from "./extensions";
 export * from "./feature-ids";
+export * from "./function";
 export * from "./http";
 export * from "./identity";
 export * from "./logger";


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6960

### Description
This corrects the type declaration of the resolved version of `client.config.credentials`.
Specifically, it restores the `MemoizedProvider` type, merging it with the type that had overwritten it from SRA ID&Auth. 

### Testing
Added type assertion test
