### PR TITLE
chore(codegen): use block for token provider call

### DIFF
--- a/clients/client-codecatalyst/src/runtimeConfig.ts
+++ b/clients/client-codecatalyst/src/runtimeConfig.ts
@@ -51,7 +51,9 @@ export const getRuntimeConfig = (config: CodeCatalystClientConfig) => {
         schemeId: "smithy.api#httpBearerAuth",
         identityProvider: (ipc: IdentityProviderConfig) =>
           ipc.getIdentityProvider("smithy.api#httpBearerAuth") ||
-          (async (idProps) => await nodeProvider(idProps as FromSsoInit)(idProps)),
+          (async (idProps) => {
+            return await nodeProvider(idProps as FromSsoInit)(idProps);
+          }),
         signer: new HttpBearerAuthSigner(),
       },
     ],

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeHttpBearerTokenAuth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeHttpBearerTokenAuth.java
@@ -55,7 +55,9 @@ public final class AwsSdkCustomizeHttpBearerTokenAuth implements HttpAuthTypeScr
                     .addDependency(AwsDependency.TOKEN_PROVIDERS)
                     .addImport("nodeProvider", null, AwsDependency.TOKEN_PROVIDERS)
                     .addImport("FromSsoInit", null, AwsDependency.TOKEN_PROVIDERS)
-                    .write("async (idProps) => await nodeProvider(idProps as FromSsoInit)(idProps)"))
+                    .openBlock("async (idProps) => {", "}", () -> {
+                        w.write("return await nodeProvider(idProps as FromSsoInit)(idProps);");
+                    }))
                 // Add identityProperties for backward compatibility of the `nodeProvider` default provider.
                 // If adding new properties that need to be passed into `nodeProvider`, make sure
                 // to update the propertiesExtractor below.


### PR DESCRIPTION
### Issue
Avoid conflicts with JS-5860

### Description
Uses block for token provider call

### Testing
N/A, as it's formatting change

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
