### PR TITLE
test(middleware-flexible-checksums): retry reuses the computed checksum

### DIFF
--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -1,0 +1,54 @@
+import { S3 } from "@aws-sdk/client-s3";
+import { HttpResponse } from "@smithy/protocol-http";
+import { describe, expect, test as it } from "vitest";
+
+import { flexibleChecksumsMiddleware } from "./flexibleChecksumsMiddleware";
+
+describe("middleware-flexible-checksums.retry", () => {
+  it("retry reuses the checksum", async () => {
+    const maxAttempts = 3;
+    const client = new S3({
+      maxAttempts,
+      requestHandler: {
+        handle: async () => ({
+          response: new HttpResponse({
+            statusCode: 500, // Fake Trasient Error
+          }),
+        }),
+      },
+    });
+
+    let flexChecksCallCount = 0;
+    const flexChecksCallCountMiddleware = (next: any) => async (args: any) => {
+      console.log("after flexChecks");
+      flexChecksCallCount++;
+      return await next(args);
+    };
+    client.middlewareStack.addRelativeTo(flexChecksCallCountMiddleware, {
+      name: flexChecksCallCountMiddleware.name,
+      toMiddleware: flexibleChecksumsMiddleware.name,
+      relation: "after",
+      override: true,
+    });
+
+    client.middlewareStack.identifyOnResolve(true);
+
+    await client
+      .putObject({
+        Bucket: "b",
+        Key: "k",
+        Body: "hello",
+      })
+      .catch((err) => {
+        console.log({ err, flexChecksCallCount });
+        // Expected, since we're faking transient error which is retried.
+
+        // Validate that flexibleChecksumsMiddleware is called once.
+        expect(flexChecksCallCount).toEqual(1);
+        // Validate that retryMiddleware is called maxAttempts times.
+        expect(err.$metadata.attempts).toEqual(maxAttempts);
+      });
+
+    expect.assertions(2);
+  });
+});

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -1,37 +1,47 @@
 import { S3 } from "@aws-sdk/client-s3";
+import { retryMiddleware } from "@smithy/middleware-retry";
 import { HttpResponse } from "@smithy/protocol-http";
 import { describe, expect, test as it } from "vitest";
 
+import { requireRequestsFrom } from "../../../private/aws-util-test/src";
 import { flexibleChecksumsMiddleware } from "./flexibleChecksumsMiddleware";
 
 describe("middleware-flexible-checksums.retry", () => {
   it("retry reuses the checksum", async () => {
     const maxAttempts = 3;
-    const client = new S3({
-      maxAttempts,
-      requestHandler: {
-        handle: async () => ({
-          response: new HttpResponse({
-            statusCode: 500, // Fake Trasient Error
-          }),
-        }),
-      },
-    });
+    const client = new S3({ maxAttempts });
 
     let flexChecksCallCount = 0;
-    const flexChecksCallCountMiddleware = (next: any) => async (args: any) => {
-      console.log("after flexChecks");
-      flexChecksCallCount++;
-      return await next(args);
-    };
-    client.middlewareStack.addRelativeTo(flexChecksCallCountMiddleware, {
-      name: flexChecksCallCountMiddleware.name,
-      toMiddleware: flexibleChecksumsMiddleware.name,
-      relation: "after",
-      override: true,
-    });
+    client.middlewareStack.addRelativeTo(
+      (next: any) => async (args: any) => {
+        flexChecksCallCount++;
+        return next(args);
+      },
+      {
+        toMiddleware: flexibleChecksumsMiddleware.name,
+        relation: "after",
+      }
+    );
 
-    client.middlewareStack.identifyOnResolve(true);
+    let retryMiddlewareCalls = 0;
+    client.middlewareStack.addRelativeTo(
+      (next: any) => async (args: any) => {
+        retryMiddlewareCalls++;
+        return next(args);
+      },
+      {
+        toMiddleware: retryMiddleware.name,
+        relation: "after",
+      }
+    );
+
+    requireRequestsFrom(client)
+      .toMatch({ method: "PUT" })
+      .respondWith(
+        new HttpResponse({
+          statusCode: 500, // Fake Trasient Error
+        })
+      );
 
     await client
       .putObject({
@@ -40,15 +50,12 @@ describe("middleware-flexible-checksums.retry", () => {
         Body: "hello",
       })
       .catch((err) => {
-        console.log({ err, flexChecksCallCount });
         // Expected, since we're faking transient error which is retried.
-
-        // Validate that flexibleChecksumsMiddleware is called once.
-        expect(flexChecksCallCount).toEqual(1);
-        // Validate that retryMiddleware is called maxAttempts times.
-        expect(err.$metadata.attempts).toEqual(maxAttempts);
       });
 
-    expect.assertions(2);
+    // Validate that flexibleChecksumsMiddleware is called once.
+    expect(flexChecksCallCount).toEqual(1);
+    // Validate that retryMiddleware is called maxAttempts times.
+    expect(retryMiddlewareCalls).toEqual(maxAttempts);
   });
 });

--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -9,7 +9,14 @@ import { flexibleChecksumsMiddleware } from "./flexibleChecksumsMiddleware";
 describe("middleware-flexible-checksums.retry", () => {
   it("retry reuses the checksum", async () => {
     const maxAttempts = 3;
-    const client = new S3({ maxAttempts });
+    const client = new S3({
+      region: "us-west-2",
+      credentials: {
+        accessKeyId: "INTEG",
+        secretAccessKey: "INTEG",
+      },
+      maxAttempts,
+    });
 
     let flexChecksCallCount = 0;
     client.middlewareStack.addRelativeTo(


### PR DESCRIPTION
### Issue
* Internal JS-5905
* Repeat of https://github.com/aws/aws-sdk-js-v3/pull/7277 which uses `requireRequestsFrom` utility for faking response.

### Description
Adds an integration test which confirms checksum is not recomputed on retries

### Testing
* CI
* Dry run is successful

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
