### PR TITLE
chore(aws-util-test): add @aws-sdk/weather as workspace dependency

### DIFF
--- a/private/aws-util-test/package.json
+++ b/private/aws-util-test/package.json
@@ -18,6 +18,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-sdk/aws-protocoltests-json": "*",
+    "@aws-sdk/weather": "workspace:^",
     "@smithy/protocol-http": "^5.1.0",
     "@smithy/shared-ini-file-loader": "^4.0.2",
     "@smithy/types": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,6 +841,7 @@ __metadata:
   resolution: "@aws-sdk/aws-util-test@workspace:private/aws-util-test"
   dependencies:
     "@aws-sdk/aws-protocoltests-json": "npm:*"
+    "@aws-sdk/weather": "workspace:^"
     "@smithy/protocol-http": "npm:^5.1.0"
     "@smithy/shared-ini-file-loader": "npm:^4.0.2"
     "@smithy/types": "npm:^4.2.0"
@@ -23809,7 +23810,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/weather@workspace:private/weather":
+"@aws-sdk/weather@workspace:^, @aws-sdk/weather@workspace:private/weather":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/weather@workspace:private/weather"
   dependencies:


### PR DESCRIPTION
### Issue
Internal JS-5802 

### Description
adds `aws-sdk/weather` as workspace dependency in `aws-util-test`

### Testing
Locally:
```
• Running build in 496 packages
• Remote caching disabled

 Tasks:    496 successful, 496 total
Cached:    496 cached, 496 total
  Time:    30.839s >>> FULL TURBO

 PASS  packages/signature-v4-crt/src/CrtSignerV4.spec.ts
 PASS  packages/signature-v4-crt/src/crtSuite.spec.ts

Test Suites: 2 passed, 2 total
Tests:       25 passed, 25 total
Snapshots:   0 total
Time:        4.177 s
Ran all test suites.
lerna notice cli v5.5.2
lerna notice filter including "@aws-sdk/{fetch-http-handler,hash-blob-browser}"
lerna info filter [ '@aws-sdk/{fetch-http-handler,hash-blob-browser}' ]
lerna ERR! EFILTER No packages remain after filtering [ '@aws-sdk/{fetch-http-handler,hash-blob-browser}' ]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
