### PR TITLE
fix(aws-util-test): exclude '**/*.spec.ts'

### DIFF
--- a/private/aws-util-test/tsconfig.json
+++ b/private/aws-util-test/tsconfig.json
@@ -9,5 +9,6 @@
     "rootDir": "src",
     "useUnknownInCatchVariables": false
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.spec.ts"]
 }


### PR DESCRIPTION
### Issue
Noticed intermittent build failure in [example run](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiVnM3QlR0eTdOUHRHVlIvMkQ1YmtqN2Fnb1pONXJaQWdRUVBZM1hwNjlwaHMyYXVQaDdySkxVNE4zZS9mWUtaMnRHYWt3NVA3bTIyRkJxSHdUamRLWDJwMUFvRXFObVc2ZlpNb21jMy8iLCJpdlBhcmFtZXRlclNwZWMiOiJ0cWtVN3E3WVRMMTAvWjJjIiwibWF0ZXJpYWxTZXRTZXJpYWwiOjF9/build/d9c45868-7631-4a6d-a41d-c57fcb9801b7)

### Description
Repeat of https://github.com/aws/aws-sdk-js-v3/pull/7003, was missed when https://github.com/aws/aws-sdk-js-v3/pull/7266 was implemented.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
