### PR TITLE
test(aws-client-retry-test): use Lambda client for retry test

### DIFF
--- a/private/aws-client-retry-test/package.json
+++ b/private/aws-client-retry-test/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-sdk/client-s3": "*",
+    "@aws-sdk/client-lambda": "*",
     "@smithy/protocol-http": "^5.1.3",
     "@smithy/types": "^4.3.2",
     "@smithy/util-retry": "^4.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,7 +146,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk/aws-client-retry-test@workspace:private/aws-client-retry-test"
   dependencies:
-    "@aws-sdk/client-s3": "npm:*"
+    "@aws-sdk/client-lambda": "npm:*"
     "@smithy/protocol-http": "npm:^5.1.3"
     "@smithy/types": "npm:^4.3.2"
     "@smithy/util-retry": "npm:^4.0.7"


### PR DESCRIPTION
### Issue
Noticed while attempting to [upgrading vitest to 3.x](https://github.com/aws/aws-sdk-js-v3/pull/7270) because of a more strict error equality https://vitest.dev/guide/migration.html#more-strict-error-equality

The existing test seems to be incorrect as:
* The check for `x-amzn-errortype` is specific to clients using JSON protocols, like Lambda, and ones using XML protocol, like S3
  * https://github.com/search?q=repo%3Aaws%2Faws-sdk-js-v3%20x-amzn-errortype&type=code
* The expected exception and mocked exceptions are not same
  * Expected is `ThrottlingException`: https://github.com/aws/aws-sdk-js-v3/blob/b585daac7f44db07fd51ddb8387555fb6366c6f6/private/aws-client-retry-test/src/ClientRetryTest.spec.ts#L100
  * Mocked is `ThrottledException`: https://github.com/aws/aws-sdk-js-v3/blob/b585daac7f44db07fd51ddb8387555fb6366c6f6/private/aws-client-retry-test/src/ClientRetryTest.spec.ts#L35C39-L35C57

### Description

Uses Lambda Client (JSON protocol based) in retry test error checking

### Testing
CI (verified working in vitest 3.x too)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
