### PR TITLE
fix(core/protocols): conditionally append xml declaration

### DIFF
--- a/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
+++ b/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
@@ -72,7 +72,9 @@ export class AwsRestXmlProtocol extends HttpBindingProtocol {
 
     if (request.headers["content-type"] === this.getDefaultContentType()) {
       if (typeof request.body === "string") {
-        request.body = '<?xml version="1.0" encoding="UTF-8"?>' + request.body;
+        if (!request.body.startsWith("<?xml ")) {
+          request.body = '<?xml version="1.0" encoding="UTF-8"?>' + request.body;
+        }
       }
     }
 


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7550

### Description
makes the prepending of `<?xml version="1.0" encoding="UTF-8"?>` to an AWS REST XML operation request body conditional on both the request having content type application/xml and the input not already starting with the xml declaration. 

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
