### PR TITLE
chore(codegen): enable Gradle configuration cache

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,3 +1,4 @@
 smithyVersion=1.62.0
 smithyGradleVersion=1.3.0
 org.gradle.jvmargs=-Xmx4096M
+org.gradle.configuration-cache=true


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/pull/1722

### Description
Enables Gradle configuration cache

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
