### PR TITLE
test(e2e): skip S3 Vectors can put vectors

### DIFF
--- a/clients/client-s3vectors/test/S3Vectors.e2e.spec.ts
+++ b/clients/client-s3vectors/test/S3Vectors.e2e.spec.ts
@@ -48,6 +48,7 @@ describe(
       }
     });
 
+    // todo(s3): this is a temporary issue (D349093610), re-enable this test later.
     it.skip("can put vectors", async () => {
       const texts = [
         "Santa Bear is a bear who wears a Santa outfit.",


### PR DESCRIPTION
### Issue
Internal JS-6389

### Description
Skips S3 Vectors 'can put vectors' test, as it's blocking release

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
