### PR TITLE
test: increase beforeAll hook timeouts

### DIFF
--- a/clients/client-cognito-identity/test/e2e/CognitoIdentity.e2e.spec.ts
+++ b/clients/client-cognito-identity/test/e2e/CognitoIdentity.e2e.spec.ts
@@ -1,6 +1,6 @@
+import { getE2eTestResources } from "@aws-sdk/aws-util-test/src";
 import { beforeAll, describe, expect, test as it } from "vitest";
 
-import { getE2eTestResources } from "@aws-sdk/aws-util-test/src";
 import { CognitoIdentity } from "../../src/index";
 
 describe("@aws-sdk/client-cognito-identity", () => {
@@ -20,7 +20,7 @@ describe("@aws-sdk/client-cognito-identity", () => {
     unAuthClient = new CognitoIdentity({
       region,
     });
-  });
+  }, 60_000);
 
   it("should successfully fetch Id and get credentials", async () => {
     // Test getId()

--- a/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
+++ b/packages/middleware-sdk-s3/src/region-redirect-middleware.e2e.spec.ts
@@ -54,7 +54,7 @@ describe("S3 Global Client Test", () => {
       })
     );
     await Promise.all(bucketNames.map((bucketName, index) => s3Clients[index].headBucket({ Bucket: bucketName })));
-  });
+  }, 60_000);
 
   afterAll(async () => {
     await Promise.all(bucketNames.map((bucketName, index) => deleteBucket(s3Clients[index], bucketName)));


### PR DESCRIPTION
### Issue
P337039454, P337091181

### Description
increase hook timeouts. Despite timeouts existing at the top describe level, the beforeAll hooks were timing out at 10s. 