### PR TITLE
chore(core/protocols): make error lookup in runtime protocol consistent with existing codegen

### DIFF
--- a/packages/core/src/submodules/protocols/ProtocolLib.ts
+++ b/packages/core/src/submodules/protocols/ProtocolLib.ts
@@ -1,4 +1,4 @@
-import { ErrorSchema, NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
+import { NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
 import type { HttpResponse as IHttpResponse, MetadataBearer, ResponseMetadata, StaticErrorSchema } from "@smithy/types";
 
 /**

--- a/packages/core/src/submodules/protocols/query/AwsQueryProtocol.ts
+++ b/packages/core/src/submodules/protocols/query/AwsQueryProtocol.ts
@@ -158,10 +158,15 @@ export class AwsQueryProtocol extends RpcProtocol {
       response,
       errorData,
       metadata,
-      (registry: TypeRegistry, errorName: string) =>
-        registry.find(
-          (schema) => (NormalizedSchema.of(schema).getMergedTraits().awsQueryError as any)?.[0] === errorName
-        ) as StaticErrorSchema
+      (registry: TypeRegistry, errorName: string) => {
+        try {
+          return registry.getSchema(errorName) as StaticErrorSchema;
+        } catch (e) {
+          return registry.find(
+            (schema) => (NormalizedSchema.of(schema).getMergedTraits().awsQueryError as any)?.[0] === errorName
+          ) as StaticErrorSchema;
+        }
+      }
     );
 
     const ns = NormalizedSchema.of(errorSchema);


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/issues/1600

### Description
prerelease fixes

- after parsing the error identifier in AWS Query runtime protocol, attempt a direct lookup of the error shape by name first, before checking for error shapes where the awsQueryError.Code matches the error identifier. 
  - this is consistent with how MICG error deserialization would work once awsQueryCompat is enabled

### Testing
passes the existing cloudwatch querycompat e2e test, and CI


### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
