### PR TITLE
chore(codegen): git fetch smithy-ts only when necessary

### DIFF
--- a/scripts/generate-clients/build-smithy-typescript.js
+++ b/scripts/generate-clients/build-smithy-typescript.js
@@ -13,8 +13,12 @@ const buildSmithyTypeScript = async (repo, commit) => {
     await spawnProcess("git", ["clone", "https://github.com/awslabs/smithy-typescript.git", repo, "--depth=1"]);
   }
 
-  // Checkout commit
-  await spawnProcess("git", ["fetch", "origin", commit, "--depth=1"], { cwd: repo });
+  // Checkout commit (connect to remote only when necessary)
+  try {
+    await spawnProcess("git", ["cat-file", "-e", commit], { cwd: repo });
+  } catch (error) {
+    await spawnProcess("git", ["fetch", "origin", commit, "--depth=1"], { cwd: repo });
+  }
 
   // Switch to branch with commit
   const tempBranchName = `temp-${commit}`;


### PR DESCRIPTION
### Issue
Internal JS-6252

### Description
Updates codegen of clients to perform git fetch only when necessary

### Testing
* CI
* Done in JS-6252

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
