### PR TITLE
test(middleware-flexible-checksums): retry reuses the computed checksum

### DIFF
--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -1,0 +1,61 @@
+import { S3 } from "@aws-sdk/client-s3";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { HttpResponse } from "@smithy/protocol-http";
+import { describe, expect, test as it } from "vitest";
+
+describe("middleware-flexible-checksums.retry", () => {
+  it("retry reuses the checksum", async () => {
+    const maxAttempts = 3;
+    class CustomHandler extends NodeHttpHandler {
+      async handle() {
+        return {
+          response: new HttpResponse({
+            statusCode: 500, // Fake Trasient Error
+            headers: {},
+          }),
+        };
+      }
+    }
+    const requestHandler = new CustomHandler();
+    const client = new S3({ maxAttempts, requestHandler });
+
+    let flexChecksCalls = 0;
+    client.middlewareStack.addRelativeTo(
+      (next: any) => async (args: any) => {
+        flexChecksCalls++;
+        return next(args);
+      },
+      {
+        toMiddleware: "flexibleChecksumsMiddleware",
+        relation: "after",
+      }
+    );
+
+    let retryMiddlewareCalls = 0;
+    client.middlewareStack.addRelativeTo(
+      (next: any) => async (args: any) => {
+        retryMiddlewareCalls++;
+        return next(args);
+      },
+      {
+        toMiddleware: "retryMiddleware",
+        relation: "after",
+      }
+    );
+
+    await client
+      .putObject({
+        Bucket: "b",
+        Key: "k",
+        Body: "hello",
+      })
+      .catch(() => {
+        // Expected, since we're faking transient error which is retried.
+      });
+
+    // Validate that flexibleChecksumsMiddleware is called once.
+    expect(flexChecksCalls).toEqual(1);
+    // Validate that retryMiddleware is called maxAttempts times.
+    expect(retryMiddlewareCalls).toEqual(maxAttempts);
+  });
+});

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -51,13 +51,15 @@ describe("middleware-flexible-checksums.retry", () => {
         Body: "hello",
       })
       .catch((err) => {
-        console.log({ err });
+        console.log({ err, flexChecksCalls, retryMiddlewareCalls });
         // Expected, since we're faking transient error which is retried.
+
+        // Validate that flexibleChecksumsMiddleware is called once.
+        expect(flexChecksCalls).toEqual(1);
+        // Validate that retryMiddleware is called maxAttempts times.
+        expect(retryMiddlewareCalls).toEqual(maxAttempts);
       });
 
-    // Validate that flexibleChecksumsMiddleware is called once.
-    expect(flexChecksCalls).toEqual(1);
-    // Validate that retryMiddleware is called maxAttempts times.
-    expect(retryMiddlewareCalls).toEqual(maxAttempts);
+    expect.assertions(2);
   });
 });

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -17,11 +17,13 @@ describe("middleware-flexible-checksums.retry", () => {
     });
 
     let flexChecksCallCount = 0;
-    const flexChecksCallCountMiddleware = (next: any) => async (args: any) => {
-      console.log("after flexChecks");
-      flexChecksCallCount++;
-      return next(args);
-    };
+    function flexChecksCallCountMiddleware(next: any) {
+      return async function (args: any) {
+        console.log("after flexChecks");
+        flexChecksCallCount++;
+        return next(args);
+      };
+    }
     client.middlewareStack.addRelativeTo(flexChecksCallCountMiddleware, {
       name: flexChecksCallCountMiddleware.name,
       toMiddleware: "flexibleChecksumsMiddleware",

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -2,8 +2,6 @@ import { S3 } from "@aws-sdk/client-s3";
 import { HttpResponse } from "@smithy/protocol-http";
 import { describe, expect, test as it } from "vitest";
 
-import { flexibleChecksumsMiddlewareOptions } from "./flexibleChecksumsMiddleware";
-
 describe("middleware-flexible-checksums.retry", () => {
   it("retry reuses the checksum", async () => {
     const maxAttempts = 3;
@@ -26,9 +24,10 @@ describe("middleware-flexible-checksums.retry", () => {
         return next(args);
       };
     }
-    client.middlewareStack.add(flexChecksCallCountMiddleware, {
+    client.middlewareStack.addRelativeTo(flexChecksCallCountMiddleware, {
       name: flexChecksCallCountMiddleware.name,
-      step: flexibleChecksumsMiddlewareOptions.step,
+      toMiddleware: "flexibleChecksumsMiddleware",
+      relation: "after",
     });
 
     client.middlewareStack.identifyOnResolve(true);

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -2,6 +2,8 @@ import { S3 } from "@aws-sdk/client-s3";
 import { HttpResponse } from "@smithy/protocol-http";
 import { describe, expect, test as it } from "vitest";
 
+import { flexibleChecksumsMiddlewareOptions } from "./flexibleChecksumsMiddleware";
+
 describe("middleware-flexible-checksums.retry", () => {
   it("retry reuses the checksum", async () => {
     const maxAttempts = 3;
@@ -24,10 +26,9 @@ describe("middleware-flexible-checksums.retry", () => {
         return next(args);
       };
     }
-    client.middlewareStack.addRelativeTo(flexChecksCallCountMiddleware, {
+    client.middlewareStack.add(flexChecksCallCountMiddleware, {
       name: flexChecksCallCountMiddleware.name,
-      toMiddleware: "flexibleChecksumsMiddleware",
-      relation: "after",
+      step: flexibleChecksumsMiddlewareOptions.step,
     });
 
     client.middlewareStack.identifyOnResolve(true);

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -23,6 +23,7 @@ describe("middleware-flexible-checksums.retry", () => {
       return next(args);
     };
     client.middlewareStack.addRelativeTo(flexChecksCallCountMiddleware, {
+      name: flexChecksCallCountMiddleware.name,
       toMiddleware: "flexibleChecksumsMiddleware",
       relation: "after",
     });

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -17,13 +17,11 @@ describe("middleware-flexible-checksums.retry", () => {
     });
 
     let flexChecksCallCount = 0;
-    function flexChecksCallCountMiddleware(next: any) {
-      return async function (args: any) {
-        console.log("after flexChecks");
-        flexChecksCallCount++;
-        return next(args);
-      };
-    }
+    const flexChecksCallCountMiddleware = (next: any) => async (args: any) => {
+      console.log("after flexChecks");
+      flexChecksCallCount++;
+      return next(args);
+    };
     client.middlewareStack.addRelativeTo(flexChecksCallCountMiddleware, {
       name: flexChecksCallCountMiddleware.name,
       toMiddleware: "flexibleChecksumsMiddleware",

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -19,6 +19,7 @@ describe("middleware-flexible-checksums.retry", () => {
     let flexChecksCalls = 0;
     client.middlewareStack.addRelativeTo(
       (next: any) => async (args: any) => {
+        console.log("after flexChecks");
         flexChecksCalls++;
         return next(args);
       },
@@ -31,6 +32,7 @@ describe("middleware-flexible-checksums.retry", () => {
     let retryMiddlewareCalls = 0;
     client.middlewareStack.addRelativeTo(
       (next: any) => async (args: any) => {
+        console.log("after retryMiddleware");
         retryMiddlewareCalls++;
         return next(args);
       },
@@ -46,7 +48,8 @@ describe("middleware-flexible-checksums.retry", () => {
         Key: "k",
         Body: "hello",
       })
-      .catch(() => {
+      .catch((err) => {
+        console.log({ err });
         // Expected, since we're faking transient error which is retried.
       });
 

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -22,7 +22,7 @@ describe("middleware-flexible-checksums.retry", () => {
     const flexChecksCallCountMiddleware = (next: any) => async (args: any) => {
       console.log("after flexChecks");
       flexChecksCallCount++;
-      return next(args);
+      return await next(args);
     };
     client.middlewareStack.addRelativeTo(flexChecksCallCountMiddleware, {
       name: flexChecksCallCountMiddleware.name,

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -42,6 +42,8 @@ describe("middleware-flexible-checksums.retry", () => {
       }
     );
 
+    client.middlewareStack.identifyOnResolve(true);
+
     await client
       .putObject({
         Bucket: "b",

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -2,6 +2,8 @@ import { S3 } from "@aws-sdk/client-s3";
 import { HttpResponse } from "@smithy/protocol-http";
 import { describe, expect, test as it } from "vitest";
 
+import { flexibleChecksumsMiddleware } from "./flexibleChecksumsMiddleware";
+
 describe("middleware-flexible-checksums.retry", () => {
   it("retry reuses the checksum", async () => {
     const maxAttempts = 3;
@@ -24,8 +26,9 @@ describe("middleware-flexible-checksums.retry", () => {
     };
     client.middlewareStack.addRelativeTo(flexChecksCallCountMiddleware, {
       name: flexChecksCallCountMiddleware.name,
-      toMiddleware: "flexibleChecksumsMiddleware",
+      toMiddleware: flexibleChecksumsMiddleware.name,
       relation: "after",
+      override: true,
     });
 
     client.middlewareStack.identifyOnResolve(true);


### PR DESCRIPTION
### Issue
* Internal JS-5905
* Repeat of https://github.com/aws/aws-sdk-js-v3/pull/7256 after vitest upgrade to 3.x

### Description
Adds an integration test which confirms checksum is not recomputed on retries

### Testing
* CI
* ToDo: Dry run is successful

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
