### PR TITLE
fix(middleware-sdk-s3): handle cross-region redirects for HeadBucket with 400 status

### DIFF
--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
@@ -39,7 +39,10 @@ export function regionRedirectMiddleware(clientConfig: PreviouslyResolved): Init
           if (
             err?.$metadata?.httpStatusCode === 301 ||
             // err.name === "PermanentRedirect" && --> removing the error name check, as that allows for HEAD operations (which have the 301 status code, but not the same error name) to be covered for region redirection as well
-            (err?.$metadata?.httpStatusCode === 400 && err?.name === "IllegalLocationConstraintException")
+            (err?.$metadata?.httpStatusCode === 400 && err?.name === "IllegalLocationConstraintException") ||
+            (err?.$metadata?.httpStatusCode === 400 &&
+              context.commandName === "HeadBucketCommand" &&
+              err?.$response?.headers?.["x-amz-bucket-region"])
           ) {
             try {
               const actualRegion = err.$response.headers["x-amz-bucket-region"];

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.ts
@@ -38,14 +38,14 @@ export function regionRedirectMiddleware(clientConfig: PreviouslyResolved): Init
         if (clientConfig.followRegionRedirects) {
           const statusCode = err?.$metadata?.httpStatusCode;
           const isHeadBucket = context.commandName === "HeadBucketCommand";
-          const hasBucketRegionHeader = err?.$response?.headers?.["x-amz-bucket-region"];
+          const bucketRegionHeader = err?.$response?.headers?.["x-amz-bucket-region"];
           if (
             statusCode === 301 ||
             (statusCode === 400 &&
-              (err?.name === "IllegalLocationConstraintException" || (isHeadBucket && hasBucketRegionHeader)))
+              (err?.name === "IllegalLocationConstraintException" || (isHeadBucket && bucketRegionHeader)))
           ) {
             try {
-              const actualRegion = err.$response.headers["x-amz-bucket-region"];
+              const actualRegion = bucketRegionHeader;
               context.logger?.debug(`Redirecting from ${await clientConfig.region()} to ${actualRegion}`);
               context.__s3RegionRedirect = actualRegion;
             } catch (e) {


### PR DESCRIPTION
### Issue
#7304 

### Description
Fixes HeadBucket cross-region redirects for 400 responses for newer regions with `x-amz-bucket-region` header

### Testing
Locally
```
 RUN  v3.2.4 /local/home/smilkuri/aws-sdk-js-v3/packages/middleware-sdk-s3

 ✓ src/s3-express/classes/S3ExpressIdentityCache.spec.ts (2 tests) 5ms
 ✓ src/s3-express/classes/S3ExpressIdentityCacheEntry.spec.ts (1 test) 13ms
 ✓ src/s3-express/classes/S3ExpressIdentityProviderImpl.spec.ts (2 tests) 7ms
 ✓ src/region-redirect-middleware.spec.ts (4 tests) 5ms
 ✓ src/validate-bucket-name.spec.ts (3 tests) 5ms
 ✓ src/s3-express/classes/SignatureV4S3Express.spec.ts (1 test) 2ms
 ✓ src/check-content-length-header.spec.ts (6 tests) 6ms
 ✓ src/throw-200-exceptions.spec.ts (6 tests) 11ms
 ✓ src/s3-express/functions/s3ExpressMiddleware.spec.ts (1 test) 2ms
 ✓ src/s3Configuration.spec.ts (1 test) 4ms

 Test Files  10 passed (10)
      Tests  27 passed (27)
   Start at  17:20:14
   Duration  568ms (transform 735ms, setup 0ms, collect 1.43s, tests 60ms, environment 2ms, prepare 1.37s)
  ```
### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
