### PR TITLE
fix(core/protocols): read error code case-insensitively

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsSmithyRpcV2Cbor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsSmithyRpcV2Cbor.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.aws.typescript.codegen;
 
 import software.amazon.smithy.aws.traits.protocols.AwsQueryCompatibleTrait;
+import software.amazon.smithy.typescript.codegen.SmithyCoreSubmodules;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
@@ -55,9 +56,7 @@ public final class AwsSmithyRpcV2Cbor extends SmithyRpcV2Cbor {
 
     @Override
     protected void writeErrorCodeParser(GenerationContext generationContext) {
-        super.writeErrorCodeParser(generationContext);
         TypeScriptWriter writer = generationContext.getWriter();
-
         if (generationContext.getService().hasTrait(AwsQueryCompatibleTrait.class)) {
             // Populate parsedOutput.body with 'Code' and 'Type' fields
             // "x-amzn-query-error" header is available when AwsQueryCompatibleTrait is applied to a service
@@ -65,5 +64,10 @@ public final class AwsSmithyRpcV2Cbor extends SmithyRpcV2Cbor {
             // E.g. "MalformedInput;Sender" or "InternalFailure;Receiver"
             writer.write("populateBodyWithQueryCompatibility(parsedOutput, output.headers);");
         }
+        writer.addImportSubmodule(
+            "loadSmithyRpcV2CborErrorCode", null,
+            TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CBOR
+        );
+        writer.write("const errorCode = loadSmithyRpcV2CborErrorCode(output, parsedOutput.body);");
     }
 }

--- a/packages/core/src/submodules/protocols/json/parseJsonBody.spec.ts
+++ b/packages/core/src/submodules/protocols/json/parseJsonBody.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test as it } from "vitest";
+
+import { loadRestJsonErrorCode } from "./parseJsonBody";
+
+describe(loadRestJsonErrorCode.name, () => {
+  it("reads the code of the error case-insensitively", () => {
+    const code = loadRestJsonErrorCode(
+      { statusCode: 200, headers: {} },
+      {
+        cOdE: "OhNoException:Sender",
+      }
+    );
+    expect(code).toEqual("OhNoException");
+  });
+});

--- a/packages/core/src/submodules/protocols/json/parseJsonBody.ts
+++ b/packages/core/src/submodules/protocols/json/parseJsonBody.ts
@@ -59,12 +59,14 @@ export const loadRestJsonErrorCode = (output: HttpResponse, data: any): string |
     return sanitizeErrorCode(output.headers[headerKey]);
   }
 
-  const codeKey = findKey(data, "code");
-  if (codeKey && data[codeKey] !== undefined) {
-    return sanitizeErrorCode(data[codeKey]);
-  }
+  if (data && typeof data === "object") {
+    const codeKey = findKey(data, "code");
+    if (codeKey && data[codeKey] !== undefined) {
+      return sanitizeErrorCode(data[codeKey]);
+    }
 
-  if (data["__type"] !== undefined) {
-    return sanitizeErrorCode(data["__type"]);
+    if (data["__type"] !== undefined) {
+      return sanitizeErrorCode(data["__type"]);
+    }
   }
 };

--- a/packages/core/src/submodules/protocols/json/parseJsonBody.ts
+++ b/packages/core/src/submodules/protocols/json/parseJsonBody.ts
@@ -59,8 +59,9 @@ export const loadRestJsonErrorCode = (output: HttpResponse, data: any): string |
     return sanitizeErrorCode(output.headers[headerKey]);
   }
 
-  if (data.code !== undefined) {
-    return sanitizeErrorCode(data.code);
+  const codeKey = findKey(data, "code");
+  if (codeKey && data[codeKey] !== undefined) {
+    return sanitizeErrorCode(data[codeKey]);
   }
 
   if (data["__type"] !== undefined) {


### PR DESCRIPTION
Our current awsQueryCompatibility implementations reads the `x-amzn-query-error` response header and places this value in the error object's `Code` field.

However, our error parsers read from the `code` field, missing that data.

For the end users, this can cause the thrown error to have a generic "ServiceException" type rather than a more specific type, but it will contain the same data fields. This affects clients for services running in awsQueryCompatibility mode (currently only SQS).

related: https://github.com/smithy-lang/smithy-typescript/pull/1597