### PR TITLE
test(middleware-flexible-checksums): retry reuses the computed checksum

### DIFF
--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -1,0 +1,61 @@
+import { S3 } from "@aws-sdk/client-s3";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { HttpResponse } from "@smithy/protocol-http";
+import { describe, expect, test as it } from "vitest";
+
+describe("middleware-flexible-checksums.retry", () => {
+  it("retry reuses the checksum", async () => {
+    const maxAttempts = 3;
+    class CustomHandler extends NodeHttpHandler {
+      async handle() {
+        return {
+          response: new HttpResponse({
+            statusCode: 500, // Fake Trasient Error
+            headers: {},
+          }),
+        };
+      }
+    }
+    const requestHandler = new CustomHandler();
+    const client = new S3({ maxAttempts, requestHandler });
+
+    let flexChecksCalls = 0;
+    client.middlewareStack.addRelativeTo(
+      (next: any) => async (args: any) => {
+        flexChecksCalls++;
+        return next(args);
+      },
+      {
+        toMiddleware: "flexibleChecksumsMiddleware",
+        relation: "after",
+      }
+    );
+
+    let retryMiddlewareCalls = 0;
+    client.middlewareStack.addRelativeTo(
+      (next: any) => async (args: any) => {
+        retryMiddlewareCalls++;
+        return next(args);
+      },
+      {
+        toMiddleware: "retryMiddleware",
+        relation: "after",
+      }
+    );
+
+    await client
+      .putObject({
+        Bucket: "b",
+        Key: "k",
+        Body: "hello",
+      })
+      .catch(() => {
+        // Expected, since we're faking transient error which is retried.
+      });
+
+    // Validate that flexibleChecksumsMiddleware is called once.
+    expect(flexChecksCalls).toEqual(1);
+    // Validate that retryMiddleware is called maxAttempts times.
+    expect(retryMiddlewareCalls).toEqual(maxAttempts);
+  });
+});


### PR DESCRIPTION
### Issue
Internal JS-5905

### Description
Adds an integration test which confirms checksum is not recomputed on retries 

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
