### PR TITLE
chore: keep vite build directory contents between builds

### DIFF
--- a/tests/bundlers/runner/BundlerSizeBenchmarker.mjs
+++ b/tests/bundlers/runner/BundlerSizeBenchmarker.mjs
@@ -70,6 +70,8 @@ export class BundlerSizeBenchmarker {
           name: "dist",
           fileName: `vite-${this.application}`,
         },
+        minify: true,
+        emptyOutDir: false,
         rollupOptions: {
           input: {
             input: inputFile,


### PR DESCRIPTION
prevent vite build from deleting the dist directory between builds, so build artifacts from different builds can be compared