### PR TITLE
fix(credential-provider-web-identity): make fromTokenFile aware of runtime caller client

### DIFF
--- a/packages/credential-provider-web-identity/src/fromTokenFile.ts
+++ b/packages/credential-provider-web-identity/src/fromTokenFile.ts
@@ -1,8 +1,8 @@
 import { setCredentialFeature } from "@aws-sdk/core/client";
-import { AttributedAwsCredentialIdentity, CredentialProviderOptions } from "@aws-sdk/types";
+import type { AttributedAwsCredentialIdentity, CredentialProviderOptions } from "@aws-sdk/types";
+import { AwsIdentityProperties, RuntimeConfigAwsCredentialIdentityProvider } from "@aws-sdk/types/src";
 import { CredentialsProviderError } from "@smithy/property-provider";
 import { externalDataInterceptor } from "@smithy/shared-ini-file-loader";
-import type { AwsCredentialIdentityProvider } from "@smithy/types";
 import { readFileSync } from "fs";
 
 import { fromWebToken, FromWebTokenInit } from "./fromWebToken";
@@ -29,8 +29,8 @@ export interface FromTokenFileInit
  * Represents OIDC credentials from a file on disk.
  */
 export const fromTokenFile =
-  (init: FromTokenFileInit = {}): AwsCredentialIdentityProvider =>
-  async () => {
+  (init: FromTokenFileInit = {}): RuntimeConfigAwsCredentialIdentityProvider =>
+  async (awsIdentityProperties?: AwsIdentityProperties) => {
     init.logger?.debug("@aws-sdk/credential-provider-web-identity - fromTokenFile");
     const webIdentityTokenFile = init?.webIdentityTokenFile ?? process.env[ENV_TOKEN_FILE];
     const roleArn = init?.roleArn ?? process.env[ENV_ROLE_ARN];
@@ -49,7 +49,7 @@ export const fromTokenFile =
         readFileSync(webIdentityTokenFile, { encoding: "ascii" }),
       roleArn,
       roleSessionName,
-    })();
+    })(awsIdentityProperties);
 
     if (webIdentityTokenFile === process.env[ENV_TOKEN_FILE]) {
       setCredentialFeature(credentials, "CREDENTIALS_ENV_VARS_STS_WEB_ID_TOKEN", "h");


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7452

### Description
turns `fromTokenFile` into a runtime aware credential provider for improved inference of the intended STS region

### Testing
new integ test

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
