### PR TITLE
chore: add exception to eslint rule for import paths

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,7 @@ module.exports = {
           {
             patterns: [
               {
-                group: ["*src*", "*dist-*"],
+                group: ["*src*", "*dist-*", "!*csrc*"],
               },
             ],
           },


### PR DESCRIPTION
### Issue
n/a

### Description
Add an exception to the eslint rule banning import paths so it doesn't block

```js
import {
  CreateCertificateFromCsrCommand,
  CreateCertificateFromCsrCommandInput,
  CreateCertificateFromCsrCommandOutput,
} from "./commands/CreateCertificateFromCsrCommand";
```

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
