### PR TITLE
test(client-s3): **DO NOT MERGE** move selectObjectContent test from e2e to integ 

### DIFF
--- a/clients/client-s3/test/e2e/S3.browser.e2e.spec.ts
+++ b/clients/client-s3/test/e2e/S3.browser.e2e.spec.ts
@@ -315,50 +315,6 @@ describe("@aws-sdk/client-s3", () => {
     });
   });
 
-  describe("selectObjectContent", () => {
-    const csvFile = `user_name,age
-jsrocks,13
-node4life,22
-esfuture,29`;
-
-    beforeEach(async () => {
-      Key = `${Date.now()}`;
-      await client.putObject({ Bucket, Key, Body: csvFile });
-    });
-
-    afterEach(async () => {
-      await client.deleteObject({ Bucket, Key });
-    });
-
-    it("should succeed", async () => {
-      onTestFailed(setTestFailed);
-      const { Payload } = await client.selectObjectContent({
-        Bucket,
-        Key,
-        ExpressionType: "SQL",
-        Expression: "SELECT user_name FROM S3Object WHERE cast(age as int) > 20",
-        InputSerialization: {
-          CSV: {
-            FileHeaderInfo: "USE",
-            RecordDelimiter: "\n",
-            FieldDelimiter: ",",
-          },
-        },
-        OutputSerialization: {
-          CSV: {},
-        },
-      });
-      const events: SelectObjectContentEventStream[] = [];
-      for await (const event of Payload!) {
-        events.push(event);
-      }
-      expect(events.length).toEqual(3);
-      expect(new TextDecoder().decode(events[0].Records?.Payload)).toEqual("node4life\nesfuture\n");
-      expect(events[1].Stats?.Details).toBeDefined();
-      expect(events[2].End).toBeDefined();
-    });
-  });
-
   describe("Multi-region access point", () => {
     beforeEach(async () => {
       Key = `${Date.now()}`;

--- a/clients/client-s3/test/e2e/S3.e2e.spec.ts
+++ b/clients/client-s3/test/e2e/S3.e2e.spec.ts
@@ -231,46 +231,6 @@ describe("@aws-sdk/client-s3", () => {
     });
   });
 
-  describe("selectObjectContent", () => {
-    const csvFile = `user_name,age
-jsrocks,13
-node4life,22
-esfuture,29`;
-    beforeAll(async () => {
-      Key = `${Date.now()}`;
-      await client.putObject({ Bucket, Key, Body: csvFile });
-    });
-    afterAll(async () => {
-      await client.deleteObject({ Bucket, Key });
-    });
-    it("should succeed", async () => {
-      const { Payload } = await client.selectObjectContent({
-        Bucket,
-        Key,
-        ExpressionType: "SQL",
-        Expression: "SELECT user_name FROM S3Object WHERE cast(age as int) > 20",
-        InputSerialization: {
-          CSV: {
-            FileHeaderInfo: "USE",
-            RecordDelimiter: "\n",
-            FieldDelimiter: ",",
-          },
-        },
-        OutputSerialization: {
-          CSV: {},
-        },
-      });
-      const events: SelectObjectContentEventStream[] = [];
-      for await (const event of Payload!) {
-        events.push(event);
-      }
-      expect(events.length).toEqual(3);
-      expect(new TextDecoder().decode(events[0].Records?.Payload)).toEqual("node4life\nesfuture\n");
-      expect(events[1].Stats?.Details).toBeDefined();
-      expect(events[2].End).toBeDefined();
-    });
-  });
-
   describe("Multi-region access point", () => {
     beforeAll(async () => {
       Key = `${Date.now()}`;

--- a/clients/client-s3/test/integ/selectObjectContent.integ.spec.ts
+++ b/clients/client-s3/test/integ/selectObjectContent.integ.spec.ts
@@ -1,0 +1,60 @@
+import { S3, SelectObjectContentEventStream } from "@aws-sdk/client-s3";
+import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
+
+import { getIntegTestResources } from "../../../../tests/e2e/get-integ-test-resources";
+
+describe("selectObjectContent", () => {
+  let client: S3;
+  let Bucket: string;
+  let Key: string;
+
+  const csvFile = `user_name,age
+jsrocks,13
+node4life,22
+esfuture,29`;
+
+  beforeAll(async () => {
+    const integTestResourcesEnv = await getIntegTestResources();
+    Object.assign(process.env, integTestResourcesEnv);
+
+    const region = process?.env?.AWS_SMOKE_TEST_REGION as string;
+    Bucket = process?.env?.AWS_SMOKE_TEST_BUCKET as string;
+    Key = `selectObjectContent-${Date.now()}`;
+
+    client = new S3({ region });
+    await client.putObject({ Bucket, Key, Body: csvFile });
+  });
+
+  afterAll(async () => {
+    await client.deleteObject({ Bucket, Key });
+  });
+
+  it("should succeed", async () => {
+    const { Payload } = await client.selectObjectContent({
+      Bucket,
+      Key,
+      ExpressionType: "SQL",
+      Expression: "SELECT user_name FROM S3Object WHERE cast(age as int) > 20",
+      InputSerialization: {
+        CSV: {
+          FileHeaderInfo: "USE",
+          RecordDelimiter: "\n",
+          FieldDelimiter: ",",
+        },
+      },
+      OutputSerialization: {
+        CSV: {},
+      },
+    });
+
+    const events: SelectObjectContentEventStream[] = [];
+    for await (const event of Payload!) {
+      events.push(event);
+    }
+
+    expect(events.length).toEqual(3);
+    expect(new TextDecoder().decode(events[0].Records?.Payload)).toEqual("node4life\nesfuture\n");
+    expect(events[1].Stats?.Details).toBeDefined();
+    expect(events[2].End).toBeDefined();
+  });
+});


### PR DESCRIPTION
### Description
The selectObjectContent e2e test is failing with `MethodNotAllowed` error because [S3 Select](https://aws.amazon.com/blogs/storage/how-to-optimize-querying-your-data-in-amazon-s3/)  requests cannot be processed by AWS accounts created after July 25, 2024. This is blocking local e2e testing and development. To unblock this, moved it an integ test file.

### Testing
yarn `test:e2e` was successful


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
