### PR TITLE
test(core/protocols): add shape serde perf baselines

### DIFF
--- a/packages/core/src/submodules/protocols/cbor/CborCodec.spec.ts
+++ b/packages/core/src/submodules/protocols/cbor/CborCodec.spec.ts
@@ -36,7 +36,7 @@ describe("performance baseline indicator", () => {
     /**
      * No assertion here.
      * In the initial dual-pass implementation,
-     * par time is 0 to 10ms for up to 200746 bytes of CBOR. Up to 30 kb/ms. (kuhe's computer)
+     * par time is 0 to 23ms for up to 381014 bytes of CBOR. Up to 15 kb/ms. (kuhe's computer)
      */
     console.log("CborShapeSerializer performance timings", timings);
   });
@@ -65,8 +65,8 @@ describe("performance baseline indicator", () => {
     /**
      * No assertion here.
      * In the initial dual-pass implementation,
-     * par time is 0 to 3ms for up to 100394 bytes of CBOR. Up to 45 kb/ms. (kuhe's computer)
+     * par time is 0 to 9ms for up to 190550 bytes of CBOR. Up to 23 kb/ms. (kuhe's computer)
      */
     console.log("CborShapeDeserializer performance timings", timings);
   });
-});
+}, 30_000);

--- a/packages/core/src/submodules/protocols/json/JsonShapeDeserializer.spec.ts
+++ b/packages/core/src/submodules/protocols/json/JsonShapeDeserializer.spec.ts
@@ -190,9 +190,9 @@ describe(JsonShapeDeserializer.name, () => {
       /**
        * No assertion here.
        * In the initial dual-pass implementation,
-       * par time is 0 to 10ms for up to 135224 chars of JSON. Up to 20 kb/ms. (kuhe's computer)
+       * par time is 0 to 25ms for up to 288899 chars of JSON. Up to 13 kb/ms. (kuhe's computer)
        */
       console.log("JsonShapeDeserializer performance timings", timings);
     });
-  });
+  }, 30_000);
 });

--- a/packages/core/src/submodules/protocols/json/JsonShapeSerializer.ts
+++ b/packages/core/src/submodules/protocols/json/JsonShapeSerializer.ts
@@ -102,10 +102,7 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
       if (ns === this.rootSchema) {
         return value;
       }
-      if (!this.serdeContext?.base64Encoder) {
-        return toBase64(value);
-      }
-      return this.serdeContext?.base64Encoder(value);
+      return (this.serdeContext?.base64Encoder ?? toBase64)(value);
     }
 
     if ((ns.isTimestampSchema() || ns.isDocumentSchema()) && value instanceof Date) {

--- a/packages/core/src/submodules/protocols/json/experimental/SinglePassJsonShapeSerializer.ts
+++ b/packages/core/src/submodules/protocols/json/experimental/SinglePassJsonShapeSerializer.ts
@@ -1,0 +1,168 @@
+import { determineTimestampFormat } from "@smithy/core/protocols";
+import { NormalizedSchema } from "@smithy/core/schema";
+import { dateToUtcString, generateIdempotencyToken, LazyJsonString, NumericValue } from "@smithy/core/serde";
+import type {
+  Schema,
+  ShapeSerializer,
+  TimestampDateTimeSchema,
+  TimestampEpochSecondsSchema,
+  TimestampHttpDateSchema,
+} from "@smithy/types";
+import { toBase64 } from "@smithy/util-base64";
+
+import { SerdeContextConfig } from "../../ConfigurableSerdeContext";
+import type { JsonSettings } from "../JsonCodec";
+
+/**
+ * This implementation uses single-pass JSON serialization with JS code instead of
+ * JSON.stringify.
+ *
+ * It isn't significantly faster than dual-pass ending with native JSON.stringify
+ * that I would want to use it. It seems to be barely faster in some mid-range object
+ * sizes but slower on the high end.
+ *
+ * @internal
+ */
+export class SinglePassJsonShapeSerializer extends SerdeContextConfig implements ShapeSerializer<string> {
+  private buffer: any;
+  private rootSchema: NormalizedSchema | undefined;
+
+  public constructor(public readonly settings: JsonSettings) {
+    super();
+  }
+
+  public write(schema: Schema, value: unknown): void {
+    this.rootSchema = NormalizedSchema.of(schema);
+    this.buffer = this.writeObject(this.rootSchema, value);
+  }
+
+  /**
+   * @internal
+   */
+  public writeDiscriminatedDocument(schema: Schema, value: unknown): void {
+    this.write(schema, value);
+    if (typeof this.buffer === "object") {
+      this.buffer.__type = NormalizedSchema.of(schema).getName(true);
+    }
+  }
+
+  public flush(): string {
+    this.rootSchema = undefined;
+
+    return this.buffer;
+  }
+
+  private writeObject(schema: Schema, value: unknown): string {
+    if (value == undefined) {
+      return "";
+    }
+
+    let b = "";
+    const ns = NormalizedSchema.of(schema);
+    const sparse = !!ns.getMergedTraits().sparse;
+
+    if (Array.isArray(value) && (ns.isDocumentSchema() || ns.isListSchema())) {
+      b += "[";
+      for (let i = 0; i < value.length; ++i) {
+        const item = value[i];
+        if (item != null || sparse) {
+          b += this.writeValue(ns.getValueSchema(), item);
+          b += ",";
+        }
+      }
+    } else if (ns.isStructSchema()) {
+      b += "{";
+      for (const [name, member] of ns.structIterator()) {
+        const item = (value as any)[name];
+        const targetKey = this.settings.jsonName ? member.getMergedTraits().jsonName ?? name : name;
+        const serializableValue = this.writeValue(member, item);
+        if (item != null || member.isIdempotencyToken()) {
+          b += `"${targetKey}":${serializableValue}`;
+          b += ",";
+        }
+      }
+    } else if (ns.isMapSchema() || ns.isDocumentSchema()) {
+      b += "{";
+      for (const [k, v] of Object.entries(value)) {
+        if (v != null || sparse) {
+          b += `"${k}":${this.writeValue(ns, v)}`;
+          b += ",";
+        }
+      }
+    }
+
+    if (b[b.length - 1] === ",") {
+      b = b.slice(0, -1);
+    }
+    if (b[0] === "[") {
+      b += "]";
+    }
+    if (b[0] === "{") {
+      b += "}";
+    }
+    return b;
+  }
+
+  private writeValue(schema: Schema, value: unknown): string {
+    const isObject = value !== null && typeof value === "object";
+
+    const ns = NormalizedSchema.of(schema);
+    const quote = (_: string) => `"${_}"`;
+
+    if (
+      (ns.isBlobSchema() && (value instanceof Uint8Array || typeof value === "string")) ||
+      (ns.isDocumentSchema() && value instanceof Uint8Array)
+    ) {
+      return quote((this.serdeContext?.base64Encoder ?? toBase64)(value));
+    }
+
+    if ((ns.isTimestampSchema() || ns.isDocumentSchema()) && value instanceof Date) {
+      const format = determineTimestampFormat(ns, this.settings);
+      switch (format) {
+        case 5 satisfies TimestampDateTimeSchema:
+          return quote(value.toISOString().replace(".000Z", "Z"));
+        case 6 satisfies TimestampHttpDateSchema:
+          return quote(dateToUtcString(value));
+        case 7 satisfies TimestampEpochSecondsSchema:
+          return String(value.getTime() / 1000);
+        default:
+          console.warn("Missing timestamp format, using epoch seconds", value);
+          return String(value.getTime() / 1000);
+      }
+    }
+
+    if (ns.isNumericSchema() && typeof value === "number") {
+      if (Math.abs(value) === Infinity || isNaN(value)) {
+        return quote(String(value));
+      }
+    }
+
+    if (ns.isStringSchema()) {
+      if (typeof value === "undefined" && ns.isIdempotencyToken()) {
+        return quote(generateIdempotencyToken());
+      }
+
+      if (typeof value === "string") {
+        const mediaType = ns.getMergedTraits().mediaType;
+
+        if (mediaType) {
+          const isJson = mediaType === "application/json" || mediaType.endsWith("+json");
+          if (isJson) {
+            return quote(LazyJsonString.from(value).toString());
+          }
+        }
+      }
+    }
+
+    if (value instanceof NumericValue) {
+      // ns can be BigDecimal or Document.
+      return value.string;
+    }
+
+    if (isObject) {
+      return this.writeObject(ns, value);
+    }
+
+    return typeof value === "string" ? quote(value) : String(value);
+  }
+}

--- a/packages/core/src/submodules/protocols/test-schema.spec.ts
+++ b/packages/core/src/submodules/protocols/test-schema.spec.ts
@@ -41,13 +41,28 @@ export const nestingWidget: StaticStructureSchema = [
   "ns",
   "Struct",
   0,
-  ["string", "date", "blob", "nested"],
-  [0 satisfies StringSchema, 4 satisfies TimestampDefaultSchema, 21 satisfies BlobSchema, () => nestingWidget],
+  ["string", "date", "blob", "number", "list", "map", "nested"],
+  [
+    0 satisfies StringSchema,
+    4 satisfies TimestampDefaultSchema,
+    21 satisfies BlobSchema,
+    1 satisfies NumericSchema,
+    64 | 1,
+    128 | 0,
+    () => nestingWidget,
+  ],
 ];
 
 export function createNestingWidget(nesting = 0) {
   const object = {
     string: "hello, world",
+    number: 100000,
+    list: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    map: {
+      a: "A",
+      b: "B",
+      c: "C",
+    },
     date: new Date(0),
     blob: new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]),
     nested: undefined,

--- a/packages/core/src/submodules/protocols/xml/XmlShapeDeserializer.spec.ts
+++ b/packages/core/src/submodules/protocols/xml/XmlShapeDeserializer.spec.ts
@@ -46,7 +46,7 @@ describe(XmlShapeDeserializer.name, () => {
       const strings = [];
 
       // warmup
-      for (let i = 0; i < 13; ++i) {
+      for (let i = 0; i < 12; ++i) {
         const o = createNestingWidget(2 ** i);
         serializer.write(nestingWidget, o);
         const json = serializer.flush();
@@ -65,9 +65,9 @@ describe(XmlShapeDeserializer.name, () => {
       /**
        * No assertion here.
        * In the initial dual-pass implementation,
-       * par time is 0 to 45ms for up to 426106 chars of XML. Up to 10 kb/ms. (kuhe's computer)
+       * par time is 0 to 187ms for up to 905676 chars of XML. Up to 10 kb/ms. (kuhe's computer)
        */
       console.log("XmlShapeDeserializer performance timings", timings);
     });
-  });
+  }, 30_000);
 });

--- a/packages/core/src/submodules/protocols/xml/XmlShapeSerializer.spec.ts
+++ b/packages/core/src/submodules/protocols/xml/XmlShapeSerializer.spec.ts
@@ -70,9 +70,9 @@ describe(XmlShapeSerializer.name, () => {
       /**
        * No assertion here.
        * In the initial dual-pass implementation,
-       * par time is 0 to 170ms for up to 426106 chars of XML. Up to 25 kb/ms. (kuhe's computer)
+       * par time is 0 to 600ms for up to 1810892 chars of XML. Up to 28 kb/ms. (kuhe's computer)
        */
       console.log("XmlShapeSerializer performance timings", timings);
     });
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
### Issue
n/a

### Description
Adds unit tests that give information about kb/sec throughput in some of the shape serializers and deserializers.

### Testing
CI - new unit tests