### PR TITLE
chore(core/protocols): preparatory fixes for schemas

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,6 @@
     "@smithy/smithy-client": "^4.6.4",
     "@smithy/types": "^4.5.0",
     "@smithy/util-base64": "^4.1.0",
-    "@smithy/util-body-length-browser": "^4.1.0",
     "@smithy/util-middleware": "^4.1.1",
     "@smithy/util-utf8": "^4.1.0",
     "tslib": "^2.6.2"

--- a/packages/core/src/submodules/protocols/ProtocolLib.ts
+++ b/packages/core/src/submodules/protocols/ProtocolLib.ts
@@ -108,9 +108,7 @@ export class ProtocolLib {
       const errorSchema = getErrorSchema?.(registry, errorName) ?? (registry.getSchema(errorIdentifier) as ErrorSchema);
       return { errorSchema, errorMetadata };
     } catch (e) {
-      if (dataObject.Message) {
-        dataObject.message = dataObject.Message;
-      }
+      dataObject.message = dataObject.message ?? dataObject.Message ?? "UnknownError";
       const baseExceptionSchema = TypeRegistry.for("smithy.ts.sdk.synthetic." + namespace).getBaseException();
       if (baseExceptionSchema) {
         const ErrorCtor = baseExceptionSchema.ctor;

--- a/packages/core/src/submodules/protocols/ProtocolLib.ts
+++ b/packages/core/src/submodules/protocols/ProtocolLib.ts
@@ -1,12 +1,5 @@
 import { ErrorSchema, NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
-import type {
-  BodyLengthCalculator,
-  HttpResponse as IHttpResponse,
-  MetadataBearer,
-  ResponseMetadata,
-  SerdeFunctions,
-} from "@smithy/types";
-import { calculateBodyLength } from "@smithy/util-body-length-browser";
+import type { HttpResponse as IHttpResponse, MetadataBearer, ResponseMetadata } from "@smithy/types";
 
 /**
  * @internal
@@ -22,23 +15,6 @@ type ErrorMetadataBearer = MetadataBearer & {
  * @internal
  */
 export class ProtocolLib {
-  /**
-   * @param body - to be inspected.
-   * @param serdeContext - this is a subset type but in practice is the client.config having a property called bodyLengthChecker.
-   *
-   * @returns content-length value for the body if possible.
-   * @throws Error and should be caught and handled if not possible to determine length.
-   */
-  public calculateContentLength(body: any, serdeContext?: SerdeFunctions) {
-    const bodyLengthCalculator: BodyLengthCalculator =
-      (
-        serdeContext as SerdeFunctions & {
-          bodyLengthChecker?: BodyLengthCalculator;
-        }
-      )?.bodyLengthChecker ?? calculateBodyLength;
-    return String(bodyLengthCalculator(body));
-  }
-
   /**
    * This is only for REST protocols.
    *

--- a/packages/core/src/submodules/protocols/json/AwsJson1_0Protocol.spec.ts
+++ b/packages/core/src/submodules/protocols/json/AwsJson1_0Protocol.spec.ts
@@ -115,7 +115,6 @@ describe(AwsJson1_0Protocol.name, () => {
       );
 
       expect(request.headers).toEqual({
-        "content-length": "60",
         "content-type": "application/x-amz-json-1.0",
         "x-amz-target": "JsonRpc10.MyOperation",
       });

--- a/packages/core/src/submodules/protocols/json/AwsJsonRpcProtocol.ts
+++ b/packages/core/src/submodules/protocols/json/AwsJsonRpcProtocol.ts
@@ -71,9 +71,9 @@ export abstract class AwsJsonRpcProtocol extends RpcProtocol {
     if (deref(operationSchema.input) === "unit" || !request.body) {
       request.body = "{}";
     }
-    try {
-      request.headers["content-length"] = this.mixin.calculateContentLength(request.body, this.serdeContext);
-    } catch (e) {}
+
+    // content-length header is set by the contentLengthMiddleware.
+
     return request;
   }
 

--- a/packages/core/src/submodules/protocols/json/AwsRestJsonProtocol.spec.ts
+++ b/packages/core/src/submodules/protocols/json/AwsRestJsonProtocol.spec.ts
@@ -161,7 +161,6 @@ describe(AwsRestJsonProtocol.name, () => {
       );
 
       expect(request.headers).toEqual({
-        "content-length": "25",
         "content-type": "application/json",
         header: "hello",
         a: "1",
@@ -265,7 +264,6 @@ describe(AwsRestJsonProtocol.name, () => {
 
       expect(request.headers).toEqual({
         "content-type": "application/json",
-        "content-length": "24",
         "header-default-date": "Thu, 01 Jan 1970 00:00:00 GMT",
         "header-member-trait-date": "1970-01-01T00:00:00Z",
         "header-epoch-seconds": "0",

--- a/packages/core/src/submodules/protocols/json/AwsRestJsonProtocol.ts
+++ b/packages/core/src/submodules/protocols/json/AwsRestJsonProtocol.ts
@@ -78,11 +78,7 @@ export class AwsRestJsonProtocol extends HttpBindingProtocol {
       request.body = "{}";
     }
 
-    if (request.body) {
-      try {
-        request.headers["content-length"] = this.mixin.calculateContentLength(request.body, this.serdeContext);
-      } catch (e) {}
-    }
+    // content-length header is set by the contentLengthMiddleware.
 
     return request;
   }

--- a/packages/core/src/submodules/protocols/json/JsonShapeSerializer.ts
+++ b/packages/core/src/submodules/protocols/json/JsonShapeSerializer.ts
@@ -130,7 +130,7 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
 
       const mediaType = ns.getMergedTraits().mediaType;
 
-      if (typeof value === "string" && mediaType) {
+      if (value != null && mediaType) {
         const isJson = mediaType === "application/json" || mediaType.endsWith("+json");
         if (isJson) {
           return LazyJsonString.from(value);

--- a/packages/core/src/submodules/protocols/query/AwsQueryProtocol.ts
+++ b/packages/core/src/submodules/protocols/query/AwsQueryProtocol.ts
@@ -142,6 +142,8 @@ export class AwsQueryProtocol extends RpcProtocol {
   ): Promise<never> {
     const errorIdentifier = this.loadQueryErrorCode(response, dataObject) ?? "Unknown";
     const errorData = this.loadQueryError(dataObject);
+    const message = this.loadQueryErrorMessage(dataObject);
+    errorData.message = message;
 
     const { errorSchema, errorMetadata } = await this.mixin.getErrorSchemaOrThrowBaseException(
       errorIdentifier,
@@ -156,7 +158,6 @@ export class AwsQueryProtocol extends RpcProtocol {
     );
 
     const ns = NormalizedSchema.of(errorSchema);
-    const message = this.loadQueryErrorMessage(dataObject);
     const exception = new errorSchema.ctor(message);
 
     const output = {} as any;

--- a/packages/core/src/submodules/protocols/query/AwsQueryProtocol.ts
+++ b/packages/core/src/submodules/protocols/query/AwsQueryProtocol.ts
@@ -82,9 +82,8 @@ export class AwsQueryProtocol extends RpcProtocol {
       request.body = request.body.slice(-1);
     }
 
-    try {
-      request.headers["content-length"] = this.mixin.calculateContentLength(request.body, this.serdeContext);
-    } catch (e) {}
+    // content-length header is set by the contentLengthMiddleware.
+
     return request;
   }
 

--- a/packages/core/src/submodules/protocols/query/AwsQueryProtocol.ts
+++ b/packages/core/src/submodules/protocols/query/AwsQueryProtocol.ts
@@ -144,6 +144,11 @@ export class AwsQueryProtocol extends RpcProtocol {
     const errorData = this.loadQueryError(dataObject);
     const message = this.loadQueryErrorMessage(dataObject);
     errorData.message = message;
+    errorData.Error = {
+      Type: errorData.Type,
+      Code: errorData.Code,
+      Message: message,
+    };
 
     const { errorSchema, errorMetadata } = await this.mixin.getErrorSchemaOrThrowBaseException(
       errorIdentifier,
@@ -160,7 +165,9 @@ export class AwsQueryProtocol extends RpcProtocol {
     const ns = NormalizedSchema.of(errorSchema);
     const exception = new errorSchema.ctor(message);
 
-    const output = {} as any;
+    const output = {
+      Error: errorData.Error,
+    } as any;
 
     for (const [name, member] of ns.structIterator()) {
       const target = member.getMergedTraits().xmlName ?? name;

--- a/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.spec.ts
+++ b/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.spec.ts
@@ -37,7 +37,6 @@ describe(AwsRestXmlProtocol.name, () => {
             method: "POST",
             headers: {
               "content-type": "application/xml",
-              "content-length": "167",
             },
             query: {
               delete: "",

--- a/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
+++ b/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
@@ -74,11 +74,7 @@ export class AwsRestXmlProtocol extends HttpBindingProtocol {
       }
     }
 
-    if (request.body) {
-      try {
-        request.headers["content-length"] = this.mixin.calculateContentLength(request.body, this.serdeContext);
-      } catch (e) {}
-    }
+    // content-length header is set by the contentLengthMiddleware.
 
     return request;
   }

--- a/packages/core/src/submodules/protocols/xml/XmlShapeDeserializer.ts
+++ b/packages/core/src/submodules/protocols/xml/XmlShapeDeserializer.ts
@@ -58,6 +58,11 @@ export class XmlShapeDeserializer extends SerdeContextConfig implements ShapeDes
 
   public readSchema(_schema: Schema, value: any): any {
     const ns = NormalizedSchema.of(_schema);
+
+    if (ns.isUnitSchema()) {
+      return;
+    }
+
     const traits = ns.getMergedTraits();
 
     if (ns.isListSchema() && !Array.isArray(value)) {

--- a/packages/middleware-sdk-ec2/src/index.ts
+++ b/packages/middleware-sdk-ec2/src/index.ts
@@ -5,7 +5,6 @@ import { SignatureV4 } from "@smithy/signature-v4";
 import { extendedEncodeURIComponent } from "@smithy/smithy-client";
 import type {
   AwsCredentialIdentity,
-  BodyLengthCalculator,
   ChecksumConstructor,
   Endpoint,
   HandlerExecutionContext,
@@ -30,7 +29,6 @@ interface PreviouslyResolved {
   sha256: ChecksumConstructor | HashConstructor;
   signingEscapePath: boolean;
   regionInfoProvider?: RegionInfoProvider;
-  bodyLengthChecker: BodyLengthCalculator;
 }
 
 const version = "2016-11-15";
@@ -124,9 +122,6 @@ export function copySnapshotPresignedUrlMiddleware(options: PreviouslyResolved):
           }
           if (!(request.body ?? "").includes("PresignedUrl=")) {
             request.body += `&PresignedUrl=${extendedEncodeURIComponent(args.input.PresignedUrl)}`;
-          }
-          if (typeof options.bodyLengthChecker === "function") {
-            request.headers["content-length"] = String(options.bodyLengthChecker(request.body));
           }
         }
       }

--- a/packages/middleware-sdk-ec2/src/middleware-sdk-ec2.e2e.spec.ts
+++ b/packages/middleware-sdk-ec2/src/middleware-sdk-ec2.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { EC2, EC2ServiceException, waitUntilSnapshotCompleted, waitUntilVolumeAvailable } from "@aws-sdk/client-ec2";
 import { KMS } from "@aws-sdk/client-kms";
+import { getHttpDebugLogPlugin } from "@aws-sdk/middleware-http-debug-log";
 import { afterAll, beforeAll, describe, expect, onTestFailed, test as it } from "vitest";
 
 const errors = [] as any[];
@@ -107,6 +108,14 @@ describe("EC2 feature test", () => {
 
     const sourceKms = new KMS({ region: sourceRegion, logger });
     const destinationKms = new KMS({ region: destRegion, logger });
+
+    for (const client of [sourceEc2, destinationEc2, sourceKms, destinationKms]) {
+      // I'm leaving this debug call in the test because it's so slow that
+      // you will want to see active request progress.
+      void getHttpDebugLogPlugin;
+      void client;
+      // client.middlewareStack.use(getHttpDebugLogPlugin("line"));
+    }
 
     async function teardown() {
       if (volumeId) {

--- a/private/aws-client-retry-test/src/ClientRetryTest.spec.ts
+++ b/private/aws-client-retry-test/src/ClientRetryTest.spec.ts
@@ -1,4 +1,4 @@
-import { ListFunctionsCommand, Lambda, LambdaClient, LambdaServiceException } from "@aws-sdk/client-lambda";
+import { Lambda, LambdaClient, LambdaServiceException, ListFunctionsCommand } from "@aws-sdk/client-lambda";
 import { HttpHandler, HttpResponse } from "@smithy/protocol-http";
 import { AwsCredentialIdentity, RequestHandlerOutput } from "@smithy/types";
 import { ConfiguredRetryStrategy, StandardRetryStrategy } from "@smithy/util-retry";

--- a/private/aws-middleware-test/src/middleware-content-length.spec.ts
+++ b/private/aws-middleware-test/src/middleware-content-length.spec.ts
@@ -1,9 +1,8 @@
+import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
 import { AccessAnalyzer } from "@aws-sdk/client-accessanalyzer";
 import { S3 } from "@aws-sdk/client-s3";
 import { XRay } from "@aws-sdk/client-xray";
 import { describe, expect, test as it } from "vitest";
-
-import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
 
 describe("middleware-content-length", () => {
   describe(AccessAnalyzer.name, () => {
@@ -40,6 +39,7 @@ describe("middleware-content-length", () => {
         headers: {
           "content-length": /106/,
         },
+        body: /clientToken/, // must include idempotencyToken.
       });
 
       await client.createAccessPreview({
@@ -47,7 +47,7 @@ describe("middleware-content-length", () => {
         analyzerArn: "my-analyzer-arn",
       });
 
-      expect.assertions(1);
+      expect.assertions(2);
     });
   });
 

--- a/private/aws-middleware-test/src/middleware-serde.spec.ts
+++ b/private/aws-middleware-test/src/middleware-serde.spec.ts
@@ -1,10 +1,9 @@
+import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
 import { EC2 } from "@aws-sdk/client-ec2";
 import { S3 } from "@aws-sdk/client-s3";
 import { SageMaker } from "@aws-sdk/client-sagemaker";
 import { SageMakerRuntime } from "@aws-sdk/client-sagemaker-runtime";
 import { describe, test as it } from "vitest";
-
-import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
 
 describe("middleware-serde", () => {
   describe(S3.name, () => {
@@ -75,7 +74,15 @@ describe("middleware-serde", () => {
           "content-type": "application/x-www-form-urlencoded",
           host: "ec2.us-west-2.amazonaws.com",
         },
-        body: /ClientCidrBlock=ClientCidrBlock&ServerCertificateArn=ServerCertificateArn(.*?)&Action=CreateClientVpnEndpoint&Version=2016-11-15/,
+        body(body: any) {
+          const params = Object.fromEntries(new URLSearchParams(body).entries());
+          expect(params).toMatchObject({
+            Action: "CreateClientVpnEndpoint",
+            Version: "2016-11-15",
+            ClientCidrBlock: "ClientCidrBlock",
+            ServerCertificateArn: "ServerCertificateArn",
+          });
+        },
         protocol: "https:",
         path: "/",
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -23355,7 +23355,6 @@ __metadata:
     "@smithy/smithy-client": "npm:^4.6.4"
     "@smithy/types": "npm:^4.5.0"
     "@smithy/util-base64": "npm:^4.1.0"
-    "@smithy/util-body-length-browser": "npm:^4.1.0"
     "@smithy/util-middleware": "npm:^4.1.1"
     "@smithy/util-utf8": "npm:^4.1.0"
     "@tsconfig/recommended": "npm:1.0.1"


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/issues/1600
preparatory compatibility fixes for Schemas

### Description
Fixes for unreleased features.

- fix for applying the LazyJsonString adapter in cases where the input is a JSON object rather than a string
- change test assertions to ignore ordering of query parameters
- return early for unit schema in XML shape deserializer
- fix to fully populate error fields in AwsQuery protocol
- defer content length determination to the contentLengthMiddleware rather than protocol methods

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
