### PR TITLE
chore(deps): bump spotbugs to 6.0.26

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -14,6 +14,7 @@
  */
 
 import org.jreleaser.model.Active
+import com.github.spotbugs.snom.Effort
 
 plugins {
     `java-library`
@@ -240,7 +241,7 @@ subprojects {
 
         // Configure the bug filter for spotbugs.
         spotbugs {
-            setEffort("max")
+            effort.set(Effort.MAX)
             val excludeFile = rootProject.file("gradleConfig/spotbugs/filter.xml")
             if (excludeFile.exists()) {
                 excludeFilter.set(excludeFile)


### PR DESCRIPTION
### Issue
N/A

### Description
Bumps spotbugs to 6.0.26

### Testing
CI

The following warning no longer appears
```console
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by edu.umd.cs.findbugs.ba.jsr305.TypeQualifierValue (file:/home/runner/.gradle/caches/modules-2/files-2.1/com.github.spotbugs/spotbugs/4.2.2/fef7e4208082fc1c6a1b7dfd84eb382add52dead/spotbugs-4.2.2.jar)
WARNING: Please consider reporting this to the maintainers of edu.umd.cs.findbugs.ba.jsr305.TypeQualifierValue
WARNING: System::setSecurityManager will be removed in a future release
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
