### PR TITLE
chore(codegen): bump codegen version to 0.29.1

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.29.1 (2025-04-24)
+
+## Features
+- Upgraded to smithy-typescript 0.29.1 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0291-2025-04-24))
+
+## Bug Fixes
+- Removed host prefix behaviour ([#7025](https://github.com/aws/aws-sdk-js-v3/pull/7025))
+
 ## 0.29.0 (2025-04-11)
 
 ## Features

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Upgraded to smithy-typescript 0.29.1 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0291-2025-04-24))
 
 ## Bug Fixes
-- Removed host prefix behaviour ([#7025](https://github.com/aws/aws-sdk-js-v3/pull/7025))
+- Removed host prefix behaviour for S3 and S3Control ([#7025](https://github.com/aws/aws-sdk-js-v3/pull/7025))
 
 ## 0.29.0 (2025-04-11)
 

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.29.0"
+    version = "0.29.1"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.29.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.29.1")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "47e23f6185502c4148acc84a24eb048bbf25cd90",
+  SMITHY_TS_COMMIT: "7af8ef9daa0f7f6525dbd5039d166e716fdc2b52",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Internal JS-5859

### Description
Bumps codegen version to 0.29.1

### Testing
CI

### Additional context
Add any other context about the PR here.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
