### PR TITLE
chore(ci): run publish for codegen

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -42,3 +42,8 @@ jobs:
         run: |
           cd ./codegen
           ./gradlew clean sdk-codegen:build smithy-aws-typescript-codegen:build protocol-test-codegen:build -Plog-tests
+
+      - name: publish codegen
+        run: |
+          cd ./codegen
+          ./gradlew :smithy-aws-typescript-codegen:publish


### PR DESCRIPTION
### Issue
* Internal JS-6284
* This would have helped catch fix done in https://github.com/aws/aws-sdk-js-v3/pull/7409

### Description
Runs publish for codegen in CI

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
