### PR TITLE
feat(xhr-http-handler): add support for per-request/per-operation timeouts

### DIFF
--- a/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
@@ -246,35 +246,92 @@ describe(XhrHttpHandler.name, () => {
   });
 
   describe("per-request requestTimeout", () => {
-    it("should use per-request timeout over handler config timeout", () => {
-      const handler1 = new XhrHttpHandler({ requestTimeout: 5000 });
-      const handler2 = new XhrHttpHandler({ requestTimeout: 200 });
+    it("should use per-request timeout over handler config timeout", async () => {
+      const handler = new XhrHttpHandler({ requestTimeout: 5000 });
 
-      const testTimeout = (handlerTimeout: number, requestTimeout?: number) => {
-        const expectedTimeout = Number(requestTimeout ?? handlerTimeout) | 0;
-        return expectedTimeout;
-      };
+      const requestTimeoutSpy = vi.spyOn(await import("./request-timeout"), "requestTimeout");
 
-      // per-request timeout takes precedence
-      expect(testTimeout(5000, 100)).toBe(100);
+      const mockRequest = new HttpRequest({
+        method: "GET",
+        hostname: "example.com",
+        protocol: "https:",
+        path: "/",
+        headers: {},
+      });
 
-      // fallback to handler config timeout
-      expect(testTimeout(200, undefined)).toBe(200);
-      expect(testTimeout(200)).toBe(200);
+      class TimeoutXhrMock extends XhrMock {
+        send(...args: any[]) {
+          this.captureArgs("send")(...args);
+          // let it timeout
+        }
+      }
+
+      (global as any).XMLHttpRequest = TimeoutXhrMock;
+
+      try {
+        await handler.handle(mockRequest, { requestTimeout: 100 });
+      } catch (error) {
+        // expected to timeout
+      }
+
+      // verify requestTimeout function was called with per-request timeout (100), not handler timeout (5000)
+      expect(requestTimeoutSpy).toHaveBeenCalledWith(100);
+
+      requestTimeoutSpy.mockRestore();
+      (global as any).XMLHttpRequest = XhrMock; // restore original mock
     });
 
-    it("should pass correct timeout values to internal functions", async () => {
-      const handler = new XhrHttpHandler({ requestTimeout: 5000 });
-      (handler as any).config = { requestTimeout: 5000 };
+    it("should fall back to handler config timeout when per-request timeout not provided", async () => {
+      const handler = new XhrHttpHandler({ requestTimeout: 200 });
 
-      const options1 = { requestTimeout: 100 };
-      const options2: { requestTimeout?: number } = {};
+      const requestTimeoutSpy = vi.spyOn(await import("./request-timeout"), "requestTimeout");
 
-      const effectiveTimeout1 = Number(options1.requestTimeout ?? (handler as any).config.requestTimeout) | 0;
-      const effectiveTimeout2 = Number(options2.requestTimeout ?? (handler as any).config.requestTimeout) | 0;
+      const mockRequest = new HttpRequest({
+        method: "GET",
+        hostname: "example.com",
+        protocol: "https:",
+        path: "/",
+        headers: {},
+      });
 
-      expect(effectiveTimeout1).toBe(100); // per-request timeout used
-      expect(effectiveTimeout2).toBe(5000); // handler config timeout used
+      class TimeoutXhrMock extends XhrMock {
+        send(...args: any[]) {
+          this.captureArgs("send")(...args);
+        }
+      }
+
+      (global as any).XMLHttpRequest = TimeoutXhrMock;
+
+      try {
+        await handler.handle(mockRequest, {});
+      } catch (error) {}
+
+      expect(requestTimeoutSpy).toHaveBeenCalledWith(200);
+
+      requestTimeoutSpy.mockRestore();
+      (global as any).XMLHttpRequest = XhrMock;
+    });
+
+    it("should handle zero timeout correctly", async () => {
+      const handler = new XhrHttpHandler({ requestTimeout: 1000 });
+
+      const requestTimeoutSpy = vi.spyOn(await import("./request-timeout"), "requestTimeout");
+
+      const mockRequest = new HttpRequest({
+        method: "GET",
+        hostname: "example.com",
+        protocol: "https:",
+        path: "/",
+        headers: {},
+      });
+
+      try {
+        await handler.handle(mockRequest, { requestTimeout: 0 });
+      } catch (error) {}
+
+      expect(requestTimeoutSpy).toHaveBeenCalledWith(0);
+
+      requestTimeoutSpy.mockRestore();
     });
   });
 });

--- a/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
@@ -14,7 +14,7 @@ class XhrMock {
   public static captures: any[] = [];
   public static DONE = 4;
 
-  private captureArgs =
+  protected captureArgs =
     (caller: string) =>
     (...args: any[]) => {
       XhrMock.captures.push([caller, ...args]);

--- a/packages/xhr-http-handler/src/xhr-http-handler.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.ts
@@ -3,7 +3,7 @@ import { buildQueryString } from "@smithy/querystring-builder";
 import { HttpHandlerOptions, Provider } from "@smithy/types";
 import { EventEmitter } from "events";
 
-import { requestTimeout } from "./request-timeout";
+import { requestTimeout as requestTimeoutFn } from "./request-timeout";
 
 /**
  * Represents the http options that can be passed to the xhr http client.
@@ -114,12 +114,12 @@ export class XhrHttpHandler extends EventEmitter implements HttpHandler<XhrHttpH
 
   public async handle(
     request: HttpRequest,
-    { abortSignal }: HttpHandlerOptions = {}
+    { abortSignal, requestTimeout }: HttpHandlerOptions = {}
   ): Promise<{ response: HttpResponse }> {
     if (!this.config) {
       this.config = await this.configProvider;
     }
-    const requestTimeoutInMs = Number(this.config!.requestTimeout) | 0;
+    const requestTimeoutInMs = Number(requestTimeout ?? this.config!.requestTimeout) | 0;
 
     // if the request was already aborted, prevent doing extra work
     if (abortSignal?.aborted) {
@@ -214,7 +214,7 @@ export class XhrHttpHandler extends EventEmitter implements HttpHandler<XhrHttpH
         this.emit(EVENTS.BEFORE_XHR_SEND, xhr);
         xhr.send(body);
       }),
-      requestTimeout(requestTimeoutInMs),
+      requestTimeoutFn(requestTimeoutInMs),
     ];
     let removeSignalEventListener = () => {};
     if (abortSignal) {


### PR DESCRIPTION
### Issue
Internal JS-5992

### Description
Support per-request timeouts if provided, fallback to the timeout provided in handler config.

### Testing
```console
 RUN  v2.1.9 /local/home/sidddsri/workspace/aws-sdk-js-v3/packages/xhr-http-handler

 ✓ src/index.spec.ts (1)
 ✓ src/xhr-http-handler.spec.ts (8) 314ms

 Test Files  2 passed (2)
      Tests  9 passed (9)
   Start at  18:06:33
   Duration  1.10s (transform 129ms, setup 0ms, collect 214ms, tests 317ms, environment 848ms, prepare 181ms)
```

### Additional context
Partner PR in smithy-ts: https://github.com/smithy-lang/smithy-typescript/pull/1636


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
