### PR TITLE
 test(clients): run endpoint tests in client mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-integration: bundles
 	make test-endpoints
 
 test-endpoints:
-	npx jest -c ./tests/endpoints-2.0/jest.config.js --bail --watch --verbose false
+	npx jest -c ./tests/endpoints-2.0/jest.config.js --bail --verbose false
 
 test-e2e: bundles
 	yarn g:vitest run -c vitest.config.e2e.ts --retry=4

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-integration: bundles
 	make test-endpoints
 
 test-endpoints:
-	npx jest -c ./tests/endpoints-2.0/jest.config.js --bail
+	npx jest -c ./tests/endpoints-2.0/jest.config.js --bail --watch --verbose false
 
 test-e2e: bundles
 	yarn g:vitest run -c vitest.config.e2e.ts --retry=4

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -24,6 +24,7 @@
     "@aws-crypto/sha256-js": "5.2.0",
     "@aws-sdk/core": "*",
     "@aws-sdk/credential-provider-node": "*",
+    "@aws-sdk/middleware-bucket-endpoint": "*",
     "@aws-sdk/middleware-host-header": "*",
     "@aws-sdk/middleware-logger": "*",
     "@aws-sdk/middleware-recursion-detection": "*",

--- a/clients/client-s3-control/src/S3ControlClient.ts
+++ b/clients/client-s3-control/src/S3ControlClient.ts
@@ -708,6 +708,10 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   credentialDefaultProvider?: (input: any) => AwsCredentialIdentityProvider;
 
   /**
+   * Whether to override the request region with the region inferred from requested resource's ARN. Defaults to undefined.
+   */
+  useArnRegion?: boolean | undefined | Provider<boolean | undefined>;
+  /**
    * Value for how many times a request will be made at most in case of retry.
    */
   maxAttempts?: number | __Provider<number>;

--- a/clients/client-s3-control/src/models/models_1.ts
+++ b/clients/client-s3-control/src/models/models_1.ts
@@ -19,7 +19,6 @@ import {
   StorageLensTag,
   Tag,
 } from "./models_0";
-
 import { S3ControlServiceException as __BaseException } from "./S3ControlServiceException";
 
 /**

--- a/clients/client-s3-control/src/runtimeConfig.shared.ts
+++ b/clients/client-s3-control/src/runtimeConfig.shared.ts
@@ -33,6 +33,7 @@ export const getRuntimeConfig = (config: S3ControlClientConfig) => {
     serviceId: config?.serviceId ?? "S3 Control",
     signingEscapePath: config?.signingEscapePath ?? false,
     urlParser: config?.urlParser ?? parseUrl,
+    useArnRegion: config?.useArnRegion ?? undefined,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,
     utf8Encoder: config?.utf8Encoder ?? toUtf8,
   };

--- a/clients/client-s3-control/src/runtimeConfig.ts
+++ b/clients/client-s3-control/src/runtimeConfig.ts
@@ -4,6 +4,7 @@ import packageInfo from "../package.json"; // eslint-disable-line
 
 import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS, emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
+import { NODE_USE_ARN_REGION_CONFIG_OPTIONS } from "@aws-sdk/middleware-bucket-endpoint";
 import { NODE_APP_ID_CONFIG_OPTIONS, createDefaultUserAgentProvider } from "@aws-sdk/util-user-agent-node";
 import {
   NODE_REGION_CONFIG_FILE_OPTIONS,
@@ -67,6 +68,7 @@ export const getRuntimeConfig = (config: S3ControlClientConfig) => {
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     streamHasher: config?.streamHasher ?? streamHasher,
+    useArnRegion: config?.useArnRegion ?? loadNodeConfig(NODE_USE_ARN_REGION_CONFIG_OPTIONS, loaderConfig),
     useDualstackEndpoint:
       config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS, loaderConfig),
     useFipsEndpoint: config?.useFipsEndpoint ?? loadNodeConfig(NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS, loaderConfig),

--- a/clients/client-s3-control/test/S3Control.spec.ts
+++ b/clients/client-s3-control/test/S3Control.spec.ts
@@ -98,7 +98,7 @@ describe("S3Control Client", () => {
       expect(request.headers[HEADER_OUTPOST_ID]).eql(OutpostId);
       expect(request.headers[HEADER_ACCOUNT_ID]).eql(AccountId);
       expect(request.headers["authorization"]).contains(
-        `Credential=${credentials.accessKeyId}/${dateStr}/${region}/s3/aws4_request`
+        `Credential=${credentials.accessKeyId}/${dateStr}/${region}/s3-outposts/aws4_request`
       );
     });
   });
@@ -129,7 +129,7 @@ describe("S3Control Client", () => {
       expect(request.headers[HEADER_OUTPOST_ID]).eql(OutpostId);
       expect(request.headers[HEADER_ACCOUNT_ID]).eql(AccountId);
       expect(request.headers["authorization"]).contains(
-        `Credential=${credentials.accessKeyId}/${dateStr}/${region}/s3/aws4_request`
+        `Credential=${credentials.accessKeyId}/${dateStr}/${region}/s3-outposts/aws4_request`
       );
     });
   });

--- a/clients/client-s3/src/S3Client.ts
+++ b/clients/client-s3/src/S3Client.ts
@@ -755,9 +755,9 @@ export interface ClientDefaults extends Partial<__SmithyConfiguration<__HttpHand
   signingEscapePath?: boolean;
 
   /**
-   * Whether to override the request region with the region inferred from requested resource's ARN. Defaults to false.
+   * Whether to override the request region with the region inferred from requested resource's ARN. Defaults to undefined.
    */
-  useArnRegion?: boolean | Provider<boolean>;
+  useArnRegion?: boolean | undefined | Provider<boolean | undefined>;
   /**
    * The internal function that inject utilities to runtime-specific stream to help users consume the data
    * @internal

--- a/clients/client-s3/src/models/models_0.ts
+++ b/clients/client-s3/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
-
 import { StreamingBlobTypes } from "@smithy/types";
 
 import { S3ServiceException as __BaseException } from "./S3ServiceException";

--- a/clients/client-s3/src/models/models_1.ts
+++ b/clients/client-s3/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@smithy/smithy-client";
-
 import { StreamingBlobTypes } from "@smithy/types";
 
 import {
@@ -41,7 +40,6 @@ import {
   Tag,
   TransitionDefaultMinimumObjectSize,
 } from "./models_0";
-
 import { S3ServiceException as __BaseException } from "./S3ServiceException";
 
 /**

--- a/clients/client-s3/src/runtimeConfig.shared.ts
+++ b/clients/client-s3/src/runtimeConfig.shared.ts
@@ -43,7 +43,7 @@ export const getRuntimeConfig = (config: S3ClientConfig) => {
     signerConstructor: config?.signerConstructor ?? SignatureV4MultiRegion,
     signingEscapePath: config?.signingEscapePath ?? false,
     urlParser: config?.urlParser ?? parseUrl,
-    useArnRegion: config?.useArnRegion ?? false,
+    useArnRegion: config?.useArnRegion ?? undefined,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,
     utf8Encoder: config?.utf8Encoder ?? toUtf8,
   };

--- a/packages/middleware-bucket-endpoint/src/NodeUseArnRegionConfigOptions.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/NodeUseArnRegionConfigOptions.spec.ts
@@ -44,8 +44,8 @@ describe("NODE_USE_ARN_REGION_CONFIG_OPTIONS", () => {
     test(configFileSelector, profileContent, NODE_USE_ARN_REGION_INI_NAME, SelectorType.CONFIG);
   });
 
-  it("returns false for default", () => {
+  it("returns undefined for default", () => {
     const { default: defaultValue } = NODE_USE_ARN_REGION_CONFIG_OPTIONS;
-    expect(defaultValue).toEqual(false);
+    expect(defaultValue).toEqual(undefined);
   });
 });

--- a/packages/middleware-bucket-endpoint/src/NodeUseArnRegionConfigOptions.ts
+++ b/packages/middleware-bucket-endpoint/src/NodeUseArnRegionConfigOptions.ts
@@ -7,11 +7,15 @@ export const NODE_USE_ARN_REGION_INI_NAME = "s3_use_arn_region";
 /**
  * Config to load useArnRegion from environment variables and shared INI files
  *
- * @api private
+ * @internal
  */
-export const NODE_USE_ARN_REGION_CONFIG_OPTIONS: LoadedConfigSelectors<boolean> = {
+export const NODE_USE_ARN_REGION_CONFIG_OPTIONS: LoadedConfigSelectors<boolean | undefined> = {
   environmentVariableSelector: (env: NodeJS.ProcessEnv) =>
     booleanSelector(env, NODE_USE_ARN_REGION_ENV_NAME, SelectorType.ENV),
   configFileSelector: (profile) => booleanSelector(profile, NODE_USE_ARN_REGION_INI_NAME, SelectorType.CONFIG),
-  default: false,
+  /**
+   * useArnRegion has specific behavior when undefined instead of false.
+   * We therefore use undefined as the default value instead of false.
+   */
+  default: undefined,
 };

--- a/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.spec.ts
@@ -19,7 +19,10 @@ import { parse, validate } from "@aws-sdk/util-arn-parser";
 import { bucketEndpointMiddleware } from "./bucketEndpointMiddleware";
 import { bucketHostname } from "./bucketHostname";
 
-describe("bucketEndpointMiddleware", () => {
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
+describe.skip("bucketEndpointMiddleware", () => {
   const input = { Bucket: "bucket" };
   const mockRegion = "us-foo-1";
   const requestInput = {

--- a/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.ts
@@ -14,6 +14,10 @@ import {
 import { bucketHostname } from "./bucketHostname";
 import { BucketEndpointResolvedConfig } from "./configurations";
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export const bucketEndpointMiddleware =
   (options: BucketEndpointResolvedConfig): BuildMiddleware<any, any> =>
   <Output extends MetadataBearer>(
@@ -98,6 +102,10 @@ export const bucketEndpointMiddleware =
     return next({ ...args, request });
   };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export const bucketEndpointMiddlewareOptions: RelativeMiddlewareOptions = {
   tags: ["BUCKET_ENDPOINT"],
   name: "bucketEndpointMiddleware",
@@ -106,6 +114,10 @@ export const bucketEndpointMiddlewareOptions: RelativeMiddlewareOptions = {
   override: true,
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export const getBucketEndpointPlugin = (options: BucketEndpointResolvedConfig): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
     clientStack.addRelativeTo(bucketEndpointMiddleware(options), bucketEndpointMiddlewareOptions);

--- a/packages/middleware-bucket-endpoint/src/bucketHostname.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostname.spec.ts
@@ -3,7 +3,10 @@ import { describe, expect, test as it } from "vitest";
 
 import { bucketHostname } from "./bucketHostname";
 
-describe("bucketHostname", () => {
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
+describe.skip("bucketHostname", () => {
   const region = "us-west-2";
   describe("from bucket name", () => {
     [

--- a/packages/middleware-bucket-endpoint/src/bucketHostname.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostname.ts
@@ -14,16 +14,18 @@ import {
   validateCustomEndpoint,
   validateDNSHostLabel,
   validateMrapAlias,
-  validateNoDualstack,
   validateNoFIPS,
   validateOutpostService,
   validatePartition,
-  validateRegion,
   validateRegionalClient,
   validateS3Service,
   validateService,
 } from "./bucketHostnameUtils";
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export interface BucketHostname {
   hostname: string;
   bucketEndpoint: boolean;
@@ -31,6 +33,10 @@ export interface BucketHostname {
   signingService?: string;
 }
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export const bucketHostname = (options: BucketHostnameParams | ArnHostnameParams): BucketHostname => {
   validateCustomEndpoint(options);
   return isBucketNameOptions(options)
@@ -40,6 +46,10 @@ export const bucketHostname = (options: BucketHostnameParams | ArnHostnameParams
       getEndpointFromArn(options);
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 const getEndpointFromBucketName = ({
   accelerateEndpoint = false,
   clientRegion: region,
@@ -71,6 +81,10 @@ const getEndpointFromBucketName = ({
   };
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 const getEndpointFromArn = (options: ArnHostnameParams): BucketHostname => {
   const { isCustomEndpoint, baseHostname, clientRegion } = options;
   const hostnameSuffix = isCustomEndpoint ? baseHostname : getSuffixForArnEndpoint(baseHostname)[1];
@@ -104,6 +118,10 @@ const getEndpointFromArn = (options: ArnHostnameParams): BucketHostname => {
   return getEndpointFromAccessPointArn({ ...options, clientRegion, accesspointName, hostnameSuffix });
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 const getEndpointFromObjectLambdaArn = ({
   dualstackEndpoint = false,
   fipsEndpoint = false,
@@ -121,14 +139,6 @@ const getEndpointFromObjectLambdaArn = ({
 }): BucketHostname => {
   const { accountId, region, service } = bucketName;
   validateRegionalClient(clientRegion);
-  validateRegion(region, {
-    useArnRegion,
-    clientRegion,
-    clientSigningRegion,
-    allowFipsRegion: true,
-    useFipsEndpoint: fipsEndpoint,
-  });
-  validateNoDualstack(dualstackEndpoint);
   const DNSHostLabel = `${accesspointName}-${accountId}`;
   validateDNSHostLabel(DNSHostLabel, { tlsCompatible });
 
@@ -143,6 +153,10 @@ const getEndpointFromObjectLambdaArn = ({
   };
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 const getEndpointFromMRAPArn = ({
   disableMultiregionAccessPoints,
   dualstackEndpoint = false,
@@ -155,7 +169,6 @@ const getEndpointFromMRAPArn = ({
     throw new Error("SDK is attempting to use a MRAP ARN. Please enable to feature.");
   }
   validateMrapAlias(mrapAlias);
-  validateNoDualstack(dualstackEndpoint);
   return {
     bucketEndpoint: true,
     hostname: `${mrapAlias}${isCustomEndpoint ? "" : `.accesspoint.s3-global`}.${hostnameSuffix}`,
@@ -163,6 +176,10 @@ const getEndpointFromMRAPArn = ({
   };
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 const getEndpointFromOutpostArn = ({
   useArnRegion,
   clientRegion,
@@ -178,14 +195,12 @@ const getEndpointFromOutpostArn = ({
 }: ArnHostnameParams & { outpostId: string; accesspointName: string; hostnameSuffix: string }): BucketHostname => {
   // if this is an Outpost ARN
   validateRegionalClient(clientRegion);
-  validateRegion(bucketName.region, { useArnRegion, clientRegion, clientSigningRegion, useFipsEndpoint: fipsEndpoint });
   const DNSHostLabel = `${accesspointName}-${bucketName.accountId}`;
   validateDNSHostLabel(DNSHostLabel, { tlsCompatible });
   const endpointRegion = useArnRegion ? bucketName.region : clientRegion;
   const signingRegion = useArnRegion ? bucketName.region : clientSigningRegion;
   validateOutpostService(bucketName.service);
   validateDNSHostLabel(outpostId, { tlsCompatible });
-  validateNoDualstack(dualstackEndpoint);
   validateNoFIPS(fipsEndpoint);
   const hostnamePrefix = `${DNSHostLabel}.${outpostId}`;
   return {
@@ -196,6 +211,10 @@ const getEndpointFromOutpostArn = ({
   };
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 const getEndpointFromAccessPointArn = ({
   useArnRegion,
   clientRegion,
@@ -210,13 +229,6 @@ const getEndpointFromAccessPointArn = ({
 }: ArnHostnameParams & { accesspointName: string; hostnameSuffix: string }): BucketHostname => {
   // construct endpoint from Accesspoint ARN
   validateRegionalClient(clientRegion);
-  validateRegion(bucketName.region, {
-    useArnRegion,
-    clientRegion,
-    clientSigningRegion,
-    allowFipsRegion: true,
-    useFipsEndpoint: fipsEndpoint,
-  });
   const hostnamePrefix = `${accesspointName}-${bucketName.accountId}`;
   validateDNSHostLabel(hostnamePrefix, { tlsCompatible });
   const endpointRegion = useArnRegion ? bucketName.region : clientRegion;

--- a/packages/middleware-bucket-endpoint/src/bucketHostnameUtils.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostnameUtils.ts
@@ -1,17 +1,49 @@
 import { ARN } from "@aws-sdk/util-arn-parser";
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 const DOMAIN_PATTERN = /^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$/;
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 const IP_ADDRESS_PATTERN = /(\d+\.){3}\d+/;
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 const DOTS_PATTERN = /\.\./;
+
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 export const DOT_PATTERN = /\./;
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 export const S3_HOSTNAME_PATTERN = /^(.+\.)?s3(-fips)?(\.dualstack)?[.-]([a-z0-9-]+)\./;
+
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 const S3_US_EAST_1_ALTNAME_PATTERN = /^s3(-external-1)?\.amazonaws\.com$/;
+
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 const AWS_PARTITION_SUFFIX = "amazonaws.com";
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export interface AccessPointArn extends ARN {
   accessPointName: string;
 }
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export interface BucketHostnameParams {
   isCustomEndpoint?: boolean;
   baseHostname: string;
@@ -24,6 +56,10 @@ export interface BucketHostnameParams {
   tlsCompatible?: boolean;
 }
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export interface ArnHostnameParams extends Omit<BucketHostnameParams, "bucketName"> {
   bucketName: ARN;
   clientSigningRegion?: string;
@@ -32,6 +68,10 @@ export interface ArnHostnameParams extends Omit<BucketHostnameParams, "bucketNam
   disableMultiregionAccessPoints?: boolean;
 }
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export const isBucketNameOptions = (
   options: BucketHostnameParams | ArnHostnameParams
 ): options is BucketHostnameParams => typeof options.bucketName === "string";
@@ -43,15 +83,25 @@ export const isBucketNameOptions = (
  * @internal
  *
  * @see https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+ *
+ * @deprecated unused as of EndpointsV2.
  */
 export const isDnsCompatibleBucketName = (bucketName: string): boolean =>
   DOMAIN_PATTERN.test(bucketName) && !IP_ADDRESS_PATTERN.test(bucketName) && !DOTS_PATTERN.test(bucketName);
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 const getRegionalSuffix = (hostname: string): [string, string] => {
   const parts = hostname.match(S3_HOSTNAME_PATTERN)!;
   return [parts[4], hostname.replace(new RegExp(`^${parts[0]}`), "")];
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export const getSuffix = (hostname: string): [string, string] =>
   S3_US_EAST_1_ALTNAME_PATTERN.test(hostname) ? ["us-east-1", AWS_PARTITION_SUFFIX] : getRegionalSuffix(hostname);
 
@@ -60,12 +110,18 @@ export const getSuffix = (hostname: string): [string, string] =>
  * @internal
  * @param hostname - Hostname
  * @returns [Region, Hostname suffix]
+ *
+ * @deprecated unused as of EndpointsV2.
  */
 export const getSuffixForArnEndpoint = (hostname: string): [string, string] =>
   S3_US_EAST_1_ALTNAME_PATTERN.test(hostname)
     ? [hostname.replace(`.${AWS_PARTITION_SUFFIX}`, ""), AWS_PARTITION_SUFFIX]
     : getRegionalSuffix(hostname);
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export const validateArnEndpointOptions = (options: {
   accelerateEndpoint?: boolean;
   tlsCompatible?: boolean;
@@ -82,18 +138,29 @@ export const validateArnEndpointOptions = (options: {
   }
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export const validateService = (service: string) => {
   if (service !== "s3" && service !== "s3-outposts" && service !== "s3-object-lambda") {
     throw new Error("Expect 's3' or 's3-outposts' or 's3-object-lambda' in ARN service component");
   }
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ * @internal
+ */
 export const validateS3Service = (service: string) => {
   if (service !== "s3") {
     throw new Error("Expect 's3' in Accesspoint ARN service component");
   }
 };
 
+/**
+ * @internal
+ */
 export const validateOutpostService = (service: string) => {
   if (service !== "s3-outposts") {
     throw new Error("Expect 's3-posts' in Outpost ARN service component");
@@ -111,10 +178,14 @@ export const validatePartition = (partition: string, options: { clientPartition:
 };
 
 /**
+ * (Previous to deprecation)
  * validate region value inferred from ARN. If `options.useArnRegion` is set, it validates the region is not a FIPS
  * region. If `options.useArnRegion` is unset, it validates the region is equal to `options.clientRegion` or
  * `options.clientSigningRegion`.
+ *
  * @internal
+ *
+ * @deprecated validation is deferred to the endpoint ruleset.
  */
 export const validateRegion = (
   region: string,
@@ -125,37 +196,16 @@ export const validateRegion = (
     clientSigningRegion: string;
     useFipsEndpoint: boolean;
   }
-) => {
-  if (region === "") {
-    throw new Error("ARN region is empty");
-  }
-  if (options.useFipsEndpoint) {
-    if (!options.allowFipsRegion) {
-      throw new Error("FIPS region is not supported");
-    } else if (!isEqualRegions(region, options.clientRegion)) {
-      throw new Error(`Client FIPS region ${options.clientRegion} doesn't match region ${region} in ARN`);
-    }
-  }
-  if (
-    !options.useArnRegion &&
-    !isEqualRegions(region, options.clientRegion || "") &&
-    !isEqualRegions(region, options.clientSigningRegion || "")
-  ) {
-    throw new Error(`Region in ARN is incompatible, got ${region} but expected ${options.clientRegion}`);
-  }
-};
+) => {};
 
 /**
- *
- * @param region
+ * @deprecated unused as of EndpointsV2.
  */
 export const validateRegionalClient = (region: string) => {
   if (["s3-external-1", "aws-global"].includes(region)) {
     throw new Error(`Client region ${region} is not regional`);
   }
 };
-
-const isEqualRegions = (regionA: string, regionB: string) => regionA === regionB;
 
 /**
  * Validate an account ID
@@ -170,6 +220,7 @@ export const validateAccountId = (accountId: string) => {
 /**
  * Validate a host label according to https://tools.ietf.org/html/rfc3986#section-3.2.2
  * @internal
+ * @deprecated unused as of EndpointsV2.
  */
 export const validateDNSHostLabel = (label: string, options: { tlsCompatible?: boolean } = { tlsCompatible: true }) => {
   // reference: https://tools.ietf.org/html/rfc3986#section-3.2.2
@@ -184,6 +235,9 @@ export const validateDNSHostLabel = (label: string, options: { tlsCompatible?: b
   }
 };
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 export const validateCustomEndpoint = (options: {
   isCustomEndpoint?: boolean;
   dualstackEndpoint?: boolean;
@@ -231,17 +285,17 @@ export const getArnResources = (
 };
 
 /**
- * Throw if dual stack configuration is set to true.
+ * (Prior to deprecation) Throw if dual stack configuration is set to true.
  * @internal
+ *
+ * @deprecated validation deferred to endpoints ruleset.
  */
-export const validateNoDualstack = (dualstackEndpoint?: boolean) => {
-  if (dualstackEndpoint)
-    throw new Error("Dualstack endpoint is not supported with Outpost or Multi-region Access Point ARN.");
-};
+export const validateNoDualstack = (dualstackEndpoint?: boolean) => {};
 
 /**
  * Validate fips endpoint is not set up.
  * @internal
+ * @deprecated unused as of EndpointsV2.
  */
 export const validateNoFIPS = (useFipsEndpoint?: boolean) => {
   if (useFipsEndpoint) throw new Error(`FIPS region is not supported with Outpost.`);
@@ -250,6 +304,7 @@ export const validateNoFIPS = (useFipsEndpoint?: boolean) => {
 /**
  * Validate the multi-region access point alias.
  * @internal
+ * @deprecated unused as of EndpointsV2.
  */
 export const validateMrapAlias = (name: string) => {
   try {

--- a/packages/middleware-bucket-endpoint/src/configurations.ts
+++ b/packages/middleware-bucket-endpoint/src/configurations.ts
@@ -1,5 +1,8 @@
 import { Provider, RegionInfoProvider } from "@smithy/types";
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 export interface BucketEndpointInputConfig {
   /**
    * Whether to use the bucket name as the endpoint for this request. The bucket
@@ -33,6 +36,9 @@ export interface BucketEndpointInputConfig {
   disableMultiregionAccessPoints?: boolean | Provider<boolean>;
 }
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 interface PreviouslyResolved {
   isCustomEndpoint?: boolean;
   region: Provider<string>;
@@ -41,6 +47,9 @@ interface PreviouslyResolved {
   useDualstackEndpoint: Provider<boolean>;
 }
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 export interface BucketEndpointResolvedConfig {
   /**
    * Whether the endpoint is specified by caller.
@@ -70,7 +79,7 @@ export interface BucketEndpointResolvedConfig {
   /**
    * Resolved value for input config {@link BucketEndpointInputConfig.useArnRegion}
    */
-  useArnRegion: Provider<boolean>;
+  useArnRegion: Provider<boolean | undefined>;
   /**
    * Resolved value for input config {@link RegionInputConfig.region}
    */
@@ -83,6 +92,9 @@ export interface BucketEndpointResolvedConfig {
   disableMultiregionAccessPoints: Provider<boolean>;
 }
 
+/**
+ * @deprecated unused as of EndpointsV2.
+ */
 export function resolveBucketEndpointConfig<T>(
   input: T & PreviouslyResolved & BucketEndpointInputConfig
 ): T & BucketEndpointResolvedConfig {
@@ -90,9 +102,11 @@ export function resolveBucketEndpointConfig<T>(
     bucketEndpoint = false,
     forcePathStyle = false,
     useAccelerateEndpoint = false,
-    useArnRegion = false,
+    // useArnRegion has specific behavior when undefined instead of false.
+    useArnRegion,
     disableMultiregionAccessPoints = false,
   } = input;
+
   return Object.assign(input, {
     bucketEndpoint,
     forcePathStyle,

--- a/packages/middleware-sdk-s3-control/src/configurations.ts
+++ b/packages/middleware-sdk-s3-control/src/configurations.ts
@@ -8,7 +8,7 @@ export interface S3ControlInputConfig {
   /**
    * Whether to override the request region with the region inferred from requested resource's ARN. Defaults to false
    */
-  useArnRegion?: boolean | Provider<boolean>;
+  useArnRegion?: boolean | undefined | Provider<boolean | undefined>;
 }
 
 interface PreviouslyResolved {
@@ -36,7 +36,7 @@ export interface S3ControlResolvedConfig {
   /**
    * Resolved value for input config {@link S3ControlInputConfig.useArnRegion}
    */
-  useArnRegion: Provider<boolean>;
+  useArnRegion: Provider<boolean | undefined>;
   /**
    * Resolved value for input config {@link RegionInputConfig.region}
    */
@@ -51,7 +51,8 @@ export interface S3ControlResolvedConfig {
 export function resolveS3ControlConfig<T>(
   input: T & PreviouslyResolved & S3ControlInputConfig
 ): T & S3ControlResolvedConfig {
-  const { useArnRegion = false } = input;
+  const { useArnRegion } = input;
+  // useArnRegion has specific behavior when undefined instead of false.
   return Object.assign(input, {
     useArnRegion: typeof useArnRegion === "function" ? useArnRegion : () => Promise.resolve(useArnRegion),
   });

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getProcessArnablesPlugin.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getProcessArnablesPlugin.ts
@@ -6,7 +6,7 @@ import { updateArnablesRequestMiddleware, updateArnablesRequestMiddlewareOptions
 
 export const getProcessArnablesPlugin = (options: S3ControlResolvedConfig): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
-    clientStack.add(parseOutpostArnablesMiddleaware(options), parseOutpostArnablesMiddleawareOptions);
-    clientStack.add(updateArnablesRequestMiddleware(options), updateArnablesRequestMiddlewareOptions);
+    clientStack.addRelativeTo(parseOutpostArnablesMiddleaware(options), parseOutpostArnablesMiddleawareOptions);
+    clientStack.addRelativeTo(updateArnablesRequestMiddleware(options), updateArnablesRequestMiddlewareOptions);
   },
 });

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
@@ -65,13 +65,13 @@ export const parseOutpostArnablesMiddleaware =
       arn = parseArn(input.Name!);
       validateOutpostsArn(arn, validatorOptions);
       const { outpostId, accesspointName } = parseOutpostsAccessPointArnResource(arn.resource);
-      input.Name = accesspointName;
+      // input.Name = accesspointName;
       context[CONTEXT_OUTPOST_ID] = outpostId;
     } else {
       arn = parseArn(input.Bucket!);
       validateOutpostsArn(arn, validatorOptions);
       const { outpostId, bucketName } = parseOutpostBucketArnResource(arn.resource);
-      input.Bucket = bucketName;
+      // input.Bucket = bucketName;
       context[CONTEXT_OUTPOST_ID] = outpostId;
     }
     context[CONTEXT_SIGNING_SERVICE] = arn.service; // s3-outposts

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
@@ -1,18 +1,19 @@
 import {
   getArnResources as getS3AccesspointArnResources,
   validateAccountId,
-  validateNoDualstack,
   validateOutpostService,
   validatePartition,
-  validateRegion,
 } from "@aws-sdk/middleware-bucket-endpoint";
 import { ARN, parse as parseArn, validate as validateArn } from "@aws-sdk/util-arn-parser";
 import { partition } from "@aws-sdk/util-endpoints";
-import { InitializeHandlerOptions, InitializeMiddleware } from "@smithy/types";
+import { RelativeMiddlewareOptions, SerializeMiddleware } from "@smithy/types";
 
 import { S3ControlResolvedConfig } from "../configurations";
 import { CONTEXT_ARN_REGION, CONTEXT_OUTPOST_ID, CONTEXT_SIGNING_REGION, CONTEXT_SIGNING_SERVICE } from "../constants";
 
+/**
+ * @internal
+ */
 type ArnableInput = {
   Name?: string;
   Bucket?: string;
@@ -23,9 +24,10 @@ type ArnableInput = {
  * Validate input `Name` or `Bucket` parameter is acceptable ARN format. If so, modify the input ARN to inferred
  * resource identifier, notify later middleware to redirect request to Outpost endpoint, signing service and signing
  * region.
+ * @internal
  */
 export const parseOutpostArnablesMiddleaware =
-  (options: S3ControlResolvedConfig): InitializeMiddleware<ArnableInput, any> =>
+  (options: S3ControlResolvedConfig): SerializeMiddleware<ArnableInput, any> =>
   (next, context) =>
   async (args) => {
     const { input } = args;
@@ -65,22 +67,21 @@ export const parseOutpostArnablesMiddleaware =
       arn = parseArn(input.Name!);
       validateOutpostsArn(arn, validatorOptions);
       const { outpostId, accesspointName } = parseOutpostsAccessPointArnResource(arn.resource);
-      // input.Name = accesspointName;
+      input.Name = accesspointName;
       context[CONTEXT_OUTPOST_ID] = outpostId;
     } else {
       arn = parseArn(input.Bucket!);
       validateOutpostsArn(arn, validatorOptions);
       const { outpostId, bucketName } = parseOutpostBucketArnResource(arn.resource);
-      // input.Bucket = bucketName;
+      input.Bucket = bucketName;
       context[CONTEXT_OUTPOST_ID] = outpostId;
     }
+
     context[CONTEXT_SIGNING_SERVICE] = arn.service; // s3-outposts
     context[CONTEXT_SIGNING_REGION] = useArnRegion ? arn.region : signingRegion;
 
     if (!input.AccountId) {
       input.AccountId = arn.accountId;
-    } else if (input.AccountId !== arn.accountId) {
-      throw new Error(`AccountId is incompatible with account id inferred from ${parameter}`);
     }
 
     if (useArnRegion) context[CONTEXT_ARN_REGION] = arn.region;
@@ -88,17 +89,29 @@ export const parseOutpostArnablesMiddleaware =
     return next(args);
   };
 
-export const parseOutpostArnablesMiddleawareOptions: InitializeHandlerOptions = {
-  step: "initialize",
+/**
+ * This middleware must go after endpoint resolution and before serialization.
+ * The transform applied to the input.Bucket or input.Name ARN must not have occurred
+ * by the time endpoint resolution happens, but must have completed by the time serialization
+ * happens.
+ *
+ * @internal
+ */
+export const parseOutpostArnablesMiddleawareOptions: RelativeMiddlewareOptions = {
+  toMiddleware: "serializerMiddleware",
+  relation: "before",
   tags: ["CONVERT_ARN", "OUTPOST_BUCKET_ARN", "OUTPOST_ACCESS_POINT_ARN", "OUTPOST"],
   name: "parseOutpostArnablesMiddleaware",
 };
 
+/**
+ * @internal
+ */
 type ValidateOutpostsArnOptions = {
   clientRegion: string;
   signingRegion: string;
   clientPartition: string;
-  useArnRegion: boolean;
+  useArnRegion?: boolean;
   useDualstackEndpoint: boolean;
   useFipsEndpoint: boolean;
 };
@@ -109,30 +122,14 @@ type ValidateOutpostsArnOptions = {
  *    arn:{partition}:s3-outposts:{region}:{accountId}:outpost/{outpostId}/accesspoint/{accesspointName}
  * ARN supplied to 'Bucket' parameter should comply template:
  *    arn:{partition}:s3-outposts:{region}:{accountId}:outpost/{outpostId}/bucket/{bucketName}
+ *
+ * @internal
  */
-const validateOutpostsArn = (
-  arn: ARN,
-  {
-    clientRegion,
-    signingRegion,
-    clientPartition,
-    useArnRegion,
-    useFipsEndpoint,
-    useDualstackEndpoint,
-  }: ValidateOutpostsArnOptions
-) => {
+const validateOutpostsArn = (arn: ARN, { clientPartition }: ValidateOutpostsArnOptions) => {
   const { service, partition, accountId, region } = arn;
   validateOutpostService(service);
   validatePartition(partition, { clientPartition });
   validateAccountId(accountId);
-  validateRegion(region, {
-    useArnRegion,
-    clientRegion,
-    clientSigningRegion: signingRegion,
-    useFipsEndpoint,
-    allowFipsRegion: true,
-  });
-  validateNoDualstack(useDualstackEndpoint);
 };
 
 const parseOutpostsAccessPointArnResource = (

--- a/tests/endpoints-2.0/endpoints-integration.spec.ts
+++ b/tests/endpoints-2.0/endpoints-integration.spec.ts
@@ -9,7 +9,7 @@ import { HttpRequest } from "@smithy/protocol-http";
 
 describe("client list", () => {
   const root = join(__dirname, "..", "..");
-  const clientPackageNameList = readdirSync(join(root, "clients")).filter((f) => f.startsWith("client"));
+  const clientPackageNameList = readdirSync(join(root, "clients")).filter((f) => f.startsWith("client-"));
 
   describe.each(clientPackageNameList)(`%s endpoint test cases`, (clientPackageName) => {
     const serviceName = clientPackageName.slice(7);
@@ -42,14 +42,31 @@ function runTestCases(service: ServiceModel, namespace: ServiceNamespace) {
   if (testCases) {
     for (const testCase of testCases) {
       const { documentation, params = {}, expect: expectation, operationInputs } = testCase;
+
       params.serviceId = serviceId;
 
       let test = it;
-      if (Client.name === "DynamoDBClient") {
+
+      const focus = [] as string[];
+      const skip = ["WriteGetObjectResponse"] as string[];
+
+      if ((!focus.length || focus.includes(documentation!)) && !skip.includes(documentation!)) {
+        test = it;
+      } else {
         test = it.skip;
-      } else if (Client.name === "S3ControlClient") {
+      }
+
+      if (
+        "endpoint" in expectation &&
+        expectation.endpoint.url === "https://s3.us-west-2.amazonaws.com/example.com%23"
+      ) {
+        // todo(endpoints): fix upstream in endpoint resolver customization
         test = it.skip;
-      } else if (Client.name === "S3Client") {
+      }
+
+      if ("endpoint" in expectation && (operationInputs ?? []).find((oi) => skip.includes(oi?.operationName))) {
+        // todo(endpoints): hostPrefix not expressed correctly in test case, do not change
+        // todo(endpoints): behavior to match the WriteGetObjectResponse test urls.
         test = it.skip;
       }
 
@@ -59,7 +76,9 @@ function runTestCases(service: ServiceModel, namespace: ServiceNamespace) {
           if (operationInputs) {
             for (const operationInput of operationInputs) {
               const { operationName, operationParams = {}, clientParams, builtInParams = {} } = operationInput;
-
+              if (skip.includes(operationName)) {
+                continue;
+              }
               const Command = namespace[`${operationName}Command`] as any;
               const endpointParams = await resolveParams(
                 operationParams,
@@ -69,16 +88,8 @@ function runTestCases(service: ServiceModel, namespace: ServiceNamespace) {
                   ...builtInParams,
                 })
               );
-
-              console.log({
-                client: Client.name,
-                command: Command.name,
-                config: mapClientConfig(params),
-                params: operationParams,
-              });
               const observed = await useClient(Client, Command, endpointParams, operationParams);
               // const observed = defaultEndpointResolver(endpointParams as EndpointParams);
-
               assertEndpointResolvedCorrectly(endpoint, observed);
             }
           } else {
@@ -94,15 +105,35 @@ function runTestCases(service: ServiceModel, namespace: ServiceNamespace) {
           if (operationInputs) {
             for (const operationInput of operationInputs) {
               const { operationName, operationParams = {} } = operationInput;
-              const command = namespace[`${operationName}Command`];
-              const endpointParams = await resolveParams(operationParams, command, params);
-              const observedError = await (async () => defaultEndpointResolver(endpointParams as any))().catch(pass);
+              const Command = namespace[`${operationName}Command`] as any;
+              const endpointParams = await resolveParams(
+                operationParams,
+                Command,
+                mapClientConfig({
+                  ...params,
+                })
+              );
+              const observedError = await useClient(Client, Command, endpointParams, operationParams).catch(pass);
+              // const observedError = await (async () => defaultEndpointResolver(endpointParams as any))().catch(pass);
               expect(observedError).not.toBeUndefined();
               expect(observedError?.url).toBeUndefined();
-              expect(normalizeQuotes(String(observedError))).toContain(normalizeQuotes(error));
+
+              if (
+                observedError.toString() ===
+                "Error: Invalid ARN: arn:aws:s3:us-west-2:123456789012: was an invalid ARN."
+              ) {
+                // This is a functionally equivalent error thrown by the endpoints library instead of the ruleset.
+                expect(normalizeQuotes(error)).toEqual(
+                  "Invalid ARN: arn:aws:s3:us-west-2:123456789012: was not a valid ARN"
+                );
+              } else {
+                expect(normalizeQuotes(String(observedError))).toContain(normalizeQuotes(error));
+              }
             }
           } else {
             const endpointParams = await resolveParams({}, {}, params).catch(pass);
+            // no way to call an operation if operationName not present in operationInput.
+            // we can only test this with the endpoint resolver and not the client.
             const observedError = await (async () => defaultEndpointResolver(endpointParams as any))().catch(pass);
             expect(observedError).not.toBeUndefined();
             expect(observedError?.url).toBeUndefined();
@@ -120,8 +151,19 @@ function assertEndpointResolvedCorrectly(expected: EndpointExpectation["endpoint
   const { url, headers, properties } = expected;
   const { authSchemes } = properties || {};
   if (url) {
-    expect(observed.url.href).toContain(new URL(url).href);
-    // expect(Math.abs(observed.url.href.length - url.length)).toBeLessThan(2);
+    const expectedUrl = new URL(url);
+
+    const expectedUrlWithoutPort = expectedUrl.port
+      ? expectedUrl.href.replace(`:${expectedUrl.port}`, "")
+      : expectedUrl.href;
+    const observedUrlWithoutPort = observed.url.port
+      ? observed.url.href.replace(`:${observed.url.port}`, "")
+      : observed.url.href;
+
+    expect(observedUrlWithoutPort).toContain(expectedUrlWithoutPort);
+    if (expectedUrl.port) {
+      expect(observed.url.port).toEqual(expectedUrl.port);
+    }
   }
   if (headers) {
     expect(observed.headers).toEqual(headers);
@@ -149,6 +191,7 @@ const requestInterceptorMiddleware = (next: any, context: any) => async (args: a
           hostname: request.hostname,
           pathname: request.path,
           href: `${request.protocol}//${request.hostname}${request.path}`,
+          port: request.port ? String(request.port) : undefined,
         } as URL,
       },
     } as {
@@ -167,6 +210,7 @@ const requestInterceptorMiddlewareOptions: RelativeMiddlewareOptions = {
 const paramMap = {
   Region: "region",
   "AWS::Region": "region",
+  AccountIdEndpointMode: "accountIdEndpointMode",
   UseFIPS: "useFipsEndpoint",
   UseDualStack: "useDualstackEndpoint",
   ForcePathStyle: "forcePathStyle",
@@ -182,11 +226,7 @@ const paramMap = {
 async function useClient(Client: any, Command: any, clientConfig: any, input: any): Promise<EndpointV2> {
   const client = new Client({
     ...mapClientConfig(clientConfig),
-    logger: console,
-    credentials: {
-      accessKeyId: "ENDPOINTS_TEST",
-      secretAccessKey: "ENDPOINTS_TEST",
-    },
+    // logger: console,
   });
   client.middlewareStack.addRelativeTo(requestInterceptorMiddleware, requestInterceptorMiddlewareOptions);
   const command = new Command(input);
@@ -195,9 +235,19 @@ async function useClient(Client: any, Command: any, clientConfig: any, input: an
 }
 
 function mapClientConfig(params: any) {
-  const out = {} as any;
+  const out = {
+    credentials: {
+      accessKeyId: "ENDPOINTS_TEST",
+      secretAccessKey: "ENDPOINTS_TEST",
+      accountId: undefined,
+    },
+  } as any;
   for (const [k, v] of Object.entries(params)) {
-    out[paramMap[k as keyof typeof paramMap] ?? k] = v;
+    if (k === "AccountId") {
+      out.credentials.accountId = v;
+    } else {
+      out[paramMap[k as keyof typeof paramMap] ?? k] = v;
+    }
   }
   return out;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18794,6 +18794,7 @@ __metadata:
     "@aws-crypto/sha256-js": "npm:5.2.0"
     "@aws-sdk/core": "npm:*"
     "@aws-sdk/credential-provider-node": "npm:*"
+    "@aws-sdk/middleware-bucket-endpoint": "npm:*"
     "@aws-sdk/middleware-host-header": "npm:*"
     "@aws-sdk/middleware-logger": "npm:*"
     "@aws-sdk/middleware-recursion-detection": "npm:*"


### PR DESCRIPTION
The client endpoint tests are now run through the client, including its full serializer behavior.

This also defers some legacy endpoint validations in S3 Control middleware to the endpoint rulesets.
