### PR TITLE
chore(clients): populate 'bedrock' signingName in loader config

### DIFF
--- a/clients/client-bedrock-agent-runtime/src/runtimeConfig.ts
+++ b/clients/client-bedrock-agent-runtime/src/runtimeConfig.ts
@@ -36,6 +36,7 @@ export const getRuntimeConfig = (config: BedrockAgentRuntimeClientConfig) => {
   const loaderConfig = {
     profile: config?.profile,
     logger: clientSharedValues.logger,
+    signingName: "bedrock",
   };
   return {
     ...clientSharedValues,

--- a/clients/client-bedrock-agent/src/runtimeConfig.ts
+++ b/clients/client-bedrock-agent/src/runtimeConfig.ts
@@ -35,6 +35,7 @@ export const getRuntimeConfig = (config: BedrockAgentClientConfig) => {
   const loaderConfig = {
     profile: config?.profile,
     logger: clientSharedValues.logger,
+    signingName: "bedrock",
   };
   return {
     ...clientSharedValues,

--- a/clients/client-bedrock-data-automation-runtime/src/runtimeConfig.ts
+++ b/clients/client-bedrock-data-automation-runtime/src/runtimeConfig.ts
@@ -35,6 +35,7 @@ export const getRuntimeConfig = (config: BedrockDataAutomationRuntimeClientConfi
   const loaderConfig = {
     profile: config?.profile,
     logger: clientSharedValues.logger,
+    signingName: "bedrock",
   };
   return {
     ...clientSharedValues,

--- a/clients/client-bedrock-data-automation/src/runtimeConfig.ts
+++ b/clients/client-bedrock-data-automation/src/runtimeConfig.ts
@@ -35,6 +35,7 @@ export const getRuntimeConfig = (config: BedrockDataAutomationClientConfig) => {
   const loaderConfig = {
     profile: config?.profile,
     logger: clientSharedValues.logger,
+    signingName: "bedrock",
   };
   return {
     ...clientSharedValues,

--- a/clients/client-bedrock-runtime/src/runtimeConfig.ts
+++ b/clients/client-bedrock-runtime/src/runtimeConfig.ts
@@ -37,6 +37,7 @@ export const getRuntimeConfig = (config: BedrockRuntimeClientConfig) => {
   const loaderConfig = {
     profile: config?.profile,
     logger: clientSharedValues.logger,
+    signingName: "bedrock",
   };
   return {
     ...clientSharedValues,

--- a/clients/client-bedrock/src/runtimeConfig.ts
+++ b/clients/client-bedrock/src/runtimeConfig.ts
@@ -35,6 +35,7 @@ export const getRuntimeConfig = (config: BedrockClientConfig) => {
   const loaderConfig = {
     profile: config?.profile,
     logger: clientSharedValues.logger,
+    signingName: "bedrock",
   };
   return {
     ...clientSharedValues,


### PR DESCRIPTION
### Issue
Internal JS-5860

### Description
Populates signing name in loader config for `"bedrock"`

### Testing
Done in JS-5860

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
