### PR TITLE
chore(scripts): script to build only unbuilt packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,11 @@ turbo-build:
 tpk:
 	npx turbo run build --filter='./packages/*'
 
+# builds only packages that have no build at all.
+# for development only - packages may be stale.
+unbuilt:
+	node scripts/build-only-unbuilt.js
+
 # Clears the Turborepo local build cache
 turbo-clean:
 	@read -p "Are you sure you want to delete your local cache? [y/N]: " ans && [ $${ans:-N} = y ]

--- a/scripts/build-only-unbuilt.js
+++ b/scripts/build-only-unbuilt.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/*
+usage: `make unbuilt`
+
+This script builds only those packages that are not already built.
+This is for development when you need for example newly released clients to be built
+but do not need the actual latest build of every single client (slow).
+
+As for why this is not a shell script, I found the combination of find with exec to be too slow.
+ */
+
+/**
+ * For reference, this is the equivalent shell command.
+ * @type {string}
+ */
+void `find ./clients/client-*/ -type d -maxdepth 0 -exec test -d "{}/dist-types" \\; -exec sh -c "cd {} && yarn build" \\;`;
+
+const path = require("node:path");
+const fs = require("node:fs");
+const { spawnProcess } = require("./utils/spawn-process");
+
+const root = path.join(__dirname, "..");
+
+const packageFolders = [
+  ...fs.readdirSync(path.join(root, "lib"), { withFileTypes: true }),
+  ...fs.readdirSync(path.join(root, "clients"), { withFileTypes: true }),
+  ...fs.readdirSync(path.join(root, "packages"), { withFileTypes: true }),
+  ...fs.readdirSync(path.join(root, "private"), { withFileTypes: true }),
+];
+
+(async () => {
+  for (const pkgFolder of packageFolders) {
+    const isPackage = fs.existsSync(path.join(pkgFolder.path, pkgFolder.name, "package.json"));
+    if (isPackage) {
+      const cwd = path.join(pkgFolder.path, pkgFolder.name);
+      const isBuilt = fs.existsSync(path.join(cwd, "dist-types"));
+      const hasArtifacts = fs.existsSync(path.join(cwd, "tsconfig.json"));
+
+      if (!isBuilt && hasArtifacts) {
+        console.log("Building", cwd);
+        await spawnProcess("yarn", ["build"], {
+          cwd,
+        });
+      }
+    }
+  }
+  console.log("Done.");
+})();


### PR DESCRIPTION
### Issue
none

### Description
Adds a script that builds only unbuilt packages. 

### Testing
`make unbuilt` after running clean in a random client.

### Additional context
Scenario: e.g. some new clients have been added and I don't want to run a full build because I don't need every client to be up to date. Running a full client build is slow.

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
