### PR TITLE
chore(codegen): bump codegen version to 0.34.1

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.34.1 (2025-09-10)
+
+### Bug Fixes
+- Upgraded to smithy-typescript 0.34.1 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0330-2025-09-10))
+
 ## 0.34.0 (2025-07-30)
 
 ### Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.34.0"
+    version = "0.34.1"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.34.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.34.1")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "3015d27bb80562baef9d1ce3171cbaad067e387a",
+  SMITHY_TS_COMMIT: "70766bb06f1b2c4cdccb4ce6bdbffc6f0c90f47e",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Internal JS-6204

### Description
Bumps codegen version to 0.34.1

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
