### PR TITLE
chore(codegen): use submodule imports for core pkg

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -162,7 +162,10 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
     ) {
         if (isAwsService(settings, model) && target.equals(LanguageTarget.NODE)) {
             writer.addDependency(AwsDependency.AWS_SDK_CORE);
-            writer.addImport("emitWarningIfUnsupportedVersion", "awsCheckVersion", AwsDependency.AWS_SDK_CORE);
+            writer.addImportSubmodule(
+                "emitWarningIfUnsupportedVersion", "awsCheckVersion",
+                AwsDependency.AWS_SDK_CORE, "/client"
+            );
             writer.write("awsCheckVersion(process.version);");
         }
         if (target.equals(LanguageTarget.NODE)) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -110,7 +110,10 @@ final class AwsProtocolUtils {
     static void generateJsonParseBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
         writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("parseJsonBody", "parseBody", AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule(
+            "parseJsonBody", "parseBody",
+            AwsDependency.AWS_SDK_CORE, "/protocols"
+        );
     }
 
     static void generateJsonParseBodyWithQueryHeader(GenerationContext context) {
@@ -129,7 +132,10 @@ final class AwsProtocolUtils {
     static void generateJsonParseErrorBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
         writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("parseJsonErrorBody", "parseErrorBody", AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule(
+            "parseJsonErrorBody", "parseErrorBody",
+            AwsDependency.AWS_SDK_CORE, "/protocols"
+        );
     }
 
     /**
@@ -141,7 +147,10 @@ final class AwsProtocolUtils {
     static void generateXmlParseBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
         writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("parseXmlBody", "parseBody", AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule(
+            "parseXmlBody", "parseBody",
+            AwsDependency.AWS_SDK_CORE, "/protocols"
+        );
     }
 
     /**
@@ -153,7 +162,10 @@ final class AwsProtocolUtils {
     static void generateXmlParseErrorBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
         writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("parseXmlErrorBody", "parseErrorBody", AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule(
+            "parseXmlErrorBody", "parseErrorBody",
+            AwsDependency.AWS_SDK_CORE, "/protocols"
+        );
     }
 
     /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -110,7 +110,10 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
         writer.addDependency(AwsDependency.XML_BUILDER);
 
         writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("loadRestXmlErrorCode", null, AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule(
+            "loadRestXmlErrorCode", null,
+            AwsDependency.AWS_SDK_CORE, "/protocols"
+        );
 
         writer.write(
             context.getStringStore().flushVariableDeclarationCode()

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
@@ -73,7 +73,10 @@ final class JsonMemberDeserVisitor extends MemberDeserVisitor {
     @Override
     public String unionShape(UnionShape shape) {
         context.getWriter().addDependency(AwsDependency.AWS_SDK_CORE);
-        context.getWriter().addImport("awsExpectUnion", "__expectUnion", AwsDependency.AWS_SDK_CORE);
+        context.getWriter().addImportSubmodule(
+            "awsExpectUnion", "__expectUnion",
+            AwsDependency.AWS_SDK_CORE, "/protocols"
+        );
         return getDelegateDeserializer(shape, "__expectUnion(" + dataSource + ")");
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
@@ -55,9 +55,12 @@ final class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
         this.serdeElisionEnabled = !this.isAwsQueryCompat && !context.getSettings().generateServerSdk();
         if (isAwsQueryCompat) {
             writer.addDependency(AwsDependency.AWS_SDK_CORE);
-            writer.addImport("_toStr", null, AwsDependency.AWS_SDK_CORE);
-            writer.addImport("_toNum", null, AwsDependency.AWS_SDK_CORE);
-            writer.addImport("_toBool", null, AwsDependency.AWS_SDK_CORE);
+            writer.addImportSubmodule("_toStr", null,
+                AwsDependency.AWS_SDK_CORE, "/protocols");
+            writer.addImportSubmodule("_toNum", null,
+                AwsDependency.AWS_SDK_CORE, "/protocols");
+            writer.addImportSubmodule("_toBool", null,
+                AwsDependency.AWS_SDK_CORE, "/protocols");
         }
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -107,7 +107,10 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
         TypeScriptWriter writer = context.getWriter();
         writer.addUseImports(getApplicationProtocol().getResponseType());
         writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("loadRestJsonErrorCode", null, AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule(
+            "loadRestJsonErrorCode", null,
+            AwsDependency.AWS_SDK_CORE, "/protocols"
+        );
 
         if (context.getService().hasTrait(AwsQueryCompatibleTrait.class)) {
             AwsProtocolUtils.generateJsonParseBodyWithQueryHeader(context);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -112,7 +112,10 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         writer.addUseImports(getApplicationProtocol().getResponseType());
         writer.addImport("take", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
         writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("loadRestJsonErrorCode", null, AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule(
+            "loadRestJsonErrorCode", null,
+            AwsDependency.AWS_SDK_CORE, "/protocols"
+        );
 
         writer.write(
             context.getStringStore().flushVariableDeclarationCode()
@@ -122,7 +125,10 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     @Override
     protected void importUnionDeserializer(TypeScriptWriter writer) {
         writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("awsExpectUnion", "__expectUnion", AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule(
+            "awsExpectUnion", "__expectUnion",
+            AwsDependency.AWS_SDK_CORE, "/protocols"
+        );
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
@@ -203,7 +203,10 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                     .build())
                 .putDefaultSigner(LanguageTarget.SHARED, w -> w
                     .addDependency(AwsDependency.AWS_SDK_CORE)
-                    .addImport("AwsSdkSigV4Signer", null, AwsDependency.AWS_SDK_CORE)
+                    .addImportSubmodule(
+                        "AwsSdkSigV4Signer", null,
+                        AwsDependency.AWS_SDK_CORE, "/httpAuthSchemes"
+                    )
                     .write("new AwsSdkSigV4Signer()"))
                 .build();
             supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
@@ -237,7 +240,10 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                         .build())
                     .putDefaultSigner(LanguageTarget.SHARED, w -> w
                         .addDependency(AwsDependency.AWS_SDK_CORE)
-                        .addImport("AwsSdkSigV4ASigner", null, AwsDependency.AWS_SDK_CORE)
+                        .addImportSubmodule(
+                            "AwsSdkSigV4ASigner", null,
+                            AwsDependency.AWS_SDK_CORE, "/httpAuthSchemes"
+                        )
                         .write("new AwsSdkSigV4ASigner()"))
                     .build();
                 supportedHttpAuthSchemesIndex.putHttpAuthScheme(authSchemeSigV4a.getSchemeId(), authSchemeSigV4a);


### PR DESCRIPTION
This changes codegen to import `@aws-sdk/core` components from their actual submodule instead of the root index.

- [ ] todo: run codegen