### PR TITLE
chore(scripts): use ssh private key for git sync

### DIFF
--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -12,14 +12,13 @@ jobs:
     steps:
       - name: git-sync
         env:
-          git_sync_source_repo: ${{ secrets.GIT_SYNC_SOURCE_REPO }}
           git_sync_destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }}
-        if: env.git_sync_source_repo && env.git_sync_destination_repo
+          git_sync_ssh_private_key: ${{ secrets.GIT_SYNC_SSH_PRIVATE_KEY }}
+        if: env.git_sync_destination_repo && env.git_sync_ssh_private_key
         uses: wei/git-sync@v3
         with:
-          source_repo: ${{ secrets.GIT_SYNC_SOURCE_REPO }}
+          source_repo: "git@github.com:aws/aws-sdk-js-v3.git"
           source_branch: "main"
           destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }} 
           destination_branch: "main"
-          source_ssh_private_key: ${{ secrets.GIT_SYNC_SOURCE_SSH_PRIVATE_KEY }}
-          destination_ssh_private_key:  ${{ secrets.GIT_SYNC_DESTINATION_SSH_PRIVATE_KEY }}
+          ssh_private_key: ${{ secrets.GIT_SYNC_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
### Issue

Internal JS-6078

### Description

Uses ssh private key for git sync

### Testing

Referred documentation https://github.com/wei/git-sync

Once this commit is merged, we'll verify that git-sync is successful.

On success, we'll delete the following:
* Secret: `GIT_SYNC_SOURCE_REPO`
* Secret: `GIT_SYNC_SOURCE_SSH_PRIVATE_KEY`
* Secret: `GIT_SYNC_DESTINATION_SSH_PRIVATE_KEY`
* Deploy key on this repo: `git-sync-source-public-key`
* Deploy key on destination repo: `git-sync-destination-public-key`

The ssh key rotate instructions will be updated to populate private key in secret `GIT_SYNC_SSH_PRIVATE_KEY`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
