### PR TITLE
chore(scripts): update package graph analysis script

### DIFF
--- a/scripts/validation/package-graph-analyzer.js
+++ b/scripts/validation/package-graph-analyzer.js
@@ -7,21 +7,25 @@ const libs = path.join(root, "lib");
 const clients = path.join(root, "clients");
 
 /**
- * Throw and Error if any deprecated package is not marked private.
+ * Throw and Error if any reserved package is not marked private.
  */
 {
   const excluded = [];
 
-  const deprecatedPackages = path.join(root, "deprecated", "packages");
-  for (const folder of fs.readdirSync(deprecatedPackages)) {
-    const pkgJson = require(path.join(deprecatedPackages, folder, "package.json"));
+  const reservedPackages = path.join(root, "reserved", "packages");
+  for (const folder of fs.readdirSync(reservedPackages)) {
+    const pkgJsonPath = path.join(reservedPackages, folder, "package.json");
+    if (!fs.existsSync(pkgJsonPath)) {
+      continue;
+    }
+    const pkgJson = require(path.join(reservedPackages, folder, "package.json"));
 
     if (excluded.includes(pkgJson.name)) {
       continue;
     }
 
     if (pkgJson.private !== true) {
-      throw new Error("package in deprecated folder is not marked private:", folder);
+      throw new Error("package in reserved folder is not marked private:", folder);
     } else {
     }
   }
@@ -31,9 +35,19 @@ const clients = path.join(root, "clients");
  * Analyze package dependency graph.
  */
 {
-  const packagesData = fs.readdirSync(packages).map((pkg) => require(path.join(packages, pkg, "package.json")));
-  const libsData = fs.readdirSync(libs).map((pkg) => require(path.join(libs, pkg, "package.json")));
-  const clientsData = fs.readdirSync(clients).map((pkg) => require(path.join(clients, pkg, "package.json")));
+  const hasPkgJson = (subfolder, pkg) => fs.existsSync(path.join(subfolder, pkg, "package.json"));
+  const packagesData = fs
+    .readdirSync(packages)
+    .filter(hasPkgJson.bind(null, "packages"))
+    .map((pkg) => require(path.join(packages, pkg, "package.json")));
+  const libsData = fs
+    .readdirSync(libs)
+    .filter(hasPkgJson.bind(null, "libs"))
+    .map((pkg) => require(path.join(libs, pkg, "package.json")));
+  const clientsData = fs
+    .readdirSync(clients)
+    .filter(hasPkgJson.bind(null, "clients"))
+    .map((pkg) => require(path.join(clients, pkg, "package.json")));
 
   const allPackages = [...packagesData, ...libsData, ...clientsData];
 


### PR DESCRIPTION
Update the package graph analyzer script.

The current output is:

```
@aws-sdk/cloudfront-signer: ---- NONE ----
@aws-sdk/crc64-nvme-crt: ---- NONE ----
@aws-sdk/dsql-signer: ---- NONE ----
@aws-sdk/ec2-metadata-service: ---- NONE ----
@aws-sdk/karma-credential-loader: -- devtool --
@aws-sdk/middleware-api-key: ---- NONE ----
@aws-sdk/middleware-http-debug-log: ---- NONE ----
@aws-sdk/middleware-sdk-sts: ---- NONE ----
@aws-sdk/middleware-token: ---- NONE ----
@aws-sdk/polly-request-presigner: ---- NONE ----
@aws-sdk/rds-signer: ---- NONE ----
@aws-sdk/s3-presigned-post: ---- NONE ----
@aws-sdk/s3-request-presigner: ---- NONE ----
@aws-sdk/signature-v4a: ---- NONE ----
@aws-sdk/smithy-client: ---- NONE ----
@aws-sdk/util-create-request: ---- NONE ----
@aws-sdk/util-dns: ---- NONE ----
@aws-sdk/util-dynamodb: ---- NONE ----
@aws-sdk/util-locate-window: ---- NONE ----
@aws-sdk/xhr-http-handler: ---- NONE ----
@aws-sdk/body-checksum-browser:
	@aws-sdk/client-glacier
@aws-sdk/body-checksum-node:
	@aws-sdk/client-glacier
@aws-sdk/chunked-stream-reader-node:
	@aws-sdk/body-checksum-node
@aws-sdk/credential-provider-cognito-identity:
	@aws-sdk/credential-providers
@aws-sdk/endpoint-cache:
	@aws-sdk/middleware-endpoint-discovery
@aws-sdk/middleware-expect-continue:
	@aws-sdk/client-s3
@aws-sdk/middleware-location-constraint:
	@aws-sdk/client-s3
@aws-sdk/middleware-sdk-api-gateway:
	@aws-sdk/client-api-gateway
@aws-sdk/middleware-sdk-ec2:
	@aws-sdk/client-ec2
@aws-sdk/middleware-sdk-glacier:
	@aws-sdk/client-glacier
@aws-sdk/middleware-sdk-machinelearning:
	@aws-sdk/client-machine-learning
@aws-sdk/middleware-sdk-route53:
	@aws-sdk/client-route-53
@aws-sdk/middleware-sdk-s3-control:
	@aws-sdk/client-s3-control
@aws-sdk/middleware-sdk-sqs:
	@aws-sdk/client-sqs
@aws-sdk/middleware-sdk-transcribe-streaming:
	@aws-sdk/client-transcribe-streaming
@aws-sdk/middleware-signing:
	@aws-sdk/middleware-sdk-sts
@aws-sdk/middleware-ssec:
	@aws-sdk/client-s3
@aws-sdk/credential-provider-ini:
	@aws-sdk/credential-provider-node
	@aws-sdk/credential-providers
@aws-sdk/crt-loader:
	@aws-sdk/crc64-nvme-crt
	@aws-sdk/signature-v4-crt
@aws-sdk/middleware-bucket-endpoint:
	@aws-sdk/middleware-sdk-s3-control
	@aws-sdk/client-s3
@aws-sdk/middleware-flexible-checksums:
	@aws-sdk/crc64-nvme-crt
	@aws-sdk/client-s3
@aws-sdk/middleware-sdk-s3:
	@aws-sdk/signature-v4-multi-region
	@aws-sdk/client-s3
@aws-sdk/middleware-websocket:
	@aws-sdk/client-rekognitionstreaming
	@aws-sdk/client-transcribe-streaming
@aws-sdk/sha256-tree-hash:
	@aws-sdk/body-checksum-browser
	@aws-sdk/body-checksum-node
@aws-sdk/signature-v4-crt:
	@aws-sdk/client-eventbridge
	@aws-sdk/client-s3
@aws-sdk/credential-provider-env:
	@aws-sdk/credential-provider-ini
	@aws-sdk/credential-provider-node
	@aws-sdk/credential-providers
@aws-sdk/credential-provider-http:
	@aws-sdk/credential-provider-ini
	@aws-sdk/credential-provider-node
	@aws-sdk/credential-providers
@aws-sdk/credential-provider-process:
	@aws-sdk/credential-provider-ini
	@aws-sdk/credential-provider-node
	@aws-sdk/credential-providers
@aws-sdk/credential-provider-sso:
	@aws-sdk/credential-provider-ini
	@aws-sdk/credential-provider-node
	@aws-sdk/credential-providers
@aws-sdk/credential-provider-web-identity:
	@aws-sdk/credential-provider-ini
	@aws-sdk/credential-provider-node
	@aws-sdk/credential-providers
@aws-sdk/credential-providers:
	@aws-sdk/dsql-signer
	@aws-sdk/ec2-metadata-service
	@aws-sdk/rds-signer
@aws-sdk/middleware-endpoint-discovery:
	@aws-sdk/client-dynamodb
	@aws-sdk/client-timestream-query
	@aws-sdk/client-timestream-write
@aws-sdk/middleware-sdk-rds:
	@aws-sdk/client-docdb
	@aws-sdk/client-neptune
	@aws-sdk/client-rds
@aws-sdk/token-providers:
	@aws-sdk/credential-provider-sso
	@aws-sdk/middleware-token
	@aws-sdk/client-codecatalyst
@aws-sdk/util-arn-parser:
	@aws-sdk/middleware-bucket-endpoint
	@aws-sdk/middleware-sdk-s3
	@aws-sdk/middleware-sdk-s3-control
@aws-sdk/xml-builder:
	@aws-sdk/client-cloudfront
	@aws-sdk/client-route-53
	@aws-sdk/client-s3
	@aws-sdk/client-s3-control
@aws-sdk/eventstream-handler-node:
	@aws-sdk/client-bedrock-runtime
	@aws-sdk/client-lex-runtime-v2
	@aws-sdk/client-qbusiness
	@aws-sdk/client-rekognitionstreaming
	@aws-sdk/client-transcribe-streaming
@aws-sdk/middleware-eventstream:
	@aws-sdk/client-bedrock-runtime
	@aws-sdk/client-lex-runtime-v2
	@aws-sdk/client-qbusiness
	@aws-sdk/client-rekognitionstreaming
	@aws-sdk/client-transcribe-streaming
@aws-sdk/nested-clients:
	@aws-sdk/credential-provider-ini
	@aws-sdk/credential-provider-web-identity
	@aws-sdk/credential-providers
	@aws-sdk/karma-credential-loader
	@aws-sdk/token-providers
@aws-sdk/signature-v4-multi-region: ** 6 packages **
@aws-sdk/util-format-url: ** 9 packages **
@aws-sdk/credential-provider-node: ** 405 packages (clients) **
@aws-sdk/middleware-host-header: ** 406 packages (clients) **
@aws-sdk/middleware-logger: ** 406 packages (clients) **
@aws-sdk/middleware-recursion-detection: ** 406 packages (clients) **
@aws-sdk/region-config-resolver: ** 406 packages (clients) **
@aws-sdk/util-user-agent-browser: ** 406 packages (clients) **
@aws-sdk/middleware-user-agent: ** 407 packages (clients) **
@aws-sdk/util-user-agent-node: ** 407 packages (clients) **
@aws-sdk/util-endpoints: ** 408 packages (clients) **
@aws-sdk/core: ** 416 packages (clients) **
@aws-sdk/types: ** 462 packages (clients) **
