### PR TITLE
fix(tests): prevent changeset race condition in parallel tests

### DIFF
--- a/tests/e2e/delete-stale-changesets.js
+++ b/tests/e2e/delete-stale-changesets.js
@@ -13,7 +13,7 @@ exports.deleteStaleChangesets = async (client, stackName) => {
         changeset.Status === "FAILED" &&
         changeset.StatusReason ===
           `The submitted information didn't contain changes. Submit different information to create a change set.` &&
-        changeset.creationDate < new Date(Date.now() - 5 * 60 * 1000)
+        changeset.CreationTime < new Date(Date.now() - 5 * 60 * 1000)
       ) {
         console.log("Deleting stale changeset", changeset.ChangeSetId);
         await new Promise((r) => setTimeout(r, 200));

--- a/tests/e2e/delete-stale-changesets.js
+++ b/tests/e2e/delete-stale-changesets.js
@@ -12,7 +12,8 @@ exports.deleteStaleChangesets = async (client, stackName) => {
       if (
         changeset.Status === "FAILED" &&
         changeset.StatusReason ===
-          `The submitted information didn't contain changes. Submit different information to create a change set.`
+          `The submitted information didn't contain changes. Submit different information to create a change set.` &&
+        changeset.creationDate < new Date(Date.now() - 5 * 60 * 1000)
       ) {
         console.log("Deleting stale changeset", changeset.ChangeSetId);
         await new Promise((r) => setTimeout(r, 200));


### PR DESCRIPTION
### Issue
Internal JS-5881

### Description
Modified `deleteStaleChangesets()` to only delete changesets older than 5 minutes to prevent deletion of changesets that are actively being processed by other test processes.

### Testing
CI


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
