### PR TITLE
chore(core/protocols): add fallback for schema short name

### DIFF
--- a/packages/core/src/submodules/protocols/ProtocolLib.ts
+++ b/packages/core/src/submodules/protocols/ProtocolLib.ts
@@ -67,7 +67,8 @@ export class ProtocolLib {
     } else if (!inputSchema.isUnitSchema()) {
       const hasBody = Object.values(members).find((m) => {
         const { httpQuery, httpQueryParams, httpHeader, httpLabel, httpPrefixHeaders } = m.getMergedTraits();
-        return !httpQuery && !httpQueryParams && !httpHeader && !httpLabel && httpPrefixHeaders === void 0;
+        const noPrefixHeaders = httpPrefixHeaders === void 0;
+        return !httpQuery && !httpQueryParams && !httpHeader && !httpLabel && noPrefixHeaders;
       });
       if (hasBody) {
         return defaultContentType;

--- a/packages/core/src/submodules/protocols/query/AwsQueryProtocol.ts
+++ b/packages/core/src/submodules/protocols/query/AwsQueryProtocol.ts
@@ -76,7 +76,8 @@ export class AwsQueryProtocol extends RpcProtocol {
     if (deref(operationSchema.input) === "unit" || !request.body) {
       request.body = "";
     }
-    request.body = `Action=${operationSchema.name.split("#")[1]}&Version=${this.options.version}` + request.body;
+    const action = operationSchema.name.split("#")[1] ?? operationSchema.name;
+    request.body = `Action=${action}&Version=${this.options.version}` + request.body;
     if (request.body.endsWith("&")) {
       request.body = request.body.slice(-1);
     }
@@ -110,9 +111,8 @@ export class AwsQueryProtocol extends RpcProtocol {
       delete response.headers[header];
       response.headers[header.toLowerCase()] = value;
     }
-
-    const awsQueryResultKey =
-      ns.isStructSchema() && this.useNestedResult() ? operationSchema.name.split("#")[1] + "Result" : undefined;
+    const shortName = operationSchema.name.split("#")[1] ?? operationSchema.name;
+    const awsQueryResultKey = ns.isStructSchema() && this.useNestedResult() ? shortName + "Result" : undefined;
     const bytes: Uint8Array = await collectBody(response.body, context as SerdeFunctions);
     if (bytes.byteLength > 0) {
       Object.assign(dataObject, await deserializer.read(ns, bytes, awsQueryResultKey));


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/issues/1600 (epic)

https://github.com/smithy-lang/smithy-typescript/pull/1681 - schema refactor includes adding a namespace string to all unwrapped schema objects, such that the `name` field contains only the short name.

### Description
Makes the SDK compatible with both pre and post merge of the above smithy-ts PR.

### Testing
`make test-protocols` both with current code and changes from [1681](https://github.com/smithy-lang/smithy-typescript/pull/1681)

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
