### PR TITLE
chore(scripts): reduce publish concurrency to fix socket hang up

### DIFF
--- a/scripts/verdaccio-publish/index.js
+++ b/scripts/verdaccio-publish/index.js
@@ -35,7 +35,7 @@ const args = [
   "--ignore-scripts",
   "--no-verify-access",
   "--concurrency",
-  "8",
+  "4",
   "--dist-tag",
   "ci",
 ];

--- a/tests/canary/canary.js
+++ b/tests/canary/canary.js
@@ -92,7 +92,7 @@ async function localPublishChangedPackages(root) {
     "--ignore-scripts",
     "--no-verify-access",
     "--concurrency",
-    "8",
+    "4",
     "--dist-tag",
     "ci",
   ];


### PR DESCRIPTION
### Issue
Internal JS-5953

### Description
Intermittent network errors during lerna publish operations causing build failures:
- `socket hang up` errors from npm registry
- `503 resource unavailable` responses
- `UnhandledPromiseRejection` when publish commands fail

Reduced lerna publish concurrency from 8 to 4 in verdaccio-publish script to reduce the number of concurrent requests.

### Testing
CI


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
