### PR TITLE
test(e2e): improve CloudFormation changeset error handling and timeout

### DIFF
--- a/tests/e2e/ensure-test-stack.js
+++ b/tests/e2e/ensure-test-stack.js
@@ -43,14 +43,16 @@ exports.ensureTestStack = async (client, stackName, templateBody) => {
 
   try {
     // TODO: Feature Request: return the last describe response from the waiter result, so we can inspect failure reasons.
-    await waitUntilChangeSetCreateComplete({ client }, { ChangeSetName: Id });
+    await waitUntilChangeSetCreateComplete({ client, maxWaitTime: 300 }, { ChangeSetName: Id });
   } catch (e) {
-    const { Status, StatusReason } = await client.send(
-      new DescribeChangeSetCommand({
-        StackName: stackName,
-        ChangeSetName: Id,
-      })
-    );
+    const { Status, StatusReason = "" } = await client
+      .send(
+        new DescribeChangeSetCommand({
+          StackName: stackName,
+          ChangeSetName: Id,
+        })
+      )
+      .catch((e) => console.warn("Failed to describe changeset", e));
     if (Status === "FAILED" && StatusReason.includes("The submitted information didn't contain changes")) {
       await client
         .send(


### PR DESCRIPTION
### Issue
Internal JS-5881

### Description
What does this implement/fix? Explain your changes.
Adds a 5-min waitTime for the ChangeSet waiter and adds a catch block for the error handling

### Testing
How was this change tested?
CI


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
