### PR TITLE
chore(core/protocols): generate idempotencyTokens in ShapeSerializers

### DIFF
--- a/packages/core/src/submodules/protocols/idempotencyToken.spec.ts
+++ b/packages/core/src/submodules/protocols/idempotencyToken.spec.ts
@@ -1,0 +1,69 @@
+import { CborShapeSerializer } from "@smithy/core/cbor";
+import { sim, struct } from "@smithy/core/schema";
+import { describe, expect, test as it } from "vitest";
+
+import { JsonShapeSerializer } from "./json/JsonShapeSerializer";
+import { QueryShapeSerializer } from "./query/QueryShapeSerializer";
+import { XmlShapeSerializer } from "./xml/XmlShapeSerializer";
+
+describe("idempotencyToken", () => {
+  const structureSchema = struct(
+    "ns",
+    "StructureWithIdempotencyToken",
+    0,
+    ["idempotencyToken", "plain"],
+    [sim("ns", "IdempotencyTokenString", 0, 0b0100), sim("ns", "PlainString", 0, 0b0000)]
+  );
+
+  it("all ShapeSerializer implementations should generate an idempotency token if no input was provided by the caller", () => {
+    const serializers = [
+      new JsonShapeSerializer({
+        timestampFormat: { default: 7, useTrait: true },
+        jsonName: true,
+      }),
+      new QueryShapeSerializer({
+        timestampFormat: { default: 7, useTrait: true },
+      }),
+      new XmlShapeSerializer({
+        serviceNamespace: "ServiceNamespace",
+        timestampFormat: { default: 7, useTrait: true },
+        xmlNamespace: "XmlNamespace",
+      }),
+      new CborShapeSerializer(),
+    ];
+
+    const expectedSerializations = [
+      /{"idempotencyToken":"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}","plain":"potatoes"}/,
+      /&idempotencyToken=[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}&plain=potatoes/,
+      /<StructureWithIdempotencyToken xmlns="XmlNamespace"><idempotencyToken>([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})<\/idempotencyToken><plain>potatoes<\/plain><\/StructureWithIdempotencyToken>/,
+      /�pidempotencyTokenx\$([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})eplainhpotatoes/,
+    ];
+
+    for (let i = 0; i < expectedSerializations.length; i++) {
+      const serializer = serializers[i];
+      const expectedSerialization = expectedSerializations[i];
+
+      // automatic token
+      {
+        serializer.write(structureSchema, {
+          idempotencyToken: undefined,
+          plain: "potatoes",
+        });
+        const data = serializer.flush();
+        const serialization = Buffer.from(data).toString("utf8");
+        expect(serialization).toMatch(expectedSerialization);
+      }
+
+      // manual token
+      {
+        serializer.write(structureSchema, {
+          idempotencyToken: "00000000-0000-4000-9000-000000000000",
+          plain: "potatoes",
+        });
+        const data = serializer.flush();
+        const serialization = Buffer.from(data).toString("utf8");
+        expect(serialization).toMatch(expectedSerialization);
+      }
+    }
+  });
+});

--- a/packages/core/src/submodules/protocols/json/JsonShapeSerializer.ts
+++ b/packages/core/src/submodules/protocols/json/JsonShapeSerializer.ts
@@ -1,6 +1,5 @@
 import { NormalizedSchema, SCHEMA } from "@smithy/core/schema";
-import { dateToUtcString } from "@smithy/core/serde";
-import { LazyJsonString } from "@smithy/core/serde";
+import { dateToUtcString, generateIdempotencyToken, LazyJsonString } from "@smithy/core/serde";
 import { Schema, ShapeSerializer } from "@smithy/types";
 
 import { SerdeContextConfig } from "../ConfigurableSerdeContext";
@@ -110,11 +109,18 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
       }
     }
 
-    const mediaType = ns.getMergedTraits().mediaType;
-    if (ns.isStringSchema() && typeof value === "string" && mediaType) {
-      const isJson = mediaType === "application/json" || mediaType.endsWith("+json");
-      if (isJson) {
-        return LazyJsonString.from(value);
+    if (ns.isStringSchema()) {
+      if (typeof value === "undefined" && ns.isIdempotencyToken()) {
+        return generateIdempotencyToken();
+      }
+
+      const mediaType = ns.getMergedTraits().mediaType;
+
+      if (typeof value === "string" && mediaType) {
+        const isJson = mediaType === "application/json" || mediaType.endsWith("+json");
+        if (isJson) {
+          return LazyJsonString.from(value);
+        }
       }
     }
 

--- a/packages/core/src/submodules/protocols/json/jsonReplacer.ts
+++ b/packages/core/src/submodules/protocols/json/jsonReplacer.ts
@@ -33,7 +33,7 @@ export class JsonReplacer {
 
     return (key: string, value: unknown) => {
       if (value instanceof NumericValue) {
-        const v = `${NUMERIC_CONTROL_CHAR + +"nv" + this.counter++}_` + value.string;
+        const v = `${NUMERIC_CONTROL_CHAR + "nv" + this.counter++}_` + value.string;
         this.values.set(`"${v}"`, value.string);
         return v;
       }


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/issues/1600

### Description
Generate idempotency tokens in ShapeSerializers used by schema-serde.

### Testing
New unit test

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
