### PR TITLE
chore: pull request build on PR opened event

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -1,7 +1,7 @@
 name: Build SDK
 on:
   pull_request:
-    types: [synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review]
 
 concurrency:
   group: start-pull-request-build-${{ github.ref }}


### PR DESCRIPTION
### Issue
n/a

### Description
execute a PR build on the PR `opened` event. `synchronized` appears not to include opening the PR.