### PR TITLE
fix(nested-clients): propagate clientConfig to inner STS client in role assumption

### DIFF
--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -15,7 +15,7 @@ import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSC
 /**
  * @public
  */
-export type STSRoleAssumerOptions = Pick<STSClientConfig, "logger" | "region" | "requestHandler"> & {
+export type STSRoleAssumerOptions = Pick<STSClientConfig, "logger" | "region" | "requestHandler" | "profile"> & {
   credentialProviderLogger?: Logger;
   parentClientConfig?: CredentialProviderOptions["parentClientConfig"];
 };
@@ -93,6 +93,7 @@ export const getDefaultRoleAssumer = (
     if (!stsClient) {
       const {
         logger = stsOptions?.parentClientConfig?.logger,
+        profile = stsOptions?.parentClientConfig?.profile,
         region,
         requestHandler = stsOptions?.parentClientConfig?.requestHandler,
         credentialProviderLogger,
@@ -106,6 +107,7 @@ export const getDefaultRoleAssumer = (
 
       stsClient = new STSClient({
         ...stsOptions,
+        profile,
         // A hack to make sts client uses the credential in current closure.
         credentialDefaultProvider: () => async () => closureSourceCreds,
         region: resolvedRegion,
@@ -154,6 +156,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     if (!stsClient) {
       const {
         logger = stsOptions?.parentClientConfig?.logger,
+        profile = stsOptions?.parentClientConfig?.profile,
         region,
         requestHandler = stsOptions?.parentClientConfig?.requestHandler,
         credentialProviderLogger,
@@ -167,6 +170,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
 
       stsClient = new STSClient({
         ...stsOptions,
+        profile,
         region: resolvedRegion,
         requestHandler: isCompatibleRequestHandler ? (requestHandler as any) : undefined,
         logger: logger as any,

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
@@ -165,13 +165,11 @@ describe("getDefaultRoleAssumer", () => {
     };
     const region = "some-region";
     const handler = new NodeHttpHandler();
-    const customUserAgent = [["custom-agent", "1.0.0"]];
     const roleAssumer = getDefaultRoleAssumer({
       parentClientConfig: {
         region,
         logger,
         requestHandler: handler,
-        customUserAgent,
       },
     });
     const params: AssumeRoleCommandInput = {
@@ -185,7 +183,6 @@ describe("getDefaultRoleAssumer", () => {
       logger,
       requestHandler: handler,
       region,
-      customUserAgent,
     });
   });
 
@@ -278,12 +275,10 @@ describe("getDefaultRoleAssumerWithWebIdentity", () => {
     };
     const region = "some-region";
     const handler = new NodeHttpHandler();
-    const customUserAgent = [["custom-agent", "1.0.0"]];
     const roleAssumerWithWebIdentity = getDefaultRoleAssumerWithWebIdentity({
       region,
       logger,
       requestHandler: handler,
-      customUserAgent,
     });
     const params: AssumeRoleWithWebIdentityCommandInput = {
       RoleArn: "arn:aws:foo",
@@ -296,7 +291,6 @@ describe("getDefaultRoleAssumerWithWebIdentity", () => {
       logger,
       requestHandler: handler,
       region,
-      customUserAgent,
     });
   });
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -12,7 +12,7 @@ import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSC
 /**
  * @public
  */
-export type STSRoleAssumerOptions = Pick<STSClientConfig, "logger" | "region" | "requestHandler"> & {
+export type STSRoleAssumerOptions = Pick<STSClientConfig, "logger" | "region" | "requestHandler" | "profile"> & {
   credentialProviderLogger?: Logger;
   parentClientConfig?: CredentialProviderOptions["parentClientConfig"];
 };
@@ -90,6 +90,7 @@ export const getDefaultRoleAssumer = (
     if (!stsClient) {
       const {
         logger = stsOptions?.parentClientConfig?.logger,
+        profile = stsOptions?.parentClientConfig?.profile,
         region,
         requestHandler = stsOptions?.parentClientConfig?.requestHandler,
         credentialProviderLogger,
@@ -103,6 +104,7 @@ export const getDefaultRoleAssumer = (
 
       stsClient = new STSClient({
         ...stsOptions,
+        profile,
         // A hack to make sts client uses the credential in current closure.
         credentialDefaultProvider: () => async () => closureSourceCreds,
         region: resolvedRegion,
@@ -151,6 +153,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     if (!stsClient) {
       const {
         logger = stsOptions?.parentClientConfig?.logger,
+        profile = stsOptions?.parentClientConfig?.profile,
         region,
         requestHandler = stsOptions?.parentClientConfig?.requestHandler,
         credentialProviderLogger,
@@ -164,6 +167,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
 
       stsClient = new STSClient({
         ...stsOptions,
+        profile,
         region: resolvedRegion,
         requestHandler: isCompatibleRequestHandler ? (requestHandler as any) : undefined,
         logger: logger as any,

--- a/packages/nested-clients/src/submodules/sts/defaultStsRoleAssumers.ts
+++ b/packages/nested-clients/src/submodules/sts/defaultStsRoleAssumers.ts
@@ -15,7 +15,7 @@ import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSC
 /**
  * @public
  */
-export type STSRoleAssumerOptions = Pick<STSClientConfig, "logger" | "region" | "requestHandler"> & {
+export type STSRoleAssumerOptions = Pick<STSClientConfig, "logger" | "region" | "requestHandler" | "profile"> & {
   credentialProviderLogger?: Logger;
   parentClientConfig?: CredentialProviderOptions["parentClientConfig"];
 };
@@ -93,6 +93,7 @@ export const getDefaultRoleAssumer = (
     if (!stsClient) {
       const {
         logger = stsOptions?.parentClientConfig?.logger,
+        profile = stsOptions?.parentClientConfig?.profile,
         region,
         requestHandler = stsOptions?.parentClientConfig?.requestHandler,
         credentialProviderLogger,
@@ -106,6 +107,7 @@ export const getDefaultRoleAssumer = (
 
       stsClient = new STSClient({
         ...stsOptions,
+        profile,
         // A hack to make sts client uses the credential in current closure.
         credentialDefaultProvider: () => async () => closureSourceCreds,
         region: resolvedRegion,
@@ -154,6 +156,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     if (!stsClient) {
       const {
         logger = stsOptions?.parentClientConfig?.logger,
+        profile = stsOptions?.parentClientConfig?.profile,
         region,
         requestHandler = stsOptions?.parentClientConfig?.requestHandler,
         credentialProviderLogger,
@@ -167,6 +170,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
 
       stsClient = new STSClient({
         ...stsOptions,
+        profile,
         region: resolvedRegion,
         requestHandler: isCompatibleRequestHandler ? (requestHandler as any) : undefined,
         logger: logger as any,


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7439

### Description
propagate clientConfig to inner STS client

### Testing
- [x] new integration tests
- [x] CI

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

