### PR TITLE
chore(scripts): support multi-commands in cli dispatcher

### DIFF
--- a/tests/bundlers/Makefile
+++ b/tests/bundlers/Makefile
@@ -6,10 +6,13 @@ test:
 
 # create bundles
 build:
-	make vite webpack
+	make vite webpack esbuild
 
 vite:
 	npx vite build
 
 webpack:
 	npx webpack
+
+esbuild:
+	npx esbuild ./source.ts --bundle --outfile=./dist/esbuild-dist.js --format=esm --tree-shaking=true

--- a/tests/bundlers/test.spec.mjs
+++ b/tests/bundlers/test.spec.mjs
@@ -14,17 +14,25 @@ const viteDist = {
   name: "vite",
   content: fs.readFileSync(path.join(__dirname, "dist", "vite-dist.js"), "utf-8"),
 };
+const esbuildDist = {
+  name: "esbuild",
+  content: fs.readFileSync(path.join(__dirname, "dist", "esbuild-dist.js"), "utf-8"),
+};
 
-for (const { content: fileContents, name } of [webpackDist, viteDist]) {
-  console.log(name);
+for (const { content: fileContents, name } of [webpackDist, viteDist, esbuildDist]) {
+  console.log("================", name, "================");
 
   const contentSize = fileContents.replaceAll(/\s+/g, "").length;
-  const callsToClassBuilder = fileContents.match(/\.classBuilder\(\)/g);
-  const runtimeConfig = fileContents.match(/runtime: "browser"/);
+  const callsToClassBuilder = fileContents.match(/\.classBuilder\(\)/g) || [];
+  const runtimeConfig = fileContents.match(/runtime: "browser"/) || [];
+
+  const serializers = fileContents.match(/(var|const) se_/g) || [];
+  const operationSchemas = fileContents.match(/ op\(/g) || [];
+  const structSchemas = fileContents.match(/ struct\(/g) || [];
 
   try {
     assert(contentSize < 1_000_000);
-    console.info(`✅ content size is under 1M char.`);
+    console.info(`✅ content size is under 1M char. ${contentSize.toLocaleString()}`);
   } catch (e) {
     throw new Error("Content size should be less than 1M characters.");
   }
@@ -33,7 +41,9 @@ for (const { content: fileContents, name } of [webpackDist, viteDist]) {
     assert(callsToClassBuilder.length <= 2); // only GetObject and CreateSession should be present.
     console.info(`✅ two commands bundled (tree shaken).`);
   } catch (e) {
-    throw new Error("there should only be 2 calls to the Command classBuilder. Tree-shaking failure?");
+    throw new Error(
+      `there should only be 2 calls to the Command classBuilder, got ${callsToClassBuilder.length}. Tree-shaking failure?`
+    );
   }
 
   try {
@@ -42,4 +52,42 @@ for (const { content: fileContents, name } of [webpackDist, viteDist]) {
   } catch (e) {
     throw new Error("the browser runtimeConfig should be present in the bundle.");
   }
+
+  console.log("serializers", serializers.length);
+  console.log("operationSchemas", operationSchemas.length);
+  console.log("structSchemas", structSchemas.length);
 }
+
+// Model-ignorant codegen expected output:
+// problems: webpack fails to tree shake serde functions.
+/*
+================ webpack ================
+✅ content size is under 1M char. 628,148
+✅ two commands bundled (tree shaken).
+✅ runtimeConfig is browser.
+serializers 250
+operationSchemas 11
+================ vite ================
+✅ content size is under 1M char. 341,346
+✅ two commands bundled (tree shaken).
+✅ runtimeConfig is browser.
+serializers 2
+operationSchemas 10
+ */
+
+// Schema serde expected output:
+// problems: both bundlers fail to tree-shake schemas (fix WIP).
+/*
+================ webpack ================
+✅ content size is under 1M char. 557,102
+✅ two commands bundled (tree shaken).
+✅ runtimeConfig is browser.
+serializers 0
+operationSchemas 116
+================ vite ================
+✅ content size is under 1M char. 459,392
+✅ two commands bundled (tree shaken).
+✅ runtimeConfig is browser.
+serializers 0
+operationSchemas 115
+ */

--- a/tests/bundlers/vite.config.ts
+++ b/tests/bundlers/vite.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
         // Provide global variables to use in the UMD build
         // for externalized deps
         globals: {},
+        // to get an easier aggregate accounting of bundle contents
+        inlineDynamicImports: true,
       },
     },
     minify: false,

--- a/tests/bundlers/webpack.config.js
+++ b/tests/bundlers/webpack.config.js
@@ -6,6 +6,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export default {
   mode: "production",
   entry: "./source.ts",
+  target: "web",
   output: {
     path: path.resolve(__dirname, "dist"),
     filename: "webpack-dist.js",
@@ -13,5 +14,12 @@ export default {
   },
   optimization: {
     minimize: false,
+    splitChunks: false,
+    runtimeChunk: false,
+    sideEffects: true,
+    usedExports: true,
+  },
+  stats: {
+    optimizationBailout: false,
   },
 };


### PR DESCRIPTION
### Issue
none

### Description
Support multiple sequential commands in a short-form with the local CLI dispatcher devtool.

You can, for example, now run `b s3 - gen,b` to represent `cd clients/client-s3 && yarn generate:clients && yarn:build` instead of running two commands such as `b s3 - gen && b s3 - b`

