### PR TITLE
chore(codegen): bump codegen version to 0.36.1

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.36.1 (2025-10-06)
+
+### Features
+- Upgraded to smithy-typescript 0.36.1 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0361-2025-10-06))
+
+### Chores
+- Removed usage of deprecated APIs ([#7395](https://github.com/aws/aws-sdk-js-v3/pull/7395))
+
 ## 0.36.0 (2025-09-30)
 
 ### Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -32,7 +32,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.36.0"
+    version = "0.36.1"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -43,7 +43,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.36.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.36.1")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "0cbad5e63082a404fc382c697585b4145cb69f88",
+  SMITHY_TS_COMMIT: "e0a328080578a96cef153014c881f786d1aaded2",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -1,7 +1,7 @@
 // Update this commit when taking up new changes from smithy-typescript.
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
-  SMITHY_TS_COMMIT: "ce9a4b2a0af870a8eb08b977a429f001caf397b9",
+  SMITHY_TS_COMMIT: "0cbad5e63082a404fc382c697585b4145cb69f88",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/pull/1734

### Description
Bumps codegen version to 0.36.1

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
