### PR TITLE
fix(lib-storage): add validation for partCount and contentLength for multipart upload

### DIFF
--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -808,7 +808,7 @@ describe(Upload.name, () => {
       (upload as any).uploadedParts = [{ PartNumber: 1, ETag: "etag1" }];
       (upload as any).isMultiPart = true;
 
-      await expect(upload.done()).rejects.toThrow("Expected 3 number of parts but uploaded only 1 part");
+      await expect(upload.done()).rejects.toThrow("Expected 3 part(s) but uploaded 1 part(s).");
     });
 
     it("should throw error when part size doesn't match expected size except for laast part", () => {
@@ -859,7 +859,7 @@ describe(Upload.name, () => {
 
       expect(() => {
         (upload as any).__validateUploadPart(emptyPart, MOCK_PART_SIZE);
-      }).toThrow("Content length is missing on the data for part number 1");
+      }).toThrow("A dataPart was generated without a measurable data chunk size for part number 1");
     });
 
     it("should skip validation for single-part uploads", () => {

--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -825,7 +825,7 @@ describe(Upload.name, () => {
 
       expect(() => {
         (upload as any).__validateUploadPart(invalidPart, MOCK_PART_SIZE);
-      }).toThrow(`The Part size for part number 1, size 5 does not match expected size ${MOCK_PART_SIZE}`);
+      }).toThrow(`The byte size for part number 1, size 5 does not match expected size ${MOCK_PART_SIZE}`);
     });
 
     it("should allow smaller size for last part", () => {

--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -859,7 +859,7 @@ describe(Upload.name, () => {
 
       expect(() => {
         (upload as any).__validateUploadPart(emptyPart, MOCK_PART_SIZE);
-      }).toThrow("A dataPart was generated without a measurable data chunk size for part number 1");
+      }).toThrow(`The byte size for part number 1, size 0 does not match expected size ${MOCK_PART_SIZE}`);
     });
 
     it("should skip validation for single-part uploads", () => {

--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -792,4 +792,91 @@ describe(Upload.name, () => {
       new Error("@aws-sdk/lib-storage: this instance of Upload has already executed .done(). Create a new instance.")
     );
   });
+
+  describe("Upload Part and parts count validation", () => {
+    const MOCK_PART_SIZE = 1024 * 1024 * 5; // 5MB
+
+    it("should throw error when uploaded parts count doesn't match expected parts count", async () => {
+      const largeBuffer = Buffer.from("#".repeat(MOCK_PART_SIZE * 2 + 100));
+      const upload = new Upload({
+        params: { ...params, Body: largeBuffer },
+        client: new S3({}),
+      });
+
+      (upload as any).__doConcurrentUpload = vi.fn().mockResolvedValue(undefined);
+
+      (upload as any).uploadedParts = [{ PartNumber: 1, ETag: "etag1" }];
+      (upload as any).isMultiPart = true;
+
+      await expect(upload.done()).rejects.toThrow("Expected 3 number of parts but uploaded only 1 part");
+    });
+
+    it("should throw error when part size doesn't match expected size except for laast part", () => {
+      const upload = new Upload({
+        params,
+        client: new S3({}),
+      });
+
+      const invalidPart = {
+        partNumber: 1,
+        data: Buffer.from("small"),
+        lastPart: false,
+      };
+
+      expect(() => {
+        (upload as any).__validateUploadPart(invalidPart, MOCK_PART_SIZE);
+      }).toThrow(`The Part size for part number 1, size 5 does not match expected size ${MOCK_PART_SIZE}`);
+    });
+
+    it("should allow smaller size for last part", () => {
+      const upload = new Upload({
+        params,
+        client: new S3({}),
+      });
+
+      const lastPart = {
+        partNumber: 2,
+        data: Buffer.from("small"),
+        lastPart: true,
+      };
+
+      expect(() => {
+        (upload as any).__validateUploadPart(lastPart, MOCK_PART_SIZE);
+      }).not.toThrow();
+    });
+
+    it("should throw error when part has zero content length", () => {
+      const upload = new Upload({
+        params,
+        client: new S3({}),
+      });
+
+      const emptyPart = {
+        partNumber: 1,
+        data: Buffer.from(""),
+        lastPart: false,
+      };
+
+      expect(() => {
+        (upload as any).__validateUploadPart(emptyPart, MOCK_PART_SIZE);
+      }).toThrow("Content length is missing on the data for part number 1");
+    });
+
+    it("should skip validation for single-part uploads", () => {
+      const upload = new Upload({
+        params,
+        client: new S3({}),
+      });
+
+      const singlePart = {
+        partNumber: 1,
+        data: Buffer.from("small"),
+        lastPart: true,
+      };
+
+      expect(() => {
+        (upload as any).__validateUploadPart(singlePart, MOCK_PART_SIZE);
+      }).not.toThrow();
+    });
+  });
 });

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -440,21 +440,21 @@ export class Upload extends EventEmitter {
   private __validateUploadPart(dataPart: RawDataPart): void {
     const actualPartSize = byteLength(dataPart.data) || undefined;
 
-    // Skip validation for single-part uploads (PUT operations)
-    if (dataPart.partNumber === 1 && dataPart.lastPart) {
-      return;
-    }
-
     if (actualPartSize === undefined) {
       throw new Error(
         `A dataPart was generated without a measurable data chunk size for part number ${dataPart.partNumber}`
       );
     }
 
+    // Skip validation for single-part uploads (PUT operations)
+    if (dataPart.partNumber === 1 && dataPart.lastPart) {
+      return;
+    }
+
     // Validate part size (last part may be smaller)
     if (!dataPart.lastPart && actualPartSize !== this.partSize) {
       throw new Error(
-        `The Part size for part number ${dataPart.partNumber}, size ${actualPartSize} does not match expected size ${this.partSize}`
+        `The byte size for part number ${dataPart.partNumber}, size ${actualPartSize} does not match expected size ${this.partSize}`
       );
     }
   }

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -438,7 +438,7 @@ export class Upload extends EventEmitter {
   }
 
   private __validateUploadPart(dataPart: RawDataPart): void {
-    const actualPartSize = byteLength(dataPart.data) || undefined;
+    const actualPartSize = byteLength(dataPart.data);
 
     if (actualPartSize === undefined) {
       throw new Error(


### PR DESCRIPTION
### Issue
Internal JS-6196

### Description

- Adds validation to check total number of UploadPart requests the SDK has sent matches the expected number of parts.
- Adds validation to check the content length of each UploadPart request matches the expected part size.


### Testing
Locally
`yarn test` and `yarn test:e2e` are successful
```
dev-dsk-smilkuri-1a-17aece6b % yarn test

 RUN  v3.2.4 /local/home/smilkuri/aws-sdk-js-v3/lib/lib-storage

 ✓ src/chunks/getChunkUint8Array.spec.ts (6 tests) 7ms
 ✓ src/chunks/getDataReadableStream.spec.ts (4 tests) 168ms
 ✓ src/chunks/getDataReadable.spec.ts (3 tests) 167ms
 ✓ src/index.spec.ts (1 test) 2ms
 ✓ src/Upload.spec.ts (34 tests) 22888ms
   ✓ Upload > should add tags to the object if tags have been added multi-part  22807ms

 Test Files  5 passed (5)
      Tests  48 passed (48)
   Start at  16:15:06
   Duration  23.90s (transform 861ms, setup 0ms, collect 2.42s, tests 23.23s, environment 1ms, prepare 584ms)
```

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
