### PR TITLE
chore(aws-util-test): exclude spec files from types build

### DIFF
--- a/private/aws-util-test/tsconfig.types.json
+++ b/private/aws-util-test/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "exclude": ["test/**/*", "**/*.spec.ts", "dist-types/**/*", "vitest.*.ts"]
 }


### PR DESCRIPTION
Internal JS-5932

The `.spec.ts` files had [already been excluded](https://github.com/aws/aws-sdk-js-v3/pull/7003) from the cjs tsconfig, due to an old non-deterministic build failure.

This also adds that exclusion to the types tsconfig.