### PR TITLE
fix(ec2-metadata-service): custom port configuration for IMDS requests

### DIFF
--- a/packages/ec2-metadata-service/src/MetadataService.ts
+++ b/packages/ec2-metadata-service/src/MetadataService.ts
@@ -69,6 +69,7 @@ export class MetadataService {
       hostname: endpointUrl.hostname,
       path: endpointUrl.pathname + path,
       protocol: endpointUrl.protocol,
+      port: endpointUrl.port ? parseInt(endpointUrl.port) : undefined,
     });
     try {
       const { response } = await handler.handle(request, {} as HttpHandlerOptions);
@@ -102,6 +103,7 @@ export class MetadataService {
       hostname: endpointUrl.hostname,
       path: "/latest/api/token",
       protocol: endpointUrl.protocol,
+      port: endpointUrl.port ? parseInt(endpointUrl.port) : undefined,
     });
     try {
       const { response } = await handler.handle(tokenRequest, {} as HttpHandlerOptions);


### PR DESCRIPTION
### Issue
#7285 

### Description
Ensure port value can be set and respected for IMDS requests.

### Testing
New unit tests:
```console
 ✓ MetadataService Custom Ports > should use custom port from endpoint URL in request() 1ms
   ✓ MetadataService Custom Ports > should use custom port from endpoint URL in fetchMetadataToken() 0ms
   ✓ MetadataService Custom Ports > should use undefined port for standard HTTP endpoint 0ms
   ✓ MetadataService Custom Ports > should use custom HTTPS port from endpoint URL 0ms

 Test Files  1 passed (1)
      Tests  16 passed (16)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
