### PR TITLE
test(client-dynamodb): e2e test for type registry based error handling

### DIFF
--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -11,7 +11,9 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "extract:docs": "api-extractor run --local",
-    "generate:client": "node ../../scripts/generate-clients/single-service --solo dynamodb"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo dynamodb",
+    "test:e2e": "yarn g:vitest run -c vitest.config.e2e.mts",
+    "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.mts"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dynamodb/test/DynamoDB.e2e.spec.ts
+++ b/clients/client-dynamodb/test/DynamoDB.e2e.spec.ts
@@ -1,0 +1,39 @@
+import { DynamoDB, ResourceNotFoundException } from "@aws-sdk/client-dynamodb";
+import { TypeRegistry } from "@smithy/core/schema";
+import { StaticErrorSchema } from "@smithy/types";
+import { describe, expect, test as it } from "vitest";
+
+describe(DynamoDB.name, () => {
+  const ddb = new DynamoDB({
+    region: "us-west-2",
+  });
+
+  it("throws an error when table is not found", async () => {
+    const error = await ddb
+      .describeTable({
+        TableName: "DynamoDB",
+      })
+      .catch((e) => e);
+
+    delete error.$response;
+
+    expect(error).toMatchObject({
+      message: "Requested resource not found: Table: DynamoDB not found",
+      $fault: "client",
+      $metadata: {
+        attempts: 1,
+        httpStatusCode: 400,
+      },
+      name: "ResourceNotFoundException",
+    });
+
+    expect(error).toBeInstanceOf(ResourceNotFoundException);
+
+    const registry = TypeRegistry.for("com.amazonaws.dynamodb");
+    const errorSchema = registry.getSchema("ResourceNotFoundException") as StaticErrorSchema;
+    expect(errorSchema).toBeDefined();
+    const errorCtor = registry.getErrorCtor(errorSchema);
+
+    expect(errorCtor).toBe(ResourceNotFoundException);
+  });
+});

--- a/clients/client-dynamodb/vitest.config.e2e.mts
+++ b/clients/client-dynamodb/vitest.config.e2e.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["**/*.browser.e2e.spec.ts"],
+    include: ["**/*.e2e.spec.ts"],
+    environment: "node",
+  },
+  mode: "development",
+});


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/issues/1600

this is a test to augment https://github.com/aws/aws-sdk-js-v3/pull/7483

### Testing
adds e2e test in DynamoDB for error handling via schema/type registry

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
