### PR TITLE
test(client-cloudwatch): add query compatibility test for error shape ambiguity

### DIFF
--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -12,7 +12,6 @@
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "extract:docs": "api-extractor run --local",
     "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudwatch",
-    "test": "yarn g:vitest run -c vitest.config.e2e.ts",
     "test:e2e": "yarn g:vitest run -c vitest.config.e2e.ts",
     "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.ts"
   },

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -11,7 +11,10 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "extract:docs": "api-extractor run --local",
-    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudwatch"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudwatch",
+    "test": "yarn g:vitest run -c vitest.config.e2e.ts",
+    "test:e2e": "yarn g:vitest run -c vitest.config.e2e.ts",
+    "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.ts"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudwatch/test/e2e/query-compatibility.e2e.spec.ts
+++ b/clients/client-cloudwatch/test/e2e/query-compatibility.e2e.spec.ts
@@ -1,19 +1,13 @@
 import { CloudWatchClient, GetDashboardCommand } from "@aws-sdk/client-cloudwatch";
 import { beforeAll, describe, expect, test as it } from "vitest";
 
-import { getIntegTestResources } from "../../../../tests/e2e/get-integ-test-resources";
-
 describe("CloudWatch Query Compatibility E2E", () => {
   let client: CloudWatchClient;
-  let region: string;
 
   beforeAll(async () => {
-    const integTestResourcesEnv = await getIntegTestResources();
-    Object.assign(process.env, integTestResourcesEnv);
-
-    region = process?.env?.AWS_SMOKE_TEST_REGION as string;
-
-    client = new CloudWatchClient({ region });
+    client = new CloudWatchClient({
+      region: "us-west-2",
+    });
   });
 
   it("AmbiguousErrorResolution", async () => {

--- a/clients/client-cloudwatch/test/e2e/query-compatibility.e2e.spec.ts
+++ b/clients/client-cloudwatch/test/e2e/query-compatibility.e2e.spec.ts
@@ -1,17 +1,19 @@
 import { CloudWatchClient, GetDashboardCommand } from "@aws-sdk/client-cloudwatch";
-import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
+import { beforeAll, describe, expect, test as it } from "vitest";
+
+import { getIntegTestResources } from "../../../../tests/e2e/get-integ-test-resources";
 
 describe("CloudWatch Query Compatibility E2E", () => {
   let client: CloudWatchClient;
+  let region: string;
 
-  beforeAll(() => {
-    client = new CloudWatchClient({
-      region: "us-west-2",
-    });
-  });
+  beforeAll(async () => {
+    const integTestResourcesEnv = await getIntegTestResources();
+    Object.assign(process.env, integTestResourcesEnv);
 
-  afterAll(() => {
-    client.destroy();
+    region = process?.env?.AWS_SMOKE_TEST_REGION as string;
+
+    client = new CloudWatchClient({ region });
   });
 
   it("AmbiguousErrorResolution", async () => {

--- a/clients/client-cloudwatch/test/e2e/query-compatibility.e2e.spec.ts
+++ b/clients/client-cloudwatch/test/e2e/query-compatibility.e2e.spec.ts
@@ -1,0 +1,29 @@
+import { CloudWatchClient, GetDashboardCommand } from "@aws-sdk/client-cloudwatch";
+import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
+
+describe("CloudWatch Query Compatibility E2E", () => {
+  let client: CloudWatchClient;
+
+  beforeAll(() => {
+    client = new CloudWatchClient({
+      region: "us-west-2",
+    });
+  });
+
+  afterAll(() => {
+    client.destroy();
+  });
+
+  it("AmbiguousErrorResolution", async () => {
+    const command = new GetDashboardCommand({
+      DashboardName: "foo",
+    });
+
+    try {
+      await client.send(command);
+      fail("Expected ResourceNotFound error");
+    } catch (error: any) {
+      expect(error.name).toBe("ResourceNotFound");
+    }
+  });
+});

--- a/clients/client-cloudwatch/tsconfig.json
+++ b/clients/client-cloudwatch/tsconfig.json
@@ -9,5 +9,5 @@
     "rootDir": "src",
     "useUnknownInCatchVariables": false
   },
-  "exclude": ["test/"]
+  "exclude": ["test/", "vitest.*.ts"]
 }

--- a/clients/client-cloudwatch/tsconfig.types.json
+++ b/clients/client-cloudwatch/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
 }

--- a/clients/client-cloudwatch/vitest.config.e2e.ts
+++ b/clients/client-cloudwatch/vitest.config.e2e.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["**/*.browser.e2e.spec.ts"],
+    include: ["**/*.e2e.spec.ts"],
+    environment: "node",
+  },
+  mode: "development",
+});

--- a/clients/client-cloudwatch/vitest.config.ts
+++ b/clients/client-cloudwatch/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["**/*.{integ,e2e,browser}.spec.ts"],
+    include: ["**/*.spec.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
### Issue
Internal JS-6017

### Description
Implements smoke test equivalent for AmbiguousErrorResolution to ensure ResourceNotFound error code consistently maps to expected exception type,

### Testing
Locally
```
 RUN  v2.1.9 /local/home/smilkuri/aws-sdk-js-v3/clients/client-cloudwatch

 ✓ test/e2e/query-compatibility.e2e.spec.ts (1) 541ms
   ✓ CloudWatch Query Compatibility E2E (1) 541ms
     ✓ AmbiguousErrorResolution 535ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  02:21:52
   Duration  1.06s (transform 141ms, setup 0ms, collect 246ms, tests 541ms, environment 0ms, prepare 90ms)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
