### PR TITLE
fix(xml-builder): move DOMParser init from module level to function call 

### DIFF
--- a/packages/xml-builder/src/xml-parser.browser.ts
+++ b/packages/xml-builder/src/xml-parser.browser.ts
@@ -1,4 +1,4 @@
-const parser = new DOMParser();
+let parser: DOMParser | undefined;
 
 /**
  * Cases where this differs from fast-xml-parser:
@@ -9,6 +9,10 @@ const parser = new DOMParser();
  * @internal
  */
 export function parseXML(xmlString: string): any {
+  if (!parser) {
+     parser = new DOMParser();
+  }
+
   const xmlDocument = parser.parseFromString(xmlString, "application/xml");
 
   if (xmlDocument.getElementsByTagName("parsererror").length > 0) {


### PR DESCRIPTION
Remove DOMParser initialization import side-effect.

### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7375

### Description
Prevents the entire lib from breaking in environments where global DOMParser is not available and XML parsing is not required.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
