### PR TITLE
fix(client-sts): propagate parent configuration to nested sts client

### DIFF
--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -105,7 +105,7 @@ export const getDefaultRoleAssumer = (
       const isCompatibleRequestHandler = !isH2(requestHandler);
 
       stsClient = new STSClient({
-        profile: stsOptions?.parentClientConfig?.profile,
+        ...stsOptions?.parentClientConfig,
         // A hack to make sts client uses the credential in current closure.
         credentialDefaultProvider: () => async () => closureSourceCreds,
         region: resolvedRegion,
@@ -166,7 +166,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
       const isCompatibleRequestHandler = !isH2(requestHandler);
 
       stsClient = new STSClient({
-        profile: stsOptions?.parentClientConfig?.profile,
+        ...stsOptions?.parentClientConfig,
         region: resolvedRegion,
         requestHandler: isCompatibleRequestHandler ? (requestHandler as any) : undefined,
         logger: logger as any,

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
@@ -165,11 +165,13 @@ describe("getDefaultRoleAssumer", () => {
     };
     const region = "some-region";
     const handler = new NodeHttpHandler();
+    const customUserAgent = [["custom-agent", "1.0.0"]];
     const roleAssumer = getDefaultRoleAssumer({
       parentClientConfig: {
         region,
         logger,
         requestHandler: handler,
+        customUserAgent,
       },
     });
     const params: AssumeRoleCommandInput = {
@@ -183,6 +185,7 @@ describe("getDefaultRoleAssumer", () => {
       logger,
       requestHandler: handler,
       region,
+      customUserAgent,
     });
   });
 
@@ -275,10 +278,12 @@ describe("getDefaultRoleAssumerWithWebIdentity", () => {
     };
     const region = "some-region";
     const handler = new NodeHttpHandler();
+    const customUserAgent = [["custom-agent", "1.0.0"]];
     const roleAssumerWithWebIdentity = getDefaultRoleAssumerWithWebIdentity({
       region,
       logger,
       requestHandler: handler,
+      customUserAgent,
     });
     const params: AssumeRoleWithWebIdentityCommandInput = {
       RoleArn: "arn:aws:foo",
@@ -291,6 +296,7 @@ describe("getDefaultRoleAssumerWithWebIdentity", () => {
       logger,
       requestHandler: handler,
       region,
+      customUserAgent,
     });
   });
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -102,7 +102,7 @@ export const getDefaultRoleAssumer = (
       const isCompatibleRequestHandler = !isH2(requestHandler);
 
       stsClient = new STSClient({
-        profile: stsOptions?.parentClientConfig?.profile,
+        ...stsOptions?.parentClientConfig,
         // A hack to make sts client uses the credential in current closure.
         credentialDefaultProvider: () => async () => closureSourceCreds,
         region: resolvedRegion,
@@ -163,7 +163,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
       const isCompatibleRequestHandler = !isH2(requestHandler);
 
       stsClient = new STSClient({
-        profile: stsOptions?.parentClientConfig?.profile,
+        ...stsOptions?.parentClientConfig,
         region: resolvedRegion,
         requestHandler: isCompatibleRequestHandler ? (requestHandler as any) : undefined,
         logger: logger as any,

--- a/packages/nested-clients/src/submodules/sts/defaultStsRoleAssumers.ts
+++ b/packages/nested-clients/src/submodules/sts/defaultStsRoleAssumers.ts
@@ -105,7 +105,7 @@ export const getDefaultRoleAssumer = (
       const isCompatibleRequestHandler = !isH2(requestHandler);
 
       stsClient = new STSClient({
-        profile: stsOptions?.parentClientConfig?.profile,
+        ...stsOptions?.parentClientConfig,
         // A hack to make sts client uses the credential in current closure.
         credentialDefaultProvider: () => async () => closureSourceCreds,
         region: resolvedRegion,
@@ -166,7 +166,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
       const isCompatibleRequestHandler = !isH2(requestHandler);
 
       stsClient = new STSClient({
-        profile: stsOptions?.parentClientConfig?.profile,
+        ...stsOptions?.parentClientConfig,
         region: resolvedRegion,
         requestHandler: isCompatibleRequestHandler ? (requestHandler as any) : undefined,
         logger: logger as any,


### PR DESCRIPTION
### Issue
#7439 Custom user-agent not propagated to nested STS client

### Description

Propagates all properties to the nested sts client, instead of just selected ones.

### Testing

Added `customUserAgent` to the existing tests, but I don't know how to run them.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
