### PR TITLE
test(polly-request-presigner): make polly presigner test compatible with model change

### DIFF
--- a/packages/polly-request-presigner/src/polly-request-presigner.integ.spec.ts
+++ b/packages/polly-request-presigner/src/polly-request-presigner.integ.spec.ts
@@ -26,10 +26,10 @@ describe("polly-request-presigner", () => {
       "VoiceId=Kimberly",
       "X-Amz-Algorithm=AWS4-HMAC-SHA256",
       /X-Amz-Credential=(.*?)%2F(\d{8})%2Fus-east-1%2Fpolly%2Faws4_request/,
-      /X-Amz-Date=\d{8}T\d+Z/,
+      /X-Amz-Date=\d{8}T\d{6}Z/,
       "X-Amz-Expires=3600",
-      /X-Amz-Signature=(.*?)/,
-      "X-Amz-SignedHeaders=host",
+      /X-Amz-Signature=[a-f0-9]+/,
+      /X-Amz-SignedHeaders=(host|%3Aauthority)/,
       "https://polly.us-east-1.amazonaws.com/v1/speech?OutputFormat=mp3",
       /x-amz-user-agent=aws-sdk-js%2F\d\.\d+\.\d+/,
     ]);


### PR DESCRIPTION
### Issue
Internal JS-P293169653

### Description
The integration test was failing due to changes in the model.json, because the test assertions were too precise and expected 
exact values.

- Updated X-Amz-Date regex from `\d{8}T\d+Z` to `\d{8}T\d{6}Z` for precise timestamp format
- Updated X-Amz-Signature regex from `(.*?)` to `[a-f0-9]+` for hex signature validation
- Updated X-Amz-SignedHeaders regex to accept both 'host' and '%3Aauthority' values

### Testing

**For existing model**
```
dev-dsk-smilkuri-1a-17aece6b % yarn test:integration

 RUN  v3.2.4 /local/home/smilkuri/aws-sdk-js-v3/packages/polly-request-presigner

 ✓ src/polly-request-presigner.integ.spec.ts (1 test) 19ms
   ✓ polly-request-presigner > should sign URLs 18ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  19:23:50
   Duration  558ms (transform 130ms, setup 0ms, collect 225ms, tests 19ms, environment 0ms, prepare 133ms)
   
```
**For new model**

Regenerated and built the client for latest model and tested it with `yarn test:integartion`

`$ b client polly - gen,b`

```
dev-dsk-smilkuri-1a-17aece6b % yarn test:integration

 RUN  v3.2.4 /local/home/smilkuri/aws-sdk-js-v3/packages/polly-request-presigner

 ✓ src/polly-request-presigner.integ.spec.ts (1 test) 19ms
   ✓ polly-request-presigner > should sign URLs 18ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  19:36:39
   Duration  562ms (transform 130ms, setup 0ms, collect 237ms, tests 19ms, environment 0ms, prepare 122ms)
```


### Additional context
Add any other context about the PR here.

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
