### PR TITLE
fix(cloudfront-signer): skip extended encoding for query parameters in the base url

### DIFF
--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -812,7 +812,7 @@ describe("getSignedUrl- when signing a URL with a date range", () => {
 });
 
 describe("url component encoding", () => {
-  it("should use extended encoding for query params in the base URL", () => {
+  it("should use standard encoding for query params in the base URL", () => {
     const url =
       "https://d111111abcdef8.cloudfront.net/private-content/private.jpeg?q=!@#$%^&*()&image-description=aws's image&'''&!()=5";
     const signedUrl = getSignedUrl({
@@ -823,7 +823,7 @@ describe("url component encoding", () => {
     });
 
     const target =
-      "https://d111111abcdef8.cloudfront.net/private-content/private.jpeg?q=%21%40%23%24%25%5E&%2A%28%29=&image-description=aws%27s%20image&%27%27%27=&%21%28%29=5";
+      "https://d111111abcdef8.cloudfront.net/private-content/private.jpeg?q=!%40%23%24%25%5E&*()=&image-description=aws's%20image&'''=&!()=5";
 
     expect(signedUrl.slice(0, target.length)).toBe(target);
   });

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -147,7 +147,7 @@ export function getSignedUrl({
     if (url.includes("?")) {
       const [hostAndPath, query] = url.split("?");
       const params = [...new URLSearchParams(query).entries()]
-        .map(([key, value]) => `${extendedEncodeURIComponent(key)}=${extendedEncodeURIComponent(value)}`)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
         .join("&");
       return `${hostAndPath}?${params}`;
     }


### PR DESCRIPTION
### Issue

#7470
https://github.com/aws/aws-sdk-js-v3/pull/7437#issuecomment-3467437014

### Description

using the extended encoding encodes characters that do not need to be encoded, resulting in invalid signed urls

### Testing

Updated the unit test
Manually tested against an internal app that is currently broken with the latest version

### Additional context
I was not sure if the extended encoding is important or not for the cloudfront parameters that get added, so I've left it there ([line 143](https://github.com/aws/aws-sdk-js-v3/blob/a617d7cd813082fed8f70ea69e1735c466548f3a/packages/cloudfront-signer/src/sign.ts#L143)), I suspect though that it's unnecessary but have no idea how to confirm


### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`). (N/A)
- [x] If you wrote E2E tests, are they resilient to concurrent I/O? (N/A)
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package? (N/A)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
