### PR TITLE
chore(protocoltests): rename vite.config.js to *.mjs

### DIFF
--- a/private/aws-protocoltests-ec2-schema/vite.config.mjs
+++ b/private/aws-protocoltests-ec2-schema/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-ec2/vite.config.mjs
+++ b/private/aws-protocoltests-ec2/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-json-10-schema/vite.config.mjs
+++ b/private/aws-protocoltests-json-10-schema/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-json-10/vite.config.mjs
+++ b/private/aws-protocoltests-json-10/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-json-machinelearning/vite.config.mjs
+++ b/private/aws-protocoltests-json-machinelearning/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-json-schema-machinelearning/vite.config.mjs
+++ b/private/aws-protocoltests-json-schema-machinelearning/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-json-schema/vite.config.mjs
+++ b/private/aws-protocoltests-json-schema/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-json/vite.config.mjs
+++ b/private/aws-protocoltests-json/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-query-schema/vite.config.mjs
+++ b/private/aws-protocoltests-query-schema/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-query/vite.config.mjs
+++ b/private/aws-protocoltests-query/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-restjson-apigateway/vite.config.mjs
+++ b/private/aws-protocoltests-restjson-apigateway/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-restjson-glacier/vite.config.mjs
+++ b/private/aws-protocoltests-restjson-glacier/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-restjson-schema-apigateway/vite.config.mjs
+++ b/private/aws-protocoltests-restjson-schema-apigateway/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-restjson-schema-glacier/vite.config.mjs
+++ b/private/aws-protocoltests-restjson-schema-glacier/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-restjson-schema/src/schemas/schemas.ts
+++ b/private/aws-protocoltests-restjson-schema/src/schemas/schemas.ts
@@ -2046,8 +2046,8 @@ export var TimestampFormatHeadersIO = struct(
 );
 export var TopLevel = struct(n0, _TLo, 0, [_di, _dLi, _dMi], [() => Dialog, () => DialogList, () => DialogMap]);
 export var UnionInputOutput = struct(n0, _UIO, 0, [_con], [() => MyUnion]);
-export var GreetingStruct = struct(n2, _GS, 0, [_sa], [0]);
-export var GreetingStruct_n1 = struct(n1, _GS, 0, [_hi], [0]);
+export var GreetingStruct_n2 = struct(n2, _GS, 0, [_sa], [0]);
+export var GreetingStruct = struct(n1, _GS, 0, [_hi], [0]);
 export var Unit = "unit" as const;
 
 export var RestJsonProtocolServiceException = error(
@@ -2110,7 +2110,7 @@ export var DenseNumberMap = 128 | 1;
 export var DenseSetMap = map(n0, _DSM, 0, 0, 64 | 0);
 export var DenseStringMap = 128 | 0;
 
-export var DenseStructMap = map(n0, _DSMe, 0, 0, () => GreetingStruct_n1);
+export var DenseStructMap = map(n0, _DSMe, 0, 0, () => GreetingStruct);
 export var DialogMap = map(n0, _DM, 0, 0, () => Dialog);
 export var DocumentValuedMap = 128 | 15;
 
@@ -2150,7 +2150,7 @@ export var SparseStructMap = map(
     [_sp]: 1,
   },
   0,
-  () => GreetingStruct_n1
+  () => GreetingStruct
 );
 export var TestStringMap = 128 | 0;
 
@@ -2175,7 +2175,7 @@ export var MyUnion = uni(
   _MU,
   0,
   [_sV, _bVo, _nVu, _bVl, _tV, _eV, _lVi, _mV, _sVt, _rSV],
-  [0, 2, 1, 21, 4, 0, 64 | 0, 128 | 0, () => GreetingStruct_n1, () => GreetingStruct]
+  [0, 2, 1, 21, 4, 0, 64 | 0, 128 | 0, () => GreetingStruct, () => GreetingStruct_n2]
 );
 export var PlayerAction = uni(n0, _PA, 0, [_qu], [() => Unit]);
 export var SimpleUnion = uni(n0, _SU, 0, [_int, _st], [1, 0]);
@@ -2570,7 +2570,7 @@ export var MalformedAcceptWithBody = op(
     [_ht]: ["POST", "/MalformedAcceptWithBody", 200],
   },
   () => Unit,
-  () => GreetingStruct_n1
+  () => GreetingStruct
 );
 export var MalformedAcceptWithGenericString = op(
   n0,
@@ -2623,7 +2623,7 @@ export var MalformedContentTypeWithBody = op(
   {
     [_ht]: ["POST", "/MalformedContentTypeWithBody", 200],
   },
-  () => GreetingStruct_n1,
+  () => GreetingStruct,
   () => Unit
 );
 export var MalformedContentTypeWithGenericString = op(

--- a/private/aws-protocoltests-restjson-schema/vite.config.mjs
+++ b/private/aws-protocoltests-restjson-schema/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-restjson/vite.config.mjs
+++ b/private/aws-protocoltests-restjson/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-restxml-schema/vite.config.mjs
+++ b/private/aws-protocoltests-restxml-schema/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-restxml/vite.config.mjs
+++ b/private/aws-protocoltests-restxml/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/vite.config.mjs
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-protocoltests-smithy-rpcv2-cbor/vite.config.mjs
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-restjson-server/vite.config.mjs
+++ b/private/aws-restjson-server/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})

--- a/private/aws-restjson-validation-server/vite.config.mjs
+++ b/private/aws-restjson-validation-server/vite.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})


### PR DESCRIPTION
### Issue
Codegen for https://github.com/smithy-lang/smithy-typescript/pull/1664

### Description
Renames vite.config.js to *.mjs in generated code

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
