### PR TITLE
chore(codegen): fix gradle task dependency and duplicate handling in sourcesJar

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -91,6 +91,9 @@ subprojects {
             metaInf.with(licenseSpec)
             from(sourceSets.main.get().allSource)
             archiveClassifier.set("sources")
+            // Add explicit dependency on the task that generates resources
+            dependsOn("set-aws-sdk-versions")
+            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }
 
         tasks.register<Jar>("javadocJar") {

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -93,7 +93,7 @@ subprojects {
             archiveClassifier.set("sources")
             // Add explicit dependency on the task that generates resources
             dependsOn("set-aws-sdk-versions")
-            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            duplicatesStrategy = DuplicatesStrategy.INCLUDE
         }
 
         tasks.register<Jar>("javadocJar") {


### PR DESCRIPTION
### Issue
Internal JS-6275

### Description
Fix implicit dependency error and duplicate files in smithy-aws-typescript-codegen

- Add explicit dependsOn for set-aws-sdk-versions task
- Set duplicatesStrategy to EXCLUDE for META-INF files

### Testing
Locally
```
./gradlew :smithy-aws-typescript-codegen:publish
Calculating task graph as configuration cache cannot be reused because file 'build.gradle.kts' has changed.

BUILD SUCCESSFUL in 2s
10 actionable tasks: 5 executed, 5 up-to-date
Configuration cache entry stored.
```

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
