### PR TITLE
test(lib-dynamodb): add consistent reads between transactWrite and transactRead

### DIFF
--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -346,6 +346,17 @@ describe(
         })
         .catch(passError);
 
+      for (const k of Object.keys(data)) {
+        await doc
+          .get({
+            TableName,
+            Key: {
+              id: k + "-transact",
+            },
+          })
+          .catch(passError);
+      }
+
       log.transactRead = await doc
         .transactGet({
           TransactItems: [

--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -347,6 +347,8 @@ describe(
         .catch(passError);
 
       for (const k of Object.keys(data)) {
+        // this GET request uses ConsistentRead to ensure the previous TransactWrite
+        // has completed before the next TransactRead fires.
         await doc
           .get({
             TableName,


### PR DESCRIPTION
### Issue
Internal JS-5881

### Description
This fix addresses the `TransactionCanceledException` errors in Dynamodb e2e test by reading each item after TransactWrite to ensure all transaction locks are released, preventing conflicts.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
