### PR TITLE
chore(verdaccio): enable offline publishing for packages

### DIFF
--- a/verdaccio/config.yaml
+++ b/verdaccio/config.yaml
@@ -53,6 +53,9 @@ packages:
     # if package is not available locally, proxy requests to 'npmjs' registry
     proxy: npmjs
 
+publish:
+  allow_offline: true
+
 # You can specify HTTP/1.1 server keep-alive timeout in seconds for incoming connections.
 # A value of 0 makes the http server behave similarly to Node.js versions prior to 8.0.0, which did not have a keep-alive timeout.
 # WORKAROUND: Through given configuration you can work around the following issue https://github.com/verdaccio/verdaccio/issues/301. Set to 0 in case 60 is not enough.


### PR DESCRIPTION
### Issue
Internal JS-5879

### Description
This PR adds the `offline_publish: true` setting to the configuration in the Verdaccio config.yaml file. This change allows publishing the packages even when the registry is offline or when the npmjs uplink is not available.

### Testing
How was this change tested?
CI


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
