### PR TITLE
test(middleware-flexible-checksums): update instructions for MD5 fallback

### DIFF
--- a/packages/middleware-flexible-checksums/src/middleware-md5-fallback.e2e.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-md5-fallback.e2e.spec.ts
@@ -100,7 +100,7 @@ describe("S3 MD5 Fallback for DeleteObjects", () => {
         Object.keys(headers).forEach((header) => {
           const lowerHeader = header.toLowerCase();
           if (lowerHeader.startsWith("x-amz-checksum-") || lowerHeader.startsWith("x-amz-sdk-checksum-")) {
-            console.log(`[${context.commandName} - ${context.step}] Removing header: ${header}`);
+            console.log(`[${context.commandName}] Removing header: ${header}`);
             delete headers[header];
             crc32Removed = true;
           }

--- a/packages/middleware-flexible-checksums/src/middleware-md5-fallback.e2e.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-md5-fallback.e2e.spec.ts
@@ -93,14 +93,14 @@ describe("S3 MD5 Fallback for DeleteObjects", () => {
 
         const headers = request.headers;
 
-        // Log headers *before* modification (in build step)
+        // Log headers *before* modification
         // console.log(`[${context.commandName}] Headers before MD5 middleware:`, JSON.stringify(headers, null, 2));
 
         // Remove checksum headers
         Object.keys(headers).forEach((header) => {
           const lowerHeader = header.toLowerCase();
           if (lowerHeader.startsWith("x-amz-checksum-") || lowerHeader.startsWith("x-amz-sdk-checksum-")) {
-            console.log(`[${context.commandName}] Removing header: ${header}`);
+            // console.log(`[${context.commandName}] Removing header: ${header}`);
             delete headers[header];
             crc32Removed = true;
           }
@@ -111,11 +111,11 @@ describe("S3 MD5 Fallback for DeleteObjects", () => {
           const bodyContent = Buffer.from(request.body);
           const md5Hash = createHash("md5").update(bodyContent).digest("base64");
           headers["Content-MD5"] = md5Hash;
-          console.log(`[${context.commandName}] Added Content-MD5: ${md5Hash}`);
+          // console.log(`[${context.commandName}] Added Content-MD5: ${md5Hash}`);
           md5Added = true;
         }
 
-        // Log headers *after* modification (in build step)
+        // Log headers *after* modification
         // console.log(`[${context.commandName}] Headers after MD5 middleware:`, JSON.stringify(headers, null, 2));
 
         return await next(args);


### PR DESCRIPTION
### Description
- make middleware ordering relative to `flexibleChecksumsMiddleware`
- update instructions regarding the `DeleteObjects` command

### Testing
E2E test to confirm removal and addition of relevant headers (uncomment logging in the test file to confirm the headers)
```console
[DeleteObjectsCommand] Headers before MD5 middleware: {
  "content-type": "application/xml",
  "content-length": "145",
  "Expect": "100-continue",
  "x-amz-sdk-checksum-algorithm": "CRC32",
  "x-amz-checksum-crc32": "<signature>"
}
[DeleteObjectsCommand] Removing header: x-amz-sdk-checksum-algorithm
[DeleteObjectsCommand] Removing header: x-amz-checksum-crc32
[DeleteObjectsCommand] Added Content-MD5: <signature>
[DeleteObjectsCommand] Headers after MD5 middleware: {
  "content-type": "application/xml",
  "content-length": "145",
  "Expect": "100-continue",
  "Content-MD5": "<signature>"
}

 ✓ src/middleware-flexible-checksums.e2e.spec.ts (9) 7738ms
 ✓ src/middleware-md5-fallback.e2e.spec.ts (2) 4583ms

 Test Files  2 passed (2)
      Tests  11 passed (11)
   Start at  16:44:45
   Duration  8.44s (transform 259ms, setup 0ms, collect 785ms, tests 12.32s, environment 0ms, prepare 170ms)
```


### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
