### PR TITLE
fix(core/protocols): rest-json default request body conditions

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocolConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocolConfig.java
@@ -37,7 +37,11 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public final class AddProtocolConfig implements TypeScriptIntegration {
 
-    public AddProtocolConfig() {
+    static {
+        init();
+    }
+
+    static void init() {
         List<ShapeId> allowed = List.of(
             AwsJson1_0Trait.ID,
             AwsJson1_1Trait.ID,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -61,7 +61,6 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpSigningPlugin;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
-import software.amazon.smithy.typescript.codegen.schema.SchemaGenerationAllowlist;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SetUtils;

--- a/packages/middleware-sdk-glacier/src/account-id-default.ts
+++ b/packages/middleware-sdk-glacier/src/account-id-default.ts
@@ -11,7 +11,7 @@ export function accountIdDefaultMiddleware(): InitializeMiddleware<any, any> {
   return <Output extends MetadataBearer>(next: InitializeHandler<any, Output>): InitializeHandler<any, Output> =>
     async (args: InitializeHandlerArguments<any>): Promise<InitializeHandlerOutput<Output>> => {
       const { input } = args;
-      if (input.accountId === undefined) {
+      if (!input.accountId) {
         input.accountId = "-";
       }
       return next({ ...args, input });

--- a/private/aws-protocoltests-restjson-glacier/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson-glacier/test/functional/restjson1.spec.ts
@@ -282,7 +282,7 @@ it("GlacierChecksums:Request", async () => {
  * hyphen (-) to indicate the current account. This should be default
  * behavior if the customer provides a null or empty string.
  */
-it.skip("GlacierAccountId:Request", async () => {
+it("GlacierAccountId:Request", async () => {
   const client = new GlacierClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-restjson-schema-glacier/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson-schema-glacier/test/functional/restjson1.spec.ts
@@ -282,7 +282,7 @@ it("GlacierChecksums:Request", async () => {
  * hyphen (-) to indicate the current account. This should be default
  * behavior if the customer provides a null or empty string.
  */
-it.skip("GlacierAccountId:Request", async () => {
+it("GlacierAccountId:Request", async () => {
   const client = new GlacierClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-restjson-schema/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson-schema/test/functional/restjson1.spec.ts
@@ -7030,7 +7030,7 @@ it("RestJsonNoInputAndOutputNoPayload:Response", async () => {
 /**
  * Do not send null values, but do send empty strings and empty lists over the wire in headers
  */
-it.skip("RestJsonNullAndEmptyHeaders:Request", async () => {
+it("RestJsonNullAndEmptyHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -7030,7 +7030,7 @@ it("RestJsonNoInputAndOutputNoPayload:Response", async () => {
 /**
  * Do not send null values, but do send empty strings and empty lists over the wire in headers
  */
-it.skip("RestJsonNullAndEmptyHeaders:Request", async () => {
+it("RestJsonNullAndEmptyHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-restxml-schema/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml-schema/test/functional/restxml.spec.ts
@@ -3838,7 +3838,7 @@ it("FlatNestedXmlMapResponse:Response", async () => {
 /**
  * Serializes nested XML Maps in requests that have xmlName on members
  */
-it.skip("NestedXmlMapWithXmlNameSerializes:Request", async () => {
+it("NestedXmlMapWithXmlNameSerializes:Request", async () => {
   const client = new RestXmlProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -4090,7 +4090,7 @@ it("NoInputAndOutput:Response", async () => {
 /**
  * Do not send null values, but do send empty strings and empty lists over the wire in headers
  */
-it.skip("NullAndEmptyHeaders:Request", async () => {
+it("NullAndEmptyHeaders:Request", async () => {
   const client = new RestXmlProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
@@ -3838,7 +3838,7 @@ it("FlatNestedXmlMapResponse:Response", async () => {
 /**
  * Serializes nested XML Maps in requests that have xmlName on members
  */
-it.skip("NestedXmlMapWithXmlNameSerializes:Request", async () => {
+it("NestedXmlMapWithXmlNameSerializes:Request", async () => {
   const client = new RestXmlProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -4090,7 +4090,7 @@ it("NoInputAndOutput:Response", async () => {
 /**
  * Do not send null values, but do send empty strings and empty lists over the wire in headers
  */
-it.skip("NullAndEmptyHeaders:Request", async () => {
+it("NullAndEmptyHeaders:Request", async () => {
   const client = new RestXmlProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7500

### Description
This makes the preconditions for setting a default REST JSON request body of `{}` more precise and consistent with older behavior.

This relates to operations with httpPayload bindings where a falsy non-byte-array value is being used to represent an empty byte array.

### Testing
- [x] add unit tests
- [x] re-enabled some backlogged protocol tests for REST JSON to increase coverage 

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?


