### PR TITLE
test(core): modify request compression threshold values

### DIFF
--- a/packages/core/integ/request-compression.integ.spec.ts
+++ b/packages/core/integ/request-compression.integ.spec.ts
@@ -82,10 +82,10 @@ describe("request compression", () => {
       });
     });
 
-    it("should compress payloads barely beyond the specified limit", async () => {
+    it("should compress payloads beyond the specified limit", async () => {
       const cw = new CloudWatch({
         credentials,
-        requestMinCompressionSizeBytes: 277_419,
+        requestMinCompressionSizeBytes: 100_000,
         region: "us-west-2",
       });
 
@@ -101,10 +101,10 @@ describe("request compression", () => {
       });
     });
 
-    it("should not compress payloads barely below the specified limit", async () => {
+    it("should not compress payloads below the specified limit", async () => {
       const cw = new CloudWatch({
         credentials,
-        requestMinCompressionSizeBytes: 277_420,
+        requestMinCompressionSizeBytes: 300_000,
         region: "us-west-2",
       });
 


### PR DESCRIPTION
### Issue
Internal P312458591

### Description

- The test expected compression to occur at a precise byte count, but the actual payload size can vary depending on spec.
- Changed from exact values (277,419/277,420 bytes) to a general range (100,000/300,000 bytes) to make the test compatible across different scenarios.

### Testing
Locally

```
yarn test:integration

 RUN  v3.2.4 ../aws-sdk-js-v3/packages/core

 ✓ integ/defaults-mode.integ.spec.ts (4 tests) 9ms
 ✓ integ/configuration-file/aws-config-file.integ.spec.ts (2 tests) 18ms
 ✓ integ/request-handlers/request-handlers.integ.spec.ts (12 tests) 28ms
 ✓ integ/lazy-json-string.integ.spec.ts (1 test) 18ms
 ✓ integ/pagination.integ.spec.ts (1 test) 19ms
 ✓ integ/account-id-endpoint.integ.spec.ts (10 tests) 40ms
 ✓ integ/request-compression.integ.spec.ts (5 tests) 178ms
 ✓ integ/service-id.integ.spec.ts (9 tests) 4ms
 ✓ integ/waiters.integ.spec.ts (2 tests) 10038ms
   ✓ waiters > should poll until a return condition is met (http status)  5025ms
   ✓ waiters > should poll until a return condition is met (nested property)  5011ms

 Test Files  9 passed (9)
      Tests  46 passed (46)
   Start at  20:02:27
   Duration  11.71s (transform 2.56s, setup 0ms, collect 10.33s, tests 10.35s, environment 2ms, prepare 1.15s)
```


### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
