### PR TITLE
feat(lib-storage): skip uploading parts if they are already listed in uploadedParts.

### DIFF
--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -247,10 +247,8 @@ export class Upload extends EventEmitter {
         }
       }
 
-      // If the part is already uploaded, skip it.
-      if (this.uploadedParts.some((uploadedPart) => uploadedPart.PartNumber === dataPart.partNumber)) {
-        continue;
-      }
+      // ✅ Suggestion: Use early continue with concise condition
+      if (this.uploadedParts.some(p => p.PartNumber === dataPart.partNumber)) continue;
 
       const partSize: number = byteLength(dataPart.data) || 0;
 


### PR DESCRIPTION
Skip uploading parts if they are already listed in uploadedParts.


### Description

In our biz scenario, we record `uploadId` `uploadedParts` `bytesUploadedSoFar` params to preserve information about uploaded parts. When an unexpected interruption occurs and the upload is resumed, we overwrite the previously recorded params. However, during the traversal of parts, the already recorded parts are not currently being skipped.

Therefore, adding this check will have a positive impact on the resume upload functionality.

### Checklist
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
