### PR TITLE
chore(core): fix compilation build

### DIFF
--- a/packages/core/api-extractor.json
+++ b/packages/core/api-extractor.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../api-extractor.packages.json",
-  "mainEntryPointFilePath": "./src/api-extractor-type-index.d.ts"
+  "mainEntryPointFilePath": "./dist-types/api-extractor-type-index.d.ts"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,8 +4,8 @@
   "description": "Core functions & classes shared by multiple AWS SDK clients.",
   "scripts": {
     "build": "yarn lint && concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
-    "build:cjs": "node ../../scripts/compilation/inline core",
-    "build:es": "tsc -p tsconfig.es.json",
+    "build:cjs": "node ../../scripts/compilation/inline core && rimraf ./dist-cjs/api-extractor-type-index.js",
+    "build:es": "tsc -p tsconfig.es.json && rimraf ./dist-es/api-extractor-type-index.js",
     "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
@@ -22,11 +22,11 @@
   "types": "./dist-types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist-types/index.d.ts",
       "module": "./dist-es/index.js",
       "node": "./dist-cjs/index.js",
       "import": "./dist-es/index.js",
-      "require": "./dist-cjs/index.js",
-      "types": "./dist-types/index.d.ts"
+      "require": "./dist-cjs/index.js"
     },
     "./package.json": {
       "module": "./package.json",
@@ -35,32 +35,32 @@
       "require": "./package.json"
     },
     "./client": {
+      "types": "./dist-types/submodules/client/index.d.ts",
       "module": "./dist-es/submodules/client/index.js",
       "node": "./dist-cjs/submodules/client/index.js",
       "import": "./dist-es/submodules/client/index.js",
-      "require": "./dist-cjs/submodules/client/index.js",
-      "types": "./dist-types/submodules/client/index.d.ts"
+      "require": "./dist-cjs/submodules/client/index.js"
     },
     "./httpAuthSchemes": {
+      "types": "./dist-types/submodules/httpAuthSchemes/index.d.ts",
       "module": "./dist-es/submodules/httpAuthSchemes/index.js",
       "node": "./dist-cjs/submodules/httpAuthSchemes/index.js",
       "import": "./dist-es/submodules/httpAuthSchemes/index.js",
-      "require": "./dist-cjs/submodules/httpAuthSchemes/index.js",
-      "types": "./dist-types/submodules/httpAuthSchemes/index.d.ts"
+      "require": "./dist-cjs/submodules/httpAuthSchemes/index.js"
     },
     "./account-id-endpoint": {
+      "types": "./dist-types/submodules/account-id-endpoint/index.d.ts",
       "module": "./dist-es/submodules/account-id-endpoint/index.js",
       "node": "./dist-cjs/submodules/account-id-endpoint/index.js",
       "import": "./dist-es/submodules/account-id-endpoint/index.js",
-      "require": "./dist-cjs/submodules/account-id-endpoint/index.js",
-      "types": "./dist-types/submodules/account-id-endpoint/index.d.ts"
+      "require": "./dist-cjs/submodules/account-id-endpoint/index.js"
     },
     "./protocols": {
+      "types": "./dist-types/submodules/protocols/index.d.ts",
       "module": "./dist-es/submodules/protocols/index.js",
       "node": "./dist-cjs/submodules/protocols/index.js",
       "import": "./dist-es/submodules/protocols/index.js",
-      "require": "./dist-cjs/submodules/protocols/index.js",
-      "types": "./dist-types/submodules/protocols/index.d.ts"
+      "require": "./dist-cjs/submodules/protocols/index.js"
     }
   },
   "files": [

--- a/packages/core/src/api-extractor-type-index.d.ts
+++ b/packages/core/src/api-extractor-type-index.d.ts
@@ -1,5 +1,0 @@
-export * from "../dist-types";
-export * from "../dist-types/submodules/account-id-endpoint";
-export * from "../dist-types/submodules/client";
-export * from "../dist-types/submodules/httpAuthSchemes";
-export * from "../dist-types/submodules/protocols";

--- a/packages/core/src/api-extractor-type-index.ts
+++ b/packages/core/src/api-extractor-type-index.ts
@@ -1,0 +1,5 @@
+export * from "./index";
+export * from "./submodules/account-id-endpoint/index";
+export * from "./submodules/client/index";
+export * from "./submodules/httpAuthSchemes/index";
+export * from "./submodules/protocols/index";

--- a/scripts/validation/submodules-linter.js
+++ b/scripts/validation/submodules-linter.js
@@ -24,13 +24,13 @@ for (const submodulePackage of submodulePackages) {
     const submodulePath = path.join(root, "src", "submodules", submodule);
     if (fs.existsSync(submodulePath) && fs.lstatSync(submodulePath).isDirectory()) {
       // api extractor type index
-      const apiExtractorAggregateTypeIndexPath = path.join(root, "src", "api-extractor-type-index.d.ts");
+      const apiExtractorAggregateTypeIndexPath = path.join(root, "src", "api-extractor-type-index.ts");
       if (fs.existsSync(apiExtractorAggregateTypeIndexPath)) {
         const fileContents = fs.readFileSync(apiExtractorAggregateTypeIndexPath, "utf-8");
-        if (!fileContents.includes(`export * from "../dist-types/submodules/${submodule}";`)) {
+        if (!fileContents.includes(`export * from "./submodules/${submodule}/index";`)) {
           fs.writeFileSync(
             apiExtractorAggregateTypeIndexPath,
-            fileContents + `export * from "../dist-types/submodules/${submodule}";`
+            fileContents + `export * from "./submodules/${submodule}/index";`
           );
           errors.push(`${submodule} not exported from src/api-extractor-type-index.d.ts`);
         }
@@ -39,11 +39,11 @@ for (const submodulePackage of submodulePackages) {
       if (!pkgJson.exports[`./${submodule}`]) {
         errors.push(`${submodule} submodule is missing exports statement in package.json`);
         pkgJson.exports[`./${submodule}`] = {
+          types: `./dist-types/submodules/${submodule}/index.d.ts`,
           module: `./dist-es/submodules/${submodule}/index.js`,
           node: `./dist-cjs/submodules/${submodule}/index.js`,
           import: `./dist-es/submodules/${submodule}/index.js`,
           require: `./dist-cjs/submodules/${submodule}/index.js`,
-          types: `./dist-types/submodules/${submodule}/index.d.ts`,
         };
         fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(pkgJson, null, 2) + "\n");
       }


### PR DESCRIPTION
fix the build step for the core package

the recently introduced `.d.ts` file was causing issues with the compilation inclusion set