### PR TITLE
chore: bump gradle to 8.13

### DIFF
--- a/codegen/gradle/wrapper/gradle-wrapper.properties
+++ b/codegen/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Description
Upgrade gradle version to 8.13

### Testing
Ran `./gradlew clean build` in codegen directory and also tested that are no changes in clients by running `yarn generate-clients --d`


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
