### PR TITLE
fix(core/httpAuthSchemes): allow extensions to set signer credentials

### DIFF
--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/resolveAwsSdkSigV4Config.ts
@@ -60,6 +60,25 @@ export interface AwsSdkSigV4AuthInputConfig {
 }
 
 /**
+ * Used to indicate whether a credential provider function was memoized by this resolver.
+ * @public
+ */
+export type AwsSdkSigV4Memoized = {
+  /**
+   * The credential provider has been memoized by the AWS SDK SigV4 config resolver.
+   */
+  memoized?: boolean;
+  /**
+   * The credential provider has the caller client config object bound to its arguments.
+   */
+  configBound?: boolean;
+  /**
+   * Function is wrapped with attribution transform.
+   */
+  attributed?: boolean;
+};
+
+/**
  * @internal
  */
 export interface AwsSdkSigV4PreviouslyResolved {
@@ -82,7 +101,8 @@ export interface AwsSdkSigV4AuthResolvedConfig {
    * Resolved value for input config {@link AwsSdkSigV4AuthInputConfig.credentials}
    * This provider MAY memoize the loaded credentials for certain period.
    */
-  credentials: MergeFunctions<AwsCredentialIdentityProvider, MemoizedProvider<AwsCredentialIdentity>>;
+  credentials: MergeFunctions<AwsCredentialIdentityProvider, MemoizedProvider<AwsCredentialIdentity>> &
+    AwsSdkSigV4Memoized;
   /**
    * Resolved value for input config {@link AwsSdkSigV4AuthInputConfig.signer}
    */
@@ -103,33 +123,42 @@ export interface AwsSdkSigV4AuthResolvedConfig {
 export const resolveAwsSdkSigV4Config = <T>(
   config: T & AwsSdkSigV4AuthInputConfig & AwsSdkSigV4PreviouslyResolved
 ): T & AwsSdkSigV4AuthResolvedConfig => {
-  let isUserSupplied = false;
-  // Normalize credentials
-  let credentialsProvider: AwsCredentialIdentityProvider | undefined;
-  if (config.credentials) {
-    isUserSupplied = true;
-    credentialsProvider = memoizeIdentityProvider(config.credentials, isIdentityExpired, doesIdentityRequireRefresh);
-  }
-  if (!credentialsProvider) {
-    // credentialDefaultProvider should always be populated, but in case
-    // it isn't, set a default identity provider that throws an error
-    if (config.credentialDefaultProvider) {
-      credentialsProvider = normalizeProvider(
-        config.credentialDefaultProvider(
-          Object.assign({}, config as any, {
-            parentClientConfig: config,
-          })
-        )
-      );
-    } else {
-      credentialsProvider = async () => {
-        throw new Error("`credentials` is missing");
-      };
-    }
-  }
+  let inputCredentials = config.credentials;
+  let isUserSupplied = !!config.credentials;
+  let resolvedCredentials: AwsSdkSigV4AuthResolvedConfig["credentials"] | undefined = undefined;
 
-  const boundCredentialsProvider = async (options: Record<string, any> | undefined) =>
-    credentialsProvider!({ ...options, callerClientConfig: config });
+  Object.defineProperty(config, "credentials", {
+    set(credentials: AwsSdkSigV4AuthInputConfig["credentials"]) {
+      if (credentials && credentials !== inputCredentials && credentials !== resolvedCredentials) {
+        isUserSupplied = true;
+      }
+      inputCredentials = credentials;
+      const memoizedProvider = normalizeCredentialProvider(config, {
+        credentials: inputCredentials,
+        credentialDefaultProvider: config.credentialDefaultProvider,
+      });
+      const boundProvider = bindCallerConfig(config, memoizedProvider);
+      if (isUserSupplied && !boundProvider.attributed) {
+        resolvedCredentials = async (options: Record<string, any> | undefined) =>
+          boundProvider(options).then((creds: AttributedAwsCredentialIdentity) =>
+            setCredentialFeature(creds, "CREDENTIALS_CODE", "e")
+          );
+        resolvedCredentials.memoized = boundProvider.memoized;
+        resolvedCredentials.configBound = boundProvider.configBound;
+        resolvedCredentials.attributed = true;
+      } else {
+        resolvedCredentials = boundProvider;
+      }
+    },
+    get(): AwsSdkSigV4AuthResolvedConfig["credentials"] {
+      return resolvedCredentials!;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+
+  // invoke setter so that resolvedCredentials is set.
+  config.credentials = inputCredentials;
 
   // Populate sigv4 arguments
   const {
@@ -172,7 +201,7 @@ export const resolveAwsSdkSigV4Config = <T>(
 
           const params: SignatureV4Init & SignatureV4CryptoInit = {
             ...config,
-            credentials: boundCredentialsProvider,
+            credentials: config.credentials as AwsSdkSigV4AuthResolvedConfig["credentials"],
             region: config.signingRegion,
             service: config.signingName,
             sha256,
@@ -208,7 +237,7 @@ export const resolveAwsSdkSigV4Config = <T>(
 
       const params: SignatureV4Init & SignatureV4CryptoInit = {
         ...config,
-        credentials: boundCredentialsProvider,
+        credentials: config.credentials as AwsSdkSigV4AuthResolvedConfig["credentials"],
         region: config.signingRegion,
         service: config.signingName,
         sha256,
@@ -220,17 +249,16 @@ export const resolveAwsSdkSigV4Config = <T>(
     };
   }
 
-  return Object.assign(config, {
+  const resolvedConfig = Object.assign(config, {
     systemClockOffset,
     signingEscapePath,
-    credentials: isUserSupplied
-      ? async (options: Record<string, any> | undefined) =>
-          boundCredentialsProvider!(options).then((creds: AttributedAwsCredentialIdentity) =>
-            setCredentialFeature(creds, "CREDENTIALS_CODE", "e")
-          )
-      : boundCredentialsProvider!,
     signer,
   });
+
+  return resolvedConfig as typeof resolvedConfig & {
+    // this was set earlier with Object.defineProperty.
+    credentials: AwsSdkSigV4AuthResolvedConfig["credentials"];
+  };
 };
 
 /**
@@ -256,3 +284,63 @@ export interface AWSSDKSigV4AuthResolvedConfig extends AwsSdkSigV4AuthResolvedCo
  * @deprecated renamed to {@link resolveAwsSdkSigV4Config}
  */
 export const resolveAWSSDKSigV4Config = resolveAwsSdkSigV4Config;
+
+/**
+ * Normalizes the credentials to a memoized provider and sets memoized=true on the function
+ * object. This prevents multiple layering of the memoization process.
+ */
+function normalizeCredentialProvider(
+  config: Parameters<typeof resolveAwsSdkSigV4Config>[0],
+  {
+    credentials,
+    credentialDefaultProvider,
+  }: Pick<Parameters<typeof resolveAwsSdkSigV4Config>[0], "credentials" | "credentialDefaultProvider">
+): AwsSdkSigV4AuthResolvedConfig["credentials"] {
+  let credentialsProvider: AwsSdkSigV4AuthResolvedConfig["credentials"] | undefined;
+
+  if (credentials) {
+    if (!(credentials as typeof credentials & AwsSdkSigV4Memoized)?.memoized) {
+      credentialsProvider = memoizeIdentityProvider(credentials, isIdentityExpired, doesIdentityRequireRefresh)!;
+    } else {
+      credentialsProvider = credentials as AwsSdkSigV4AuthResolvedConfig["credentials"];
+    }
+  } else {
+    // credentialDefaultProvider should always be populated, but in case
+    // it isn't, set a default identity provider that throws an error
+    if (credentialDefaultProvider) {
+      credentialsProvider = normalizeProvider(
+        credentialDefaultProvider(
+          Object.assign({}, config as any, {
+            parentClientConfig: config,
+          })
+        )
+      );
+    } else {
+      credentialsProvider = async () => {
+        throw new Error(
+          "@aws-sdk/core::resolveAwsSdkSigV4Config - `credentials` not provided and no credentialDefaultProvider was configured."
+        );
+      };
+    }
+  }
+  credentialsProvider.memoized = true;
+  return credentialsProvider;
+}
+
+/**
+ * Binds the caller client config as an argument to the credentialsProvider function.
+ * Uses a state marker on the function to avoid doing this more than once.
+ */
+function bindCallerConfig(
+  config: Parameters<typeof resolveAwsSdkSigV4Config>[0],
+  credentialsProvider: AwsSdkSigV4AuthResolvedConfig["credentials"]
+): AwsSdkSigV4AuthResolvedConfig["credentials"] {
+  if (credentialsProvider.configBound) {
+    return credentialsProvider;
+  }
+  const fn: typeof credentialsProvider = async (options: Parameters<typeof credentialsProvider>[0]) =>
+    credentialsProvider({ ...options, callerClientConfig: config });
+  fn.memoized = credentialsProvider.memoized;
+  fn.configBound = true;
+  return fn;
+}


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6954

### Description
After merging the "[client config object custody](https://github.com/aws/aws-sdk-js-v3/pull/6959)" feature, the fix to allow extensions to set credentials is to read credentials from the config object when creating the signer.

### Testing
added integration test
