### PR TITLE
chore(codegen): bump codegen version to 0.33.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.33.0 (2025-07-10)
+
+### Features
+- Upgraded to smithy-typescript 0.33.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0330-2025-07-10))
+- Upgraded smithy version to 1.60.3 ([#7170](https://github.com/aws/aws-sdk-js-v3/pull/7170))
+- Updated codegen to get token from environment variable ([#7166](https://github.com/aws/aws-sdk-js-v3/pull/7166))
+- Updated codegen to use Websocket in browser runtime for Bedrock Runtime ([#7175](https://github.com/aws/aws-sdk-js-v3/pull/7175))
+
+### Bug Fixes
+- Used model service instead of iterating services ([#7184](https://github.com/aws/aws-sdk-js-v3/pull/7184))
+- Generated default endpoint provider for default regional AWS endpoints ([#7190](https://github.com/aws/aws-sdk-js-v3/pull/7190))
+
+### Documentation
+
 ## 0.32.0 (2025-06-26)
 
 ## Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.32.0"
+    version = "0.33.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.32.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.33.0")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "91f91d9bb0d5f7068a0594a13b36ac3806f05cba",
+  SMITHY_TS_COMMIT: "437f58f271a67f0745005f16faf53696df1b5af8",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Internal JS-6058

### Description
Bumps codegen version to 0.33.0

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
