### PR TITLE
chore(ci): cache gradle in GitHub workflow

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'corretto'
+          cache: gradle
       
       - name: build and publish smithy-typescript
         run: |

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "70766bb06f1b2c4cdccb4ce6bdbffc6f0c90f47e",
+  SMITHY_TS_COMMIT: "2dd7348b752d7d4722b911fe8343bd9302aed15e",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
* Similar to https://github.com/smithy-lang/smithy-typescript/pull/1684
* Docs https://github.com/actions/setup-java#caching-packages-dependencies

### Description
Caches gradle in GitHub workflow

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
