### PR TITLE
test(credential-provider-node): attempt 2 to migrate integ tests to vitest

### DIFF
--- a/packages/credential-provider-node/jest.config.integ.js
+++ b/packages/credential-provider-node/jest.config.integ.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.integ.spec.ts"],
-};

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -16,8 +16,9 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "yarn g:vitest run",
-    "test:integration": "yarn g:jest -c jest.config.integ.js",
-    "test:watch": "yarn g:vitest watch"
+    "test:watch": "yarn g:vitest watch",
+    "test:integration": "yarn g:vitest run -c vitest.config.integ.mts",
+    "test:integration:watch": "yarn g:vitest watch -c vitest.config.integ.mts"
   },
   "keywords": [
     "aws",


### PR DESCRIPTION
### Issue
N/A

### Description
Attempt #2 of https://github.com/aws/aws-sdk-js-v3/pull/7331, which uses actual imports instead of vi.importActual

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
