### PR TITLE
test(core/protocols): add test and additional condition for xml declaration

### DIFF
--- a/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.spec.ts
+++ b/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.spec.ts
@@ -1,7 +1,6 @@
 import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
-import { StaticOperationSchema } from "@smithy/types";
+import { StaticOperationSchema, StaticStructureSchema } from "@smithy/types";
 import { toUtf8 } from "@smithy/util-utf8";
-import { Readable } from "node:stream";
 import { describe, expect, test as it } from "vitest";
 
 import { context, deleteObjects } from "../test-schema.spec";
@@ -12,6 +11,11 @@ describe(AwsRestXmlProtocol.name, () => {
   const command = {
     schema: deleteObjects,
   };
+
+  const protocol = new AwsRestXmlProtocol({
+    xmlNamespace: "http://s3.amazonaws.com/doc/2006-03-01/",
+    defaultNamespace: "com.amazonaws.s3",
+  });
 
   describe("serialization", () => {
     const testCases = [
@@ -59,11 +63,6 @@ describe(AwsRestXmlProtocol.name, () => {
 
     for (const testCase of testCases) {
       it(`should serialize HTTP Requests: ${testCase.name}`, async () => {
-        const protocol = new AwsRestXmlProtocol({
-          xmlNamespace: "http://s3.amazonaws.com/doc/2006-03-01/",
-          defaultNamespace: "com.amazonaws.s3",
-        });
-
         const [, namespace, name, traits, input, output] = command.schema as StaticOperationSchema;
 
         const httpRequest = await protocol.serializeRequest(
@@ -95,74 +94,135 @@ describe(AwsRestXmlProtocol.name, () => {
         );
       });
     }
-  });
 
-  it("deserializes http responses", async () => {
-    const httpResponse = new HttpResponse({
-      statusCode: 200,
-      headers: {},
-    });
+    it("should prepend an xml declaration only if the content type is application/xml and the input schema does not have a payload binding", async () => {
+      const document = [
+        3,
+        "ns",
+        "Struct",
+        0,
+        ["a", "b", "c", "h"],
+        [0, 0, 0, [0, { httpHeader: "content-type" }]],
+      ] satisfies StaticStructureSchema;
+      const payload = [
+        3,
+        "ns",
+        "PayloadStruct",
+        0,
+        ["a", "b", "c", "h"],
+        [0, 0, [0, { httpPayload: 1 }], [0, { httpHeader: "content-type" }]],
+      ] satisfies StaticStructureSchema;
 
-    const protocol = new AwsRestXmlProtocol({
-      defaultNamespace: "",
-      xmlNamespace: "ns",
-    });
+      const createOperation = (input: StaticStructureSchema) => ({
+        namespace: "ns",
+        name: "operation",
+        traits: {},
+        input,
+        output: "unit" as const,
+      });
 
-    const output = await protocol.deserializeResponse(
-      {
-        namespace: deleteObjects[1],
-        name: deleteObjects[2],
-        traits: deleteObjects[3],
-        input: deleteObjects[4],
-        output: deleteObjects[5],
-      },
-      context,
-      httpResponse
-    );
-
-    expect(output).toEqual({
-      $metadata: {
-        httpStatusCode: 200,
-        requestId: undefined,
-        extendedRequestId: undefined,
-        cfId: undefined,
-      },
-    });
-  });
-
-  it("decorates service exceptions with unmodeled fields", async () => {
-    const httpResponse = new HttpResponse({
-      statusCode: 400,
-      headers: {},
-      body: Buffer.from(`<Exception><UnmodeledField>Oh no</UnmodeledField></Exception>`),
-    });
-
-    const protocol = new AwsRestXmlProtocol({
-      defaultNamespace: "",
-      xmlNamespace: "ns",
-    });
-
-    const output = await protocol
-      .deserializeResponse(
+      const httpRequest1 = await protocol.serializeRequest(
+        createOperation(document),
         {
-          namespace: "ns",
-          name: "Empty",
-          traits: 0,
-          input: "unit" as const,
-          output: [3, "ns", "EmptyOutput", 0, [], []],
+          c: "<XML></XML>",
+          h: "application/xml",
+        },
+        context
+      );
+
+      // this is not a payload binding, so although the
+      // content and header appear to be XML,
+      // the data is encoded within an XML container structure and the xml declaration
+      // is prepended by the SDK.
+      expect(httpRequest1.body).toBe(
+        `<?xml version="1.0" encoding="UTF-8"?><Struct xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><c>&lt;XML&gt;&lt;/XML&gt;</c></Struct>`
+      );
+
+      const httpRequest2 = await protocol.serializeRequest(
+        createOperation(payload),
+        {
+          c: "<XML></XML>",
+          h: "application/xml",
+        },
+        context
+      );
+
+      // even though this could be interpreted as XML input by the content and the header value,
+      // because this operation is a payload binding of a string,
+      // we simply send what the caller has provided rather than prepending the XML declaration.
+      expect(httpRequest2.body).toBe(`<XML></XML>`);
+
+      const httpRequest3 = await protocol.serializeRequest(
+        createOperation(payload),
+        {
+          c: "<XML></XML>",
+          h: "text/xml",
+        },
+        context
+      );
+
+      expect(httpRequest3.body).toBe(`<XML></XML>`);
+    });
+  });
+
+  describe("deserialization", () => {
+    it("deserializes http responses", async () => {
+      const httpResponse = new HttpResponse({
+        statusCode: 200,
+        headers: {},
+      });
+
+      const output = await protocol.deserializeResponse(
+        {
+          namespace: deleteObjects[1],
+          name: deleteObjects[2],
+          traits: deleteObjects[3],
+          input: deleteObjects[4],
+          output: deleteObjects[5],
         },
         context,
         httpResponse
-      )
-      .catch((e) => {
-        return e;
+      );
+
+      expect(output).toEqual({
+        $metadata: {
+          httpStatusCode: 200,
+          requestId: undefined,
+          extendedRequestId: undefined,
+          cfId: undefined,
+        },
+      });
+    });
+
+    it("decorates service exceptions with unmodeled fields", async () => {
+      const httpResponse = new HttpResponse({
+        statusCode: 400,
+        headers: {},
+        body: Buffer.from(`<Exception><UnmodeledField>Oh no</UnmodeledField></Exception>`),
       });
 
-    expect(output).toMatchObject({
-      UnmodeledField: "Oh no",
-      $metadata: {
-        httpStatusCode: 400,
-      },
+      const output = await protocol
+        .deserializeResponse(
+          {
+            namespace: "ns",
+            name: "Empty",
+            traits: 0,
+            input: "unit" as const,
+            output: [3, "ns", "EmptyOutput", 0, [], []],
+          },
+          context,
+          httpResponse
+        )
+        .catch((e) => {
+          return e;
+        });
+
+      expect(output).toMatchObject({
+        UnmodeledField: "Oh no",
+        $metadata: {
+          httpStatusCode: 400,
+        },
+      });
     });
   });
 });

--- a/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
+++ b/packages/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
@@ -70,12 +70,17 @@ export class AwsRestXmlProtocol extends HttpBindingProtocol {
       }
     }
 
-    if (request.headers["content-type"] === this.getDefaultContentType()) {
-      if (typeof request.body === "string") {
-        if (!request.body.startsWith("<?xml ")) {
-          request.body = '<?xml version="1.0" encoding="UTF-8"?>' + request.body;
-        }
-      }
+    if (
+      typeof request.body === "string" &&
+      request.headers["content-type"] === this.getDefaultContentType() &&
+      !request.body.startsWith("<?xml ") &&
+      !this.hasUnstructuredPayloadBinding(inputSchema)
+    ) {
+      // string type excludes event streams.
+      // if the body is a string, it is either XML serialized from a structure
+      // or a text payload. We exclude text payloads by checking
+      // whether the schema has a payload binding.
+      request.body = '<?xml version="1.0" encoding="UTF-8"?>' + request.body;
     }
 
     // content-length header is set by the contentLengthMiddleware.
@@ -144,5 +149,16 @@ export class AwsRestXmlProtocol extends HttpBindingProtocol {
    */
   protected getDefaultContentType(): string {
     return "application/xml";
+  }
+
+  private hasUnstructuredPayloadBinding(ns: NormalizedSchema): boolean {
+    for (const [, member] of ns.structIterator()) {
+      if (member.getMergedTraits().httpPayload) {
+        // all struct members can be http payloads, but the serialization of
+        // simple types are probably not in XML format.
+        return !(member.isStructSchema() || member.isMapSchema() || member.isListSchema());
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
### Issue
This is a more thorough form of the fast-fix made in https://github.com/aws/aws-sdk-js-v3/pull/7551.

### Description
This adds the required condition of there being no payload binding for the AwsRestXml protocol to prepend the XML declaration.

### Testing
Added unit tests.

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
