### PR TITLE
fix(ec2-metadata-service): preserve statusCode when rethrowing errors for IMDS requests

### DIFF
--- a/packages/ec2-metadata-service/src/MetadataService.ts
+++ b/packages/ec2-metadata-service/src/MetadataService.ts
@@ -76,10 +76,16 @@ export class MetadataService {
         // handle response.body as stream
         return sdkStreamMixin(response.body).transformToString();
       } else {
-        throw new Error(`Request failed with status code ${response.statusCode}`);
+        throw Object.assign(new Error(`Request failed with status code ${response.statusCode}`), {
+          statusCode: response.statusCode,
+        });
       }
     } catch (error) {
-      throw new Error(`Error making request to the metadata service: ${error}`);
+      const wrappedError = new Error(`Error making request to the metadata service: ${error}`);
+      if ((error as any).statusCode !== undefined) {
+        (wrappedError as any).statusCode = (error as any).statusCode;
+      }
+      throw wrappedError;
     }
   }
 


### PR DESCRIPTION
### Issue
#7357 

### Description
Bubbles up status code for users to access in case of errors when making an IMDS `request()`.

### Testing
Minimal repro:
```js
import { MetadataService } from '@aws-sdk/ec2-metadata-service';

try {
    const metaService = new MetadataService({});
    await metaService.request(`/latest/meta-data/DNE`, {});
} catch (e) {
    console.log(e.statusCode)
    console.log(e.message)
}
```

Before the fix:
```console
undefined
Error making request to the metadata service: Error: Request failed with status code 404
```

After the fix:
```console
404
Error making request to the metadata service: Error: Request failed with status code 404
```

Unit tests in the package are passing.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
