### PR TITLE
fix(codegen): apply reserved word escaping to union shape in Json serializer

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
@@ -18,10 +18,10 @@ package software.amazon.smithy.aws.typescript.codegen;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
-import software.amazon.smithy.codegen.core.ReservedWords;
-import software.amazon.smithy.codegen.core.ReservedWordsBuilder;
 import java.util.function.BiFunction;
 import software.amazon.smithy.aws.typescript.codegen.validation.UnaryFunctionCall;
+import software.amazon.smithy.codegen.core.ReservedWords;
+import software.amazon.smithy.codegen.core.ReservedWordsBuilder;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -216,7 +216,8 @@ final class JsonShapeSerVisitor extends DocumentShapeSerVisitor {
         ServiceShape serviceShape = context.getService();
 
         // Visit over the union type, then get the right serialization for the member.
-        writer.openBlock("return $L.visit(input, {", "});", reservedWords.escape(shape.getId().getName(serviceShape)), () -> {
+        writer.openBlock("return $L.visit(input, {", "});",
+            reservedWords.escape(shape.getId().getName(serviceShape)), () -> {
             // Use a TreeMap to sort the members.
             Map<String, MemberShape> members = new TreeMap<>(shape.getAllMembers());
             members.forEach((memberName, memberShape) -> {


### PR DESCRIPTION
### Issue
Internal JS-6273

### Description
Apply reservedWords.escape() to union shape names when generating the visitor pattern code to avoid TypeScript compilation errors when union names conflict with reserved words like 'Parameters'.

### Testing
Locally
```
yarn build:all

 Tasks:    516 successful, 516 total
Cached:    42 cached, 516 total
  Time:    15m45.413s 

    ...Finishing writing to cache...                                                                                                                                                                                                                           WARNING  no output files found for task @aws-sdk/aws-middleware-test#build. Please check your `outputs` key in `turbo.json`
 ```

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
