### PR TITLE
chore(codegen): array flatten fix for operationContextParams

### DIFF
--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "76264f4925e5cf6eb659be4dbb786ec5de817d89",
+  SMITHY_TS_COMMIT: "a821f249cd7e1c3e5926e97140494b7ef7fdda22",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
Brings in the fix from https://github.com/smithy-lang/smithy-typescript/pull/1559. 

No codegen diff.