### PR TITLE
chore(ci): enable error output logging for turbo build

### DIFF
--- a/scripts/turbo/index.js
+++ b/scripts/turbo/index.js
@@ -3,7 +3,7 @@ const { spawnProcess } = require("../utils/spawn-process");
 const path = require("path");
 
 const runTurbo = async (task, args, { apiSecret, apiEndpoint, apiSignatureKey } = {}) => {
-  const command = ["turbo", "run", task, "--concurrency=100%", "--output-logs=full"];
+  const command = ["turbo", "run", task, "--concurrency=100%", "--output-logs=errors-only"];
 
   const cacheReadWriteKey = process.env.AWS_JSV3_TURBO_CACHE_BUILD_TYPE ?? "dev";
 

--- a/scripts/turbo/index.js
+++ b/scripts/turbo/index.js
@@ -3,7 +3,7 @@ const { spawnProcess } = require("../utils/spawn-process");
 const path = require("path");
 
 const runTurbo = async (task, args, { apiSecret, apiEndpoint, apiSignatureKey } = {}) => {
-  const command = ["turbo", "run", task, "--concurrency=100%", "--output-logs=hash-only"];
+  const command = ["turbo", "run", task, "--concurrency=100%", "--output-logs=full"];
 
   const cacheReadWriteKey = process.env.AWS_JSV3_TURBO_CACHE_BUILD_TYPE ?? "dev";
 


### PR DESCRIPTION
### Issue
Internal 5781

### Description
It enables full output logs only for the packages with errors during the Turbo build by changing the configuration from `output-logs=hash-only` to `output-logs=errors-only`.

### Testing
Locally.
Build output before making the change if there is any error in a workspace:
```
@aws-sdk/cloudfront-signer:build: ERROR: command finished with error: command (/local/home/smilkuri/aws-sdk-js-v3/packages/cloudfront-signer) /tmp/xfs-45e744bc/yarn run build exited (1)
@aws-sdk/util-user-agent-node:build: cache hit, suppressing logs 250d8ac137df25a0
@aws-sdk/signature-v4-multi-region:build: cache hit, suppressing logs cc2e11db6290d72a
@aws-sdk/cloudfront-signer#build: command (/local/home/smilkuri/aws-sdk-js-v3/packages/cloudfront-signer) /tmp/xfs-45e744bc/yarn run build exited (1)

 Tasks:    52 successful, 53 total
Cached:    52 cached, 53 total
  Time:    12.141s 
Failed:    @aws-sdk/cloudfront-signer#build

 ERROR  run failed: command  exited (1)
Error running turbo: yarn failed with { code: 1, signal: null }
node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "yarn failed with { code: 1, signal: null }".] {
  code: 'ERR_UNHANDLED_REJECTION'
}

Node.js v18.20.2
```
After making the change if there is an error in a workspace:
```
@aws-sdk/cloudfront-signer:build: cache miss, executing 64ae2e594474d05a
@aws-sdk/cloudfront-signer:build: 
@aws-sdk/cloudfront-signer:build: [build:es] src/sign.ts(10,3): error TS2322: Type 'number' is not assignable to type 'string'.
@aws-sdk/cloudfront-signer:build: [build:types] src/sign.ts(10,3): error TS2322: Type 'number' is not assignable to type 'string'.
@aws-sdk/cloudfront-signer:build: [build:es] yarn run build:es exited with code 2
@aws-sdk/cloudfront-signer:build: [build:types] yarn run build:types exited with code 2
@aws-sdk/cloudfront-signer:build: [build:cjs] src/sign.ts(10,3): error TS2322: Type 'number' is not assignable to type 'string'.
@aws-sdk/cloudfront-signer:build: [build:cjs] node:internal/process/promises:288
@aws-sdk/cloudfront-signer:build: [build:cjs]             triggerUncaughtException(err, true /* fromPromise */);
@aws-sdk/cloudfront-signer:build: [build:cjs]             ^
@aws-sdk/cloudfront-signer:build: [build:cjs] 
@aws-sdk/cloudfront-signer:build: [build:cjs] [UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "yarn failed with { code: 2, signal: null }".] {
@aws-sdk/cloudfront-signer:build: [build:cjs]   code: 'ERR_UNHANDLED_REJECTION'
@aws-sdk/cloudfront-signer:build: [build:cjs] }
@aws-sdk/cloudfront-signer:build: [build:cjs] 
@aws-sdk/cloudfront-signer:build: [build:cjs] Node.js v18.20.2
@aws-sdk/cloudfront-signer:build: [build:cjs] yarn run build:cjs exited with code 1
@aws-sdk/cloudfront-signer:build: ERROR: command finished with error: command (/local/home/smilkuri/aws-sdk-js-v3/packages/cloudfront-signer) /tmp/xfs-d572b394/yarn run build exited (1)
@aws-sdk/cloudfront-signer#build: command (/local/home/smilkuri/aws-sdk-js-v3/packages/cloudfront-signer) /tmp/xfs-d572b394/yarn run build exited (1)

 Tasks:    52 successful, 53 total
Cached:    52 cached, 53 total
  Time:    12.114s 
Failed:    @aws-sdk/cloudfront-signer#build

 ERROR  run failed: command  exited (1)
Error running turbo: yarn failed with { code: 1, signal: null }
node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "yarn failed with { code: 1, signal: null }".] {
  code: 'ERR_UNHANDLED_REJECTION'
}

Node.js v18.20.2

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
