### PR TITLE
chore: install typescript native preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test-unit: bundles
 
 # typecheck for test code.
 test-types:
-	npx tsc -p tsconfig.test.json
+	npx tsgo -p tsconfig.test.json
 
 test-protocols: bundles
 	yarn g:vitest run -c vitest.config.protocols.integ.ts

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/jsdom": "20.0.1",
     "@typescript-eslint/eslint-plugin": "5.55.0",
     "@typescript-eslint/parser": "5.55.0",
+    "@typescript/native-preview": "^7.0.0-dev.20250623.1",
     "async": "3.2.4",
     "concurrently": "7.0.0",
     "decomment": "0.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29572,6 +29572,87 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20250623.1":
+  version: 7.0.0-dev.20250623.1
+  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20250623.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20250623.1":
+  version: 7.0.0-dev.20250623.1
+  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20250623.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20250623.1":
+  version: 7.0.0-dev.20250623.1
+  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20250623.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20250623.1":
+  version: 7.0.0-dev.20250623.1
+  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20250623.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20250623.1":
+  version: 7.0.0-dev.20250623.1
+  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20250623.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20250623.1":
+  version: 7.0.0-dev.20250623.1
+  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20250623.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20250623.1":
+  version: 7.0.0-dev.20250623.1
+  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20250623.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview@npm:^7.0.0-dev.20250623.1":
+  version: 7.0.0-dev.20250623.1
+  resolution: "@typescript/native-preview@npm:7.0.0-dev.20250623.1"
+  dependencies:
+    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20250623.1"
+    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20250623.1"
+    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20250623.1"
+    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20250623.1"
+    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20250623.1"
+    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20250623.1"
+    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20250623.1"
+  dependenciesMeta:
+    "@typescript/native-preview-darwin-arm64":
+      optional: true
+    "@typescript/native-preview-darwin-x64":
+      optional: true
+    "@typescript/native-preview-linux-arm":
+      optional: true
+    "@typescript/native-preview-linux-arm64":
+      optional: true
+    "@typescript/native-preview-linux-x64":
+      optional: true
+    "@typescript/native-preview-win32-arm64":
+      optional: true
+    "@typescript/native-preview-win32-x64":
+      optional: true
+  bin:
+    tsgo: bin/tsgo.js
+  checksum: 10c0/06689ca132c418b55d9db668537ce4bb7d5455c270e5594b4867eaaba255067dc5b90d325349cac8a6f1dedb1196b536d3f0270f24ea83a6d1c29084a6932d53
+  languageName: node
+  linkType: hard
+
 "@verdaccio/commons-api@npm:10.2.0":
   version: 10.2.0
   resolution: "@verdaccio/commons-api@npm:10.2.0"
@@ -30740,6 +30821,7 @@ __metadata:
     "@types/jsdom": "npm:20.0.1"
     "@typescript-eslint/eslint-plugin": "npm:5.55.0"
     "@typescript-eslint/parser": "npm:5.55.0"
+    "@typescript/native-preview": "npm:^7.0.0-dev.20250623.1"
     async: "npm:3.2.4"
     concurrently: "npm:7.0.0"
     decomment: "npm:0.9.5"


### PR DESCRIPTION
- use the TS native preview to run the test source code type-check, which is non-critical

```
time npx tsc -p tsconfig.test.json
       12.85 real        18.63 user         1.85 sys
time npx tsgo -p tsconfig.test.json
        5.50 real         7.35 user         1.84 sys
```