### PR TITLE
chore(core): return httpBearerAuth in authSchemePreference if token is set in env

### DIFF
--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/NODE_AUTH_SCHEME_PREFERENCE_OPTIONS.spec.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/NODE_AUTH_SCHEME_PREFERENCE_OPTIONS.spec.ts
@@ -1,15 +1,19 @@
 import { afterEach, describe, expect, test as it, vi } from "vitest";
 
 import { getArrayForCommaSeparatedString } from "../utils/getArrayForCommaSeparatedString";
+import { getBearerTokenEnvKey } from "../utils/getBearerTokenEnvKey";
 import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "./NODE_AUTH_SCHEME_PREFERENCE_OPTIONS";
 
 vi.mock("../utils/getArrayForCommaSeparatedString");
+vi.mock("../utils/getBearerTokenEnvKey");
 
 describe("NODE_AUTH_SCHEME_PREFERENCE_OPTIONS", () => {
   const mockInput = "a,b,c";
   const mockOutput = ["a", "b", "c"];
+  const mockBearerTokenEnvKey = "AWS_BEARER_TOKEN_SERVICE_NAME";
 
   vi.mocked(getArrayForCommaSeparatedString).mockReturnValue(mockOutput);
+  vi.mocked(getBearerTokenEnvKey).mockReturnValue(mockBearerTokenEnvKey);
 
   afterEach(() => {
     vi.clearAllMocks();
@@ -19,18 +23,42 @@ describe("NODE_AUTH_SCHEME_PREFERENCE_OPTIONS", () => {
     it("returns undefined if no value is provided", () => {
       expect(func({})).toEqual(undefined);
       expect(getArrayForCommaSeparatedString).not.toBeCalled();
+      expect(getBearerTokenEnvKey).not.toBeCalled();
     });
 
     it("returns list if value is defined", () => {
       expect(func({ [key]: mockInput })).toEqual(mockOutput);
       expect(getArrayForCommaSeparatedString).toHaveBeenCalledTimes(1);
       expect(getArrayForCommaSeparatedString).toBeCalledWith(mockInput);
+      expect(getBearerTokenEnvKey).not.toBeCalled();
     });
   };
 
   describe("environmentVariableSelector", () => {
     const { environmentVariableSelector } = NODE_AUTH_SCHEME_PREFERENCE_OPTIONS;
     test(environmentVariableSelector, "AWS_AUTH_SCHEME_PREFERENCE");
+
+    describe("if signingName is defined", () => {
+      const env = { AWS_AUTH_SCHEME_PREFERENCE: mockInput };
+      const options = { signingName: "Signing Name" };
+
+      afterEach(() => {
+        expect(getBearerTokenEnvKey).toHaveBeenCalledTimes(1);
+        expect(getBearerTokenEnvKey).toBeCalledWith(options.signingName);
+      });
+
+      it(`ignores if mockBearerTokenEnvKey is not set`, () => {
+        expect(environmentVariableSelector(env, options)).toEqual(mockOutput);
+        expect(getArrayForCommaSeparatedString).toHaveBeenCalledTimes(1);
+        expect(getArrayForCommaSeparatedString).toBeCalledWith(mockInput);
+      });
+
+      it("returns ['httpBearerAuth'] if mockBearerTokenEnvKey is set", () => {
+        const envWithToken = { ...env, [mockBearerTokenEnvKey]: "token" };
+        expect(environmentVariableSelector(envWithToken, options)).toEqual(["httpBearerAuth"]);
+        expect(getArrayForCommaSeparatedString).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("configFileSelector", () => {

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/NODE_AUTH_SCHEME_PREFERENCE_OPTIONS.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/NODE_AUTH_SCHEME_PREFERENCE_OPTIONS.ts
@@ -1,6 +1,4 @@
-// ToDo: replace with EnvOptions once exported from node-config-provider
-import { LoadedConfigSelectors } from "@smithy/node-config-provider";
-import { EnvOptions } from "@smithy/node-config-provider/dist-types/fromEnv";
+import { EnvOptions, LoadedConfigSelectors } from "@smithy/node-config-provider";
 
 import { getArrayForCommaSeparatedString } from "../utils/getArrayForCommaSeparatedString";
 import { getBearerTokenEnvKey } from "../utils/getBearerTokenEnvKey";

--- a/packages/core/src/submodules/httpAuthSchemes/aws_sdk/NODE_AUTH_SCHEME_PREFERENCE_OPTIONS.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/aws_sdk/NODE_AUTH_SCHEME_PREFERENCE_OPTIONS.ts
@@ -1,6 +1,9 @@
+// ToDo: replace with EnvOptions once exported from node-config-provider
 import { LoadedConfigSelectors } from "@smithy/node-config-provider";
+import { EnvOptions } from "@smithy/node-config-provider/dist-types/fromEnv";
 
 import { getArrayForCommaSeparatedString } from "../utils/getArrayForCommaSeparatedString";
+import { getBearerTokenEnvKey } from "../utils/getBearerTokenEnvKey";
 
 const NODE_AUTH_SCHEME_PREFERENCE_ENV_KEY = "AWS_AUTH_SCHEME_PREFERENCE";
 const NODE_AUTH_SCHEME_PREFERENCE_CONFIG_KEY = "auth_scheme_preference";
@@ -14,7 +17,11 @@ export const NODE_AUTH_SCHEME_PREFERENCE_OPTIONS: LoadedConfigSelectors<string[]
    * @param env - Node process environment object
    * @returns Array of auth scheme strings if preference is set, undefined otherwise
    */
-  environmentVariableSelector: (env: NodeJS.ProcessEnv) => {
+  environmentVariableSelector: (env: NodeJS.ProcessEnv, options?: EnvOptions) => {
+    if (options?.signingName) {
+      const bearerTokenKey = getBearerTokenEnvKey(options.signingName);
+      if (bearerTokenKey in env) return ["httpBearerAuth"];
+    }
     if (!(NODE_AUTH_SCHEME_PREFERENCE_ENV_KEY in env)) return undefined;
     return getArrayForCommaSeparatedString(env[NODE_AUTH_SCHEME_PREFERENCE_ENV_KEY] as string);
   },

--- a/packages/core/src/submodules/httpAuthSchemes/utils/getBearerTokenEnvKey.spec.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/utils/getBearerTokenEnvKey.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { getBearerTokenEnvKey } from "./getBearerTokenEnvKey";
+
+describe("getBearerTokenEnvKey", () => {
+  it.each([
+    ["SIGNING_NAME", "signing name"],
+    ["SIGNING_NAME", "SigNinG nAmE"],
+    ["SIGNING_NAME", "signing-name"],
+    ["SIGNING_NAME", "signing\tname"],
+  ])("returns AWS_BEARER_TOKEN_%s for '%s'", (output, input) => {
+    expect(getBearerTokenEnvKey(input)).toEqual(`AWS_BEARER_TOKEN_${output}`);
+  });
+});

--- a/packages/core/src/submodules/httpAuthSchemes/utils/getBearerTokenEnvKey.ts
+++ b/packages/core/src/submodules/httpAuthSchemes/utils/getBearerTokenEnvKey.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns an environment variable key base on signing name.
+ * @param signingName - The signing name to use in the key
+ * @returns The environment variable key in format AWS_BEARER_TOKEN_<SIGNING_NAME>
+ */
+export const getBearerTokenEnvKey = (signingName: string) =>
+  `AWS_BEARER_TOKEN_${signingName.replace(/[\s-]/g, "_").toUpperCase()}`;


### PR DESCRIPTION
### Issue
Internal JS-5860

### Description
Returns httpBearerAuth in authSchemePreference if token is set in env

### Testing
Unit tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
