### PR TITLE
test(middleware-flexible-checksums): increase hook timeout to 60s

### DIFF
--- a/packages/middleware-flexible-checksums/src/middleware-md5-fallback.e2e.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-md5-fallback.e2e.spec.ts
@@ -44,7 +44,7 @@ describe("S3 MD5 Fallback for DeleteObjects", () => {
       console.error("Setup failed:", err);
       throw err;
     }
-  });
+  }, 60_000);
 
   afterAll(async () => {
     try {
@@ -60,7 +60,7 @@ describe("S3 MD5 Fallback for DeleteObjects", () => {
     } catch (error) {
       console.error("Cleanup failed:", error);
     }
-  });
+  }, 60_000);
 
   it("should use CRC32 checksum by default for DeleteObjects", async () => {
     const response = await s3.send(


### PR DESCRIPTION
### Issue
Internal JS-5881

### Description
This PR resolves the transient hook timed out error by increasing the beforeAll and afterAll hook timeout to 60 seconds in S3-md5-fallback test suite. 

### Testing
CI


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
