### PR TITLE
chore: use 'include' in tsconfig.types.json

### DIFF
--- a/clients/client-accessanalyzer/tsconfig.types.json
+++ b/clients/client-accessanalyzer/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-account/tsconfig.types.json
+++ b/clients/client-account/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-acm-pca/tsconfig.types.json
+++ b/clients/client-acm-pca/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-acm/tsconfig.types.json
+++ b/clients/client-acm/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-aiops/tsconfig.types.json
+++ b/clients/client-aiops/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-amp/tsconfig.types.json
+++ b/clients/client-amp/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-amplify/tsconfig.types.json
+++ b/clients/client-amplify/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-amplifybackend/tsconfig.types.json
+++ b/clients/client-amplifybackend/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-amplifyuibuilder/tsconfig.types.json
+++ b/clients/client-amplifyuibuilder/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-api-gateway/tsconfig.types.json
+++ b/clients/client-api-gateway/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-apigatewaymanagementapi/tsconfig.types.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-apigatewayv2/tsconfig.types.json
+++ b/clients/client-apigatewayv2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-app-mesh/tsconfig.types.json
+++ b/clients/client-app-mesh/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-appconfig/tsconfig.types.json
+++ b/clients/client-appconfig/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-appconfigdata/tsconfig.types.json
+++ b/clients/client-appconfigdata/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-appfabric/tsconfig.types.json
+++ b/clients/client-appfabric/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-appflow/tsconfig.types.json
+++ b/clients/client-appflow/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-appintegrations/tsconfig.types.json
+++ b/clients/client-appintegrations/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-application-auto-scaling/tsconfig.types.json
+++ b/clients/client-application-auto-scaling/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-application-discovery-service/tsconfig.types.json
+++ b/clients/client-application-discovery-service/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-application-insights/tsconfig.types.json
+++ b/clients/client-application-insights/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-application-signals/tsconfig.types.json
+++ b/clients/client-application-signals/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-applicationcostprofiler/tsconfig.types.json
+++ b/clients/client-applicationcostprofiler/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-apprunner/tsconfig.types.json
+++ b/clients/client-apprunner/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-appstream/tsconfig.types.json
+++ b/clients/client-appstream/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-appsync/tsconfig.types.json
+++ b/clients/client-appsync/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-apptest/tsconfig.types.json
+++ b/clients/client-apptest/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-arc-region-switch/tsconfig.types.json
+++ b/clients/client-arc-region-switch/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-arc-zonal-shift/tsconfig.types.json
+++ b/clients/client-arc-zonal-shift/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-artifact/tsconfig.types.json
+++ b/clients/client-artifact/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-athena/tsconfig.types.json
+++ b/clients/client-athena/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-auditmanager/tsconfig.types.json
+++ b/clients/client-auditmanager/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-auto-scaling-plans/tsconfig.types.json
+++ b/clients/client-auto-scaling-plans/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-auto-scaling/tsconfig.types.json
+++ b/clients/client-auto-scaling/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-b2bi/tsconfig.types.json
+++ b/clients/client-b2bi/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-backup-gateway/tsconfig.types.json
+++ b/clients/client-backup-gateway/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-backup/tsconfig.types.json
+++ b/clients/client-backup/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-backupsearch/tsconfig.types.json
+++ b/clients/client-backupsearch/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-batch/tsconfig.types.json
+++ b/clients/client-batch/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bcm-dashboards/tsconfig.types.json
+++ b/clients/client-bcm-dashboards/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bcm-data-exports/tsconfig.types.json
+++ b/clients/client-bcm-data-exports/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bcm-pricing-calculator/tsconfig.types.json
+++ b/clients/client-bcm-pricing-calculator/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bcm-recommended-actions/tsconfig.types.json
+++ b/clients/client-bcm-recommended-actions/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bedrock-agent-runtime/tsconfig.types.json
+++ b/clients/client-bedrock-agent-runtime/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bedrock-agent/tsconfig.types.json
+++ b/clients/client-bedrock-agent/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bedrock-agentcore-control/tsconfig.types.json
+++ b/clients/client-bedrock-agentcore-control/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bedrock-agentcore/tsconfig.types.json
+++ b/clients/client-bedrock-agentcore/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bedrock-data-automation-runtime/tsconfig.types.json
+++ b/clients/client-bedrock-data-automation-runtime/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bedrock-data-automation/tsconfig.types.json
+++ b/clients/client-bedrock-data-automation/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bedrock-runtime/tsconfig.types.json
+++ b/clients/client-bedrock-runtime/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-bedrock/tsconfig.types.json
+++ b/clients/client-bedrock/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-billing/tsconfig.types.json
+++ b/clients/client-billing/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-billingconductor/tsconfig.types.json
+++ b/clients/client-billingconductor/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-braket/tsconfig.types.json
+++ b/clients/client-braket/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-budgets/tsconfig.types.json
+++ b/clients/client-budgets/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-chatbot/tsconfig.types.json
+++ b/clients/client-chatbot/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-chime-sdk-identity/tsconfig.types.json
+++ b/clients/client-chime-sdk-identity/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-chime-sdk-media-pipelines/tsconfig.types.json
+++ b/clients/client-chime-sdk-media-pipelines/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-chime-sdk-meetings/tsconfig.types.json
+++ b/clients/client-chime-sdk-meetings/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-chime-sdk-messaging/tsconfig.types.json
+++ b/clients/client-chime-sdk-messaging/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-chime-sdk-voice/tsconfig.types.json
+++ b/clients/client-chime-sdk-voice/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-chime/tsconfig.types.json
+++ b/clients/client-chime/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cleanrooms/tsconfig.types.json
+++ b/clients/client-cleanrooms/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cleanroomsml/tsconfig.types.json
+++ b/clients/client-cleanroomsml/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloud9/tsconfig.types.json
+++ b/clients/client-cloud9/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudcontrol/tsconfig.types.json
+++ b/clients/client-cloudcontrol/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-clouddirectory/tsconfig.types.json
+++ b/clients/client-clouddirectory/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudformation/tsconfig.types.json
+++ b/clients/client-cloudformation/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudfront-keyvaluestore/tsconfig.types.json
+++ b/clients/client-cloudfront-keyvaluestore/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudfront/tsconfig.types.json
+++ b/clients/client-cloudfront/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudhsm-v2/tsconfig.types.json
+++ b/clients/client-cloudhsm-v2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudhsm/tsconfig.types.json
+++ b/clients/client-cloudhsm/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudsearch-domain/tsconfig.types.json
+++ b/clients/client-cloudsearch-domain/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudsearch/tsconfig.types.json
+++ b/clients/client-cloudsearch/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudtrail-data/tsconfig.types.json
+++ b/clients/client-cloudtrail-data/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudtrail/tsconfig.types.json
+++ b/clients/client-cloudtrail/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudwatch-events/tsconfig.types.json
+++ b/clients/client-cloudwatch-events/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudwatch-logs/tsconfig.types.json
+++ b/clients/client-cloudwatch-logs/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cloudwatch/tsconfig.types.json
+++ b/clients/client-cloudwatch/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/clients/client-codeartifact/tsconfig.types.json
+++ b/clients/client-codeartifact/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codebuild/tsconfig.types.json
+++ b/clients/client-codebuild/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codecatalyst/tsconfig.types.json
+++ b/clients/client-codecatalyst/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codecommit/tsconfig.types.json
+++ b/clients/client-codecommit/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codeconnections/tsconfig.types.json
+++ b/clients/client-codeconnections/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codedeploy/tsconfig.types.json
+++ b/clients/client-codedeploy/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codeguru-reviewer/tsconfig.types.json
+++ b/clients/client-codeguru-reviewer/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codeguru-security/tsconfig.types.json
+++ b/clients/client-codeguru-security/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codeguruprofiler/tsconfig.types.json
+++ b/clients/client-codeguruprofiler/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codepipeline/tsconfig.types.json
+++ b/clients/client-codepipeline/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codestar-connections/tsconfig.types.json
+++ b/clients/client-codestar-connections/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-codestar-notifications/tsconfig.types.json
+++ b/clients/client-codestar-notifications/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cognito-identity-provider/tsconfig.types.json
+++ b/clients/client-cognito-identity-provider/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cognito-identity/tsconfig.types.json
+++ b/clients/client-cognito-identity/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/clients/client-cognito-sync/tsconfig.types.json
+++ b/clients/client-cognito-sync/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-comprehend/tsconfig.types.json
+++ b/clients/client-comprehend/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-comprehendmedical/tsconfig.types.json
+++ b/clients/client-comprehendmedical/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-compute-optimizer/tsconfig.types.json
+++ b/clients/client-compute-optimizer/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-config-service/tsconfig.types.json
+++ b/clients/client-config-service/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-connect-contact-lens/tsconfig.types.json
+++ b/clients/client-connect-contact-lens/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-connect/tsconfig.types.json
+++ b/clients/client-connect/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-connectcampaigns/tsconfig.types.json
+++ b/clients/client-connectcampaigns/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-connectcampaignsv2/tsconfig.types.json
+++ b/clients/client-connectcampaignsv2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-connectcases/tsconfig.types.json
+++ b/clients/client-connectcases/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-connectparticipant/tsconfig.types.json
+++ b/clients/client-connectparticipant/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-controlcatalog/tsconfig.types.json
+++ b/clients/client-controlcatalog/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-controltower/tsconfig.types.json
+++ b/clients/client-controltower/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cost-and-usage-report-service/tsconfig.types.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cost-explorer/tsconfig.types.json
+++ b/clients/client-cost-explorer/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-cost-optimization-hub/tsconfig.types.json
+++ b/clients/client-cost-optimization-hub/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-customer-profiles/tsconfig.types.json
+++ b/clients/client-customer-profiles/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-data-pipeline/tsconfig.types.json
+++ b/clients/client-data-pipeline/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-database-migration-service/tsconfig.types.json
+++ b/clients/client-database-migration-service/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-databrew/tsconfig.types.json
+++ b/clients/client-databrew/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-dataexchange/tsconfig.types.json
+++ b/clients/client-dataexchange/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-datasync/tsconfig.types.json
+++ b/clients/client-datasync/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-datazone/tsconfig.types.json
+++ b/clients/client-datazone/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-dax/tsconfig.types.json
+++ b/clients/client-dax/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-deadline/tsconfig.types.json
+++ b/clients/client-deadline/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-detective/tsconfig.types.json
+++ b/clients/client-detective/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-device-farm/tsconfig.types.json
+++ b/clients/client-device-farm/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-devops-guru/tsconfig.types.json
+++ b/clients/client-devops-guru/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-direct-connect/tsconfig.types.json
+++ b/clients/client-direct-connect/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-directory-service-data/tsconfig.types.json
+++ b/clients/client-directory-service-data/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-directory-service/tsconfig.types.json
+++ b/clients/client-directory-service/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-dlm/tsconfig.types.json
+++ b/clients/client-dlm/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-docdb-elastic/tsconfig.types.json
+++ b/clients/client-docdb-elastic/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-docdb/tsconfig.types.json
+++ b/clients/client-docdb/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-drs/tsconfig.types.json
+++ b/clients/client-drs/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-dsql/tsconfig.types.json
+++ b/clients/client-dsql/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-dynamodb-streams/tsconfig.types.json
+++ b/clients/client-dynamodb-streams/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-dynamodb/tsconfig.types.json
+++ b/clients/client-dynamodb/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ebs/tsconfig.types.json
+++ b/clients/client-ebs/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ec2-instance-connect/tsconfig.types.json
+++ b/clients/client-ec2-instance-connect/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ec2/tsconfig.types.json
+++ b/clients/client-ec2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ecr-public/tsconfig.types.json
+++ b/clients/client-ecr-public/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ecr/tsconfig.types.json
+++ b/clients/client-ecr/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ecs/tsconfig.types.json
+++ b/clients/client-ecs/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-efs/tsconfig.types.json
+++ b/clients/client-efs/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-eks-auth/tsconfig.types.json
+++ b/clients/client-eks-auth/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-eks/tsconfig.types.json
+++ b/clients/client-eks/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-elastic-beanstalk/tsconfig.types.json
+++ b/clients/client-elastic-beanstalk/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-elastic-load-balancing-v2/tsconfig.types.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-elastic-load-balancing/tsconfig.types.json
+++ b/clients/client-elastic-load-balancing/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-elastic-transcoder/tsconfig.types.json
+++ b/clients/client-elastic-transcoder/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-elasticache/tsconfig.types.json
+++ b/clients/client-elasticache/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-elasticsearch-service/tsconfig.types.json
+++ b/clients/client-elasticsearch-service/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-emr-containers/tsconfig.types.json
+++ b/clients/client-emr-containers/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-emr-serverless/tsconfig.types.json
+++ b/clients/client-emr-serverless/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-emr/tsconfig.types.json
+++ b/clients/client-emr/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-entityresolution/tsconfig.types.json
+++ b/clients/client-entityresolution/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-eventbridge/tsconfig.types.json
+++ b/clients/client-eventbridge/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/clients/client-evidently/tsconfig.types.json
+++ b/clients/client-evidently/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-evs/tsconfig.types.json
+++ b/clients/client-evs/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-finspace-data/tsconfig.types.json
+++ b/clients/client-finspace-data/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-finspace/tsconfig.types.json
+++ b/clients/client-finspace/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-firehose/tsconfig.types.json
+++ b/clients/client-firehose/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-fis/tsconfig.types.json
+++ b/clients/client-fis/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-fms/tsconfig.types.json
+++ b/clients/client-fms/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-forecast/tsconfig.types.json
+++ b/clients/client-forecast/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-forecastquery/tsconfig.types.json
+++ b/clients/client-forecastquery/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-frauddetector/tsconfig.types.json
+++ b/clients/client-frauddetector/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-freetier/tsconfig.types.json
+++ b/clients/client-freetier/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-fsx/tsconfig.types.json
+++ b/clients/client-fsx/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-gamelift/tsconfig.types.json
+++ b/clients/client-gamelift/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-gameliftstreams/tsconfig.types.json
+++ b/clients/client-gameliftstreams/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-geo-maps/tsconfig.types.json
+++ b/clients/client-geo-maps/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-geo-places/tsconfig.types.json
+++ b/clients/client-geo-places/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-geo-routes/tsconfig.types.json
+++ b/clients/client-geo-routes/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-glacier/tsconfig.types.json
+++ b/clients/client-glacier/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-global-accelerator/tsconfig.types.json
+++ b/clients/client-global-accelerator/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-glue/tsconfig.types.json
+++ b/clients/client-glue/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-grafana/tsconfig.types.json
+++ b/clients/client-grafana/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-greengrass/tsconfig.types.json
+++ b/clients/client-greengrass/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-greengrassv2/tsconfig.types.json
+++ b/clients/client-greengrassv2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-groundstation/tsconfig.types.json
+++ b/clients/client-groundstation/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-guardduty/tsconfig.types.json
+++ b/clients/client-guardduty/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-health/tsconfig.types.json
+++ b/clients/client-health/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-healthlake/tsconfig.types.json
+++ b/clients/client-healthlake/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iam/tsconfig.types.json
+++ b/clients/client-iam/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-identitystore/tsconfig.types.json
+++ b/clients/client-identitystore/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-imagebuilder/tsconfig.types.json
+++ b/clients/client-imagebuilder/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-inspector-scan/tsconfig.types.json
+++ b/clients/client-inspector-scan/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-inspector/tsconfig.types.json
+++ b/clients/client-inspector/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-inspector2/tsconfig.types.json
+++ b/clients/client-inspector2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-internetmonitor/tsconfig.types.json
+++ b/clients/client-internetmonitor/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-invoicing/tsconfig.types.json
+++ b/clients/client-invoicing/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iot-data-plane/tsconfig.types.json
+++ b/clients/client-iot-data-plane/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iot-events-data/tsconfig.types.json
+++ b/clients/client-iot-events-data/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iot-events/tsconfig.types.json
+++ b/clients/client-iot-events/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iot-jobs-data-plane/tsconfig.types.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iot-managed-integrations/tsconfig.types.json
+++ b/clients/client-iot-managed-integrations/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iot-wireless/tsconfig.types.json
+++ b/clients/client-iot-wireless/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iot/tsconfig.types.json
+++ b/clients/client-iot/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iotanalytics/tsconfig.types.json
+++ b/clients/client-iotanalytics/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iotdeviceadvisor/tsconfig.types.json
+++ b/clients/client-iotdeviceadvisor/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iotfleethub/tsconfig.types.json
+++ b/clients/client-iotfleethub/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iotfleetwise/tsconfig.types.json
+++ b/clients/client-iotfleetwise/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iotsecuretunneling/tsconfig.types.json
+++ b/clients/client-iotsecuretunneling/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iotsitewise/tsconfig.types.json
+++ b/clients/client-iotsitewise/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iotthingsgraph/tsconfig.types.json
+++ b/clients/client-iotthingsgraph/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-iottwinmaker/tsconfig.types.json
+++ b/clients/client-iottwinmaker/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ivs-realtime/tsconfig.types.json
+++ b/clients/client-ivs-realtime/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ivs/tsconfig.types.json
+++ b/clients/client-ivs/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ivschat/tsconfig.types.json
+++ b/clients/client-ivschat/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kafka/tsconfig.types.json
+++ b/clients/client-kafka/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kafkaconnect/tsconfig.types.json
+++ b/clients/client-kafkaconnect/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kendra-ranking/tsconfig.types.json
+++ b/clients/client-kendra-ranking/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kendra/tsconfig.types.json
+++ b/clients/client-kendra/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-keyspaces/tsconfig.types.json
+++ b/clients/client-keyspaces/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-keyspacesstreams/tsconfig.types.json
+++ b/clients/client-keyspacesstreams/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kinesis-analytics-v2/tsconfig.types.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kinesis-analytics/tsconfig.types.json
+++ b/clients/client-kinesis-analytics/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kinesis-video-archived-media/tsconfig.types.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kinesis-video-media/tsconfig.types.json
+++ b/clients/client-kinesis-video-media/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kinesis-video-signaling/tsconfig.types.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kinesis-video-webrtc-storage/tsconfig.types.json
+++ b/clients/client-kinesis-video-webrtc-storage/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kinesis-video/tsconfig.types.json
+++ b/clients/client-kinesis-video/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-kinesis/tsconfig.types.json
+++ b/clients/client-kinesis/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/clients/client-kms/tsconfig.types.json
+++ b/clients/client-kms/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-lakeformation/tsconfig.types.json
+++ b/clients/client-lakeformation/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-lambda/tsconfig.types.json
+++ b/clients/client-lambda/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-launch-wizard/tsconfig.types.json
+++ b/clients/client-launch-wizard/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-lex-model-building-service/tsconfig.types.json
+++ b/clients/client-lex-model-building-service/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-lex-models-v2/tsconfig.types.json
+++ b/clients/client-lex-models-v2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-lex-runtime-service/tsconfig.types.json
+++ b/clients/client-lex-runtime-service/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/clients/client-lex-runtime-v2/tsconfig.types.json
+++ b/clients/client-lex-runtime-v2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-license-manager-linux-subscriptions/tsconfig.types.json
+++ b/clients/client-license-manager-linux-subscriptions/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-license-manager-user-subscriptions/tsconfig.types.json
+++ b/clients/client-license-manager-user-subscriptions/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-license-manager/tsconfig.types.json
+++ b/clients/client-license-manager/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-lightsail/tsconfig.types.json
+++ b/clients/client-lightsail/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-location/tsconfig.types.json
+++ b/clients/client-location/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-lookoutequipment/tsconfig.types.json
+++ b/clients/client-lookoutequipment/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-lookoutmetrics/tsconfig.types.json
+++ b/clients/client-lookoutmetrics/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-lookoutvision/tsconfig.types.json
+++ b/clients/client-lookoutvision/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-m2/tsconfig.types.json
+++ b/clients/client-m2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-machine-learning/tsconfig.types.json
+++ b/clients/client-machine-learning/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-macie2/tsconfig.types.json
+++ b/clients/client-macie2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mailmanager/tsconfig.types.json
+++ b/clients/client-mailmanager/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-managedblockchain-query/tsconfig.types.json
+++ b/clients/client-managedblockchain-query/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-managedblockchain/tsconfig.types.json
+++ b/clients/client-managedblockchain/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-marketplace-agreement/tsconfig.types.json
+++ b/clients/client-marketplace-agreement/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-marketplace-catalog/tsconfig.types.json
+++ b/clients/client-marketplace-catalog/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-marketplace-commerce-analytics/tsconfig.types.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-marketplace-deployment/tsconfig.types.json
+++ b/clients/client-marketplace-deployment/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-marketplace-entitlement-service/tsconfig.types.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-marketplace-metering/tsconfig.types.json
+++ b/clients/client-marketplace-metering/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-marketplace-reporting/tsconfig.types.json
+++ b/clients/client-marketplace-reporting/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mediaconnect/tsconfig.types.json
+++ b/clients/client-mediaconnect/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mediaconvert/tsconfig.types.json
+++ b/clients/client-mediaconvert/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-medialive/tsconfig.types.json
+++ b/clients/client-medialive/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mediapackage-vod/tsconfig.types.json
+++ b/clients/client-mediapackage-vod/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mediapackage/tsconfig.types.json
+++ b/clients/client-mediapackage/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mediapackagev2/tsconfig.types.json
+++ b/clients/client-mediapackagev2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mediastore-data/tsconfig.types.json
+++ b/clients/client-mediastore-data/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/clients/client-mediastore/tsconfig.types.json
+++ b/clients/client-mediastore/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mediatailor/tsconfig.types.json
+++ b/clients/client-mediatailor/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-medical-imaging/tsconfig.types.json
+++ b/clients/client-medical-imaging/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-memorydb/tsconfig.types.json
+++ b/clients/client-memorydb/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mgn/tsconfig.types.json
+++ b/clients/client-mgn/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-migration-hub-refactor-spaces/tsconfig.types.json
+++ b/clients/client-migration-hub-refactor-spaces/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-migration-hub/tsconfig.types.json
+++ b/clients/client-migration-hub/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-migrationhub-config/tsconfig.types.json
+++ b/clients/client-migrationhub-config/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-migrationhuborchestrator/tsconfig.types.json
+++ b/clients/client-migrationhuborchestrator/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-migrationhubstrategy/tsconfig.types.json
+++ b/clients/client-migrationhubstrategy/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mpa/tsconfig.types.json
+++ b/clients/client-mpa/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mq/tsconfig.types.json
+++ b/clients/client-mq/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mturk/tsconfig.types.json
+++ b/clients/client-mturk/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-mwaa/tsconfig.types.json
+++ b/clients/client-mwaa/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-neptune-graph/tsconfig.types.json
+++ b/clients/client-neptune-graph/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-neptune/tsconfig.types.json
+++ b/clients/client-neptune/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-neptunedata/tsconfig.types.json
+++ b/clients/client-neptunedata/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-network-firewall/tsconfig.types.json
+++ b/clients/client-network-firewall/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-networkflowmonitor/tsconfig.types.json
+++ b/clients/client-networkflowmonitor/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-networkmanager/tsconfig.types.json
+++ b/clients/client-networkmanager/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-networkmonitor/tsconfig.types.json
+++ b/clients/client-networkmonitor/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-notifications/tsconfig.types.json
+++ b/clients/client-notifications/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-notificationscontacts/tsconfig.types.json
+++ b/clients/client-notificationscontacts/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-oam/tsconfig.types.json
+++ b/clients/client-oam/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-observabilityadmin/tsconfig.types.json
+++ b/clients/client-observabilityadmin/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-odb/tsconfig.types.json
+++ b/clients/client-odb/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-omics/tsconfig.types.json
+++ b/clients/client-omics/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-opensearch/tsconfig.types.json
+++ b/clients/client-opensearch/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-opensearchserverless/tsconfig.types.json
+++ b/clients/client-opensearchserverless/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-opsworks/tsconfig.types.json
+++ b/clients/client-opsworks/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-opsworkscm/tsconfig.types.json
+++ b/clients/client-opsworkscm/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-organizations/tsconfig.types.json
+++ b/clients/client-organizations/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-osis/tsconfig.types.json
+++ b/clients/client-osis/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-outposts/tsconfig.types.json
+++ b/clients/client-outposts/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-panorama/tsconfig.types.json
+++ b/clients/client-panorama/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-partnercentral-selling/tsconfig.types.json
+++ b/clients/client-partnercentral-selling/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-payment-cryptography-data/tsconfig.types.json
+++ b/clients/client-payment-cryptography-data/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-payment-cryptography/tsconfig.types.json
+++ b/clients/client-payment-cryptography/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-pca-connector-ad/tsconfig.types.json
+++ b/clients/client-pca-connector-ad/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-pca-connector-scep/tsconfig.types.json
+++ b/clients/client-pca-connector-scep/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-pcs/tsconfig.types.json
+++ b/clients/client-pcs/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-personalize-events/tsconfig.types.json
+++ b/clients/client-personalize-events/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-personalize-runtime/tsconfig.types.json
+++ b/clients/client-personalize-runtime/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-personalize/tsconfig.types.json
+++ b/clients/client-personalize/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-pi/tsconfig.types.json
+++ b/clients/client-pi/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-pinpoint-email/tsconfig.types.json
+++ b/clients/client-pinpoint-email/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-pinpoint-sms-voice-v2/tsconfig.types.json
+++ b/clients/client-pinpoint-sms-voice-v2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-pinpoint-sms-voice/tsconfig.types.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-pinpoint/tsconfig.types.json
+++ b/clients/client-pinpoint/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-pipes/tsconfig.types.json
+++ b/clients/client-pipes/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-polly/tsconfig.types.json
+++ b/clients/client-polly/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-pricing/tsconfig.types.json
+++ b/clients/client-pricing/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-proton/tsconfig.types.json
+++ b/clients/client-proton/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-qapps/tsconfig.types.json
+++ b/clients/client-qapps/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-qbusiness/tsconfig.types.json
+++ b/clients/client-qbusiness/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-qconnect/tsconfig.types.json
+++ b/clients/client-qconnect/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-qldb-session/tsconfig.types.json
+++ b/clients/client-qldb-session/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-qldb/tsconfig.types.json
+++ b/clients/client-qldb/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-quicksight/tsconfig.types.json
+++ b/clients/client-quicksight/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ram/tsconfig.types.json
+++ b/clients/client-ram/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-rbin/tsconfig.types.json
+++ b/clients/client-rbin/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-rds-data/tsconfig.types.json
+++ b/clients/client-rds-data/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-rds/tsconfig.types.json
+++ b/clients/client-rds/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-redshift-data/tsconfig.types.json
+++ b/clients/client-redshift-data/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-redshift-serverless/tsconfig.types.json
+++ b/clients/client-redshift-serverless/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-redshift/tsconfig.types.json
+++ b/clients/client-redshift/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-rekognition/tsconfig.types.json
+++ b/clients/client-rekognition/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-rekognitionstreaming/tsconfig.types.json
+++ b/clients/client-rekognitionstreaming/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-repostspace/tsconfig.types.json
+++ b/clients/client-repostspace/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-resiliencehub/tsconfig.types.json
+++ b/clients/client-resiliencehub/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-resource-explorer-2/tsconfig.types.json
+++ b/clients/client-resource-explorer-2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-resource-groups-tagging-api/tsconfig.types.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-resource-groups/tsconfig.types.json
+++ b/clients/client-resource-groups/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-robomaker/tsconfig.types.json
+++ b/clients/client-robomaker/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-rolesanywhere/tsconfig.types.json
+++ b/clients/client-rolesanywhere/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-route-53-domains/tsconfig.types.json
+++ b/clients/client-route-53-domains/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-route-53/tsconfig.types.json
+++ b/clients/client-route-53/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-route53-recovery-cluster/tsconfig.types.json
+++ b/clients/client-route53-recovery-cluster/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-route53-recovery-control-config/tsconfig.types.json
+++ b/clients/client-route53-recovery-control-config/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-route53-recovery-readiness/tsconfig.types.json
+++ b/clients/client-route53-recovery-readiness/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-route53profiles/tsconfig.types.json
+++ b/clients/client-route53profiles/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-route53resolver/tsconfig.types.json
+++ b/clients/client-route53resolver/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-rum/tsconfig.types.json
+++ b/clients/client-rum/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-s3-control/tsconfig.types.json
+++ b/clients/client-s3-control/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/clients/client-s3/tsconfig.types.json
+++ b/clients/client-s3/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/clients/client-s3outposts/tsconfig.types.json
+++ b/clients/client-s3outposts/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-s3tables/tsconfig.types.json
+++ b/clients/client-s3tables/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-s3vectors/tsconfig.types.json
+++ b/clients/client-s3vectors/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.types.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sagemaker-edge/tsconfig.types.json
+++ b/clients/client-sagemaker-edge/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sagemaker-featurestore-runtime/tsconfig.types.json
+++ b/clients/client-sagemaker-featurestore-runtime/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sagemaker-geospatial/tsconfig.types.json
+++ b/clients/client-sagemaker-geospatial/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sagemaker-metrics/tsconfig.types.json
+++ b/clients/client-sagemaker-metrics/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sagemaker-runtime/tsconfig.types.json
+++ b/clients/client-sagemaker-runtime/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sagemaker/tsconfig.types.json
+++ b/clients/client-sagemaker/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-savingsplans/tsconfig.types.json
+++ b/clients/client-savingsplans/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-scheduler/tsconfig.types.json
+++ b/clients/client-scheduler/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-schemas/tsconfig.types.json
+++ b/clients/client-schemas/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-secrets-manager/tsconfig.types.json
+++ b/clients/client-secrets-manager/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-security-ir/tsconfig.types.json
+++ b/clients/client-security-ir/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-securityhub/tsconfig.types.json
+++ b/clients/client-securityhub/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-securitylake/tsconfig.types.json
+++ b/clients/client-securitylake/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-serverlessapplicationrepository/tsconfig.types.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-service-catalog-appregistry/tsconfig.types.json
+++ b/clients/client-service-catalog-appregistry/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-service-catalog/tsconfig.types.json
+++ b/clients/client-service-catalog/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-service-quotas/tsconfig.types.json
+++ b/clients/client-service-quotas/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-servicediscovery/tsconfig.types.json
+++ b/clients/client-servicediscovery/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ses/tsconfig.types.json
+++ b/clients/client-ses/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sesv2/tsconfig.types.json
+++ b/clients/client-sesv2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sfn/tsconfig.types.json
+++ b/clients/client-sfn/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-shield/tsconfig.types.json
+++ b/clients/client-shield/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-signer/tsconfig.types.json
+++ b/clients/client-signer/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-simspaceweaver/tsconfig.types.json
+++ b/clients/client-simspaceweaver/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sms/tsconfig.types.json
+++ b/clients/client-sms/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-snow-device-management/tsconfig.types.json
+++ b/clients/client-snow-device-management/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-snowball/tsconfig.types.json
+++ b/clients/client-snowball/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sns/tsconfig.types.json
+++ b/clients/client-sns/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-socialmessaging/tsconfig.types.json
+++ b/clients/client-socialmessaging/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sqs/tsconfig.types.json
+++ b/clients/client-sqs/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ssm-contacts/tsconfig.types.json
+++ b/clients/client-ssm-contacts/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ssm-guiconnect/tsconfig.types.json
+++ b/clients/client-ssm-guiconnect/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ssm-incidents/tsconfig.types.json
+++ b/clients/client-ssm-incidents/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ssm-quicksetup/tsconfig.types.json
+++ b/clients/client-ssm-quicksetup/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ssm-sap/tsconfig.types.json
+++ b/clients/client-ssm-sap/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-ssm/tsconfig.types.json
+++ b/clients/client-ssm/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sso-admin/tsconfig.types.json
+++ b/clients/client-sso-admin/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sso-oidc/tsconfig.types.json
+++ b/clients/client-sso-oidc/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sso/tsconfig.types.json
+++ b/clients/client-sso/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-storage-gateway/tsconfig.types.json
+++ b/clients/client-storage-gateway/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-sts/tsconfig.types.json
+++ b/clients/client-sts/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/clients/client-supplychain/tsconfig.types.json
+++ b/clients/client-supplychain/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-support-app/tsconfig.types.json
+++ b/clients/client-support-app/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-support/tsconfig.types.json
+++ b/clients/client-support/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-swf/tsconfig.types.json
+++ b/clients/client-swf/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-synthetics/tsconfig.types.json
+++ b/clients/client-synthetics/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-taxsettings/tsconfig.types.json
+++ b/clients/client-taxsettings/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-textract/tsconfig.types.json
+++ b/clients/client-textract/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-timestream-influxdb/tsconfig.types.json
+++ b/clients/client-timestream-influxdb/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-timestream-query/tsconfig.types.json
+++ b/clients/client-timestream-query/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-timestream-write/tsconfig.types.json
+++ b/clients/client-timestream-write/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-tnb/tsconfig.types.json
+++ b/clients/client-tnb/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-transcribe-streaming/tsconfig.types.json
+++ b/clients/client-transcribe-streaming/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/clients/client-transcribe/tsconfig.types.json
+++ b/clients/client-transcribe/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-transfer/tsconfig.types.json
+++ b/clients/client-transfer/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-translate/tsconfig.types.json
+++ b/clients/client-translate/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-trustedadvisor/tsconfig.types.json
+++ b/clients/client-trustedadvisor/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-verifiedpermissions/tsconfig.types.json
+++ b/clients/client-verifiedpermissions/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-voice-id/tsconfig.types.json
+++ b/clients/client-voice-id/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-vpc-lattice/tsconfig.types.json
+++ b/clients/client-vpc-lattice/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-waf-regional/tsconfig.types.json
+++ b/clients/client-waf-regional/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-waf/tsconfig.types.json
+++ b/clients/client-waf/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-wafv2/tsconfig.types.json
+++ b/clients/client-wafv2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-wellarchitected/tsconfig.types.json
+++ b/clients/client-wellarchitected/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-wisdom/tsconfig.types.json
+++ b/clients/client-wisdom/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-workdocs/tsconfig.types.json
+++ b/clients/client-workdocs/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-workmail/tsconfig.types.json
+++ b/clients/client-workmail/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-workmailmessageflow/tsconfig.types.json
+++ b/clients/client-workmailmessageflow/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-workspaces-instances/tsconfig.types.json
+++ b/clients/client-workspaces-instances/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-workspaces-thin-client/tsconfig.types.json
+++ b/clients/client-workspaces-thin-client/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-workspaces-web/tsconfig.types.json
+++ b/clients/client-workspaces-web/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-workspaces/tsconfig.types.json
+++ b/clients/client-workspaces/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/clients/client-xray/tsconfig.types.json
+++ b/clients/client-xray/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-client-api-test/tsconfig.types.json
+++ b/private/aws-client-api-test/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-client-retry-test/tsconfig.types.json
+++ b/private/aws-client-retry-test/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-echo-service/tsconfig.types.json
+++ b/private/aws-echo-service/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-ec2-schema/tsconfig.types.json
+++ b/private/aws-protocoltests-ec2-schema/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-ec2/tsconfig.types.json
+++ b/private/aws-protocoltests-ec2/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-json-10-schema/tsconfig.types.json
+++ b/private/aws-protocoltests-json-10-schema/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-json-10/tsconfig.types.json
+++ b/private/aws-protocoltests-json-10/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-json-machinelearning/tsconfig.types.json
+++ b/private/aws-protocoltests-json-machinelearning/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-json-schema-machinelearning/tsconfig.types.json
+++ b/private/aws-protocoltests-json-schema-machinelearning/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-json-schema/tsconfig.types.json
+++ b/private/aws-protocoltests-json-schema/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-json/tsconfig.types.json
+++ b/private/aws-protocoltests-json/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-query-schema/tsconfig.types.json
+++ b/private/aws-protocoltests-query-schema/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-query/tsconfig.types.json
+++ b/private/aws-protocoltests-query/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-restjson-apigateway/tsconfig.types.json
+++ b/private/aws-protocoltests-restjson-apigateway/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-restjson-glacier/tsconfig.types.json
+++ b/private/aws-protocoltests-restjson-glacier/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-restjson-schema-apigateway/tsconfig.types.json
+++ b/private/aws-protocoltests-restjson-schema-apigateway/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-restjson-schema-glacier/tsconfig.types.json
+++ b/private/aws-protocoltests-restjson-schema-glacier/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-restjson-schema/tsconfig.types.json
+++ b/private/aws-protocoltests-restjson-schema/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-restjson/tsconfig.types.json
+++ b/private/aws-protocoltests-restjson/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-restxml-schema/tsconfig.types.json
+++ b/private/aws-protocoltests-restxml-schema/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-restxml/tsconfig.types.json
+++ b/private/aws-protocoltests-restxml/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/tsconfig.types.json
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/tsconfig.types.json
@@ -7,5 +7,5 @@
     "emitDeclarationOnly": true,
     "noCheck": false
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-protocoltests-smithy-rpcv2-cbor/tsconfig.types.json
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-restjson-server/tsconfig.types.json
+++ b/private/aws-restjson-server/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-restjson-validation-server/tsconfig.types.json
+++ b/private/aws-restjson-validation-server/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/aws-util-test/tsconfig.types.json
+++ b/private/aws-util-test/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "**/*.spec.ts", "dist-types/**/*", "vitest.*.ts"]
+  "include": ["src"]
 }

--- a/private/weather-legacy-auth/tsconfig.types.json
+++ b/private/weather-legacy-auth/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }

--- a/private/weather/tsconfig.types.json
+++ b/private/weather/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "dist-types/**/*"]
+  "include": ["src"]
 }


### PR DESCRIPTION
### Issue
Codegen for https://github.com/smithy-lang/smithy-typescript/pull/1667

### Description
Uses 'include' in tsconfig.types.json

### Testing
* CI
* Dry run is successful

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
