### PR TITLE
fix(lib-storage): update Upload params type to intersection of all S3 upload command inputs

### DIFF
--- a/lib/lib-storage/src/types.ts
+++ b/lib/lib-storage/src/types.ts
@@ -1,4 +1,11 @@
-import { PutObjectCommandInput, S3Client, Tag } from "@aws-sdk/client-s3";
+import {
+  CompleteMultipartUploadCommandInput,
+  CreateMultipartUploadCommandInput,
+  PutObjectCommandInput,
+  S3Client,
+  Tag,
+  UploadPartCommandInput,
+} from "@aws-sdk/client-s3";
 import type { AbortController } from "@smithy/types";
 
 export interface Progress {
@@ -52,7 +59,8 @@ export interface Options extends Partial<Configuration> {
   /**
    * This is the data that is uploaded.
    */
-  params: PutObjectCommandInput;
+  params: PutObjectCommandInput &
+    Partial<CreateMultipartUploadCommandInput & UploadPartCommandInput & CompleteMultipartUploadCommandInput>;
 
   /**
    * A service client.


### PR DESCRIPTION
### Issue
#7311 

### Description
The Upload class uses PutObject, CreateMultipartUpload, UploadPart, and CompleteMultipartUpload operations internally, so the type should accept parameters for all of these commands.

### Testing
Locally
```
 RUN  v3.2.4 /local/home/smilkuri/aws-sdk-js-v3/lib/lib-storage

 ✓ src/chunks/getChunkUint8Array.spec.ts (6 tests) 7ms
 ✓ src/chunks/getDataReadableStream.spec.ts (4 tests) 161ms
 ✓ src/chunks/getDataReadable.spec.ts (3 tests) 161ms
 ✓ src/index.spec.ts (1 test) 2ms
 ✓ src/Upload.spec.ts (29 tests) 23777ms
   ✓ Upload > should add tags to the object if tags have been added multi-part  23724ms

 Test Files  5 passed (5)
      Tests  43 passed (43)
   Start at  14:04:05
   Duration  24.74s (transform 655ms, setup 0ms, collect 2.25s, tests 24.11s, environment 1ms, prepare 603ms)
```

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
