### PR TITLE
docs(cloudfront-signer): Fixed typo in example code

### DIFF
--- a/packages/cloudfront-signer/README.md
+++ b/packages/cloudfront-signer/README.md
@@ -55,7 +55,7 @@ const policy = {
 
 const policyString = JSON.stringify(policy);
 
-const cookies = getSignedUrl({
+const signedUrl = getSignedUrl({
   keyPairId,
   privateKey,
   policy: policyString,


### PR DESCRIPTION
### Description
Fixed:- The second example has a typo "const cookies" instead of "const signedUrl".

