### PR TITLE
chore: increase Verdaccio uplink timeout to 300s

### DIFF
--- a/verdaccio/config.yaml
+++ b/verdaccio/config.yaml
@@ -30,6 +30,7 @@ web:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
+    timeout: 300s
 
 packages:
   "@aws-sdk/*":


### PR DESCRIPTION
### Issue
Internal JS-6154

### Description
Increase the verdaccio uplink timeout from 30s to 300s

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
