### PR TITLE
fix(codegen): run aws protocols after smithy protocols

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocols.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocols.java
@@ -27,6 +27,13 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public class AddProtocols implements TypeScriptIntegration {
 
+    @Override
+    public List<String> runAfter() {
+        return List.of(
+            software.amazon.smithy.typescript.codegen.protocols.AddProtocols.class.getCanonicalName()
+        );
+    }
+
     /**
      * This order differs from the base protocol selection specification
      * in that for JavaScript runtimes, JSON-based protocols have higher default priority than CBOR-based.


### PR DESCRIPTION
This change moves the AWS protocols to after the Smithy protocols.

This allows AWS builds to select the `AwsSmithyRpcV2Cbor` override of `SmithyRpcV2Cbor`.