### PR TITLE
fix(tests): remove the catch statement

### DIFF
--- a/tests/e2e/ensure-test-stack.js
+++ b/tests/e2e/ensure-test-stack.js
@@ -45,14 +45,12 @@ exports.ensureTestStack = async (client, stackName, templateBody) => {
     // TODO: Feature Request: return the last describe response from the waiter result, so we can inspect failure reasons.
     await waitUntilChangeSetCreateComplete({ client, maxWaitTime: 300 }, { ChangeSetName: Id });
   } catch (e) {
-    const { Status, StatusReason = "" } = await client
-      .send(
-        new DescribeChangeSetCommand({
-          StackName: stackName,
-          ChangeSetName: Id,
-        })
-      )
-      .catch((e) => console.warn("Failed to describe changeset", e));
+    const { Status, StatusReason = "" } = await client.send(
+      new DescribeChangeSetCommand({
+        StackName: stackName,
+        ChangeSetName: Id,
+      })
+    );
     if (Status === "FAILED" && StatusReason.includes("The submitted information didn't contain changes")) {
       await client
         .send(


### PR DESCRIPTION
### Description
This PR removes the catch block that was added in the previous [PR.](https://github.com/aws/aws-sdk-js-v3/pull/7073)
### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
