### PR TITLE
chore(scripts): validate no Uint8Array with type parameters are generated by compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ test-schema: bundles
 
 test-integration: bundles
 	rm -rf ./clients/client-sso/node_modules/\@smithy # todo(yarn) incompatible redundant nesting.
+	node ./scripts/validation/no-generic-byte-arrays.js
 	yarn g:vitest run -c vitest.config.integ.mts
 	make test-protocols
 	make test-types

--- a/packages/crc64-nvme-crt/src/CrtCrc64Nvme.ts
+++ b/packages/crc64-nvme-crt/src/CrtCrc64Nvme.ts
@@ -9,7 +9,7 @@ export class CrtCrc64Nvme implements Checksum {
     this.checksum = checksums.crc64nvme(data, this.checksum);
   }
 
-  async digest() {
+  async digest(): Promise<Uint8Array> {
     return toUint8Array(this.checksum);
   }
 

--- a/packages/middleware-flexible-checksums/src/getCrc32ChecksumAlgorithmFunction.ts
+++ b/packages/middleware-flexible-checksums/src/getCrc32ChecksumAlgorithmFunction.ts
@@ -11,7 +11,7 @@ class NodeCrc32 implements Checksum {
     this.checksum = zlib.crc32(data, this.checksum);
   }
 
-  async digest() {
+  async digest(): Promise<Uint8Array> {
     return numToUint8(this.checksum);
   }
 

--- a/packages/middleware-flexible-checksums/src/stringHasher.ts
+++ b/packages/middleware-flexible-checksums/src/stringHasher.ts
@@ -4,7 +4,10 @@ import { toUint8Array } from "@smithy/util-utf8";
 /**
  * A function that, given a hash constructor and a string, calculates the hash of the string.
  */
-export const stringHasher = (checksumAlgorithmFn: ChecksumConstructor | HashConstructor, body: any) => {
+export const stringHasher = (
+  checksumAlgorithmFn: ChecksumConstructor | HashConstructor,
+  body: any
+): Promise<Uint8Array> => {
   const hash = new checksumAlgorithmFn();
   hash.update(toUint8Array(body || ""));
   return hash.digest();

--- a/packages/middleware-sdk-ec2/src/fixture.spec.ts
+++ b/packages/middleware-sdk-ec2/src/fixture.spec.ts
@@ -1,11 +1,14 @@
 import { SourceData } from "@smithy/types";
+import { describe, test as it } from "vitest";
 
 export class MockSha256 {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(secret?: string | ArrayBuffer | ArrayBufferView) {}
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   update(data?: SourceData) {}
-  digest() {
+
+  digest(): Promise<Uint8Array> {
     return Promise.resolve(new Uint8Array(5));
   }
 }
@@ -18,3 +21,7 @@ export const credentials = () =>
     secretAccessKey: "secret",
     sessionToken: "session",
   });
+
+describe("placeholder", () => {
+  it("placeholder for exports of testing constructs", () => {});
+});

--- a/packages/middleware-sdk-ec2/src/index.spec.ts
+++ b/packages/middleware-sdk-ec2/src/index.spec.ts
@@ -2,7 +2,7 @@ import { HttpRequest } from "@smithy/protocol-http";
 import { EndpointV2 } from "@smithy/types";
 import { beforeEach, describe, expect, test as it, vi } from "vitest";
 
-import { credentials, MockSha256, region } from "./fixture";
+import { credentials, MockSha256, region } from "./fixture.spec";
 import { copySnapshotPresignedUrlMiddleware } from "./index";
 
 const nextHandler = vi.fn();

--- a/packages/middleware-sdk-rds/src/fixture.spec.ts
+++ b/packages/middleware-sdk-rds/src/fixture.spec.ts
@@ -1,11 +1,12 @@
 import { SourceData } from "@smithy/types";
+import { describe, test as it } from "vitest";
 
 export class MockSha256 {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(secret?: string | ArrayBuffer | ArrayBufferView) {}
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   update(data?: SourceData) {}
-  digest() {
+  digest(): Promise<Uint8Array> {
     return Promise.resolve(new Uint8Array(5));
   }
   reset() {}
@@ -26,3 +27,7 @@ export const credentials = () =>
     secretAccessKey: "secret",
     sessionToken: "session",
   });
+
+describe("placeholder", () => {
+  it("placeholder for exports of testing constructs", () => {});
+});

--- a/packages/middleware-sdk-rds/src/index.spec.ts
+++ b/packages/middleware-sdk-rds/src/index.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import { crossRegionPresignedUrlMiddleware } from "./";
-import { credentials, endpoint, MockSha256, region } from "./fixture";
+import { credentials, endpoint, MockSha256, region } from "./fixture.spec";
 
 const nextHandler = vi.fn();
 const arn = "arn:aws:rds:src-region:000000000000:src-snapshot:dist-snapshot";

--- a/packages/middleware-signing/src/awsAuthConfiguration.spec.ts
+++ b/packages/middleware-signing/src/awsAuthConfiguration.spec.ts
@@ -118,7 +118,10 @@ describe("AuthConfig", () => {
       for (let i = 0; i < repeats; i++) {
         await signer.sign(request);
       }
-      console.log("what is credentials", credentials);
+      expect(await credentials()).toEqual({
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+      });
       expect(spy).toBeCalledTimes(2);
     });
   });

--- a/scripts/validation/no-generic-byte-arrays.js
+++ b/scripts/validation/no-generic-byte-arrays.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/**
+ * Runs after a full build to assert that Uint8Array was not generated with a type parameter
+ * by TypeScript, which is only compatible with TypeScript 5.7.
+ */
+
+const walk = require("../utils/walk");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.join(__dirname, "..", "..");
+
+const clients = path.join(root, "clients");
+const lib = path.join(root, "lib");
+const packages = path.join(root, "packages");
+const private = path.join(root, "private");
+
+(async () => {
+  const errors = [];
+  for (const group of [clients, lib, packages, private]) {
+    for (const folder of fs.readdirSync(group)) {
+      const packagePath = path.join(group, folder);
+      const distTypes = path.join(packagePath, "dist-types");
+      if (fs.existsSync(distTypes)) {
+        for await (const file of walk(distTypes)) {
+          const contents = fs.readFileSync(file, "utf-8");
+          if (contents.includes("Uint8Array<")) {
+            errors.push(file);
+          }
+        }
+      }
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      `The following files used Uint8Array in a generic way, only compatible with TypeScript 5.7:\n\t${errors.join(
+        "\n\t"
+      )}`
+    );
+  } else {
+    console.log(`✅ No Uint8Arrays with type parameters.`);
+  }
+})();


### PR DESCRIPTION
### Issue
follows https://github.com/smithy-lang/smithy-typescript/pull/1696

### Description
Asserts that no dist-types contain Uint8Array with type parameters due to the change in TypeScript 5.7 and the use of inferred types. The validator runs in ~6s including all clients.

### Testing
Runs during integration tests because by then all packages have been built.

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

