### PR TITLE
chore(ci): use gradle/actions/setup-gradle for setting up gradle

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -22,15 +22,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: gradle/actions/wrapper-validation@v4
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'corretto'
-          cache: gradle
-      
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
       - name: build and publish smithy-typescript
         run: |
           node ./scripts/generate-clients/build-smithy-typescript-ci.js

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "ceb0a0d05333af401a18a98428b0072c401ef241",
+  SMITHY_TS_COMMIT: "30c9c15812bb1ddf4726baf27e058dfe7d97022a",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/pull/1724

### Description
Uses gradle/actions/setup-gradle for setting up gradle

### Testing
* codegen-ci was successful
* Extensive testing was done in https://github.com/smithy-lang/smithy-typescript/pull/1724

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
