### PR TITLE
chore: Migrate from nexus2 to mavenCentral

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     checkstyle
     jacoco
     id("com.github.spotbugs") version "4.7.1"
-    id("org.jreleaser") version "1.9.0"
+    id("org.jreleaser") version "1.18.0"
 }
 
 allprojects {


### PR DESCRIPTION
### Issue
Internal JS-5954

### Description
This change migrates from Nexus2 to Central Portal Deployer due to Nexus2 deprecation and upcoming sunset.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
