### PR TITLE
chore(codegen): bump codegen version to 0.31.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.31.0 (2025-06-09)
+
+## Features
+- Upgraded to smithy 1.58.0 and smithy-typescript 0.31.0.
+
+## Bug Fixes
+- Fixed fallback behavior for SigV4A to SigV4 ([#7113](https://github.com/aws/aws-sdk-js-v3/pull/7113))
+
 ## 0.30.0 (2025-05-08)
 
 ## Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.30.0"
+    version = "0.31.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.30.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.31.0")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "cc243072b2c38daaa84fcbddd07dcfa7227e284e",
+  SMITHY_TS_COMMIT: "f4ab06a6513d1fa32239a9e8fd3c4a22864032fb",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Internal JS-5961

Releasing 0.31.0

synchronized with https://github.com/smithy-lang/smithy-typescript/pull/1617

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
