### PR TITLE
test(core/protocols): use static schema

### DIFF
--- a/packages/core/src/submodules/protocols/cbor/AwsSmithyRpcV2CborProtocol.spec.ts
+++ b/packages/core/src/submodules/protocols/cbor/AwsSmithyRpcV2CborProtocol.spec.ts
@@ -1,5 +1,4 @@
 import { cbor } from "@smithy/core/cbor";
-import { op } from "@smithy/core/schema";
 import { error as registerError } from "@smithy/core/schema";
 import { HttpResponse } from "@smithy/protocol-http";
 import type { NumericSchema, StringSchema } from "@smithy/types";
@@ -32,7 +31,13 @@ describe(AwsSmithyRpcV2CborProtocol.name, () => {
 
     const error = await (async () => {
       return protocol.deserializeResponse(
-        op("ns", "Operation", 0, "unit", "unit"),
+        {
+          namespace: "ns",
+          name: "Operation",
+          traits: 0,
+          input: "unit",
+          output: "unit",
+        },
         {} as any,
         new HttpResponse({
           statusCode: 400,

--- a/packages/core/src/submodules/protocols/idempotencyToken.spec.ts
+++ b/packages/core/src/submodules/protocols/idempotencyToken.spec.ts
@@ -1,5 +1,5 @@
 import { CborShapeSerializer } from "@smithy/core/cbor";
-import { sim, struct } from "@smithy/core/schema";
+import { StaticSimpleSchema, StaticStructureSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
 import { JsonShapeSerializer } from "./json/JsonShapeSerializer";
@@ -7,13 +7,17 @@ import { QueryShapeSerializer } from "./query/QueryShapeSerializer";
 import { XmlShapeSerializer } from "./xml/XmlShapeSerializer";
 
 describe("idempotencyToken", () => {
-  const structureSchema = struct(
+  const structureSchema = [
+    3,
     "ns",
     "StructureWithIdempotencyToken",
     0,
     ["idempotencyToken", "plain"],
-    [sim("ns", "IdempotencyTokenString", 0, 0b0100), sim("ns", "PlainString", 0, 0b0000)]
-  );
+    [
+      [0, "ns", "IdempotencyTokenString", 0b0100, 0] satisfies StaticSimpleSchema,
+      [0, "ns", "PlainString", 0b0000, 0] satisfies StaticSimpleSchema,
+    ],
+  ] satisfies StaticStructureSchema;
 
   it("all ShapeSerializer implementations should generate an idempotency token if no input was provided by the caller", () => {
     const serializers = [

--- a/packages/core/src/submodules/protocols/json/AwsJson1_1Protocol.spec.ts
+++ b/packages/core/src/submodules/protocols/json/AwsJson1_1Protocol.spec.ts
@@ -8,6 +8,15 @@ import { AwsJson1_1Protocol } from "./AwsJson1_1Protocol";
  * These tests are cursory since most coverage is provided by protocol tests.
  */
 describe(AwsJson1_1Protocol, () => {
+  const [, namespace, name, traits, input, output] = deleteObjects;
+  const deleteObjectsOperation = {
+    namespace,
+    name,
+    traits,
+    input,
+    output,
+  };
+
   it("is 1.0", async () => {
     const protocol = new AwsJson1_1Protocol({
       defaultNamespace: "",
@@ -22,7 +31,7 @@ describe(AwsJson1_1Protocol, () => {
       serviceTarget: "JsonRpc11",
     });
     const httpRequest = await protocol.serializeRequest(
-      deleteObjects,
+      deleteObjectsOperation,
       {
         Delete: {
           Objects: [
@@ -66,7 +75,7 @@ describe(AwsJson1_1Protocol, () => {
       serviceTarget: "JsonRpc11",
     });
 
-    const output = await protocol.deserializeResponse(deleteObjects, context, httpResponse);
+    const output = await protocol.deserializeResponse(deleteObjectsOperation, context, httpResponse);
 
     expect(output).toEqual({
       $metadata: {

--- a/packages/core/src/submodules/protocols/json/AwsJsonRpcProtocol.ts
+++ b/packages/core/src/submodules/protocols/json/AwsJsonRpcProtocol.ts
@@ -64,7 +64,7 @@ export abstract class AwsJsonRpcProtocol extends RpcProtocol {
     }
     Object.assign(request.headers, {
       "content-type": `application/x-amz-json-${this.getJsonRpcVersion()}`,
-      "x-amz-target": `${this.serviceTarget}.${NormalizedSchema.of(operationSchema).getName()}`,
+      "x-amz-target": `${this.serviceTarget}.${operationSchema.name}`,
     });
     if (this.awsQueryCompatible) {
       request.headers["x-amzn-query-mode"] = "true";

--- a/packages/core/src/submodules/protocols/schema-testing/schema-documents.spec.ts
+++ b/packages/core/src/submodules/protocols/schema-testing/schema-documents.spec.ts
@@ -1,4 +1,4 @@
-import { list, map, NormalizedSchema, sim, struct, TypeRegistry } from "@smithy/core/schema";
+import { NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
 import type {
   BigDecimalSchema,
   BigIntegerSchema,
@@ -7,6 +7,10 @@ import type {
   DocumentSchema,
   DocumentType,
   NumericSchema,
+  StaticListSchema,
+  StaticMapSchema,
+  StaticSimpleSchema,
+  StaticStructureSchema,
   StringSchema,
   TimestampDateTimeSchema,
   TimestampDefaultSchema,
@@ -20,7 +24,8 @@ import { JsonShapeDeserializer } from "../json/JsonShapeDeserializer";
 import { testCases } from "./new-document-type-test-cases.spec";
 
 /* eslint no-var: 0 */
-export var OmniWidget = struct(
+export var OmniWidget: StaticStructureSchema = [
+  3,
   "smithy.example",
   "OmniWidget",
   0,
@@ -50,15 +55,21 @@ export var OmniWidget = struct(
   [
     21 satisfies BlobSchema,
     2 satisfies BooleanSchema,
-    sim("smithy.api", "String", 0, {
-      jsonName: "String",
-      xmlName: "String",
-    }),
-    sim("smithy.api", "Byte", 1 satisfies NumericSchema, 0),
-    sim("smithy.api", "Short", 1 satisfies NumericSchema, 0),
-    sim("smithy.api", "Integer", 1 satisfies NumericSchema, 0),
-    sim("smithy.api", "Long", 1 satisfies NumericSchema, 0),
-    sim("smithy.api", "Float", 1 satisfies NumericSchema, 0),
+    [
+      0,
+      "smithy.api",
+      "String",
+      {
+        jsonName: "String",
+        xmlName: "String",
+      },
+      0,
+    ] satisfies StaticSimpleSchema,
+    [0, "smithy.api", "Byte", 0, 1 satisfies NumericSchema] satisfies StaticSimpleSchema,
+    [0, "smithy.api", "Short", 0, 1 satisfies NumericSchema] satisfies StaticSimpleSchema,
+    [0, "smithy.api", "Integer", 0, 1 satisfies NumericSchema] satisfies StaticSimpleSchema,
+    [0, "smithy.api", "Long", 0, 1 satisfies NumericSchema] satisfies StaticSimpleSchema,
+    [0, "smithy.api", "Float", 0, 1 satisfies NumericSchema] satisfies StaticSimpleSchema,
     1 satisfies NumericSchema, // double
     17 satisfies BigIntegerSchema,
     19 satisfies BigDecimalSchema,
@@ -67,15 +78,15 @@ export var OmniWidget = struct(
     6 satisfies TimestampHttpDateSchema,
     7 satisfies TimestampEpochSecondsSchema,
     15 satisfies DocumentSchema,
-    sim("smithy.api", "Enum", 0 satisfies StringSchema, 0),
-    sim("smithy.api", "IntEnum", 1 satisfies NumericSchema, 0),
-    list("smithy.example", "OmniWidgetList", 0, () => OmniWidget),
-    map("smithy.example", "OmniWidgetMap", 0, 0, () => OmniWidget),
+    [0, "smithy.api", "Enum", 0 satisfies StringSchema, 0],
+    [0, "smithy.api", "IntEnum", 1 satisfies NumericSchema, 0],
+    [1, "smithy.example", "OmniWidgetList", 0, () => OmniWidget] satisfies StaticListSchema,
+    [2, "smithy.example", "OmniWidgetMap", 0, 0, () => OmniWidget] satisfies StaticMapSchema,
     () => OmniWidget,
-  ]
-);
+  ],
+];
 
-TypeRegistry.for(OmniWidget.namespace).register(OmniWidget.getName(), OmniWidget);
+TypeRegistry.for(OmniWidget[1]).register(`${OmniWidget[1]}#${OmniWidget[2]}`, OmniWidget);
 
 function getJsonCodec(test: { settings: JsonSettings }): JsonCodec {
   const { settings } = test;

--- a/packages/core/src/submodules/protocols/test-schema.spec.ts
+++ b/packages/core/src/submodules/protocols/test-schema.spec.ts
@@ -1,9 +1,11 @@
-import { list, map, op, sim, struct } from "@smithy/core/schema";
 import type {
   BigDecimalSchema,
   BigIntegerSchema,
   BlobSchema,
   NumericSchema,
+  StaticListSchema,
+  StaticOperationSchema,
+  StaticStructureSchema,
   TimestampEpochSecondsSchema,
 } from "@smithy/types";
 import { describe, test as it } from "vitest";
@@ -12,59 +14,63 @@ describe("testing schema export", () => {
   it("placeholder", () => {});
 });
 
-export const widget = struct(
+export const widget = [
+  3,
   "",
   "Struct",
   0,
   ["list", "sparseList", "map", "sparseMap", "blob", "media", "timestamp", "bigint", "bigdecimal", "scalar"],
   [
-    [list("", "List", 0, 0), 0],
-    [list("", "List", 0, 0), { sparse: 1 }],
-    map("", "Map", 0, 0, 0),
-    [map("", "Map", 0, 0, 0), { sparse: 1 }],
+    [[1, "", "List", 0, 0] satisfies StaticListSchema, 0],
+    [[1, "", "List", 0, 0] satisfies StaticListSchema, { sparse: 1 }],
+    [2, "", "Map", 0, 0, 0],
+    [[2, "", "Map", 0, 0, 0], { sparse: 1 }],
     21 satisfies BlobSchema,
-    sim("", "Media", 0, { mediaType: "application/json" }),
+    [0, "", "Media", { mediaType: "application/json" }, 0],
     7 satisfies TimestampEpochSecondsSchema,
     17 satisfies BigIntegerSchema,
     19 satisfies BigDecimalSchema,
     1 satisfies NumericSchema,
-  ]
-);
+  ],
+] satisfies StaticStructureSchema;
 
-export const deleteObjects = op(
+export const deleteObjects: StaticOperationSchema = [
+  9,
   "ns",
   "DeleteObjects",
   {
     http: ["POST", "/{Bucket}?delete", 200],
   },
-  struct(
+  [
+    3,
     "ns",
     "DeleteObjectsRequest",
     {},
     ["Delete"],
     [
       [
-        struct(
+        [
+          3,
           "ns",
           "Delete",
           0,
           ["Objects"],
           [
             [
-              list("ns", "ObjectIdentifierList", 0, struct("ns", "ObjectIdentifier", 0, ["Key"], [[0, 0]])),
+              [1, "ns", "ObjectIdentifierList", 0, [3, "ns", "ObjectIdentifier", 0, ["Key"], [[0, 0]]]],
               { xmlFlattened: 1, xmlName: "Object" },
             ],
-          ]
-        ),
+          ],
+        ],
         {
           httpPayload: 1,
           xmlName: "Delete",
         },
       ],
-    ]
-  ),
-  struct("ns", "DeleteObjectsResponse", 0, [], [])
-);
+    ],
+  ],
+  [3, "ns", "DeleteObjectsResponse", 0, [], []] satisfies StaticStructureSchema,
+] satisfies StaticOperationSchema;
 
 export const context = {
   async endpoint() {

--- a/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
+++ b/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
@@ -3,13 +3,14 @@ import {
   HttpInterceptingShapeDeserializer,
   HttpInterceptingShapeSerializer,
 } from "@smithy/core/protocols";
-import { NormalizedSchema, OperationSchema, TypeRegistry } from "@smithy/core/schema";
+import { NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
 import type {
   EndpointBearer,
   HandlerExecutionContext,
   HttpRequest as IHttpRequest,
   HttpResponse as IHttpResponse,
   MetadataBearer,
+  OperationSchema,
   ResponseMetadata,
   SerdeFunctions,
   ShapeDeserializer,


### PR DESCRIPTION
### Issue
related to https://github.com/smithy-lang/smithy-typescript/pull/1742 but does not depend on it

### Description
Removes usage of the class-based schemas to use static schema in tests.

### Testing
CI
