### PR TITLE
chore(protocoltests): use schema log filter when available

### DIFF
--- a/private/aws-protocoltests-ec2-schema/src/commands/DatetimeOffsetsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/DatetimeOffsetsCommand.ts
@@ -69,7 +69,6 @@ export class DatetimeOffsetsCommand extends $Command
   })
   .s("AwsEc2", "DatetimeOffsets", {})
   .n("EC2ProtocolClient", "DatetimeOffsetsCommand")
-  .f(void 0, void 0)
   .sc(DatetimeOffsets)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/EmptyInputAndEmptyOutputCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/EmptyInputAndEmptyOutputCommand.ts
@@ -70,7 +70,6 @@ export class EmptyInputAndEmptyOutputCommand extends $Command
   })
   .s("AwsEc2", "EmptyInputAndEmptyOutput", {})
   .n("EC2ProtocolClient", "EmptyInputAndEmptyOutputCommand")
-  .f(void 0, void 0)
   .sc(EmptyInputAndEmptyOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/EndpointOperationCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/EndpointOperationCommand.ts
@@ -66,7 +66,6 @@ export class EndpointOperationCommand extends $Command
   })
   .s("AwsEc2", "EndpointOperation", {})
   .n("EC2ProtocolClient", "EndpointOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
@@ -69,7 +69,6 @@ export class EndpointWithHostLabelOperationCommand extends $Command
   })
   .s("AwsEc2", "EndpointWithHostLabelOperation", {})
   .n("EC2ProtocolClient", "EndpointWithHostLabelOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointWithHostLabelOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/FractionalSecondsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/FractionalSecondsCommand.ts
@@ -69,7 +69,6 @@ export class FractionalSecondsCommand extends $Command
   })
   .s("AwsEc2", "FractionalSeconds", {})
   .n("EC2ProtocolClient", "FractionalSecondsCommand")
-  .f(void 0, void 0)
   .sc(FractionalSeconds)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -79,7 +79,6 @@ export class GreetingWithErrorsCommand extends $Command
   })
   .s("AwsEc2", "GreetingWithErrors", {})
   .n("EC2ProtocolClient", "GreetingWithErrorsCommand")
-  .f(void 0, void 0)
   .sc(GreetingWithErrors)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/HostWithPathOperationCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/HostWithPathOperationCommand.ts
@@ -66,7 +66,6 @@ export class HostWithPathOperationCommand extends $Command
   })
   .s("AwsEc2", "HostWithPathOperation", {})
   .n("EC2ProtocolClient", "HostWithPathOperationCommand")
-  .f(void 0, void 0)
   .sc(HostWithPathOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/IgnoresWrappingXmlNameCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/IgnoresWrappingXmlNameCommand.ts
@@ -71,7 +71,6 @@ export class IgnoresWrappingXmlNameCommand extends $Command
   })
   .s("AwsEc2", "IgnoresWrappingXmlName", {})
   .n("EC2ProtocolClient", "IgnoresWrappingXmlNameCommand")
-  .f(void 0, void 0)
   .sc(IgnoresWrappingXmlName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/NestedStructuresCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/NestedStructuresCommand.ts
@@ -77,7 +77,6 @@ export class NestedStructuresCommand extends $Command
   })
   .s("AwsEc2", "NestedStructures", {})
   .n("EC2ProtocolClient", "NestedStructuresCommand")
-  .f(void 0, void 0)
   .sc(NestedStructures)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/NoInputAndOutputCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/NoInputAndOutputCommand.ts
@@ -70,7 +70,6 @@ export class NoInputAndOutputCommand extends $Command
   })
   .s("AwsEc2", "NoInputAndOutput", {})
   .n("EC2ProtocolClient", "NoInputAndOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputAndOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/PutWithContentEncodingCommand.ts
@@ -76,7 +76,6 @@ export class PutWithContentEncodingCommand extends $Command
   })
   .s("AwsEc2", "PutWithContentEncoding", {})
   .n("EC2ProtocolClient", "PutWithContentEncodingCommand")
-  .f(void 0, void 0)
   .sc(PutWithContentEncoding)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/QueryIdempotencyTokenAutoFillCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/QueryIdempotencyTokenAutoFillCommand.ts
@@ -69,7 +69,6 @@ export class QueryIdempotencyTokenAutoFillCommand extends $Command
   })
   .s("AwsEc2", "QueryIdempotencyTokenAutoFill", {})
   .n("EC2ProtocolClient", "QueryIdempotencyTokenAutoFillCommand")
-  .f(void 0, void 0)
   .sc(QueryIdempotencyTokenAutoFill)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/QueryListsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/QueryListsCommand.ts
@@ -87,7 +87,6 @@ export class QueryListsCommand extends $Command
   })
   .s("AwsEc2", "QueryLists", {})
   .n("EC2ProtocolClient", "QueryListsCommand")
-  .f(void 0, void 0)
   .sc(QueryLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/QueryTimestampsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/QueryTimestampsCommand.ts
@@ -75,7 +75,6 @@ export class QueryTimestampsCommand extends $Command
   })
   .s("AwsEc2", "QueryTimestamps", {})
   .n("EC2ProtocolClient", "QueryTimestampsCommand")
-  .f(void 0, void 0)
   .sc(QueryTimestamps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/RecursiveXmlShapesCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/RecursiveXmlShapesCommand.ts
@@ -81,7 +81,6 @@ export class RecursiveXmlShapesCommand extends $Command
   })
   .s("AwsEc2", "RecursiveXmlShapes", {})
   .n("EC2ProtocolClient", "RecursiveXmlShapesCommand")
-  .f(void 0, void 0)
   .sc(RecursiveXmlShapes)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/SimpleInputParamsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/SimpleInputParamsCommand.ts
@@ -79,7 +79,6 @@ export class SimpleInputParamsCommand extends $Command
   })
   .s("AwsEc2", "SimpleInputParams", {})
   .n("EC2ProtocolClient", "SimpleInputParamsCommand")
-  .f(void 0, void 0)
   .sc(SimpleInputParams)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/SimpleScalarXmlPropertiesCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/SimpleScalarXmlPropertiesCommand.ts
@@ -78,7 +78,6 @@ export class SimpleScalarXmlPropertiesCommand extends $Command
   })
   .s("AwsEc2", "SimpleScalarXmlProperties", {})
   .n("EC2ProtocolClient", "SimpleScalarXmlPropertiesCommand")
-  .f(void 0, void 0)
   .sc(SimpleScalarXmlProperties)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/XmlBlobsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/XmlBlobsCommand.ts
@@ -69,7 +69,6 @@ export class XmlBlobsCommand extends $Command
   })
   .s("AwsEc2", "XmlBlobs", {})
   .n("EC2ProtocolClient", "XmlBlobsCommand")
-  .f(void 0, void 0)
   .sc(XmlBlobs)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/XmlEmptyBlobsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/XmlEmptyBlobsCommand.ts
@@ -69,7 +69,6 @@ export class XmlEmptyBlobsCommand extends $Command
   })
   .s("AwsEc2", "XmlEmptyBlobs", {})
   .n("EC2ProtocolClient", "XmlEmptyBlobsCommand")
-  .f(void 0, void 0)
   .sc(XmlEmptyBlobs)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/XmlEmptyListsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/XmlEmptyListsCommand.ts
@@ -115,7 +115,6 @@ export class XmlEmptyListsCommand extends $Command
   })
   .s("AwsEc2", "XmlEmptyLists", {})
   .n("EC2ProtocolClient", "XmlEmptyListsCommand")
-  .f(void 0, void 0)
   .sc(XmlEmptyLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/XmlEnumsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/XmlEnumsCommand.ts
@@ -80,7 +80,6 @@ export class XmlEnumsCommand extends $Command
   })
   .s("AwsEc2", "XmlEnums", {})
   .n("EC2ProtocolClient", "XmlEnumsCommand")
-  .f(void 0, void 0)
   .sc(XmlEnums)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/XmlIntEnumsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/XmlIntEnumsCommand.ts
@@ -80,7 +80,6 @@ export class XmlIntEnumsCommand extends $Command
   })
   .s("AwsEc2", "XmlIntEnums", {})
   .n("EC2ProtocolClient", "XmlIntEnumsCommand")
-  .f(void 0, void 0)
   .sc(XmlIntEnums)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/XmlListsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/XmlListsCommand.ts
@@ -125,7 +125,6 @@ export class XmlListsCommand extends $Command
   })
   .s("AwsEc2", "XmlLists", {})
   .n("EC2ProtocolClient", "XmlListsCommand")
-  .f(void 0, void 0)
   .sc(XmlLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/XmlNamespacesCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/XmlNamespacesCommand.ts
@@ -74,7 +74,6 @@ export class XmlNamespacesCommand extends $Command
   })
   .s("AwsEc2", "XmlNamespaces", {})
   .n("EC2ProtocolClient", "XmlNamespacesCommand")
-  .f(void 0, void 0)
   .sc(XmlNamespaces)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-ec2-schema/src/commands/XmlTimestampsCommand.ts
+++ b/private/aws-protocoltests-ec2-schema/src/commands/XmlTimestampsCommand.ts
@@ -77,7 +77,6 @@ export class XmlTimestampsCommand extends $Command
   })
   .s("AwsEc2", "XmlTimestamps", {})
   .n("EC2ProtocolClient", "XmlTimestampsCommand")
-  .f(void 0, void 0)
   .sc(XmlTimestamps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/ContentTypeParametersCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/ContentTypeParametersCommand.ts
@@ -70,7 +70,6 @@ export class ContentTypeParametersCommand extends $Command
   })
   .s("JsonRpc10", "ContentTypeParameters", {})
   .n("JSONRPC10Client", "ContentTypeParametersCommand")
-  .f(void 0, void 0)
   .sc(ContentTypeParameters)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/EmptyInputAndEmptyOutputCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/EmptyInputAndEmptyOutputCommand.ts
@@ -70,7 +70,6 @@ export class EmptyInputAndEmptyOutputCommand extends $Command
   })
   .s("JsonRpc10", "EmptyInputAndEmptyOutput", {})
   .n("JSONRPC10Client", "EmptyInputAndEmptyOutputCommand")
-  .f(void 0, void 0)
   .sc(EmptyInputAndEmptyOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/EndpointOperationCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/EndpointOperationCommand.ts
@@ -66,7 +66,6 @@ export class EndpointOperationCommand extends $Command
   })
   .s("JsonRpc10", "EndpointOperation", {})
   .n("JSONRPC10Client", "EndpointOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
@@ -69,7 +69,6 @@ export class EndpointWithHostLabelOperationCommand extends $Command
   })
   .s("JsonRpc10", "EndpointWithHostLabelOperation", {})
   .n("JSONRPC10Client", "EndpointWithHostLabelOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointWithHostLabelOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -88,7 +88,6 @@ export class GreetingWithErrorsCommand extends $Command
   })
   .s("JsonRpc10", "GreetingWithErrors", {})
   .n("JSONRPC10Client", "GreetingWithErrorsCommand")
-  .f(void 0, void 0)
   .sc(GreetingWithErrors)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/HostWithPathOperationCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/HostWithPathOperationCommand.ts
@@ -66,7 +66,6 @@ export class HostWithPathOperationCommand extends $Command
   })
   .s("JsonRpc10", "HostWithPathOperation", {})
   .n("JSONRPC10Client", "HostWithPathOperationCommand")
-  .f(void 0, void 0)
   .sc(HostWithPathOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/JsonUnionsCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/JsonUnionsCommand.ts
@@ -105,7 +105,6 @@ export class JsonUnionsCommand extends $Command
   })
   .s("JsonRpc10", "JsonUnions", {})
   .n("JSONRPC10Client", "JsonUnionsCommand")
-  .f(void 0, void 0)
   .sc(JsonUnions)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/NoInputAndNoOutputCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/NoInputAndNoOutputCommand.ts
@@ -68,7 +68,6 @@ export class NoInputAndNoOutputCommand extends $Command
   })
   .s("JsonRpc10", "NoInputAndNoOutput", {})
   .n("JSONRPC10Client", "NoInputAndNoOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputAndNoOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/NoInputAndOutputCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/NoInputAndOutputCommand.ts
@@ -70,7 +70,6 @@ export class NoInputAndOutputCommand extends $Command
   })
   .s("JsonRpc10", "NoInputAndOutput", {})
   .n("JSONRPC10Client", "NoInputAndOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputAndOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/OperationWithDefaultsCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/OperationWithDefaultsCommand.ts
@@ -140,7 +140,6 @@ export class OperationWithDefaultsCommand extends $Command
   })
   .s("JsonRpc10", "OperationWithDefaults", {})
   .n("JSONRPC10Client", "OperationWithDefaultsCommand")
-  .f(void 0, void 0)
   .sc(OperationWithDefaults)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/OperationWithNestedStructureCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/OperationWithNestedStructureCommand.ts
@@ -123,7 +123,6 @@ export class OperationWithNestedStructureCommand extends $Command
   })
   .s("JsonRpc10", "OperationWithNestedStructure", {})
   .n("JSONRPC10Client", "OperationWithNestedStructureCommand")
-  .f(void 0, void 0)
   .sc(OperationWithNestedStructure)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/OperationWithRequiredMembersCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/OperationWithRequiredMembersCommand.ts
@@ -86,7 +86,6 @@ export class OperationWithRequiredMembersCommand extends $Command
   })
   .s("JsonRpc10", "OperationWithRequiredMembers", {})
   .n("JSONRPC10Client", "OperationWithRequiredMembersCommand")
-  .f(void 0, void 0)
   .sc(OperationWithRequiredMembers)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/OperationWithRequiredMembersWithDefaultsCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/OperationWithRequiredMembersWithDefaultsCommand.ts
@@ -88,7 +88,6 @@ export class OperationWithRequiredMembersWithDefaultsCommand extends $Command
   })
   .s("JsonRpc10", "OperationWithRequiredMembersWithDefaults", {})
   .n("JSONRPC10Client", "OperationWithRequiredMembersWithDefaultsCommand")
-  .f(void 0, void 0)
   .sc(OperationWithRequiredMembersWithDefaults)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/PutWithContentEncodingCommand.ts
@@ -76,7 +76,6 @@ export class PutWithContentEncodingCommand extends $Command
   })
   .s("JsonRpc10", "PutWithContentEncoding", {})
   .n("JSONRPC10Client", "PutWithContentEncodingCommand")
-  .f(void 0, void 0)
   .sc(PutWithContentEncoding)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/QueryIncompatibleOperationCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/QueryIncompatibleOperationCommand.ts
@@ -66,7 +66,6 @@ export class QueryIncompatibleOperationCommand extends $Command
   })
   .s("JsonRpc10", "QueryIncompatibleOperation", {})
   .n("JSONRPC10Client", "QueryIncompatibleOperationCommand")
-  .f(void 0, void 0)
   .sc(QueryIncompatibleOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-10-schema/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/aws-protocoltests-json-10-schema/src/commands/SimpleScalarPropertiesCommand.ts
@@ -73,7 +73,6 @@ export class SimpleScalarPropertiesCommand extends $Command
   })
   .s("JsonRpc10", "SimpleScalarProperties", {})
   .n("JSONRPC10Client", "SimpleScalarPropertiesCommand")
-  .f(void 0, void 0)
   .sc(SimpleScalarProperties)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/ContentTypeParametersCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/ContentTypeParametersCommand.ts
@@ -70,7 +70,6 @@ export class ContentTypeParametersCommand extends $Command
   })
   .s("JsonProtocol", "ContentTypeParameters", {})
   .n("JsonProtocolClient", "ContentTypeParametersCommand")
-  .f(void 0, void 0)
   .sc(ContentTypeParameters)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/DatetimeOffsetsCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/DatetimeOffsetsCommand.ts
@@ -69,7 +69,6 @@ export class DatetimeOffsetsCommand extends $Command
   })
   .s("JsonProtocol", "DatetimeOffsets", {})
   .n("JsonProtocolClient", "DatetimeOffsetsCommand")
-  .f(void 0, void 0)
   .sc(DatetimeOffsets)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/EmptyOperationCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/EmptyOperationCommand.ts
@@ -66,7 +66,6 @@ export class EmptyOperationCommand extends $Command
   })
   .s("JsonProtocol", "EmptyOperation", {})
   .n("JsonProtocolClient", "EmptyOperationCommand")
-  .f(void 0, void 0)
   .sc(EmptyOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/EndpointOperationCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/EndpointOperationCommand.ts
@@ -66,7 +66,6 @@ export class EndpointOperationCommand extends $Command
   })
   .s("JsonProtocol", "EndpointOperation", {})
   .n("JsonProtocolClient", "EndpointOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
@@ -69,7 +69,6 @@ export class EndpointWithHostLabelOperationCommand extends $Command
   })
   .s("JsonProtocol", "EndpointWithHostLabelOperation", {})
   .n("JsonProtocolClient", "EndpointWithHostLabelOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointWithHostLabelOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/FractionalSecondsCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/FractionalSecondsCommand.ts
@@ -69,7 +69,6 @@ export class FractionalSecondsCommand extends $Command
   })
   .s("JsonProtocol", "FractionalSeconds", {})
   .n("JsonProtocolClient", "FractionalSecondsCommand")
-  .f(void 0, void 0)
   .sc(FractionalSeconds)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -86,7 +86,6 @@ export class GreetingWithErrorsCommand extends $Command
   })
   .s("JsonProtocol", "GreetingWithErrors", {})
   .n("JsonProtocolClient", "GreetingWithErrorsCommand")
-  .f(void 0, void 0)
   .sc(GreetingWithErrors)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/HostWithPathOperationCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/HostWithPathOperationCommand.ts
@@ -66,7 +66,6 @@ export class HostWithPathOperationCommand extends $Command
   })
   .s("JsonProtocol", "HostWithPathOperation", {})
   .n("JsonProtocolClient", "HostWithPathOperationCommand")
-  .f(void 0, void 0)
   .sc(HostWithPathOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/JsonEnumsCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/JsonEnumsCommand.ts
@@ -93,7 +93,6 @@ export class JsonEnumsCommand extends $Command
   })
   .s("JsonProtocol", "JsonEnums", {})
   .n("JsonProtocolClient", "JsonEnumsCommand")
-  .f(void 0, void 0)
   .sc(JsonEnums)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/JsonIntEnumsCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/JsonIntEnumsCommand.ts
@@ -93,7 +93,6 @@ export class JsonIntEnumsCommand extends $Command
   })
   .s("JsonProtocol", "JsonIntEnums", {})
   .n("JsonProtocolClient", "JsonIntEnumsCommand")
-  .f(void 0, void 0)
   .sc(JsonIntEnums)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/JsonUnionsCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/JsonUnionsCommand.ts
@@ -103,7 +103,6 @@ export class JsonUnionsCommand extends $Command
   })
   .s("JsonProtocol", "JsonUnions", {})
   .n("JsonProtocolClient", "JsonUnionsCommand")
-  .f(void 0, void 0)
   .sc(JsonUnions)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/KitchenSinkOperationCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/KitchenSinkOperationCommand.ts
@@ -291,7 +291,6 @@ export class KitchenSinkOperationCommand extends $Command
   })
   .s("JsonProtocol", "KitchenSinkOperation", {})
   .n("JsonProtocolClient", "KitchenSinkOperationCommand")
-  .f(void 0, void 0)
   .sc(KitchenSinkOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/NullOperationCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/NullOperationCommand.ts
@@ -71,7 +71,6 @@ export class NullOperationCommand extends $Command
   })
   .s("JsonProtocol", "NullOperation", {})
   .n("JsonProtocolClient", "NullOperationCommand")
-  .f(void 0, void 0)
   .sc(NullOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/OperationWithOptionalInputOutputCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/OperationWithOptionalInputOutputCommand.ts
@@ -73,7 +73,6 @@ export class OperationWithOptionalInputOutputCommand extends $Command
   })
   .s("JsonProtocol", "OperationWithOptionalInputOutput", {})
   .n("JsonProtocolClient", "OperationWithOptionalInputOutputCommand")
-  .f(void 0, void 0)
   .sc(OperationWithOptionalInputOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/PutAndGetInlineDocumentsCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/PutAndGetInlineDocumentsCommand.ts
@@ -71,7 +71,6 @@ export class PutAndGetInlineDocumentsCommand extends $Command
   })
   .s("JsonProtocol", "PutAndGetInlineDocuments", {})
   .n("JsonProtocolClient", "PutAndGetInlineDocumentsCommand")
-  .f(void 0, void 0)
   .sc(PutAndGetInlineDocuments)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/PutWithContentEncodingCommand.ts
@@ -76,7 +76,6 @@ export class PutWithContentEncodingCommand extends $Command
   })
   .s("JsonProtocol", "PutWithContentEncoding", {})
   .n("JsonProtocolClient", "PutWithContentEncodingCommand")
-  .f(void 0, void 0)
   .sc(PutWithContentEncoding)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/SimpleScalarPropertiesCommand.ts
@@ -73,7 +73,6 @@ export class SimpleScalarPropertiesCommand extends $Command
   })
   .s("JsonProtocol", "SimpleScalarProperties", {})
   .n("JsonProtocolClient", "SimpleScalarPropertiesCommand")
-  .f(void 0, void 0)
   .sc(SimpleScalarProperties)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-json-schema/src/commands/SparseNullsOperationCommand.ts
+++ b/private/aws-protocoltests-json-schema/src/commands/SparseNullsOperationCommand.ts
@@ -81,7 +81,6 @@ export class SparseNullsOperationCommand extends $Command
   })
   .s("JsonProtocol", "SparseNullsOperation", {})
   .n("JsonProtocolClient", "SparseNullsOperationCommand")
-  .f(void 0, void 0)
   .sc(SparseNullsOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/DatetimeOffsetsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/DatetimeOffsetsCommand.ts
@@ -69,7 +69,6 @@ export class DatetimeOffsetsCommand extends $Command
   })
   .s("AwsQuery", "DatetimeOffsets", {})
   .n("QueryProtocolClient", "DatetimeOffsetsCommand")
-  .f(void 0, void 0)
   .sc(DatetimeOffsets)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/EmptyInputAndEmptyOutputCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/EmptyInputAndEmptyOutputCommand.ts
@@ -70,7 +70,6 @@ export class EmptyInputAndEmptyOutputCommand extends $Command
   })
   .s("AwsQuery", "EmptyInputAndEmptyOutput", {})
   .n("QueryProtocolClient", "EmptyInputAndEmptyOutputCommand")
-  .f(void 0, void 0)
   .sc(EmptyInputAndEmptyOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/EndpointOperationCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/EndpointOperationCommand.ts
@@ -66,7 +66,6 @@ export class EndpointOperationCommand extends $Command
   })
   .s("AwsQuery", "EndpointOperation", {})
   .n("QueryProtocolClient", "EndpointOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
@@ -69,7 +69,6 @@ export class EndpointWithHostLabelOperationCommand extends $Command
   })
   .s("AwsQuery", "EndpointWithHostLabelOperation", {})
   .n("QueryProtocolClient", "EndpointWithHostLabelOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointWithHostLabelOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/FlattenedXmlMapCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/FlattenedXmlMapCommand.ts
@@ -71,7 +71,6 @@ export class FlattenedXmlMapCommand extends $Command
   })
   .s("AwsQuery", "FlattenedXmlMap", {})
   .n("QueryProtocolClient", "FlattenedXmlMapCommand")
-  .f(void 0, void 0)
   .sc(FlattenedXmlMap)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/FlattenedXmlMapWithXmlNameCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/FlattenedXmlMapWithXmlNameCommand.ts
@@ -71,7 +71,6 @@ export class FlattenedXmlMapWithXmlNameCommand extends $Command
   })
   .s("AwsQuery", "FlattenedXmlMapWithXmlName", {})
   .n("QueryProtocolClient", "FlattenedXmlMapWithXmlNameCommand")
-  .f(void 0, void 0)
   .sc(FlattenedXmlMapWithXmlName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/FlattenedXmlMapWithXmlNamespaceCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/FlattenedXmlMapWithXmlNamespaceCommand.ts
@@ -73,7 +73,6 @@ export class FlattenedXmlMapWithXmlNamespaceCommand extends $Command
   })
   .s("AwsQuery", "FlattenedXmlMapWithXmlNamespace", {})
   .n("QueryProtocolClient", "FlattenedXmlMapWithXmlNamespaceCommand")
-  .f(void 0, void 0)
   .sc(FlattenedXmlMapWithXmlNamespace)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/FractionalSecondsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/FractionalSecondsCommand.ts
@@ -69,7 +69,6 @@ export class FractionalSecondsCommand extends $Command
   })
   .s("AwsQuery", "FractionalSeconds", {})
   .n("QueryProtocolClient", "FractionalSecondsCommand")
-  .f(void 0, void 0)
   .sc(FractionalSeconds)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -81,7 +81,6 @@ export class GreetingWithErrorsCommand extends $Command
   })
   .s("AwsQuery", "GreetingWithErrors", {})
   .n("QueryProtocolClient", "GreetingWithErrorsCommand")
-  .f(void 0, void 0)
   .sc(GreetingWithErrors)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/HostWithPathOperationCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/HostWithPathOperationCommand.ts
@@ -66,7 +66,6 @@ export class HostWithPathOperationCommand extends $Command
   })
   .s("AwsQuery", "HostWithPathOperation", {})
   .n("QueryProtocolClient", "HostWithPathOperationCommand")
-  .f(void 0, void 0)
   .sc(HostWithPathOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/IgnoresWrappingXmlNameCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/IgnoresWrappingXmlNameCommand.ts
@@ -72,7 +72,6 @@ export class IgnoresWrappingXmlNameCommand extends $Command
   })
   .s("AwsQuery", "IgnoresWrappingXmlName", {})
   .n("QueryProtocolClient", "IgnoresWrappingXmlNameCommand")
-  .f(void 0, void 0)
   .sc(IgnoresWrappingXmlName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/NestedStructuresCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/NestedStructuresCommand.ts
@@ -77,7 +77,6 @@ export class NestedStructuresCommand extends $Command
   })
   .s("AwsQuery", "NestedStructures", {})
   .n("QueryProtocolClient", "NestedStructuresCommand")
-  .f(void 0, void 0)
   .sc(NestedStructures)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/NoInputAndNoOutputCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/NoInputAndNoOutputCommand.ts
@@ -69,7 +69,6 @@ export class NoInputAndNoOutputCommand extends $Command
   })
   .s("AwsQuery", "NoInputAndNoOutput", {})
   .n("QueryProtocolClient", "NoInputAndNoOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputAndNoOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/NoInputAndOutputCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/NoInputAndOutputCommand.ts
@@ -70,7 +70,6 @@ export class NoInputAndOutputCommand extends $Command
   })
   .s("AwsQuery", "NoInputAndOutput", {})
   .n("QueryProtocolClient", "NoInputAndOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputAndOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/PutWithContentEncodingCommand.ts
@@ -76,7 +76,6 @@ export class PutWithContentEncodingCommand extends $Command
   })
   .s("AwsQuery", "PutWithContentEncoding", {})
   .n("QueryProtocolClient", "PutWithContentEncodingCommand")
-  .f(void 0, void 0)
   .sc(PutWithContentEncoding)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/QueryIdempotencyTokenAutoFillCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/QueryIdempotencyTokenAutoFillCommand.ts
@@ -69,7 +69,6 @@ export class QueryIdempotencyTokenAutoFillCommand extends $Command
   })
   .s("AwsQuery", "QueryIdempotencyTokenAutoFill", {})
   .n("QueryProtocolClient", "QueryIdempotencyTokenAutoFillCommand")
-  .f(void 0, void 0)
   .sc(QueryIdempotencyTokenAutoFill)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/QueryListsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/QueryListsCommand.ts
@@ -90,7 +90,6 @@ export class QueryListsCommand extends $Command
   })
   .s("AwsQuery", "QueryLists", {})
   .n("QueryProtocolClient", "QueryListsCommand")
-  .f(void 0, void 0)
   .sc(QueryLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/QueryMapsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/QueryMapsCommand.ts
@@ -98,7 +98,6 @@ export class QueryMapsCommand extends $Command
   })
   .s("AwsQuery", "QueryMaps", {})
   .n("QueryProtocolClient", "QueryMapsCommand")
-  .f(void 0, void 0)
   .sc(QueryMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/QueryTimestampsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/QueryTimestampsCommand.ts
@@ -75,7 +75,6 @@ export class QueryTimestampsCommand extends $Command
   })
   .s("AwsQuery", "QueryTimestamps", {})
   .n("QueryProtocolClient", "QueryTimestampsCommand")
-  .f(void 0, void 0)
   .sc(QueryTimestamps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/RecursiveXmlShapesCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/RecursiveXmlShapesCommand.ts
@@ -81,7 +81,6 @@ export class RecursiveXmlShapesCommand extends $Command
   })
   .s("AwsQuery", "RecursiveXmlShapes", {})
   .n("QueryProtocolClient", "RecursiveXmlShapesCommand")
-  .f(void 0, void 0)
   .sc(RecursiveXmlShapes)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/SimpleInputParamsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/SimpleInputParamsCommand.ts
@@ -77,7 +77,6 @@ export class SimpleInputParamsCommand extends $Command
   })
   .s("AwsQuery", "SimpleInputParams", {})
   .n("QueryProtocolClient", "SimpleInputParamsCommand")
-  .f(void 0, void 0)
   .sc(SimpleInputParams)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/SimpleScalarXmlPropertiesCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/SimpleScalarXmlPropertiesCommand.ts
@@ -78,7 +78,6 @@ export class SimpleScalarXmlPropertiesCommand extends $Command
   })
   .s("AwsQuery", "SimpleScalarXmlProperties", {})
   .n("QueryProtocolClient", "SimpleScalarXmlPropertiesCommand")
-  .f(void 0, void 0)
   .sc(SimpleScalarXmlProperties)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlBlobsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlBlobsCommand.ts
@@ -69,7 +69,6 @@ export class XmlBlobsCommand extends $Command
   })
   .s("AwsQuery", "XmlBlobs", {})
   .n("QueryProtocolClient", "XmlBlobsCommand")
-  .f(void 0, void 0)
   .sc(XmlBlobs)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlEmptyBlobsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlEmptyBlobsCommand.ts
@@ -69,7 +69,6 @@ export class XmlEmptyBlobsCommand extends $Command
   })
   .s("AwsQuery", "XmlEmptyBlobs", {})
   .n("QueryProtocolClient", "XmlEmptyBlobsCommand")
-  .f(void 0, void 0)
   .sc(XmlEmptyBlobs)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlEmptyListsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlEmptyListsCommand.ts
@@ -115,7 +115,6 @@ export class XmlEmptyListsCommand extends $Command
   })
   .s("AwsQuery", "XmlEmptyLists", {})
   .n("QueryProtocolClient", "XmlEmptyListsCommand")
-  .f(void 0, void 0)
   .sc(XmlEmptyLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlEmptyMapsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlEmptyMapsCommand.ts
@@ -73,7 +73,6 @@ export class XmlEmptyMapsCommand extends $Command
   })
   .s("AwsQuery", "XmlEmptyMaps", {})
   .n("QueryProtocolClient", "XmlEmptyMapsCommand")
-  .f(void 0, void 0)
   .sc(XmlEmptyMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlEnumsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlEnumsCommand.ts
@@ -80,7 +80,6 @@ export class XmlEnumsCommand extends $Command
   })
   .s("AwsQuery", "XmlEnums", {})
   .n("QueryProtocolClient", "XmlEnumsCommand")
-  .f(void 0, void 0)
   .sc(XmlEnums)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlIntEnumsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlIntEnumsCommand.ts
@@ -80,7 +80,6 @@ export class XmlIntEnumsCommand extends $Command
   })
   .s("AwsQuery", "XmlIntEnums", {})
   .n("QueryProtocolClient", "XmlIntEnumsCommand")
-  .f(void 0, void 0)
   .sc(XmlIntEnums)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlListsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlListsCommand.ts
@@ -124,7 +124,6 @@ export class XmlListsCommand extends $Command
   })
   .s("AwsQuery", "XmlLists", {})
   .n("QueryProtocolClient", "XmlListsCommand")
-  .f(void 0, void 0)
   .sc(XmlLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlMapsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlMapsCommand.ts
@@ -73,7 +73,6 @@ export class XmlMapsCommand extends $Command
   })
   .s("AwsQuery", "XmlMaps", {})
   .n("QueryProtocolClient", "XmlMapsCommand")
-  .f(void 0, void 0)
   .sc(XmlMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlMapsXmlNameCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlMapsXmlNameCommand.ts
@@ -73,7 +73,6 @@ export class XmlMapsXmlNameCommand extends $Command
   })
   .s("AwsQuery", "XmlMapsXmlName", {})
   .n("QueryProtocolClient", "XmlMapsXmlNameCommand")
-  .f(void 0, void 0)
   .sc(XmlMapsXmlName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlNamespacesCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlNamespacesCommand.ts
@@ -74,7 +74,6 @@ export class XmlNamespacesCommand extends $Command
   })
   .s("AwsQuery", "XmlNamespaces", {})
   .n("QueryProtocolClient", "XmlNamespacesCommand")
-  .f(void 0, void 0)
   .sc(XmlNamespaces)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-query-schema/src/commands/XmlTimestampsCommand.ts
+++ b/private/aws-protocoltests-query-schema/src/commands/XmlTimestampsCommand.ts
@@ -77,7 +77,6 @@ export class XmlTimestampsCommand extends $Command
   })
   .s("AwsQuery", "XmlTimestamps", {})
   .n("QueryProtocolClient", "XmlTimestampsCommand")
-  .f(void 0, void 0)
   .sc(XmlTimestamps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/AllQueryStringTypesCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/AllQueryStringTypesCommand.ts
@@ -111,7 +111,6 @@ export class AllQueryStringTypesCommand extends $Command
   })
   .s("RestJson", "AllQueryStringTypes", {})
   .n("RestJsonProtocolClient", "AllQueryStringTypesCommand")
-  .f(void 0, void 0)
   .sc(AllQueryStringTypes)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/ConstantAndVariableQueryStringCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/ConstantAndVariableQueryStringCommand.ts
@@ -72,7 +72,6 @@ export class ConstantAndVariableQueryStringCommand extends $Command
   })
   .s("RestJson", "ConstantAndVariableQueryString", {})
   .n("RestJsonProtocolClient", "ConstantAndVariableQueryStringCommand")
-  .f(void 0, void 0)
   .sc(ConstantAndVariableQueryString)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/ConstantQueryStringCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/ConstantQueryStringCommand.ts
@@ -72,7 +72,6 @@ export class ConstantQueryStringCommand extends $Command
   })
   .s("RestJson", "ConstantQueryString", {})
   .n("RestJsonProtocolClient", "ConstantQueryStringCommand")
-  .f(void 0, void 0)
   .sc(ConstantQueryString)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/ContentTypeParametersCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/ContentTypeParametersCommand.ts
@@ -70,7 +70,6 @@ export class ContentTypeParametersCommand extends $Command
   })
   .s("RestJson", "ContentTypeParameters", {})
   .n("RestJsonProtocolClient", "ContentTypeParametersCommand")
-  .f(void 0, void 0)
   .sc(ContentTypeParameters)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/DatetimeOffsetsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/DatetimeOffsetsCommand.ts
@@ -69,7 +69,6 @@ export class DatetimeOffsetsCommand extends $Command
   })
   .s("RestJson", "DatetimeOffsets", {})
   .n("RestJsonProtocolClient", "DatetimeOffsetsCommand")
-  .f(void 0, void 0)
   .sc(DatetimeOffsets)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/DocumentTypeAsMapValueCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/DocumentTypeAsMapValueCommand.ts
@@ -75,7 +75,6 @@ export class DocumentTypeAsMapValueCommand extends $Command
   })
   .s("RestJson", "DocumentTypeAsMapValue", {})
   .n("RestJsonProtocolClient", "DocumentTypeAsMapValueCommand")
-  .f(void 0, void 0)
   .sc(DocumentTypeAsMapValue)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/DocumentTypeAsPayloadCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/DocumentTypeAsPayloadCommand.ts
@@ -71,7 +71,6 @@ export class DocumentTypeAsPayloadCommand extends $Command
   })
   .s("RestJson", "DocumentTypeAsPayload", {})
   .n("RestJsonProtocolClient", "DocumentTypeAsPayloadCommand")
-  .f(void 0, void 0)
   .sc(DocumentTypeAsPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/DocumentTypeCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/DocumentTypeCommand.ts
@@ -73,7 +73,6 @@ export class DocumentTypeCommand extends $Command
   })
   .s("RestJson", "DocumentType", {})
   .n("RestJsonProtocolClient", "DocumentTypeCommand")
-  .f(void 0, void 0)
   .sc(DocumentType)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/EmptyInputAndEmptyOutputCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/EmptyInputAndEmptyOutputCommand.ts
@@ -70,7 +70,6 @@ export class EmptyInputAndEmptyOutputCommand extends $Command
   })
   .s("RestJson", "EmptyInputAndEmptyOutput", {})
   .n("RestJsonProtocolClient", "EmptyInputAndEmptyOutputCommand")
-  .f(void 0, void 0)
   .sc(EmptyInputAndEmptyOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/EndpointOperationCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/EndpointOperationCommand.ts
@@ -66,7 +66,6 @@ export class EndpointOperationCommand extends $Command
   })
   .s("RestJson", "EndpointOperation", {})
   .n("RestJsonProtocolClient", "EndpointOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
@@ -69,7 +69,6 @@ export class EndpointWithHostLabelOperationCommand extends $Command
   })
   .s("RestJson", "EndpointWithHostLabelOperation", {})
   .n("RestJsonProtocolClient", "EndpointWithHostLabelOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointWithHostLabelOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/FractionalSecondsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/FractionalSecondsCommand.ts
@@ -69,7 +69,6 @@ export class FractionalSecondsCommand extends $Command
   })
   .s("RestJson", "FractionalSeconds", {})
   .n("RestJsonProtocolClient", "FractionalSecondsCommand")
-  .f(void 0, void 0)
   .sc(FractionalSeconds)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -88,7 +88,6 @@ export class GreetingWithErrorsCommand extends $Command
   })
   .s("RestJson", "GreetingWithErrors", {})
   .n("RestJsonProtocolClient", "GreetingWithErrorsCommand")
-  .f(void 0, void 0)
   .sc(GreetingWithErrors)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HostWithPathOperationCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HostWithPathOperationCommand.ts
@@ -66,7 +66,6 @@ export class HostWithPathOperationCommand extends $Command
   })
   .s("RestJson", "HostWithPathOperation", {})
   .n("RestJsonProtocolClient", "HostWithPathOperationCommand")
-  .f(void 0, void 0)
   .sc(HostWithPathOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpChecksumRequiredCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpChecksumRequiredCommand.ts
@@ -75,7 +75,6 @@ export class HttpChecksumRequiredCommand extends $Command
   })
   .s("RestJson", "HttpChecksumRequired", {})
   .n("RestJsonProtocolClient", "HttpChecksumRequiredCommand")
-  .f(void 0, void 0)
   .sc(HttpChecksumRequired)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpEmptyPrefixHeadersCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpEmptyPrefixHeadersCommand.ts
@@ -77,7 +77,6 @@ export class HttpEmptyPrefixHeadersCommand extends $Command
   })
   .s("RestJson", "HttpEmptyPrefixHeaders", {})
   .n("RestJsonProtocolClient", "HttpEmptyPrefixHeadersCommand")
-  .f(void 0, void 0)
   .sc(HttpEmptyPrefixHeaders)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpEnumPayloadCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpEnumPayloadCommand.ts
@@ -71,7 +71,6 @@ export class HttpEnumPayloadCommand extends $Command
   })
   .s("RestJson", "HttpEnumPayload", {})
   .n("RestJsonProtocolClient", "HttpEnumPayloadCommand")
-  .f(void 0, void 0)
   .sc(HttpEnumPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpPayloadTraitsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpPayloadTraitsCommand.ts
@@ -91,7 +91,6 @@ export class HttpPayloadTraitsCommand extends $Command
   })
   .s("RestJson", "HttpPayloadTraits", {})
   .n("RestJsonProtocolClient", "HttpPayloadTraitsCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadTraits)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpPayloadTraitsWithMediaTypeCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpPayloadTraitsWithMediaTypeCommand.ts
@@ -94,7 +94,6 @@ export class HttpPayloadTraitsWithMediaTypeCommand extends $Command
   })
   .s("RestJson", "HttpPayloadTraitsWithMediaType", {})
   .n("RestJsonProtocolClient", "HttpPayloadTraitsWithMediaTypeCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadTraitsWithMediaType)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpPayloadWithStructureCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpPayloadWithStructureCommand.ts
@@ -80,7 +80,6 @@ export class HttpPayloadWithStructureCommand extends $Command
   })
   .s("RestJson", "HttpPayloadWithStructure", {})
   .n("RestJsonProtocolClient", "HttpPayloadWithStructureCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadWithStructure)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpPayloadWithUnionCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpPayloadWithUnionCommand.ts
@@ -75,7 +75,6 @@ export class HttpPayloadWithUnionCommand extends $Command
   })
   .s("RestJson", "HttpPayloadWithUnion", {})
   .n("RestJsonProtocolClient", "HttpPayloadWithUnionCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadWithUnion)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpPrefixHeadersCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpPrefixHeadersCommand.ts
@@ -77,7 +77,6 @@ export class HttpPrefixHeadersCommand extends $Command
   })
   .s("RestJson", "HttpPrefixHeaders", {})
   .n("RestJsonProtocolClient", "HttpPrefixHeadersCommand")
-  .f(void 0, void 0)
   .sc(HttpPrefixHeaders)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpPrefixHeadersInResponseCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpPrefixHeadersInResponseCommand.ts
@@ -71,7 +71,6 @@ export class HttpPrefixHeadersInResponseCommand extends $Command
   })
   .s("RestJson", "HttpPrefixHeadersInResponse", {})
   .n("RestJsonProtocolClient", "HttpPrefixHeadersInResponseCommand")
-  .f(void 0, void 0)
   .sc(HttpPrefixHeadersInResponse)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpRequestWithFloatLabelsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpRequestWithFloatLabelsCommand.ts
@@ -70,7 +70,6 @@ export class HttpRequestWithFloatLabelsCommand extends $Command
   })
   .s("RestJson", "HttpRequestWithFloatLabels", {})
   .n("RestJsonProtocolClient", "HttpRequestWithFloatLabelsCommand")
-  .f(void 0, void 0)
   .sc(HttpRequestWithFloatLabels)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpRequestWithGreedyLabelInPathCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpRequestWithGreedyLabelInPathCommand.ts
@@ -70,7 +70,6 @@ export class HttpRequestWithGreedyLabelInPathCommand extends $Command
   })
   .s("RestJson", "HttpRequestWithGreedyLabelInPath", {})
   .n("RestJsonProtocolClient", "HttpRequestWithGreedyLabelInPathCommand")
-  .f(void 0, void 0)
   .sc(HttpRequestWithGreedyLabelInPath)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpRequestWithLabelsAndTimestampFormatCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpRequestWithLabelsAndTimestampFormatCommand.ts
@@ -77,7 +77,6 @@ export class HttpRequestWithLabelsAndTimestampFormatCommand extends $Command
   })
   .s("RestJson", "HttpRequestWithLabelsAndTimestampFormat", {})
   .n("RestJsonProtocolClient", "HttpRequestWithLabelsAndTimestampFormatCommand")
-  .f(void 0, void 0)
   .sc(HttpRequestWithLabelsAndTimestampFormat)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpRequestWithLabelsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpRequestWithLabelsCommand.ts
@@ -77,7 +77,6 @@ export class HttpRequestWithLabelsCommand extends $Command
   })
   .s("RestJson", "HttpRequestWithLabels", {})
   .n("RestJsonProtocolClient", "HttpRequestWithLabelsCommand")
-  .f(void 0, void 0)
   .sc(HttpRequestWithLabels)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpRequestWithRegexLiteralCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpRequestWithRegexLiteralCommand.ts
@@ -69,7 +69,6 @@ export class HttpRequestWithRegexLiteralCommand extends $Command
   })
   .s("RestJson", "HttpRequestWithRegexLiteral", {})
   .n("RestJsonProtocolClient", "HttpRequestWithRegexLiteralCommand")
-  .f(void 0, void 0)
   .sc(HttpRequestWithRegexLiteral)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpResponseCodeCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpResponseCodeCommand.ts
@@ -69,7 +69,6 @@ export class HttpResponseCodeCommand extends $Command
   })
   .s("RestJson", "HttpResponseCode", {})
   .n("RestJsonProtocolClient", "HttpResponseCodeCommand")
-  .f(void 0, void 0)
   .sc(HttpResponseCode)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/HttpStringPayloadCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/HttpStringPayloadCommand.ts
@@ -71,7 +71,6 @@ export class HttpStringPayloadCommand extends $Command
   })
   .s("RestJson", "HttpStringPayload", {})
   .n("RestJsonProtocolClient", "HttpStringPayloadCommand")
-  .f(void 0, void 0)
   .sc(HttpStringPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/IgnoreQueryParamsInResponseCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/IgnoreQueryParamsInResponseCommand.ts
@@ -71,7 +71,6 @@ export class IgnoreQueryParamsInResponseCommand extends $Command
   })
   .s("RestJson", "IgnoreQueryParamsInResponse", {})
   .n("RestJsonProtocolClient", "IgnoreQueryParamsInResponseCommand")
-  .f(void 0, void 0)
   .sc(IgnoreQueryParamsInResponse)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/InputAndOutputWithHeadersCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/InputAndOutputWithHeadersCommand.ts
@@ -134,7 +134,6 @@ export class InputAndOutputWithHeadersCommand extends $Command
   })
   .s("RestJson", "InputAndOutputWithHeaders", {})
   .n("RestJsonProtocolClient", "InputAndOutputWithHeadersCommand")
-  .f(void 0, void 0)
   .sc(InputAndOutputWithHeaders)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/JsonBlobsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/JsonBlobsCommand.ts
@@ -71,7 +71,6 @@ export class JsonBlobsCommand extends $Command
   })
   .s("RestJson", "JsonBlobs", {})
   .n("RestJsonProtocolClient", "JsonBlobsCommand")
-  .f(void 0, void 0)
   .sc(JsonBlobs)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/JsonEnumsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/JsonEnumsCommand.ts
@@ -93,7 +93,6 @@ export class JsonEnumsCommand extends $Command
   })
   .s("RestJson", "JsonEnums", {})
   .n("RestJsonProtocolClient", "JsonEnumsCommand")
-  .f(void 0, void 0)
   .sc(JsonEnums)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/JsonIntEnumsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/JsonIntEnumsCommand.ts
@@ -93,7 +93,6 @@ export class JsonIntEnumsCommand extends $Command
   })
   .s("RestJson", "JsonIntEnums", {})
   .n("RestJsonProtocolClient", "JsonIntEnumsCommand")
-  .f(void 0, void 0)
   .sc(JsonIntEnums)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/JsonListsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/JsonListsCommand.ts
@@ -139,7 +139,6 @@ export class JsonListsCommand extends $Command
   })
   .s("RestJson", "JsonLists", {})
   .n("RestJsonProtocolClient", "JsonListsCommand")
-  .f(void 0, void 0)
   .sc(JsonLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/JsonMapsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/JsonMapsCommand.ts
@@ -107,7 +107,6 @@ export class JsonMapsCommand extends $Command
   })
   .s("RestJson", "JsonMaps", {})
   .n("RestJsonProtocolClient", "JsonMapsCommand")
-  .f(void 0, void 0)
   .sc(JsonMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/JsonTimestampsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/JsonTimestampsCommand.ts
@@ -85,7 +85,6 @@ export class JsonTimestampsCommand extends $Command
   })
   .s("RestJson", "JsonTimestamps", {})
   .n("RestJsonProtocolClient", "JsonTimestampsCommand")
-  .f(void 0, void 0)
   .sc(JsonTimestamps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/JsonUnionsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/JsonUnionsCommand.ts
@@ -109,7 +109,6 @@ export class JsonUnionsCommand extends $Command
   })
   .s("RestJson", "JsonUnions", {})
   .n("RestJsonProtocolClient", "JsonUnionsCommand")
-  .f(void 0, void 0)
   .sc(JsonUnions)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedAcceptWithBodyCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedAcceptWithBodyCommand.ts
@@ -69,7 +69,6 @@ export class MalformedAcceptWithBodyCommand extends $Command
   })
   .s("RestJson", "MalformedAcceptWithBody", {})
   .n("RestJsonProtocolClient", "MalformedAcceptWithBodyCommand")
-  .f(void 0, void 0)
   .sc(MalformedAcceptWithBody)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedAcceptWithGenericStringCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedAcceptWithGenericStringCommand.ts
@@ -71,7 +71,6 @@ export class MalformedAcceptWithGenericStringCommand extends $Command
   })
   .s("RestJson", "MalformedAcceptWithGenericString", {})
   .n("RestJsonProtocolClient", "MalformedAcceptWithGenericStringCommand")
-  .f(void 0, void 0)
   .sc(MalformedAcceptWithGenericString)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedAcceptWithPayloadCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedAcceptWithPayloadCommand.ts
@@ -79,7 +79,6 @@ export class MalformedAcceptWithPayloadCommand extends $Command
   })
   .s("RestJson", "MalformedAcceptWithPayload", {})
   .n("RestJsonProtocolClient", "MalformedAcceptWithPayloadCommand")
-  .f(void 0, void 0)
   .sc(MalformedAcceptWithPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedBlobCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedBlobCommand.ts
@@ -69,7 +69,6 @@ export class MalformedBlobCommand extends $Command
   })
   .s("RestJson", "MalformedBlob", {})
   .n("RestJsonProtocolClient", "MalformedBlobCommand")
-  .f(void 0, void 0)
   .sc(MalformedBlob)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedBooleanCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedBooleanCommand.ts
@@ -72,7 +72,6 @@ export class MalformedBooleanCommand extends $Command
   })
   .s("RestJson", "MalformedBoolean", {})
   .n("RestJsonProtocolClient", "MalformedBooleanCommand")
-  .f(void 0, void 0)
   .sc(MalformedBoolean)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedByteCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedByteCommand.ts
@@ -72,7 +72,6 @@ export class MalformedByteCommand extends $Command
   })
   .s("RestJson", "MalformedByte", {})
   .n("RestJsonProtocolClient", "MalformedByteCommand")
-  .f(void 0, void 0)
   .sc(MalformedByte)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedContentTypeWithBodyCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedContentTypeWithBodyCommand.ts
@@ -69,7 +69,6 @@ export class MalformedContentTypeWithBodyCommand extends $Command
   })
   .s("RestJson", "MalformedContentTypeWithBody", {})
   .n("RestJsonProtocolClient", "MalformedContentTypeWithBodyCommand")
-  .f(void 0, void 0)
   .sc(MalformedContentTypeWithBody)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedContentTypeWithGenericStringCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedContentTypeWithGenericStringCommand.ts
@@ -69,7 +69,6 @@ export class MalformedContentTypeWithGenericStringCommand extends $Command
   })
   .s("RestJson", "MalformedContentTypeWithGenericString", {})
   .n("RestJsonProtocolClient", "MalformedContentTypeWithGenericStringCommand")
-  .f(void 0, void 0)
   .sc(MalformedContentTypeWithGenericString)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedContentTypeWithPayloadCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedContentTypeWithPayloadCommand.ts
@@ -76,7 +76,6 @@ export class MalformedContentTypeWithPayloadCommand extends $Command
   })
   .s("RestJson", "MalformedContentTypeWithPayload", {})
   .n("RestJsonProtocolClient", "MalformedContentTypeWithPayloadCommand")
-  .f(void 0, void 0)
   .sc(MalformedContentTypeWithPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedContentTypeWithoutBodyCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedContentTypeWithoutBodyCommand.ts
@@ -66,7 +66,6 @@ export class MalformedContentTypeWithoutBodyCommand extends $Command
   })
   .s("RestJson", "MalformedContentTypeWithoutBody", {})
   .n("RestJsonProtocolClient", "MalformedContentTypeWithoutBodyCommand")
-  .f(void 0, void 0)
   .sc(MalformedContentTypeWithoutBody)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedContentTypeWithoutBodyEmptyInputCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedContentTypeWithoutBodyEmptyInputCommand.ts
@@ -70,7 +70,6 @@ export class MalformedContentTypeWithoutBodyEmptyInputCommand extends $Command
   })
   .s("RestJson", "MalformedContentTypeWithoutBodyEmptyInput", {})
   .n("RestJsonProtocolClient", "MalformedContentTypeWithoutBodyEmptyInputCommand")
-  .f(void 0, void 0)
   .sc(MalformedContentTypeWithoutBodyEmptyInput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedDoubleCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedDoubleCommand.ts
@@ -72,7 +72,6 @@ export class MalformedDoubleCommand extends $Command
   })
   .s("RestJson", "MalformedDouble", {})
   .n("RestJsonProtocolClient", "MalformedDoubleCommand")
-  .f(void 0, void 0)
   .sc(MalformedDouble)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedFloatCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedFloatCommand.ts
@@ -72,7 +72,6 @@ export class MalformedFloatCommand extends $Command
   })
   .s("RestJson", "MalformedFloat", {})
   .n("RestJsonProtocolClient", "MalformedFloatCommand")
-  .f(void 0, void 0)
   .sc(MalformedFloat)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedIntegerCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedIntegerCommand.ts
@@ -72,7 +72,6 @@ export class MalformedIntegerCommand extends $Command
   })
   .s("RestJson", "MalformedInteger", {})
   .n("RestJsonProtocolClient", "MalformedIntegerCommand")
-  .f(void 0, void 0)
   .sc(MalformedInteger)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedListCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedListCommand.ts
@@ -71,7 +71,6 @@ export class MalformedListCommand extends $Command
   })
   .s("RestJson", "MalformedList", {})
   .n("RestJsonProtocolClient", "MalformedListCommand")
-  .f(void 0, void 0)
   .sc(MalformedList)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedLongCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedLongCommand.ts
@@ -72,7 +72,6 @@ export class MalformedLongCommand extends $Command
   })
   .s("RestJson", "MalformedLong", {})
   .n("RestJsonProtocolClient", "MalformedLongCommand")
-  .f(void 0, void 0)
   .sc(MalformedLong)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedMapCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedMapCommand.ts
@@ -71,7 +71,6 @@ export class MalformedMapCommand extends $Command
   })
   .s("RestJson", "MalformedMap", {})
   .n("RestJsonProtocolClient", "MalformedMapCommand")
-  .f(void 0, void 0)
   .sc(MalformedMap)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedRequestBodyCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedRequestBodyCommand.ts
@@ -70,7 +70,6 @@ export class MalformedRequestBodyCommand extends $Command
   })
   .s("RestJson", "MalformedRequestBody", {})
   .n("RestJsonProtocolClient", "MalformedRequestBodyCommand")
-  .f(void 0, void 0)
   .sc(MalformedRequestBody)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedShortCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedShortCommand.ts
@@ -72,7 +72,6 @@ export class MalformedShortCommand extends $Command
   })
   .s("RestJson", "MalformedShort", {})
   .n("RestJsonProtocolClient", "MalformedShortCommand")
-  .f(void 0, void 0)
   .sc(MalformedShort)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedStringCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedStringCommand.ts
@@ -69,7 +69,6 @@ export class MalformedStringCommand extends $Command
   })
   .s("RestJson", "MalformedString", {})
   .n("RestJsonProtocolClient", "MalformedStringCommand")
-  .f(void 0, void 0)
   .sc(MalformedString)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampBodyDateTimeCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampBodyDateTimeCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampBodyDateTimeCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampBodyDateTime", {})
   .n("RestJsonProtocolClient", "MalformedTimestampBodyDateTimeCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampBodyDateTime)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampBodyDefaultCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampBodyDefaultCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampBodyDefaultCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampBodyDefault", {})
   .n("RestJsonProtocolClient", "MalformedTimestampBodyDefaultCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampBodyDefault)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampBodyHttpDateCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampBodyHttpDateCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampBodyHttpDateCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampBodyHttpDate", {})
   .n("RestJsonProtocolClient", "MalformedTimestampBodyHttpDateCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampBodyHttpDate)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampHeaderDateTimeCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampHeaderDateTimeCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampHeaderDateTimeCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampHeaderDateTime", {})
   .n("RestJsonProtocolClient", "MalformedTimestampHeaderDateTimeCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampHeaderDateTime)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampHeaderDefaultCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampHeaderDefaultCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampHeaderDefaultCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampHeaderDefault", {})
   .n("RestJsonProtocolClient", "MalformedTimestampHeaderDefaultCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampHeaderDefault)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampHeaderEpochCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampHeaderEpochCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampHeaderEpochCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampHeaderEpoch", {})
   .n("RestJsonProtocolClient", "MalformedTimestampHeaderEpochCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampHeaderEpoch)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampPathDefaultCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampPathDefaultCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampPathDefaultCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampPathDefault", {})
   .n("RestJsonProtocolClient", "MalformedTimestampPathDefaultCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampPathDefault)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampPathEpochCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampPathEpochCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampPathEpochCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampPathEpoch", {})
   .n("RestJsonProtocolClient", "MalformedTimestampPathEpochCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampPathEpoch)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampPathHttpDateCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampPathHttpDateCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampPathHttpDateCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampPathHttpDate", {})
   .n("RestJsonProtocolClient", "MalformedTimestampPathHttpDateCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampPathHttpDate)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampQueryDefaultCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampQueryDefaultCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampQueryDefaultCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampQueryDefault", {})
   .n("RestJsonProtocolClient", "MalformedTimestampQueryDefaultCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampQueryDefault)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampQueryEpochCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampQueryEpochCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampQueryEpochCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampQueryEpoch", {})
   .n("RestJsonProtocolClient", "MalformedTimestampQueryEpochCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampQueryEpoch)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampQueryHttpDateCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedTimestampQueryHttpDateCommand.ts
@@ -69,7 +69,6 @@ export class MalformedTimestampQueryHttpDateCommand extends $Command
   })
   .s("RestJson", "MalformedTimestampQueryHttpDate", {})
   .n("RestJsonProtocolClient", "MalformedTimestampQueryHttpDateCommand")
-  .f(void 0, void 0)
   .sc(MalformedTimestampQueryHttpDate)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MalformedUnionCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MalformedUnionCommand.ts
@@ -72,7 +72,6 @@ export class MalformedUnionCommand extends $Command
   })
   .s("RestJson", "MalformedUnion", {})
   .n("RestJsonProtocolClient", "MalformedUnionCommand")
-  .f(void 0, void 0)
   .sc(MalformedUnion)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/MediaTypeHeaderCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/MediaTypeHeaderCommand.ts
@@ -71,7 +71,6 @@ export class MediaTypeHeaderCommand extends $Command
   })
   .s("RestJson", "MediaTypeHeader", {})
   .n("RestJsonProtocolClient", "MediaTypeHeaderCommand")
-  .f(void 0, void 0)
   .sc(MediaTypeHeader)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/NoInputAndNoOutputCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/NoInputAndNoOutputCommand.ts
@@ -68,7 +68,6 @@ export class NoInputAndNoOutputCommand extends $Command
   })
   .s("RestJson", "NoInputAndNoOutput", {})
   .n("RestJsonProtocolClient", "NoInputAndNoOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputAndNoOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/NoInputAndOutputCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/NoInputAndOutputCommand.ts
@@ -70,7 +70,6 @@ export class NoInputAndOutputCommand extends $Command
   })
   .s("RestJson", "NoInputAndOutput", {})
   .n("RestJsonProtocolClient", "NoInputAndOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputAndOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/NullAndEmptyHeadersClientCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/NullAndEmptyHeadersClientCommand.ts
@@ -79,7 +79,6 @@ export class NullAndEmptyHeadersClientCommand extends $Command
   })
   .s("RestJson", "NullAndEmptyHeadersClient", {})
   .n("RestJsonProtocolClient", "NullAndEmptyHeadersClientCommand")
-  .f(void 0, void 0)
   .sc(NullAndEmptyHeadersClient)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/NullAndEmptyHeadersServerCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/NullAndEmptyHeadersServerCommand.ts
@@ -79,7 +79,6 @@ export class NullAndEmptyHeadersServerCommand extends $Command
   })
   .s("RestJson", "NullAndEmptyHeadersServer", {})
   .n("RestJsonProtocolClient", "NullAndEmptyHeadersServerCommand")
-  .f(void 0, void 0)
   .sc(NullAndEmptyHeadersServer)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/OmitsNullSerializesEmptyStringCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/OmitsNullSerializesEmptyStringCommand.ts
@@ -70,7 +70,6 @@ export class OmitsNullSerializesEmptyStringCommand extends $Command
   })
   .s("RestJson", "OmitsNullSerializesEmptyString", {})
   .n("RestJsonProtocolClient", "OmitsNullSerializesEmptyStringCommand")
-  .f(void 0, void 0)
   .sc(OmitsNullSerializesEmptyString)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/OmitsSerializingEmptyListsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/OmitsSerializingEmptyListsCommand.ts
@@ -91,7 +91,6 @@ export class OmitsSerializingEmptyListsCommand extends $Command
   })
   .s("RestJson", "OmitsSerializingEmptyLists", {})
   .n("RestJsonProtocolClient", "OmitsSerializingEmptyListsCommand")
-  .f(void 0, void 0)
   .sc(OmitsSerializingEmptyLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/OperationWithDefaultsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/OperationWithDefaultsCommand.ts
@@ -140,7 +140,6 @@ export class OperationWithDefaultsCommand extends $Command
   })
   .s("RestJson", "OperationWithDefaults", {})
   .n("RestJsonProtocolClient", "OperationWithDefaultsCommand")
-  .f(void 0, void 0)
   .sc(OperationWithDefaults)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/OperationWithNestedStructureCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/OperationWithNestedStructureCommand.ts
@@ -123,7 +123,6 @@ export class OperationWithNestedStructureCommand extends $Command
   })
   .s("RestJson", "OperationWithNestedStructure", {})
   .n("RestJsonProtocolClient", "OperationWithNestedStructureCommand")
-  .f(void 0, void 0)
   .sc(OperationWithNestedStructure)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/PostPlayerActionCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/PostPlayerActionCommand.ts
@@ -75,7 +75,6 @@ export class PostPlayerActionCommand extends $Command
   })
   .s("RestJson", "PostPlayerAction", {})
   .n("RestJsonProtocolClient", "PostPlayerActionCommand")
-  .f(void 0, void 0)
   .sc(PostPlayerAction)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/PostUnionWithJsonNameCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/PostUnionWithJsonNameCommand.ts
@@ -79,7 +79,6 @@ export class PostUnionWithJsonNameCommand extends $Command
   })
   .s("RestJson", "PostUnionWithJsonName", {})
   .n("RestJsonProtocolClient", "PostUnionWithJsonNameCommand")
-  .f(void 0, void 0)
   .sc(PostUnionWithJsonName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/PutWithContentEncodingCommand.ts
@@ -76,7 +76,6 @@ export class PutWithContentEncodingCommand extends $Command
   })
   .s("RestJson", "PutWithContentEncoding", {})
   .n("RestJsonProtocolClient", "PutWithContentEncodingCommand")
-  .f(void 0, void 0)
   .sc(PutWithContentEncoding)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/QueryIdempotencyTokenAutoFillCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/QueryIdempotencyTokenAutoFillCommand.ts
@@ -69,7 +69,6 @@ export class QueryIdempotencyTokenAutoFillCommand extends $Command
   })
   .s("RestJson", "QueryIdempotencyTokenAutoFill", {})
   .n("RestJsonProtocolClient", "QueryIdempotencyTokenAutoFillCommand")
-  .f(void 0, void 0)
   .sc(QueryIdempotencyTokenAutoFill)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/QueryParamsAsStringListMapCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/QueryParamsAsStringListMapCommand.ts
@@ -74,7 +74,6 @@ export class QueryParamsAsStringListMapCommand extends $Command
   })
   .s("RestJson", "QueryParamsAsStringListMap", {})
   .n("RestJsonProtocolClient", "QueryParamsAsStringListMapCommand")
-  .f(void 0, void 0)
   .sc(QueryParamsAsStringListMap)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/QueryPrecedenceCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/QueryPrecedenceCommand.ts
@@ -72,7 +72,6 @@ export class QueryPrecedenceCommand extends $Command
   })
   .s("RestJson", "QueryPrecedence", {})
   .n("RestJsonProtocolClient", "QueryPrecedenceCommand")
-  .f(void 0, void 0)
   .sc(QueryPrecedence)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/RecursiveShapesCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/RecursiveShapesCommand.ts
@@ -95,7 +95,6 @@ export class RecursiveShapesCommand extends $Command
   })
   .s("RestJson", "RecursiveShapes", {})
   .n("RestJsonProtocolClient", "RecursiveShapesCommand")
-  .f(void 0, void 0)
   .sc(RecursiveShapes)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/ResponseCodeHttpFallbackCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/ResponseCodeHttpFallbackCommand.ts
@@ -67,7 +67,6 @@ export class ResponseCodeHttpFallbackCommand extends $Command
   })
   .s("RestJson", "ResponseCodeHttpFallback", {})
   .n("RestJsonProtocolClient", "ResponseCodeHttpFallbackCommand")
-  .f(void 0, void 0)
   .sc(ResponseCodeHttpFallback)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/ResponseCodeRequiredCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/ResponseCodeRequiredCommand.ts
@@ -69,7 +69,6 @@ export class ResponseCodeRequiredCommand extends $Command
   })
   .s("RestJson", "ResponseCodeRequired", {})
   .n("RestJsonProtocolClient", "ResponseCodeRequiredCommand")
-  .f(void 0, void 0)
   .sc(ResponseCodeRequired)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/SimpleScalarPropertiesCommand.ts
@@ -89,7 +89,6 @@ export class SimpleScalarPropertiesCommand extends $Command
   })
   .s("RestJson", "SimpleScalarProperties", {})
   .n("RestJsonProtocolClient", "SimpleScalarPropertiesCommand")
-  .f(void 0, void 0)
   .sc(SimpleScalarProperties)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/SparseJsonListsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/SparseJsonListsCommand.ts
@@ -81,7 +81,6 @@ export class SparseJsonListsCommand extends $Command
   })
   .s("RestJson", "SparseJsonLists", {})
   .n("RestJsonProtocolClient", "SparseJsonListsCommand")
-  .f(void 0, void 0)
   .sc(SparseJsonLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/SparseJsonMapsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/SparseJsonMapsCommand.ts
@@ -107,7 +107,6 @@ export class SparseJsonMapsCommand extends $Command
   })
   .s("RestJson", "SparseJsonMaps", {})
   .n("RestJsonProtocolClient", "SparseJsonMapsCommand")
-  .f(void 0, void 0)
   .sc(SparseJsonMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/StreamingTraitsCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/StreamingTraitsCommand.ts
@@ -8,7 +8,7 @@ import {
 } from "@smithy/types";
 
 import { commonParams } from "../endpoint/EndpointParameters";
-import { StreamingTraitsInputOutput, StreamingTraitsInputOutputFilterSensitiveLog } from "../models/models_0";
+import { StreamingTraitsInputOutput } from "../models/models_0";
 import { RestJsonProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestJsonProtocolClient";
 import { StreamingTraits } from "../schemas/schemas";
 
@@ -90,7 +90,6 @@ export class StreamingTraitsCommand extends $Command
   })
   .s("RestJson", "StreamingTraits", {})
   .n("RestJsonProtocolClient", "StreamingTraitsCommand")
-  .f(StreamingTraitsInputOutputFilterSensitiveLog, StreamingTraitsInputOutputFilterSensitiveLog)
   .sc(StreamingTraits)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/StreamingTraitsRequireLengthCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/StreamingTraitsRequireLengthCommand.ts
@@ -4,10 +4,7 @@ import { Command as $Command } from "@smithy/smithy-client";
 import { MetadataBearer as __MetadataBearer, StreamingBlobPayloadInputTypes } from "@smithy/types";
 
 import { commonParams } from "../endpoint/EndpointParameters";
-import {
-  StreamingTraitsRequireLengthInput,
-  StreamingTraitsRequireLengthInputFilterSensitiveLog,
-} from "../models/models_0";
+import { StreamingTraitsRequireLengthInput } from "../models/models_0";
 import { RestJsonProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestJsonProtocolClient";
 import { StreamingTraitsRequireLength } from "../schemas/schemas";
 
@@ -80,7 +77,6 @@ export class StreamingTraitsRequireLengthCommand extends $Command
   })
   .s("RestJson", "StreamingTraitsRequireLength", {})
   .n("RestJsonProtocolClient", "StreamingTraitsRequireLengthCommand")
-  .f(StreamingTraitsRequireLengthInputFilterSensitiveLog, void 0)
   .sc(StreamingTraitsRequireLength)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/StreamingTraitsWithMediaTypeCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/StreamingTraitsWithMediaTypeCommand.ts
@@ -8,10 +8,7 @@ import {
 } from "@smithy/types";
 
 import { commonParams } from "../endpoint/EndpointParameters";
-import {
-  StreamingTraitsWithMediaTypeInputOutput,
-  StreamingTraitsWithMediaTypeInputOutputFilterSensitiveLog,
-} from "../models/models_0";
+import { StreamingTraitsWithMediaTypeInputOutput } from "../models/models_0";
 import { RestJsonProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestJsonProtocolClient";
 import { StreamingTraitsWithMediaType } from "../schemas/schemas";
 
@@ -96,10 +93,6 @@ export class StreamingTraitsWithMediaTypeCommand extends $Command
   })
   .s("RestJson", "StreamingTraitsWithMediaType", {})
   .n("RestJsonProtocolClient", "StreamingTraitsWithMediaTypeCommand")
-  .f(
-    StreamingTraitsWithMediaTypeInputOutputFilterSensitiveLog,
-    StreamingTraitsWithMediaTypeInputOutputFilterSensitiveLog
-  )
   .sc(StreamingTraitsWithMediaType)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/TestBodyStructureCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/TestBodyStructureCommand.ts
@@ -82,7 +82,6 @@ export class TestBodyStructureCommand extends $Command
   })
   .s("RestJson", "TestBodyStructure", {})
   .n("RestJsonProtocolClient", "TestBodyStructureCommand")
-  .f(void 0, void 0)
   .sc(TestBodyStructure)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/TestGetNoInputNoPayloadCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/TestGetNoInputNoPayloadCommand.ts
@@ -74,7 +74,6 @@ export class TestGetNoInputNoPayloadCommand extends $Command
   })
   .s("RestJson", "TestGetNoInputNoPayload", {})
   .n("RestJsonProtocolClient", "TestGetNoInputNoPayloadCommand")
-  .f(void 0, void 0)
   .sc(TestGetNoInputNoPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/TestGetNoPayloadCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/TestGetNoPayloadCommand.ts
@@ -76,7 +76,6 @@ export class TestGetNoPayloadCommand extends $Command
   })
   .s("RestJson", "TestGetNoPayload", {})
   .n("RestJsonProtocolClient", "TestGetNoPayloadCommand")
-  .f(void 0, void 0)
   .sc(TestGetNoPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/TestPayloadBlobCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/TestPayloadBlobCommand.ts
@@ -95,7 +95,6 @@ export class TestPayloadBlobCommand extends $Command
   })
   .s("RestJson", "TestPayloadBlob", {})
   .n("RestJsonProtocolClient", "TestPayloadBlobCommand")
-  .f(void 0, void 0)
   .sc(TestPayloadBlob)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/TestPayloadStructureCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/TestPayloadStructureCommand.ts
@@ -81,7 +81,6 @@ export class TestPayloadStructureCommand extends $Command
   })
   .s("RestJson", "TestPayloadStructure", {})
   .n("RestJsonProtocolClient", "TestPayloadStructureCommand")
-  .f(void 0, void 0)
   .sc(TestPayloadStructure)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/TestPostNoInputNoPayloadCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/TestPostNoInputNoPayloadCommand.ts
@@ -73,7 +73,6 @@ export class TestPostNoInputNoPayloadCommand extends $Command
   })
   .s("RestJson", "TestPostNoInputNoPayload", {})
   .n("RestJsonProtocolClient", "TestPostNoInputNoPayloadCommand")
-  .f(void 0, void 0)
   .sc(TestPostNoInputNoPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/TestPostNoPayloadCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/TestPostNoPayloadCommand.ts
@@ -75,7 +75,6 @@ export class TestPostNoPayloadCommand extends $Command
   })
   .s("RestJson", "TestPostNoPayload", {})
   .n("RestJsonProtocolClient", "TestPostNoPayloadCommand")
-  .f(void 0, void 0)
   .sc(TestPostNoPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/TimestampFormatHeadersCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/TimestampFormatHeadersCommand.ts
@@ -83,7 +83,6 @@ export class TimestampFormatHeadersCommand extends $Command
   })
   .s("RestJson", "TimestampFormatHeaders", {})
   .n("RestJsonProtocolClient", "TimestampFormatHeadersCommand")
-  .f(void 0, void 0)
   .sc(TimestampFormatHeaders)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/commands/UnitInputAndOutputCommand.ts
+++ b/private/aws-protocoltests-restjson-schema/src/commands/UnitInputAndOutputCommand.ts
@@ -66,7 +66,6 @@ export class UnitInputAndOutputCommand extends $Command
   })
   .s("RestJson", "UnitInputAndOutput", {})
   .n("RestJsonProtocolClient", "UnitInputAndOutputCommand")
-  .f(void 0, void 0)
   .sc(UnitInputAndOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restjson-schema/src/models/models_0.ts
+++ b/private/aws-protocoltests-restjson-schema/src/models/models_0.ts
@@ -1472,13 +1472,6 @@ export interface StreamingTraitsInputOutput {
 }
 
 /**
- * @internal
- */
-export const StreamingTraitsInputOutputFilterSensitiveLog = (obj: StreamingTraitsInputOutput): any => ({
-  ...obj,
-});
-
-/**
  * @public
  */
 export interface StreamingTraitsRequireLengthInput {
@@ -1487,28 +1480,12 @@ export interface StreamingTraitsRequireLengthInput {
 }
 
 /**
- * @internal
- */
-export const StreamingTraitsRequireLengthInputFilterSensitiveLog = (obj: StreamingTraitsRequireLengthInput): any => ({
-  ...obj,
-});
-
-/**
  * @public
  */
 export interface StreamingTraitsWithMediaTypeInputOutput {
   foo?: string | undefined;
   blob?: StreamingBlobTypes | undefined;
 }
-
-/**
- * @internal
- */
-export const StreamingTraitsWithMediaTypeInputOutputFilterSensitiveLog = (
-  obj: StreamingTraitsWithMediaTypeInputOutput
-): any => ({
-  ...obj,
-});
 
 /**
  * @public

--- a/private/aws-protocoltests-restjson-schema/src/schemas/schemas.ts
+++ b/private/aws-protocoltests-restjson-schema/src/schemas/schemas.ts
@@ -2046,8 +2046,8 @@ export var TimestampFormatHeadersIO = struct(
 );
 export var TopLevel = struct(n0, _TLo, 0, [_di, _dLi, _dMi], [() => Dialog, () => DialogList, () => DialogMap]);
 export var UnionInputOutput = struct(n0, _UIO, 0, [_con], [() => MyUnion]);
-export var GreetingStruct_n2 = struct(n2, _GS, 0, [_sa], [0]);
-export var GreetingStruct = struct(n1, _GS, 0, [_hi], [0]);
+export var GreetingStruct = struct(n2, _GS, 0, [_sa], [0]);
+export var GreetingStruct_n1 = struct(n1, _GS, 0, [_hi], [0]);
 export var Unit = "unit" as const;
 
 export var RestJsonProtocolServiceException = error(
@@ -2110,7 +2110,7 @@ export var DenseNumberMap = 128 | 1;
 export var DenseSetMap = map(n0, _DSM, 0, 0, 64 | 0);
 export var DenseStringMap = 128 | 0;
 
-export var DenseStructMap = map(n0, _DSMe, 0, 0, () => GreetingStruct);
+export var DenseStructMap = map(n0, _DSMe, 0, 0, () => GreetingStruct_n1);
 export var DialogMap = map(n0, _DM, 0, 0, () => Dialog);
 export var DocumentValuedMap = 128 | 15;
 
@@ -2150,7 +2150,7 @@ export var SparseStructMap = map(
     [_sp]: 1,
   },
   0,
-  () => GreetingStruct
+  () => GreetingStruct_n1
 );
 export var TestStringMap = 128 | 0;
 
@@ -2175,7 +2175,7 @@ export var MyUnion = uni(
   _MU,
   0,
   [_sV, _bVo, _nVu, _bVl, _tV, _eV, _lVi, _mV, _sVt, _rSV],
-  [0, 2, 1, 21, 4, 0, 64 | 0, 128 | 0, () => GreetingStruct, () => GreetingStruct_n2]
+  [0, 2, 1, 21, 4, 0, 64 | 0, 128 | 0, () => GreetingStruct_n1, () => GreetingStruct]
 );
 export var PlayerAction = uni(n0, _PA, 0, [_qu], [() => Unit]);
 export var SimpleUnion = uni(n0, _SU, 0, [_int, _st], [1, 0]);
@@ -2570,7 +2570,7 @@ export var MalformedAcceptWithBody = op(
     [_ht]: ["POST", "/MalformedAcceptWithBody", 200],
   },
   () => Unit,
-  () => GreetingStruct
+  () => GreetingStruct_n1
 );
 export var MalformedAcceptWithGenericString = op(
   n0,
@@ -2623,7 +2623,7 @@ export var MalformedContentTypeWithBody = op(
   {
     [_ht]: ["POST", "/MalformedContentTypeWithBody", 200],
   },
-  () => GreetingStruct,
+  () => GreetingStruct_n1,
   () => Unit
 );
 export var MalformedContentTypeWithGenericString = op(

--- a/private/aws-protocoltests-restxml-schema/src/commands/AllQueryStringTypesCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/AllQueryStringTypesCommand.ts
@@ -109,7 +109,6 @@ export class AllQueryStringTypesCommand extends $Command
   })
   .s("RestXml", "AllQueryStringTypes", {})
   .n("RestXmlProtocolClient", "AllQueryStringTypesCommand")
-  .f(void 0, void 0)
   .sc(AllQueryStringTypes)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/BodyWithXmlNameCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/BodyWithXmlNameCommand.ts
@@ -76,7 +76,6 @@ export class BodyWithXmlNameCommand extends $Command
   })
   .s("RestXml", "BodyWithXmlName", {})
   .n("RestXmlProtocolClient", "BodyWithXmlNameCommand")
-  .f(void 0, void 0)
   .sc(BodyWithXmlName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/ConstantAndVariableQueryStringCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/ConstantAndVariableQueryStringCommand.ts
@@ -72,7 +72,6 @@ export class ConstantAndVariableQueryStringCommand extends $Command
   })
   .s("RestXml", "ConstantAndVariableQueryString", {})
   .n("RestXmlProtocolClient", "ConstantAndVariableQueryStringCommand")
-  .f(void 0, void 0)
   .sc(ConstantAndVariableQueryString)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/ConstantQueryStringCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/ConstantQueryStringCommand.ts
@@ -72,7 +72,6 @@ export class ConstantQueryStringCommand extends $Command
   })
   .s("RestXml", "ConstantQueryString", {})
   .n("RestXmlProtocolClient", "ConstantQueryStringCommand")
-  .f(void 0, void 0)
   .sc(ConstantQueryString)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/ContentTypeParametersCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/ContentTypeParametersCommand.ts
@@ -70,7 +70,6 @@ export class ContentTypeParametersCommand extends $Command
   })
   .s("RestXml", "ContentTypeParameters", {})
   .n("RestXmlProtocolClient", "ContentTypeParametersCommand")
-  .f(void 0, void 0)
   .sc(ContentTypeParameters)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/DatetimeOffsetsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/DatetimeOffsetsCommand.ts
@@ -69,7 +69,6 @@ export class DatetimeOffsetsCommand extends $Command
   })
   .s("RestXml", "DatetimeOffsets", {})
   .n("RestXmlProtocolClient", "DatetimeOffsetsCommand")
-  .f(void 0, void 0)
   .sc(DatetimeOffsets)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/EmptyInputAndEmptyOutputCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/EmptyInputAndEmptyOutputCommand.ts
@@ -70,7 +70,6 @@ export class EmptyInputAndEmptyOutputCommand extends $Command
   })
   .s("RestXml", "EmptyInputAndEmptyOutput", {})
   .n("RestXmlProtocolClient", "EmptyInputAndEmptyOutputCommand")
-  .f(void 0, void 0)
   .sc(EmptyInputAndEmptyOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/EndpointOperationCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/EndpointOperationCommand.ts
@@ -66,7 +66,6 @@ export class EndpointOperationCommand extends $Command
   })
   .s("RestXml", "EndpointOperation", {})
   .n("RestXmlProtocolClient", "EndpointOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/EndpointWithHostLabelHeaderOperationCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/EndpointWithHostLabelHeaderOperationCommand.ts
@@ -69,7 +69,6 @@ export class EndpointWithHostLabelHeaderOperationCommand extends $Command
   })
   .s("RestXml", "EndpointWithHostLabelHeaderOperation", {})
   .n("RestXmlProtocolClient", "EndpointWithHostLabelHeaderOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointWithHostLabelHeaderOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/EndpointWithHostLabelOperationCommand.ts
@@ -69,7 +69,6 @@ export class EndpointWithHostLabelOperationCommand extends $Command
   })
   .s("RestXml", "EndpointWithHostLabelOperation", {})
   .n("RestXmlProtocolClient", "EndpointWithHostLabelOperationCommand")
-  .f(void 0, void 0)
   .sc(EndpointWithHostLabelOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/FlattenedXmlMapCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/FlattenedXmlMapCommand.ts
@@ -75,7 +75,6 @@ export class FlattenedXmlMapCommand extends $Command
   })
   .s("RestXml", "FlattenedXmlMap", {})
   .n("RestXmlProtocolClient", "FlattenedXmlMapCommand")
-  .f(void 0, void 0)
   .sc(FlattenedXmlMap)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/FlattenedXmlMapWithXmlNameCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/FlattenedXmlMapWithXmlNameCommand.ts
@@ -75,7 +75,6 @@ export class FlattenedXmlMapWithXmlNameCommand extends $Command
   })
   .s("RestXml", "FlattenedXmlMapWithXmlName", {})
   .n("RestXmlProtocolClient", "FlattenedXmlMapWithXmlNameCommand")
-  .f(void 0, void 0)
   .sc(FlattenedXmlMapWithXmlName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/FlattenedXmlMapWithXmlNamespaceCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/FlattenedXmlMapWithXmlNamespaceCommand.ts
@@ -73,7 +73,6 @@ export class FlattenedXmlMapWithXmlNamespaceCommand extends $Command
   })
   .s("RestXml", "FlattenedXmlMapWithXmlNamespace", {})
   .n("RestXmlProtocolClient", "FlattenedXmlMapWithXmlNamespaceCommand")
-  .f(void 0, void 0)
   .sc(FlattenedXmlMapWithXmlNamespace)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/FractionalSecondsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/FractionalSecondsCommand.ts
@@ -69,7 +69,6 @@ export class FractionalSecondsCommand extends $Command
   })
   .s("RestXml", "FractionalSeconds", {})
   .n("RestXmlProtocolClient", "FractionalSecondsCommand")
-  .f(void 0, void 0)
   .sc(FractionalSeconds)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -83,7 +83,6 @@ export class GreetingWithErrorsCommand extends $Command
   })
   .s("RestXml", "GreetingWithErrors", {})
   .n("RestXmlProtocolClient", "GreetingWithErrorsCommand")
-  .f(void 0, void 0)
   .sc(GreetingWithErrors)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpEmptyPrefixHeadersCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpEmptyPrefixHeadersCommand.ts
@@ -77,7 +77,6 @@ export class HttpEmptyPrefixHeadersCommand extends $Command
   })
   .s("RestXml", "HttpEmptyPrefixHeaders", {})
   .n("RestXmlProtocolClient", "HttpEmptyPrefixHeadersCommand")
-  .f(void 0, void 0)
   .sc(HttpEmptyPrefixHeaders)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpEnumPayloadCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpEnumPayloadCommand.ts
@@ -71,7 +71,6 @@ export class HttpEnumPayloadCommand extends $Command
   })
   .s("RestXml", "HttpEnumPayload", {})
   .n("RestXmlProtocolClient", "HttpEnumPayloadCommand")
-  .f(void 0, void 0)
   .sc(HttpEnumPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadTraitsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadTraitsCommand.ts
@@ -91,7 +91,6 @@ export class HttpPayloadTraitsCommand extends $Command
   })
   .s("RestXml", "HttpPayloadTraits", {})
   .n("RestXmlProtocolClient", "HttpPayloadTraitsCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadTraits)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadTraitsWithMediaTypeCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadTraitsWithMediaTypeCommand.ts
@@ -94,7 +94,6 @@ export class HttpPayloadTraitsWithMediaTypeCommand extends $Command
   })
   .s("RestXml", "HttpPayloadTraitsWithMediaType", {})
   .n("RestXmlProtocolClient", "HttpPayloadTraitsWithMediaTypeCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadTraitsWithMediaType)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithMemberXmlNameCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithMemberXmlNameCommand.ts
@@ -78,7 +78,6 @@ export class HttpPayloadWithMemberXmlNameCommand extends $Command
   })
   .s("RestXml", "HttpPayloadWithMemberXmlName", {})
   .n("RestXmlProtocolClient", "HttpPayloadWithMemberXmlNameCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadWithMemberXmlName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithStructureCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithStructureCommand.ts
@@ -80,7 +80,6 @@ export class HttpPayloadWithStructureCommand extends $Command
   })
   .s("RestXml", "HttpPayloadWithStructure", {})
   .n("RestXmlProtocolClient", "HttpPayloadWithStructureCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadWithStructure)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithUnionCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithUnionCommand.ts
@@ -75,7 +75,6 @@ export class HttpPayloadWithUnionCommand extends $Command
   })
   .s("RestXml", "HttpPayloadWithUnion", {})
   .n("RestXmlProtocolClient", "HttpPayloadWithUnionCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadWithUnion)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithXmlNameCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithXmlNameCommand.ts
@@ -76,7 +76,6 @@ export class HttpPayloadWithXmlNameCommand extends $Command
   })
   .s("RestXml", "HttpPayloadWithXmlName", {})
   .n("RestXmlProtocolClient", "HttpPayloadWithXmlNameCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadWithXmlName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithXmlNamespaceAndPrefixCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithXmlNamespaceAndPrefixCommand.ts
@@ -78,7 +78,6 @@ export class HttpPayloadWithXmlNamespaceAndPrefixCommand extends $Command
   })
   .s("RestXml", "HttpPayloadWithXmlNamespaceAndPrefix", {})
   .n("RestXmlProtocolClient", "HttpPayloadWithXmlNamespaceAndPrefixCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadWithXmlNamespaceAndPrefix)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithXmlNamespaceCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpPayloadWithXmlNamespaceCommand.ts
@@ -77,7 +77,6 @@ export class HttpPayloadWithXmlNamespaceCommand extends $Command
   })
   .s("RestXml", "HttpPayloadWithXmlNamespace", {})
   .n("RestXmlProtocolClient", "HttpPayloadWithXmlNamespaceCommand")
-  .f(void 0, void 0)
   .sc(HttpPayloadWithXmlNamespace)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpPrefixHeadersCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpPrefixHeadersCommand.ts
@@ -77,7 +77,6 @@ export class HttpPrefixHeadersCommand extends $Command
   })
   .s("RestXml", "HttpPrefixHeaders", {})
   .n("RestXmlProtocolClient", "HttpPrefixHeadersCommand")
-  .f(void 0, void 0)
   .sc(HttpPrefixHeaders)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpRequestWithFloatLabelsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpRequestWithFloatLabelsCommand.ts
@@ -70,7 +70,6 @@ export class HttpRequestWithFloatLabelsCommand extends $Command
   })
   .s("RestXml", "HttpRequestWithFloatLabels", {})
   .n("RestXmlProtocolClient", "HttpRequestWithFloatLabelsCommand")
-  .f(void 0, void 0)
   .sc(HttpRequestWithFloatLabels)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpRequestWithGreedyLabelInPathCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpRequestWithGreedyLabelInPathCommand.ts
@@ -70,7 +70,6 @@ export class HttpRequestWithGreedyLabelInPathCommand extends $Command
   })
   .s("RestXml", "HttpRequestWithGreedyLabelInPath", {})
   .n("RestXmlProtocolClient", "HttpRequestWithGreedyLabelInPathCommand")
-  .f(void 0, void 0)
   .sc(HttpRequestWithGreedyLabelInPath)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpRequestWithLabelsAndTimestampFormatCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpRequestWithLabelsAndTimestampFormatCommand.ts
@@ -77,7 +77,6 @@ export class HttpRequestWithLabelsAndTimestampFormatCommand extends $Command
   })
   .s("RestXml", "HttpRequestWithLabelsAndTimestampFormat", {})
   .n("RestXmlProtocolClient", "HttpRequestWithLabelsAndTimestampFormatCommand")
-  .f(void 0, void 0)
   .sc(HttpRequestWithLabelsAndTimestampFormat)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpRequestWithLabelsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpRequestWithLabelsCommand.ts
@@ -77,7 +77,6 @@ export class HttpRequestWithLabelsCommand extends $Command
   })
   .s("RestXml", "HttpRequestWithLabels", {})
   .n("RestXmlProtocolClient", "HttpRequestWithLabelsCommand")
-  .f(void 0, void 0)
   .sc(HttpRequestWithLabels)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpResponseCodeCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpResponseCodeCommand.ts
@@ -69,7 +69,6 @@ export class HttpResponseCodeCommand extends $Command
   })
   .s("RestXml", "HttpResponseCode", {})
   .n("RestXmlProtocolClient", "HttpResponseCodeCommand")
-  .f(void 0, void 0)
   .sc(HttpResponseCode)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/HttpStringPayloadCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/HttpStringPayloadCommand.ts
@@ -71,7 +71,6 @@ export class HttpStringPayloadCommand extends $Command
   })
   .s("RestXml", "HttpStringPayload", {})
   .n("RestXmlProtocolClient", "HttpStringPayloadCommand")
-  .f(void 0, void 0)
   .sc(HttpStringPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/IgnoreQueryParamsInResponseCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/IgnoreQueryParamsInResponseCommand.ts
@@ -71,7 +71,6 @@ export class IgnoreQueryParamsInResponseCommand extends $Command
   })
   .s("RestXml", "IgnoreQueryParamsInResponse", {})
   .n("RestXmlProtocolClient", "IgnoreQueryParamsInResponseCommand")
-  .f(void 0, void 0)
   .sc(IgnoreQueryParamsInResponse)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/InputAndOutputWithHeadersCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/InputAndOutputWithHeadersCommand.ts
@@ -126,7 +126,6 @@ export class InputAndOutputWithHeadersCommand extends $Command
   })
   .s("RestXml", "InputAndOutputWithHeaders", {})
   .n("RestXmlProtocolClient", "InputAndOutputWithHeadersCommand")
-  .f(void 0, void 0)
   .sc(InputAndOutputWithHeaders)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/NestedXmlMapWithXmlNameCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/NestedXmlMapWithXmlNameCommand.ts
@@ -79,7 +79,6 @@ export class NestedXmlMapWithXmlNameCommand extends $Command
   })
   .s("RestXml", "NestedXmlMapWithXmlName", {})
   .n("RestXmlProtocolClient", "NestedXmlMapWithXmlNameCommand")
-  .f(void 0, void 0)
   .sc(NestedXmlMapWithXmlName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/NestedXmlMapsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/NestedXmlMapsCommand.ts
@@ -89,7 +89,6 @@ export class NestedXmlMapsCommand extends $Command
   })
   .s("RestXml", "NestedXmlMaps", {})
   .n("RestXmlProtocolClient", "NestedXmlMapsCommand")
-  .f(void 0, void 0)
   .sc(NestedXmlMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/NoInputAndNoOutputCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/NoInputAndNoOutputCommand.ts
@@ -68,7 +68,6 @@ export class NoInputAndNoOutputCommand extends $Command
   })
   .s("RestXml", "NoInputAndNoOutput", {})
   .n("RestXmlProtocolClient", "NoInputAndNoOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputAndNoOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/NoInputAndOutputCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/NoInputAndOutputCommand.ts
@@ -70,7 +70,6 @@ export class NoInputAndOutputCommand extends $Command
   })
   .s("RestXml", "NoInputAndOutput", {})
   .n("RestXmlProtocolClient", "NoInputAndOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputAndOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/NullAndEmptyHeadersClientCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/NullAndEmptyHeadersClientCommand.ts
@@ -79,7 +79,6 @@ export class NullAndEmptyHeadersClientCommand extends $Command
   })
   .s("RestXml", "NullAndEmptyHeadersClient", {})
   .n("RestXmlProtocolClient", "NullAndEmptyHeadersClientCommand")
-  .f(void 0, void 0)
   .sc(NullAndEmptyHeadersClient)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/NullAndEmptyHeadersServerCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/NullAndEmptyHeadersServerCommand.ts
@@ -79,7 +79,6 @@ export class NullAndEmptyHeadersServerCommand extends $Command
   })
   .s("RestXml", "NullAndEmptyHeadersServer", {})
   .n("RestXmlProtocolClient", "NullAndEmptyHeadersServerCommand")
-  .f(void 0, void 0)
   .sc(NullAndEmptyHeadersServer)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/OmitsNullSerializesEmptyStringCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/OmitsNullSerializesEmptyStringCommand.ts
@@ -70,7 +70,6 @@ export class OmitsNullSerializesEmptyStringCommand extends $Command
   })
   .s("RestXml", "OmitsNullSerializesEmptyString", {})
   .n("RestXmlProtocolClient", "OmitsNullSerializesEmptyStringCommand")
-  .f(void 0, void 0)
   .sc(OmitsNullSerializesEmptyString)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/PutWithContentEncodingCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/PutWithContentEncodingCommand.ts
@@ -76,7 +76,6 @@ export class PutWithContentEncodingCommand extends $Command
   })
   .s("RestXml", "PutWithContentEncoding", {})
   .n("RestXmlProtocolClient", "PutWithContentEncodingCommand")
-  .f(void 0, void 0)
   .sc(PutWithContentEncoding)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/QueryIdempotencyTokenAutoFillCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/QueryIdempotencyTokenAutoFillCommand.ts
@@ -69,7 +69,6 @@ export class QueryIdempotencyTokenAutoFillCommand extends $Command
   })
   .s("RestXml", "QueryIdempotencyTokenAutoFill", {})
   .n("RestXmlProtocolClient", "QueryIdempotencyTokenAutoFillCommand")
-  .f(void 0, void 0)
   .sc(QueryIdempotencyTokenAutoFill)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/QueryParamsAsStringListMapCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/QueryParamsAsStringListMapCommand.ts
@@ -74,7 +74,6 @@ export class QueryParamsAsStringListMapCommand extends $Command
   })
   .s("RestXml", "QueryParamsAsStringListMap", {})
   .n("RestXmlProtocolClient", "QueryParamsAsStringListMapCommand")
-  .f(void 0, void 0)
   .sc(QueryParamsAsStringListMap)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/QueryPrecedenceCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/QueryPrecedenceCommand.ts
@@ -72,7 +72,6 @@ export class QueryPrecedenceCommand extends $Command
   })
   .s("RestXml", "QueryPrecedence", {})
   .n("RestXmlProtocolClient", "QueryPrecedenceCommand")
-  .f(void 0, void 0)
   .sc(QueryPrecedence)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/RecursiveShapesCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/RecursiveShapesCommand.ts
@@ -95,7 +95,6 @@ export class RecursiveShapesCommand extends $Command
   })
   .s("RestXml", "RecursiveShapes", {})
   .n("RestXmlProtocolClient", "RecursiveShapesCommand")
-  .f(void 0, void 0)
   .sc(RecursiveShapes)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/SimpleScalarPropertiesCommand.ts
@@ -89,7 +89,6 @@ export class SimpleScalarPropertiesCommand extends $Command
   })
   .s("RestXml", "SimpleScalarProperties", {})
   .n("RestXmlProtocolClient", "SimpleScalarPropertiesCommand")
-  .f(void 0, void 0)
   .sc(SimpleScalarProperties)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/TimestampFormatHeadersCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/TimestampFormatHeadersCommand.ts
@@ -83,7 +83,6 @@ export class TimestampFormatHeadersCommand extends $Command
   })
   .s("RestXml", "TimestampFormatHeaders", {})
   .n("RestXmlProtocolClient", "TimestampFormatHeadersCommand")
-  .f(void 0, void 0)
   .sc(TimestampFormatHeaders)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlAttributesCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlAttributesCommand.ts
@@ -73,7 +73,6 @@ export class XmlAttributesCommand extends $Command
   })
   .s("RestXml", "XmlAttributes", {})
   .n("RestXmlProtocolClient", "XmlAttributesCommand")
-  .f(void 0, void 0)
   .sc(XmlAttributes)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlAttributesOnPayloadCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlAttributesOnPayloadCommand.ts
@@ -77,7 +77,6 @@ export class XmlAttributesOnPayloadCommand extends $Command
   })
   .s("RestXml", "XmlAttributesOnPayload", {})
   .n("RestXmlProtocolClient", "XmlAttributesOnPayloadCommand")
-  .f(void 0, void 0)
   .sc(XmlAttributesOnPayload)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlBlobsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlBlobsCommand.ts
@@ -71,7 +71,6 @@ export class XmlBlobsCommand extends $Command
   })
   .s("RestXml", "XmlBlobs", {})
   .n("RestXmlProtocolClient", "XmlBlobsCommand")
-  .f(void 0, void 0)
   .sc(XmlBlobs)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlEmptyBlobsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlEmptyBlobsCommand.ts
@@ -71,7 +71,6 @@ export class XmlEmptyBlobsCommand extends $Command
   })
   .s("RestXml", "XmlEmptyBlobs", {})
   .n("RestXmlProtocolClient", "XmlEmptyBlobsCommand")
-  .f(void 0, void 0)
   .sc(XmlEmptyBlobs)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlEmptyListsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlEmptyListsCommand.ts
@@ -175,7 +175,6 @@ export class XmlEmptyListsCommand extends $Command
   })
   .s("RestXml", "XmlEmptyLists", {})
   .n("RestXmlProtocolClient", "XmlEmptyListsCommand")
-  .f(void 0, void 0)
   .sc(XmlEmptyLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlEmptyMapsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlEmptyMapsCommand.ts
@@ -79,7 +79,6 @@ export class XmlEmptyMapsCommand extends $Command
   })
   .s("RestXml", "XmlEmptyMaps", {})
   .n("RestXmlProtocolClient", "XmlEmptyMapsCommand")
-  .f(void 0, void 0)
   .sc(XmlEmptyMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlEmptyStringsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlEmptyStringsCommand.ts
@@ -71,7 +71,6 @@ export class XmlEmptyStringsCommand extends $Command
   })
   .s("RestXml", "XmlEmptyStrings", {})
   .n("RestXmlProtocolClient", "XmlEmptyStringsCommand")
-  .f(void 0, void 0)
   .sc(XmlEmptyStrings)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlEnumsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlEnumsCommand.ts
@@ -93,7 +93,6 @@ export class XmlEnumsCommand extends $Command
   })
   .s("RestXml", "XmlEnums", {})
   .n("RestXmlProtocolClient", "XmlEnumsCommand")
-  .f(void 0, void 0)
   .sc(XmlEnums)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlIntEnumsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlIntEnumsCommand.ts
@@ -93,7 +93,6 @@ export class XmlIntEnumsCommand extends $Command
   })
   .s("RestXml", "XmlIntEnums", {})
   .n("RestXmlProtocolClient", "XmlIntEnumsCommand")
-  .f(void 0, void 0)
   .sc(XmlIntEnums)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlListsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlListsCommand.ts
@@ -186,7 +186,6 @@ export class XmlListsCommand extends $Command
   })
   .s("RestXml", "XmlLists", {})
   .n("RestXmlProtocolClient", "XmlListsCommand")
-  .f(void 0, void 0)
   .sc(XmlLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlMapWithXmlNamespaceCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlMapWithXmlNamespaceCommand.ts
@@ -75,7 +75,6 @@ export class XmlMapWithXmlNamespaceCommand extends $Command
   })
   .s("RestXml", "XmlMapWithXmlNamespace", {})
   .n("RestXmlProtocolClient", "XmlMapWithXmlNamespaceCommand")
-  .f(void 0, void 0)
   .sc(XmlMapWithXmlNamespace)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlMapsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlMapsCommand.ts
@@ -79,7 +79,6 @@ export class XmlMapsCommand extends $Command
   })
   .s("RestXml", "XmlMaps", {})
   .n("RestXmlProtocolClient", "XmlMapsCommand")
-  .f(void 0, void 0)
   .sc(XmlMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlMapsXmlNameCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlMapsXmlNameCommand.ts
@@ -79,7 +79,6 @@ export class XmlMapsXmlNameCommand extends $Command
   })
   .s("RestXml", "XmlMapsXmlName", {})
   .n("RestXmlProtocolClient", "XmlMapsXmlNameCommand")
-  .f(void 0, void 0)
   .sc(XmlMapsXmlName)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlNamespacesCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlNamespacesCommand.ts
@@ -81,7 +81,6 @@ export class XmlNamespacesCommand extends $Command
   })
   .s("RestXml", "XmlNamespaces", {})
   .n("RestXmlProtocolClient", "XmlNamespacesCommand")
-  .f(void 0, void 0)
   .sc(XmlNamespaces)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlTimestampsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlTimestampsCommand.ts
@@ -85,7 +85,6 @@ export class XmlTimestampsCommand extends $Command
   })
   .s("RestXml", "XmlTimestamps", {})
   .n("RestXmlProtocolClient", "XmlTimestampsCommand")
-  .f(void 0, void 0)
   .sc(XmlTimestamps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-restxml-schema/src/commands/XmlUnionsCommand.ts
+++ b/private/aws-protocoltests-restxml-schema/src/commands/XmlUnionsCommand.ts
@@ -151,7 +151,6 @@ export class XmlUnionsCommand extends $Command
   })
   .s("RestXml", "XmlUnions", {})
   .n("RestXmlProtocolClient", "XmlUnionsCommand")
-  .f(void 0, void 0)
   .sc(XmlUnions)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/EmptyInputOutputCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/EmptyInputOutputCommand.ts
@@ -67,7 +67,6 @@ export class EmptyInputOutputCommand extends $Command
   })
   .s("RpcV2Protocol", "EmptyInputOutput", {})
   .n("RpcV2ProtocolClient", "EmptyInputOutputCommand")
-  .f(void 0, void 0)
   .sc(EmptyInputOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/Float16Command.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/Float16Command.ts
@@ -69,7 +69,6 @@ export class Float16Command extends $Command
   })
   .s("RpcV2Protocol", "Float16", {})
   .n("RpcV2ProtocolClient", "Float16Command")
-  .f(void 0, void 0)
   .sc(Float16)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/FractionalSecondsCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/FractionalSecondsCommand.ts
@@ -69,7 +69,6 @@ export class FractionalSecondsCommand extends $Command
   })
   .s("RpcV2Protocol", "FractionalSeconds", {})
   .n("RpcV2ProtocolClient", "FractionalSecondsCommand")
-  .f(void 0, void 0)
   .sc(FractionalSeconds)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/GreetingWithErrorsCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/GreetingWithErrorsCommand.ts
@@ -82,7 +82,6 @@ export class GreetingWithErrorsCommand extends $Command
   })
   .s("RpcV2Protocol", "GreetingWithErrors", {})
   .n("RpcV2ProtocolClient", "GreetingWithErrorsCommand")
-  .f(void 0, void 0)
   .sc(GreetingWithErrors)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/NoInputOutputCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/NoInputOutputCommand.ts
@@ -66,7 +66,6 @@ export class NoInputOutputCommand extends $Command
   })
   .s("RpcV2Protocol", "NoInputOutput", {})
   .n("RpcV2ProtocolClient", "NoInputOutputCommand")
-  .f(void 0, void 0)
   .sc(NoInputOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/OperationWithDefaultsCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/OperationWithDefaultsCommand.ts
@@ -135,7 +135,6 @@ export class OperationWithDefaultsCommand extends $Command
   })
   .s("RpcV2Protocol", "OperationWithDefaults", {})
   .n("RpcV2ProtocolClient", "OperationWithDefaultsCommand")
-  .f(void 0, void 0)
   .sc(OperationWithDefaults)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/OptionalInputOutputCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/OptionalInputOutputCommand.ts
@@ -71,7 +71,6 @@ export class OptionalInputOutputCommand extends $Command
   })
   .s("RpcV2Protocol", "OptionalInputOutput", {})
   .n("RpcV2ProtocolClient", "OptionalInputOutputCommand")
-  .f(void 0, void 0)
   .sc(OptionalInputOutput)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/RecursiveShapesCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/RecursiveShapesCommand.ts
@@ -95,7 +95,6 @@ export class RecursiveShapesCommand extends $Command
   })
   .s("RpcV2Protocol", "RecursiveShapes", {})
   .n("RpcV2ProtocolClient", "RecursiveShapesCommand")
-  .f(void 0, void 0)
   .sc(RecursiveShapes)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/RpcV2CborDenseMapsCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/RpcV2CborDenseMapsCommand.ts
@@ -112,7 +112,6 @@ export class RpcV2CborDenseMapsCommand extends $Command
   })
   .s("RpcV2Protocol", "RpcV2CborDenseMaps", {})
   .n("RpcV2ProtocolClient", "RpcV2CborDenseMapsCommand")
-  .f(void 0, void 0)
   .sc(RpcV2CborDenseMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/RpcV2CborListsCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/RpcV2CborListsCommand.ts
@@ -150,7 +150,6 @@ export class RpcV2CborListsCommand extends $Command
   })
   .s("RpcV2Protocol", "RpcV2CborLists", {})
   .n("RpcV2ProtocolClient", "RpcV2CborListsCommand")
-  .f(void 0, void 0)
   .sc(RpcV2CborLists)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/RpcV2CborSparseMapsCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/RpcV2CborSparseMapsCommand.ts
@@ -112,7 +112,6 @@ export class RpcV2CborSparseMapsCommand extends $Command
   })
   .s("RpcV2Protocol", "RpcV2CborSparseMaps", {})
   .n("RpcV2ProtocolClient", "RpcV2CborSparseMapsCommand")
-  .f(void 0, void 0)
   .sc(RpcV2CborSparseMaps)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/SimpleScalarPropertiesCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/SimpleScalarPropertiesCommand.ts
@@ -89,7 +89,6 @@ export class SimpleScalarPropertiesCommand extends $Command
   })
   .s("RpcV2Protocol", "SimpleScalarProperties", {})
   .n("RpcV2ProtocolClient", "SimpleScalarPropertiesCommand")
-  .f(void 0, void 0)
   .sc(SimpleScalarProperties)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/SparseNullsOperationCommand.ts
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/src/commands/SparseNullsOperationCommand.ts
@@ -81,7 +81,6 @@ export class SparseNullsOperationCommand extends $Command
   })
   .s("RpcV2Protocol", "SparseNullsOperation", {})
   .n("RpcV2ProtocolClient", "SparseNullsOperationCommand")
-  .f(void 0, void 0)
   .sc(SparseNullsOperation)
   .build() {
   /** @internal type navigation helper, not in runtime. */

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "1cab1f58b1ac19060e006c913125a9421a8bf453",
+  SMITHY_TS_COMMIT: "eb1ab406518ca1b38eecaf47b004dcfe5855f910",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Generated code for https://github.com/smithy-lang/smithy-typescript/pull/1662

### Description
chore(protocoltests): use schema log filter when available

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
