### PR TITLE
chore(build): allow turbo dev config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ workspace
 ./scripts/compilation/tmp/*.mjs
 
 .turbo
-turbo.private.json
+turbo.dev.json
 coverage
 dist
 dist-*

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ workspace
 ./scripts/compilation/tmp/*.mjs
 
 .turbo
+turbo.private.json
 coverage
 dist
 dist-*

--- a/scripts/turbo/index.js
+++ b/scripts/turbo/index.js
@@ -3,9 +3,9 @@ const { spawnProcess } = require("../utils/spawn-process");
 const path = require("node:path");
 
 const runTurbo = async (task, args, { apiSecret, apiEndpoint, apiSignatureKey } = {}) => {
-  const privateConfig = (() => {
+  const devConfig = (() => {
     try {
-      return require("../../turbo.private.json");
+      return require("../../turbo.dev.json");
     } catch (e) {
       return {};
     }
@@ -14,8 +14,8 @@ const runTurbo = async (task, args, { apiSecret, apiEndpoint, apiSignatureKey } 
     "turbo",
     "run",
     task,
-    `--concurrency=${privateConfig.concurrency ?? "100%"}`,
-    `--output-logs=${privateConfig.outputLogs ?? "errors-only"}`,
+    `--concurrency=${devConfig.concurrency ?? "100%"}`,
+    `--output-logs=${devConfig.outputLogs ?? "errors-only"}`,
   ];
 
   const cacheReadWriteKey = process.env.AWS_JSV3_TURBO_CACHE_BUILD_TYPE ?? "dev";

--- a/scripts/turbo/index.js
+++ b/scripts/turbo/index.js
@@ -1,9 +1,22 @@
 // Build script to handle Turborepo build execution
 const { spawnProcess } = require("../utils/spawn-process");
-const path = require("path");
+const path = require("node:path");
 
 const runTurbo = async (task, args, { apiSecret, apiEndpoint, apiSignatureKey } = {}) => {
-  const command = ["turbo", "run", task, "--concurrency=100%", "--output-logs=errors-only"];
+  const privateConfig = (() => {
+    try {
+      return require("../../turbo.private.json");
+    } catch (e) {
+      return {};
+    }
+  })();
+  const execArguments = [
+    "turbo",
+    "run",
+    task,
+    `--concurrency=${privateConfig.concurrency ?? "100%"}`,
+    `--output-logs=${privateConfig.outputLogs ?? "errors-only"}`,
+  ];
 
   const cacheReadWriteKey = process.env.AWS_JSV3_TURBO_CACHE_BUILD_TYPE ?? "dev";
 
@@ -17,8 +30,8 @@ const runTurbo = async (task, args, { apiSecret, apiEndpoint, apiSignatureKey } 
     dev: "--cache=local:rw,remote:r",
   };
 
-  command.push(cacheReadWrite[cacheReadWriteKey]);
-  command.push(...args);
+  execArguments.push(cacheReadWrite[cacheReadWriteKey]);
+  execArguments.push(...args);
 
   const turboRoot = path.join(__dirname, "..", "..");
 
@@ -36,7 +49,8 @@ const runTurbo = async (task, args, { apiSecret, apiEndpoint, apiSignatureKey } 
   };
 
   try {
-    return await spawnProcess("yarn", command, {
+    console.log("RUNNING: yarn", execArguments.join(" "));
+    return await spawnProcess("yarn", execArguments, {
       stdio: "inherit",
       cwd: turboRoot,
       env: turboEnv,


### PR DESCRIPTION
Allows individual developers to use a `turbo.dev.json` file to override build settings.

I intend to use

```json
{
  "concurrency": 4,
  "outputLogs": "new-only"
}
```

which lowers the concurrency and increases the output logging for development.