### PR TITLE
chore(aws-util-test): add @aws-sdk/weather as a dependency

### DIFF
--- a/private/aws-util-test/package.json
+++ b/private/aws-util-test/package.json
@@ -20,6 +20,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-sdk/aws-protocoltests-json": "*",
+    "@aws-sdk/weather": "*",
     "@smithy/protocol-http": "^5.1.3",
     "@smithy/shared-ini-file-loader": "^4.0.5",
     "@smithy/types": "^4.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,6 +1439,7 @@ __metadata:
   resolution: "@aws-sdk/aws-util-test@workspace:private/aws-util-test"
   dependencies:
     "@aws-sdk/aws-protocoltests-json": "npm:*"
+    "@aws-sdk/weather": "npm:*"
     "@smithy/protocol-http": "npm:^5.1.3"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
     "@smithy/types": "npm:^4.3.2"
@@ -25085,7 +25086,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/weather@workspace:private/weather":
+"@aws-sdk/weather@npm:*, @aws-sdk/weather@workspace:private/weather":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/weather@workspace:private/weather"
   dependencies:


### PR DESCRIPTION
### Issue
* Repeat of https://github.com/aws/aws-sdk-js-v3/pull/7001 which was removed because of incorrect version.
* Noticed intermittent build failure in [example run](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiVnM3QlR0eTdOUHRHVlIvMkQ1YmtqN2Fnb1pONXJaQWdRUVBZM1hwNjlwaHMyYXVQaDdySkxVNE4zZS9mWUtaMnRHYWt3NVA3bTIyRkJxSHdUamRLWDJwMUFvRXFObVc2ZlpNb21jMy8iLCJpdlBhcmFtZXRlclNwZWMiOiJ0cWtVN3E3WVRMMTAvWjJjIiwibWF0ZXJpYWxTZXRTZXJpYWwiOjF9/build/d9c45868-7631-4a6d-a41d-c57fcb9801b7)

### Description
Adds @aws-sdk/weather as a dependency in `aws-util-test`, as it's testing it
https://github.com/aws/aws-sdk-js-v3/blob/b2eec675c502b95f2a84d33c63eb7a25f867725c/private/aws-util-test/src/clients/Weather.integ.spec.ts#L1

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
