### PR TITLE
Fix account ID validation to ensure exact match

### DIFF
--- a/packages/middleware-bucket-endpoint/src/bucketHostnameUtils.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostnameUtils.ts
@@ -212,8 +212,8 @@ export const validateRegionalClient = (region: string) => {
  * @internal
  */
 export const validateAccountId = (accountId: string) => {
-  if (!/[0-9]{12}/.exec(accountId)) {
-    throw new Error("Access point ARN accountID does not match regex '[0-9]{12}'");
+  if (!/^[0-9]{12}$/.exec(accountId)) {
+    throw new Error("Access point ARN accountID does not match regex '^[0-9]{12}$'");
   }
 };
 


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
The account ID validation regex in middleware-bucket-endpoint package was missing start and end anchors (^ and $), which could allow strings with additional characters to pass validation. This PR fixes the regex pattern to ensure it matches exactly 12 digits and nothing else.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
