### PR TITLE
fix(middleware-location-constraint): insert LocationConstraint only additively

### DIFF
--- a/packages/middleware-location-constraint/src/index.ts
+++ b/packages/middleware-location-constraint/src/index.ts
@@ -25,13 +25,10 @@ export function locationConstraintMiddleware(
       //After region config resolution, region is a Provider<string>
       const region = await options.region();
       if (!CreateBucketConfiguration?.LocationConstraint && !CreateBucketConfiguration?.Location) {
-        args = {
-          ...args,
-          input: {
-            ...args.input,
-            CreateBucketConfiguration: region === "us-east-1" ? undefined : { LocationConstraint: region },
-          },
-        };
+        if (region !== "us-east-1") {
+          args.input.CreateBucketConfiguration = args.input.CreateBucketConfiguration ?? {};
+          args.input.CreateBucketConfiguration.LocationConstraint = region;
+        }
       }
 
       return next(args);

--- a/packages/middleware-location-constraint/src/middleware-location-constraint.integ.spec.ts
+++ b/packages/middleware-location-constraint/src/middleware-location-constraint.integ.spec.ts
@@ -34,6 +34,32 @@ describe("middleware-location-constraint", () => {
       expect.hasAssertions();
     });
 
+    it("should populate other elements of the CreateBucketConfiguration regardless of Location or LocationConstraint", async () => {
+      const client = new S3({ region: "us-east-1" });
+
+      requireRequestsFrom(client).toMatch({
+        body(body = "") {
+          expect(body).toContain(
+            `<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Tags><Tag><Key>my-tag-key</Key><Value>my-tag-value</Value></Tag></Tags></CreateBucketConfiguration>`
+          );
+        },
+      });
+
+      await client.createBucket({
+        Bucket: "b",
+        CreateBucketConfiguration: {
+          Tags: [
+            {
+              Key: "my-tag-key",
+              Value: "my-tag-value",
+            },
+          ],
+        },
+      });
+
+      expect.hasAssertions();
+    });
+
     it("also not for S3 Express buckets", async () => {
       const client = new S3({ region: "us-west-2" });
 


### PR DESCRIPTION
### Issue
n/a

### Description
for S3 CreateBucket, we have functionality to automatically set `CreateBucketConfiguration.LocationConstraint`.
This PR makes this functionality purely additive, rather than potentially overwriting an existing object.

### Testing
new integration test

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
