### PR TITLE
chore(aws-util-test): remove spec files from build

### DIFF
--- a/private/aws-util-test/package.json
+++ b/private/aws-util-test/package.json
@@ -18,7 +18,6 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-sdk/aws-protocoltests-json": "*",
-    "@aws-sdk/weather": "workspace:^",
     "@smithy/protocol-http": "^5.1.0",
     "@smithy/shared-ini-file-loader": "^4.0.2",
     "@smithy/types": "^4.2.0",

--- a/private/aws-util-test/tsconfig.json
+++ b/private/aws-util-test/tsconfig.json
@@ -9,5 +9,5 @@
     "rootDir": "src",
     "useUnknownInCatchVariables": false
   },
-  "exclude": ["test/", "*.spec.ts", "vitest.*.ts"]
+  "exclude": ["test/", "**/*.spec.ts", "vitest.*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,7 +841,6 @@ __metadata:
   resolution: "@aws-sdk/aws-util-test@workspace:private/aws-util-test"
   dependencies:
     "@aws-sdk/aws-protocoltests-json": "npm:*"
-    "@aws-sdk/weather": "workspace:^"
     "@smithy/protocol-http": "npm:^5.1.0"
     "@smithy/shared-ini-file-loader": "npm:^4.0.2"
     "@smithy/types": "npm:^4.2.0"
@@ -23810,7 +23809,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/weather@workspace:^, @aws-sdk/weather@workspace:private/weather":
+"@aws-sdk/weather@workspace:private/weather":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/weather@workspace:private/weather"
   dependencies:


### PR DESCRIPTION
relates to https://github.com/aws/aws-sdk-js-v3/pull/7001

The issue 7001 originally tried to fix is from the build step. aws-util-test does not take a dependency on weather because it only uses it in the integration test step. Integ tests run after everything is built, so no dependencies need to be declared for integ.spec.ts files.

The problem arises in that the tsconfig did not properly exclude the integration spec files from the build step, so the undeclared dependency would be inconsistently built by that time. The fix should be applied to the tsconfig file and not taking a dependency.