### PR TITLE
fix(aws-restjson-server): fix the failing protocol test

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -399,12 +399,6 @@ final class AwsProtocolUtils {
             || testCase.getId().equals("RestJsonWithBodyExpectsApplicationJsonContentTypeNoHeaders")) {
             return true;
         }
-
-        // ToDo: https://github.com/aws/aws-sdk-js-v3/issues/6907
-        if (testCase.getId().equals("RestJsonWithoutBodyEmptyInputExpectsEmptyContentType")) {
-            return true;
-        }
-
         return false;
     }
 }

--- a/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
@@ -2053,7 +2053,7 @@ export const deserializeMalformedContentTypeWithoutBodyEmptyInputRequest = async
   );
   if (contentTypeHeaderKey != null) {
     const contentType = output.headers[contentTypeHeaderKey];
-    if (contentType !== undefined && contentType !== "application/json") {
+    if (contentType !== undefined) {
       throw new __UnsupportedMediaTypeException();
     }
   }


### PR DESCRIPTION
### Issue
#6907

### Description
Fix the deserialization logic for `MalformedContentTypeWithoutBodyEmptyInput` operation which handles the input validation to reject requests with content-type header as per the test requirements.


### Testing
Locally
```
dev-dsk-smilkuri-1a-17aece6b % yarn lerna run test --scope '@aws-sdk/aws-restjson-*'     
lerna notice cli v5.5.2
lerna notice filter including "@aws-sdk/aws-restjson-*"
lerna info filter [ '@aws-sdk/aws-restjson-*' ]
lerna info Executing command in 2 packages: "yarn run test"
lerna info run Ran npm script 'test' in '@aws-sdk/aws-restjson-validation-server' in 4.1s:

 RUN  v2.1.9 /local/home/smilkuri/aws-sdk-js-v3/private/aws-restjson-validation-server

 ✓ test/functional/restjson1.spec.ts (126 tests | 1 skipped) 129ms

 Test Files  1 passed (1)
      Tests  125 passed | 1 skipped (126)
   Start at  16:17:51
   Duration  1.30s (transform 548ms, setup 0ms, collect 762ms, tests 129ms, environment 0ms, prepare 149ms)

lerna info run Ran npm script 'test' in '@aws-sdk/aws-restjson-server' in 5.8s:

 RUN  v2.1.9 /local/home/smilkuri/aws-sdk-js-v3/private/aws-restjson-server

 ✓ test/functional/restjson1.spec.ts (748 tests | 40 skipped) 403ms

 Test Files  1 passed (1)
      Tests  708 passed | 40 skipped (748)
   Start at  16:17:51
   Duration  3.03s (transform 1.67s, setup 0ms, collect 2.21s, tests 403ms, environment 0ms, prepare 139ms)

lerna success run Ran npm script 'test' in 2 packages in 5.8s:
lerna success - @aws-sdk/aws-restjson-server
lerna success - @aws-sdk/aws-restjson-validation-server

```

### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
