### PR TITLE
chore(packages): set sideEffects metadata

### DIFF
--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -21,6 +21,7 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
+  "sideEffects": true,
   "dependencies": {
     "@aws-sdk/crt-loader": "*",
     "@aws-sdk/signature-v4-multi-region": "*",

--- a/packages/util-endpoints/package.json
+++ b/packages/util-endpoints/package.json
@@ -23,6 +23,7 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
+  "sideEffects": true,
   "dependencies": {
     "@aws-sdk/types": "*",
     "@smithy/types": "^4.3.1",


### PR DESCRIPTION
set sideEffects=true in signature-v4-crt and util-endpoints (AWS).

- signature-v4-crt has module-level code that injects the implementation to a dependency container that is checked in signature-v4-multi-region

- util-endpoints adds implementation functions to the core endpoints lib at the module level