### PR TITLE
test(core/protocols): add Query error deserialization unit test

### DIFF
--- a/packages/core/src/submodules/protocols/query/AwsQueryProtocol.spec.ts
+++ b/packages/core/src/submodules/protocols/query/AwsQueryProtocol.spec.ts
@@ -1,10 +1,26 @@
+import { TypeRegistry } from "@smithy/core/schema";
 import { HttpResponse } from "@smithy/protocol-http";
+import { ServiceException, ServiceExceptionOptions } from "@smithy/smithy-client";
+import { StaticErrorSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
 import { context } from "../test-schema.spec";
 import { AwsQueryProtocol } from "./AwsQueryProtocol";
 
 describe(AwsQueryProtocol.name, () => {
+  class GiraffeServiceException extends ServiceException {
+    constructor(options: ServiceExceptionOptions) {
+      super(options);
+      Object.setPrototypeOf(this, GiraffeServiceException.prototype);
+    }
+  }
+
+  const syntheticNamespace = "smithy.ts.sdk.synthetic.com.amazonaws.giraffes";
+  TypeRegistry.for(syntheticNamespace).registerError(
+    [-3, syntheticNamespace, "GiraffeServiceException", 0, [], []] satisfies StaticErrorSchema,
+    GiraffeServiceException
+  );
+
   it("decorates service exceptions with unmodeled fields", async () => {
     const httpResponse = new HttpResponse({
       statusCode: 400,
@@ -40,5 +56,73 @@ describe(AwsQueryProtocol.name, () => {
         httpStatusCode: 400,
       },
     });
+  });
+
+  it("should copy Error.Code to error.name and Error.Message to error.message", async () => {
+    const httpResponse = new HttpResponse({
+      statusCode: 400,
+      headers: {},
+      body: Buffer.from(
+        "<Exception>" +
+          "<Error>" +
+          "<Type>Sender</Type>" +
+          "<Code>GiraffeServiceException</Code>" +
+          "<Message>A giraffe has eaten your umbrella</Message>" +
+          "</Error>" +
+          "</Exception>"
+      ),
+    });
+
+    const protocol = new AwsQueryProtocol({
+      version: "1999-12-31",
+      defaultNamespace: "com.amazonaws.giraffes",
+      xmlNamespace: "ns",
+    });
+
+    const actual = await protocol
+      .deserializeResponse(
+        {
+          namespace: "ns",
+          name: "Empty",
+          traits: 0,
+          input: "unit" as const,
+          output: [3, "ns", "EmptyOutput", 0, [], []],
+        },
+        context,
+        httpResponse
+      )
+      .catch((e) => {
+        return e;
+      });
+
+    const expected = Object.assign(
+      new GiraffeServiceException({
+        name: "GiraffeServiceException",
+        $fault: "client",
+        message: "A giraffe has eaten your umbrella",
+        $metadata: {
+          cfId: undefined,
+          extendedRequestId: undefined,
+          httpStatusCode: 400,
+          requestId: undefined,
+        },
+      }),
+      {
+        Type: "Sender",
+        Code: "GiraffeServiceException",
+        Error: {
+          Code: "GiraffeServiceException",
+          Message: "A giraffe has eaten your umbrella",
+          Type: "Sender",
+        },
+      }
+    );
+
+    expect(actual.constructor).toBe(expected.constructor);
+    expect(actual.name).toEqual(expected.name);
+    expect(actual.message).toEqual(expected.message);
+    expect(actual.Type).toEqual(expected.Type);
+    expect(actual.Code).toEqual(expected.Code);
+    expect(actual.Error).toEqual(expected.Error);
   });
 });


### PR DESCRIPTION
### Issue
n/a

### Testing
Adds a unit test for Aws Query Protocol error deserialization (without AwsQueryCompatible).

### Additional context
I wrote this test while investigating https://github.com/aws/aws-cdk-cli/issues/954 but this is not a fix for that issue.
This test is nonetheless a reasonable addition to our coverage, so I've submitted it as this PR.
