### PR TITLE
fix(middleware-expect-continue): Remove debug logging in packages/middleware-expect-continue/src/index.ts

### DIFF
--- a/packages/middleware-expect-continue/src/index.ts
+++ b/packages/middleware-expect-continue/src/index.ts
@@ -36,11 +36,6 @@ export function addExpectContinueMiddleware(options: PreviouslyResolved): BuildM
             const bodyLength =
               Number(request.headers?.["content-length"]) ?? options.bodyLengthChecker?.(request.body) ?? Infinity;
             sendHeader = bodyLength >= options.expectContinueHeader;
-            console.log({
-              sendHeader,
-              bodyLength,
-              threshold: options.expectContinueHeader,
-            });
           } catch (e) {}
         } else {
           sendHeader = !!options.expectContinueHeader;


### PR DESCRIPTION
### Issue
None associated with this issue

### Description
Looks like the latest release of the `@aws-sdk/middleware-expect-continue` package (v3.916.0) accidentally left a debug console.log statement within its changes. Any possibility to get this PR merged, and a new release cut? As-is, this debug logging is polluting the stdout of a handful of my projects (and I imagine a bunch of other people are impacted by this as well).

https://github.com/aws/aws-sdk-js-v3/blob/1dc88bc5e7afb5f314fa8a4425746cefacd5e0e6/packages/middleware-expect-continue/src/index.ts#L39-L43

Appears the debug logging was added in: https://github.com/aws/aws-sdk-js-v3/pull/7450

### Testing
None

### Additional context
None

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
