### PR TITLE
chore(build): make circular imports a build error

### DIFF
--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -180,6 +180,16 @@ module.exports = class Inliner {
           },
         }),
       ],
+      onwarn(warning) {
+        /*
+        Circular imports are not an error in the language spec,
+        but reasoning about the program and bundling becomes easier.
+        For that reason let's avoid them.
+         */
+        if (warning.code === "CIRCULAR_DEPENDENCY") {
+          // throw Error(warning.message);
+        }
+      },
       external: (id) => {
         const relative = !!id.match(/^\.?\.?\//);
         if (!relative) {


### PR DESCRIPTION
### Issue
matches https://github.com/smithy-lang/smithy-typescript/pull/1748

### Description
Makes circular imports a build error for Rollup. This doesn't surface cycles created in areas not built using Rollup.

### Testing
CI

