### PR TITLE
test(nested-clients): add defaultProvider assertion

### DIFF
--- a/packages/nested-clients/src/index.spec.ts
+++ b/packages/nested-clients/src/index.spec.ts
@@ -32,3 +32,15 @@ describe("@aws-sdk/nested-clients/*", () => {
     }
   });
 });
+
+describe("@aws-sdk/nested-clients/sts", () => {
+  /**
+   * This is to validate that the rewrite happened as expected in
+   * runtimeConfig.ts. This is not the case with the canonical STS client from
+   * \@aws-sdk/client-sts.
+   */
+  it("has no credentialDefaultProvider", async () => {
+    const client = new STSClient({});
+    expect(client.config.credentialDefaultProvider).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Issue
n/a

### Description
I noticed that the custom rewrite of the nested STS client removes the `credentialDefaultProvider`. Because that is a critical element of the nested client, I'm adding this unit test as an early detection. 

It's possible that a regression here would be detected by our other tests, such as credentials integration, but this small additional test won't hurt.

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?


