### PR TITLE
chore(tests): add retry mechanism for e2e tests

### DIFF
--- a/tests/canary/canary.js
+++ b/tests/canary/canary.js
@@ -77,6 +77,7 @@ async function retry(fn, attempts = 3) {
       return await fn();
     } catch (error) {
       if (i === attempts - 1) throw error;
+      console.log(`Retry ${i + 1}/${attempts} failed, retrying...`);
       await new Promise((resolve) => setTimeout(resolve, 2000));
     }
   }


### PR DESCRIPTION
### Issue
Internal JS-6108

### Description
Adds retry mechanism to handle `503 resource unavailable` errors when Verdaccio contacts npm registry during package publishing. Retries up to 3 times with 2s delays.


### Testing
Locally
`yarn test:e2e`


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
