### PR TITLE
chore(deps): bump fast-xml-parser from 4.4.1 to 5.2.5

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -94,7 +94,7 @@
     "@smithy/util-body-length-browser": "^4.0.0",
     "@smithy/util-middleware": "^4.0.4",
     "@smithy/util-utf8": "^4.0.0",
-    "fast-xml-parser": "4.4.1",
+    "fast-xml-parser": "5.2.5",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restxml-schema/package.json
+++ b/private/aws-protocoltests-restxml-schema/package.json
@@ -62,7 +62,7 @@
     "@smithy/util-utf8": "^4.0.0",
     "@types/uuid": "^9.0.1",
     "entities": "2.2.0",
-    "fast-xml-parser": "4.4.1",
+    "fast-xml-parser": "5.2.5",
     "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -62,7 +62,7 @@
     "@smithy/util-utf8": "^4.0.0",
     "@types/uuid": "^9.0.1",
     "entities": "2.2.0",
-    "fast-xml-parser": "4.4.1",
+    "fast-xml-parser": "5.2.5",
     "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "a563ee499673a0ce15452031626be5fc8bb86b6e",
+  SMITHY_TS_COMMIT: "bae1dc72101ae1868431d9004f7c5844c74fdf5f",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,7 +1029,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:4.4.1"
+    fast-xml-parser: "npm:5.2.5"
     rimraf: "npm:3.0.2"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -1090,7 +1090,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:4.4.1"
+    fast-xml-parser: "npm:5.2.5"
     rimraf: "npm:3.0.2"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -23215,7 +23215,7 @@ __metadata:
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
-    fast-xml-parser: "npm:4.4.1"
+    fast-xml-parser: "npm:5.2.5"
     rimraf: "npm:3.0.2"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -33858,14 +33858,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:4.4.1":
-  version: 4.4.1
-  resolution: "fast-xml-parser@npm:4.4.1"
+"fast-xml-parser@npm:5.2.5":
+  version: 5.2.5
+  resolution: "fast-xml-parser@npm:5.2.5"
   dependencies:
-    strnum: "npm:^1.0.5"
+    strnum: "npm:^2.1.0"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/7f334841fe41bfb0bf5d920904ccad09cefc4b5e61eaf4c225bf1e1bb69ee77ef2147d8942f783ee8249e154d1ca8a858e10bda78a5d78b8bed3f48dcee9bf33
+  checksum: 10c0/d1057d2e790c327ccfc42b872b91786a4912a152d44f9507bf053f800102dfb07ece3da0a86b33ff6a0caa5a5cad86da3326744f6ae5efb0c6c571d754fe48cd
   languageName: node
   linkType: hard
 
@@ -40663,10 +40663,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "strnum@npm:1.0.5"
-  checksum: 10c0/64fb8cc2effbd585a6821faa73ad97d4b553c8927e49086a162ffd2cc818787643390b89d567460a8e74300148d11ac052e21c921ef2049f2987f4b1b89a7ff1
+"strnum@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "strnum@npm:2.1.1"
+  checksum: 10c0/1f9bd1f9b4c68333f25c2b1f498ea529189f060cd50aa59f1876139c994d817056de3ce57c12c970f80568d75df2289725e218bd9e3cdf73cd1a876c9c102733
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue
#7174

### Description
Update `fast-xml-parser` to support ESM

### Testing
How was this change tested?
No new tests were created, but I was able to manually update the dependency in my local environment by adding the following to my package.json to force it to use version 5.2.5 and xml based web services continued to work in basic smoke testing.

```js
"overrides": {
    "fast-xml-parser": "5.2.5"
}
```

### Additional context
This can reduce bundle size by ~18K if you use esbuild.

### Checklist
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
