### PR TITLE
chore(codegen): bump codegen version to 0.31.1

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.31.1 (2025-06-23)
+
+## Features
+- Upgraded to smithy-typescript 0.31.1 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0311-2025-06-23))
+
+## Bug Fixes
+- Updated codegen for endpoint configuration, event streams, and error classification ([#7143](https://github.com/aws/aws-sdk-js-v3/pull/7143))
+- Fixed awsQueryCompat error structure for backwards compatibility ([#7133](https://github.com/aws/aws-sdk-js-v3/pull/7133))
+- Allowed explicit undefined in EndpointParameters ([#7131](https://github.com/aws/aws-sdk-js-v3/pull/7131))
+
 ## 0.31.0 (2025-06-09)
 
 ## Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.31.0"
+    version = "0.31.1"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.31.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.31.1")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "fdea2d734272ff38904dc4e37c8656e8b60bc9ca",
+  SMITHY_TS_COMMIT: "1308a1e047fffd2cfd99bcdf72c9cc2f4871ce1a",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Internal JS-6010

### Description
Bumps codegen version to 0.31.1

### Testing
CI


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
