### PR TITLE
chore: add more bundle types to the benchmark

### DIFF
--- a/tests/bundlers/applications/NormalizedSchema.ts
+++ b/tests/bundlers/applications/NormalizedSchema.ts
@@ -1,0 +1,1 @@
+export { NormalizedSchema } from "@smithy/core/schema";

--- a/tests/bundlers/applications/all-protocols.ts
+++ b/tests/bundlers/applications/all-protocols.ts
@@ -1,0 +1,10 @@
+export {
+  AwsRestJsonProtocol,
+  AwsEc2QueryProtocol,
+  AwsJsonRpcProtocol,
+  AwsRestXmlProtocol,
+  AwsJson1_0Protocol,
+  AwsJson1_1Protocol,
+  AwsSmithyRpcV2CborProtocol,
+  AwsQueryProtocol,
+} from "@aws-sdk/core/protocols";

--- a/tests/bundlers/applications/multiple-barebones-micg-sdk-clients.ts
+++ b/tests/bundlers/applications/multiple-barebones-micg-sdk-clients.ts
@@ -1,0 +1,10 @@
+export { EC2ProtocolClient } from "@aws-sdk/aws-protocoltests-ec2";
+export { JsonProtocolClient } from "@aws-sdk/aws-protocoltests-json";
+export { JSONRPC10Client } from "@aws-sdk/aws-protocoltests-json-10";
+export { MachineLearningClient } from "@aws-sdk/aws-protocoltests-json-machinelearning";
+export { QueryProtocolClient } from "@aws-sdk/aws-protocoltests-query";
+export { RestJsonProtocolClient } from "@aws-sdk/aws-protocoltests-restjson";
+export { GlacierClient } from "@aws-sdk/aws-protocoltests-restjson-glacier";
+export { APIGatewayClient } from "@aws-sdk/aws-protocoltests-restjson-apigateway";
+export { RestXmlProtocolClient } from "@aws-sdk/aws-protocoltests-restxml";
+export { RpcV2ProtocolClient } from "@aws-sdk/aws-protocoltests-smithy-rpcv2-cbor";

--- a/tests/bundlers/applications/multiple-barebones-schema-sdk-clients.ts
+++ b/tests/bundlers/applications/multiple-barebones-schema-sdk-clients.ts
@@ -1,0 +1,10 @@
+export { EC2ProtocolClient } from "@aws-sdk/aws-protocoltests-ec2-schema";
+export { JsonProtocolClient } from "@aws-sdk/aws-protocoltests-json-schema";
+export { JSONRPC10Client } from "@aws-sdk/aws-protocoltests-json-10-schema";
+export { MachineLearningClient } from "@aws-sdk/aws-protocoltests-json-schema-machinelearning";
+export { QueryProtocolClient } from "@aws-sdk/aws-protocoltests-query-schema";
+export { RestJsonProtocolClient } from "@aws-sdk/aws-protocoltests-restjson-schema";
+export { GlacierClient } from "@aws-sdk/aws-protocoltests-restjson-schema-glacier";
+export { APIGatewayClient } from "@aws-sdk/aws-protocoltests-restjson-schema-apigateway";
+export { RestXmlProtocolClient } from "@aws-sdk/aws-protocoltests-restxml-schema";
+export { RpcV2ProtocolClient } from "@aws-sdk/aws-protocoltests-smithy-rpcv2-cbor-schema";

--- a/tests/bundlers/applications/single-cbor-xml-protocol.ts
+++ b/tests/bundlers/applications/single-cbor-xml-protocol.ts
@@ -1,0 +1,1 @@
+export { AwsRestXmlProtocol } from "@aws-sdk/core/protocols";

--- a/tests/bundlers/applications/single-json-protocol.ts
+++ b/tests/bundlers/applications/single-json-protocol.ts
@@ -1,0 +1,1 @@
+export { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";

--- a/tests/bundlers/applications/single-xml-protocol.ts
+++ b/tests/bundlers/applications/single-xml-protocol.ts
@@ -1,0 +1,1 @@
+export { AwsRestXmlProtocol } from "@aws-sdk/core/protocols";

--- a/tests/bundlers/runner/BundlerSizeBenchmarker.mjs
+++ b/tests/bundlers/runner/BundlerSizeBenchmarker.mjs
@@ -97,11 +97,13 @@ export class BundlerSizeBenchmarker {
 
     await esbuild.build({
       entryPoints: [entryPoint],
+      platform: "browser",
       bundle: true,
       minify: true,
+      mainFields: ["browser", "module", "main"],
       outfile: outfile,
       format: "esm",
-      target: "es2015",
+      target: "es2022",
     });
 
     const stat = fs.statSync(outfile);

--- a/tests/bundlers/runner/run.mjs
+++ b/tests/bundlers/runner/run.mjs
@@ -12,6 +12,9 @@ const applicationFolder = path.join(__dirname, "..", "applications");
 const report = new ReportMarkdown();
 
 for (const app of fs.readdirSync(applicationFolder)) {
+  if (fs.lstatSync(path.join(applicationFolder, app)).isDirectory()) {
+    continue;
+  }
   const benchmarker = new BundlerSizeBenchmarker({ application: app });
 
   const stat = await benchmarker.all();


### PR DESCRIPTION
### Issue
Adds some entries to the bundle benchmark to test bundle sizes of core schema components and protocols
