### PR TITLE
fix(codegen): add default aws regional endpoints for generated clients

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDefaultAwsEndpointRuleSet.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDefaultAwsEndpointRuleSet.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.List;
+import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.endpointsV2.AddDefaultEndpointRuleSet;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+
+
+/**
+ * This replaces behavior from {@link EndpointGenerator}.
+ */
+public class AddDefaultAwsEndpointRuleSet implements TypeScriptIntegration {
+    /**
+     * Running before the smithy-typescript default endpoint integration
+     * will prevent it from applying its non-AWS default ruleset and
+     * the endpointRequired plugin, both of which are not applicable
+     * for default regional AWS endpoints.
+     */
+    @Override
+    public List<String> runBefore() {
+        return List.of(AddDefaultEndpointRuleSet.class.getCanonicalName());
+    }
+
+    @Override
+    public Model preprocessModel(Model model, TypeScriptSettings settings) {
+        Model.Builder modelBuilder = model.toBuilder();
+
+        model.getServiceShapes().forEach(serviceShape -> {
+            if (!serviceShape.hasTrait(EndpointRuleSetTrait.class)
+                && AwsTraitsUtils.isAwsService(settings, model)) {
+                // this branch is for models that identify as AWS services
+                // but do not include an endpoint ruleset.
+
+                modelBuilder.removeShape(serviceShape.toShapeId());
+                modelBuilder.addShape(serviceShape.toBuilder()
+                    .addTrait(getDefaultRegionalEndpointRuleSet(
+                        serviceShape.expectTrait(ServiceTrait.class).getEndpointPrefix())
+                    )
+                    .build());
+            }
+        });
+
+        return modelBuilder.build();
+    }
+
+    private EndpointRuleSetTrait getDefaultRegionalEndpointRuleSet(String endpointPrefix) {
+        return EndpointRuleSetTrait.builder()
+            .ruleSet(Node.parse("""
+{
+  "version": "1.0",
+  "parameters": {
+    "Region": {
+      "builtIn": "AWS::Region",
+      "required": false,
+      "documentation": "The AWS Region. This is a default regional AWS endpointRuleSet.",
+      "type": "String"
+    },
+    "UseDualStack": {
+      "builtIn": "AWS::UseDualStack",
+      "required": true,
+      "default": false,
+      "documentation": "Whether to use dual-stack.",
+      "type": "Boolean"
+    },
+    "UseFIPS": {
+      "builtIn": "AWS::UseFIPS",
+      "required": true,
+      "default": false,
+      "documentation": "Whether to use FIPS-compliant regional endpoint.",
+      "type": "Boolean"
+    },
+    "Endpoint": {
+      "builtIn": "SDK::Endpoint",
+      "required": false,
+      "documentation": "Override the endpoint.",
+      "type": "String"
+    }
+  },
+  "rules": [
+    {
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Endpoint"
+            }
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseFIPS"
+                },
+                true
+              ]
+            }
+          ],
+          "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+          "type": "error"
+        },
+        {
+          "conditions": [
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "ref": "UseDualStack"
+                },
+                true
+              ]
+            }
+          ],
+          "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+          "type": "error"
+        },
+        {
+          "conditions": [],
+          "endpoint": {
+            "url": {
+              "ref": "Endpoint"
+            },
+            "properties": {},
+            "headers": {}
+          },
+          "type": "endpoint"
+        }
+      ],
+      "type": "tree"
+    },
+    {
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "fn": "aws.partition",
+              "argv": [
+                {
+                  "ref": "Region"
+                }
+              ],
+              "assign": "PartitionResult"
+            }
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "UseFIPS"
+                    },
+                    true
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "UseDualStack"
+                    },
+                    true
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        true,
+                        {
+                          "fn": "getAttr",
+                          "argv": [
+                            {
+                              "ref": "PartitionResult"
+                            },
+                            "supportsFIPS"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        true,
+                        {
+                          "fn": "getAttr",
+                          "argv": [
+                            {
+                              "ref": "PartitionResult"
+                            },
+                            "supportsDualStack"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://%1$s-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                },
+                {
+                  "conditions": [],
+                  "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                  "type": "error"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "UseFIPS"
+                    },
+                    true
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        {
+                          "fn": "getAttr",
+                          "argv": [
+                            {
+                              "ref": "PartitionResult"
+                            },
+                            "supportsFIPS"
+                          ]
+                        },
+                        true
+                      ]
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": [
+                            {
+                              "fn": "getAttr",
+                              "argv": [
+                                {
+                                  "ref": "PartitionResult"
+                                },
+                                "name"
+                              ]
+                            },
+                            "aws-us-gov"
+                          ]
+                        }
+                      ],
+                      "endpoint": {
+                        "url": "https://%1$s.{Region}.amazonaws.com",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://%1$s-fips.{Region}.{PartitionResult#dnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                },
+                {
+                  "conditions": [],
+                  "error": "FIPS is enabled but this partition does not support FIPS",
+                  "type": "error"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "UseDualStack"
+                    },
+                    true
+                  ]
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [
+                        true,
+                        {
+                          "fn": "getAttr",
+                          "argv": [
+                            {
+                              "ref": "PartitionResult"
+                            },
+                            "supportsDualStack"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://%1$s.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                        "properties": {},
+                        "headers": {}
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                },
+                {
+                  "conditions": [],
+                  "error": "DualStack is enabled but this partition does not support DualStack",
+                  "type": "error"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://%1$s.{Region}.{PartitionResult#dnsSuffix}",
+                "properties": {},
+                "headers": {}
+              },
+              "type": "endpoint"
+            }
+          ],
+          "type": "tree"
+        }
+      ],
+      "type": "tree"
+    },
+    {
+      "conditions": [],
+      "error": "Invalid Configuration: Missing Region",
+      "type": "error"
+    }
+  ]
+}
+""".formatted(endpointPrefix)))
+            .build();
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -7,6 +7,7 @@ software.amazon.smithy.aws.typescript.codegen.AddAwsAuthPlugin
 software.amazon.smithy.aws.typescript.codegen.AddTokenAuthPlugin
 software.amazon.smithy.aws.typescript.codegen.AddProtocols
 software.amazon.smithy.aws.typescript.codegen.AwsEndpointGeneratorIntegration
+software.amazon.smithy.aws.typescript.codegen.AddDefaultAwsEndpointRuleSet
 software.amazon.smithy.aws.typescript.codegen.AddNimbleCustomizations
 software.amazon.smithy.aws.typescript.codegen.AwsServiceIdIntegration
 software.amazon.smithy.aws.typescript.codegen.AwsPackageFixturesGeneratorIntegration

--- a/scripts/validation/endpointRuleSet-structure-analyzer.js
+++ b/scripts/validation/endpointRuleSet-structure-analyzer.js
@@ -1,0 +1,33 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.join(__dirname, "..", "..");
+const modelsDir = path.join(root, "codegen", "sdk-codegen", "aws-models");
+
+function rulesetHasher(ruleset) {
+  return ruleset.rules
+    .map((r) => {
+      if (r.type === "error") {
+        return "error";
+      }
+      return `${r?.conditions?.[0]?.fn}(${r?.conditions?.[0]?.argv?.[0]?.ref})`;
+    })
+    .join("-");
+}
+
+const data = {};
+
+for (const modelFile of fs.readdirSync(modelsDir)) {
+  const model = require(path.join(modelsDir, modelFile));
+
+  const serviceShape = Object.values(model.shapes).find((s) => s.type === "service");
+
+  const serviceTrait = serviceShape.traits["aws.api#service"];
+  const ruleset = serviceShape.traits["smithy.rules#endpointRuleSet"];
+
+  const hash = rulesetHasher(ruleset);
+  data[hash] = data[hash] ?? {};
+  data[hash][serviceTrait.endpointPrefix] = 1;
+}
+
+console.log(data);


### PR DESCRIPTION
This PR follows up with 

https://github.com/smithy-lang/smithy-typescript/pull/1589 adds default endpoint ruleset
https://github.com/aws/aws-sdk-js-v3/pull/7077

The smithy-ts default endpoint ruleset is equivalent to the "customEndpoint" deprecated plugin where an endpoint is **required** during client instantiation.

This PR overrides the default endpoint ruleset when the model is for an AWS service. It uses an alternate default endpoint ruleset patterned after **regional AWS services**. In this ruleset, endpoint input for the client is not required, since the endpoint may be derived from the region and service endpoint prefix.

This supports Amazon/AWS model builds that occur outside of our SDK release platform, which normally applies the default endpoint rulesets. This default does not cover as many edge cases as the internal version, but works for typical regional services. Services with further endpoint customizations building outside of our release platform will need to include the endpointRuleSet trait in the model being built.