### PR TITLE
fix(lib-dynamodb): read input from middleware instead of command

### DIFF
--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
@@ -53,7 +53,7 @@ export abstract class DynamoDBDocumentClientCommand<
           args: InitializeHandlerArguments<Input | BaseInput>
         ): Promise<InitializeHandlerOutput<Output | BaseOutput>> => {
           setFeature(context, "DDB_MAPPER", "d");
-          args.input = marshallInput(this.input, this.inputKeyNodes, marshallOptions);
+          args.input = marshallInput(args.input, this.inputKeyNodes, marshallOptions);
           context.dynamoDbDocumentClientOptions =
             context.dynamoDbDocumentClientOptions || DynamoDBDocumentClientCommand.defaultLogFilterOverrides;
 


### PR DESCRIPTION
closes https://github.com/aws/aws-sdk-js-v3/pull/6984

use args.input instead of command.input in lib dynamodb middleware

e2e tests have been updated to set and verify the input field ConsistentRead via middleware.