### PR TITLE
chore: upgrade aws-lambda-invoke-store

### DIFF
--- a/packages/middleware-recursion-detection/package.json
+++ b/packages/middleware-recursion-detection/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "@aws/lambda-invoke-store": "^0.1.1",
+    "@aws/lambda-invoke-store": "^0.2.0",
     "@smithy/protocol-http": "^5.3.5",
     "@smithy/types": "^4.9.0",
     "tslib": "^2.6.2"

--- a/packages/middleware-recursion-detection/src/recursionDetectionMiddleware.ts
+++ b/packages/middleware-recursion-detection/src/recursionDetectionMiddleware.ts
@@ -1,7 +1,5 @@
 // @ts-ignore
 import { InvokeStore } from "@aws/lambda-invoke-store";
-// eslint-disable-next-line no-restricted-imports
-import type { InvokeStore as InvokeStoreType } from "@aws/lambda-invoke-store/dist-types/invoke-store.d";
 import { HttpRequest } from "@smithy/protocol-http";
 import {
   BuildHandler,
@@ -37,7 +35,8 @@ export const recursionDetectionMiddleware =
     const functionName = process.env[ENV_LAMBDA_FUNCTION_NAME];
 
     const traceIdFromEnv = process.env[ENV_TRACE_ID];
-    const traceIdFromInvokeStore = (InvokeStore as typeof InvokeStoreType).getXRayTraceId();
+    const invokeStore = await InvokeStore.getInstanceAsync();
+    const traceIdFromInvokeStore = invokeStore?.getXRayTraceId();
     const traceId = traceIdFromInvokeStore ?? traceIdFromEnv;
 
     const nonEmptyString = (str: unknown): str is string => typeof str === "string" && str.length > 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -23448,7 +23448,7 @@ __metadata:
   resolution: "@aws-sdk/middleware-recursion-detection@workspace:packages/middleware-recursion-detection"
   dependencies:
     "@aws-sdk/types": "npm:*"
-    "@aws/lambda-invoke-store": "npm:^0.1.1"
+    "@aws/lambda-invoke-store": "npm:^0.2.0"
     "@smithy/protocol-http": "npm:^5.3.5"
     "@smithy/types": "npm:^4.9.0"
     "@tsconfig/recommended": "npm:1.0.1"
@@ -24371,10 +24371,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws/lambda-invoke-store@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "@aws/lambda-invoke-store@npm:0.1.1"
-  checksum: 10c0/27c90d9af7cca7ff4870e87dc303516e6d09ebe18f5fa13813397cd6a37fd26cf3ff1715469e3c5323fea0404a55c110f35e21bcc3ea595a4f6ba6406ea1f103
+"@aws/lambda-invoke-store@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@aws/lambda-invoke-store@npm:0.2.0"
+  checksum: 10c0/ff37fe5d7c3b59afffa4591f9be89c5b53b808fe9dd85dd02d324bbd2b8f11366de481569284b9a5b65221cf17ba254730085aa00d6a3d1a57d9ab08a3a39879
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
Bump `@aws/lambda-invoke-store` to `0.2.0`.
Fix breaking changes and update tests

### Testing
`yarn g:vitest run packages/middleware-recursion-detection/src/recursionDetectionMiddleware.spec.ts`

```
 RUN  v3.2.4 /workplace/maxday/aws-sdk-js-v3

 ✓ packages/middleware-recursion-detection/src/recursionDetectionMiddleware.spec.ts (8 tests) 7ms
   ✓ recursionDetectionMiddleware > sets X-Amzn-Trace-Id header when function name and > trace id environmental variables is set 2ms
   ✓ recursionDetectionMiddleware > sets X-Amzn-Trace-Id header when function name and > trace id value is set in InvokeStore 1ms
   ✓ recursionDetectionMiddleware > sets X-Amzn-Trace-Id header when function name and > favors trace id value from InvokeStore over that from env variable 0ms
   ✓ recursionDetectionMiddleware > should NOT set X-Amzn-Trace-Id header when function name environmental variable is NOT set 0ms
   ✓ recursionDetectionMiddleware > should NOT set X-Amzn-Trace-Id header when the header is already set 0ms
   ✓ recursionDetectionMiddleware > should NOT set X-Amzn-Trace-Id header when the header is already set with some other casing 0ms
   ✓ recursionDetectionMiddleware > should NOT set X-Amzn-Trace-Id header when the header is already set with alternating case 1ms
   ✓ recursionDetectionMiddleware > should NOT set X-Amzn-Trace-Id header when the header is already set with all uppercase 0ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  01:17:16
   Duration  426ms (transform 45ms, setup 0ms, collect 55ms, tests 7ms, environment 0ms, prepare 97ms)
```

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
