### PR TITLE
fix(docs): update broken link for NodeProviderChain

### DIFF
--- a/packages/credential-providers/src/fromNodeProviderChain.ts
+++ b/packages/credential-providers/src/fromNodeProviderChain.ts
@@ -2,11 +2,9 @@ import { defaultProvider, DefaultProviderInit } from "@aws-sdk/credential-provid
 import type { AwsCredentialIdentityProvider } from "@smithy/types";
 
 /**
- * This is the same credential provider as {@link defaultProvider|the default provider for Node.js SDK},
+ * This is the same credential provider as [the default provider for Node.js SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/#fromnodeproviderchain),
  * but with default role assumers so you don't need to import them from
- * STS client and supply them manually.
- *
- * You normally don't need to use this explicitly in the client constructor.
+ * STS client and supply them manually. You normally don't need to use this explicitly in the client constructor.
  * It is useful for utility functions requiring credentials like S3 presigner,
  * or RDS signer.
  *

--- a/packages/credential-providers/src/fromNodeProviderChain.ts
+++ b/packages/credential-providers/src/fromNodeProviderChain.ts
@@ -2,7 +2,7 @@ import { defaultProvider, DefaultProviderInit } from "@aws-sdk/credential-provid
 import type { AwsCredentialIdentityProvider } from "@smithy/types";
 
 /**
- * This is the same credential provider as [the default provider for Node.js SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/#fromnodeproviderchain),
+ * This is the same credential provider as {@link https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/#fromnodeproviderchain|the default provider for Node.js SDK},
  * but with default role assumers so you don't need to import them from
  * STS client and supply them manually. You normally don't need to use this explicitly in the client constructor.
  * It is useful for utility functions requiring credentials like S3 presigner,


### PR DESCRIPTION
### Issue
Fixes https://github.com/aws/aws-sdk-js-v3/issues/5150

### Description
This PR updates the link for `the default provider for Node.js SDK` on this [page](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/Function/fromNodeProviderChain1/).

![Screenshot 2025-06-18 at 5 14 37 PM](https://github.com/user-attachments/assets/0f818bc1-881d-4c9d-b85c-b29d98236b99)
