### PR TITLE
chore(codegen): integrate prettier java plugin

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,4 +5,3 @@ CHANGELOG.md
 **/*/report.md
 clients/*/src/endpoint/ruleset.ts
 packages/nested-clients/src/submodules/*/endpoint/ruleset.ts
-**/*.java

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -4,9 +4,9 @@ This package is used to build each client in the SDK.
 
 The code generation stack is made up of 3 components:
 
- 1. [Smithy](https://github.com/smithy-lang/smithy) - the core libraries for code generation. They are not intended to contain anything specific to TypeScript or AWS SDKs.
- 2. [Smithy-TypeScript](https://github.com/awslabs/smithy-typescript) - This uses Smithy to generate code for the TypeScript (JavaScript) language runtimes. While this is maintained by AWS, it is not intended to contain anything specific to AWS.
- 3. [Smithy-AWS-TypeScript](https://github.com/aws/aws-sdk-js-v3/tree/docs/readme/codegen) - This is the component here in the AWS SDK for JavaScript (v3) repository. It uses the two upstream components, Smithy and Smithy-TypeScript, to generate the AWS SDK for JavaScript (v3). Anything specific to AWS should only be found in this package.
+1.  [Smithy](https://github.com/smithy-lang/smithy) - the core libraries for code generation. They are not intended to contain anything specific to TypeScript or AWS SDKs.
+2.  [Smithy-TypeScript](https://github.com/awslabs/smithy-typescript) - This uses Smithy to generate code for the TypeScript (JavaScript) language runtimes. While this is maintained by AWS, it is not intended to contain anything specific to AWS.
+3.  [Smithy-AWS-TypeScript](https://github.com/aws/aws-sdk-js-v3/tree/docs/readme/codegen) - This is the component here in the AWS SDK for JavaScript (v3) repository. It uses the two upstream components, Smithy and Smithy-TypeScript, to generate the AWS SDK for JavaScript (v3). Anything specific to AWS should only be found in this package.
 
 ## Building
 
@@ -16,7 +16,6 @@ By running `./gradlew :sdk-codegen:build`, this package will:
    model that represents a service to generate.
 
 2. Generate a `smithy-build.json` file.
-
    - For each model, a projection is created that uses the filename without
      ".json" as the name of the projection.
    - An `imports` value is added that imports the file.

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAccountIdEndpointModeRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAccountIdEndpointModeRuntimeConfig.java
@@ -47,13 +47,22 @@ public final class AddAccountIdEndpointModeRuntimeConfig implements TypeScriptIn
         if (isAwsService(settings, model)) {
             ServiceShape service = settings.getService(model);
             if (hasAccountIdEndpointParam(service)) {
-                    writer.addImportSubmodule("AccountIdEndpointMode", null,
-                        AwsDependency.AWS_SDK_CORE, "/account-id-endpoint");
-                    writer.writeDocs("Defines if the AWS AccountId will be used for endpoint routing.");
-                    writer.write("accountIdEndpointMode?: AccountIdEndpointMode | "
-                    + "__Provider<AccountIdEndpointMode>;\n");
-                    writer.addImportSubmodule("resolveAccountIdEndpointModeConfig", null,
-                        AwsDependency.AWS_SDK_CORE, "/account-id-endpoint");
+                writer.addImportSubmodule(
+                    "AccountIdEndpointMode",
+                    null,
+                    AwsDependency.AWS_SDK_CORE,
+                    "/account-id-endpoint"
+                );
+                writer.writeDocs("Defines if the AWS AccountId will be used for endpoint routing.");
+                writer.write(
+                    "accountIdEndpointMode?: AccountIdEndpointMode | " + "__Provider<AccountIdEndpointMode>;\n"
+                );
+                writer.addImportSubmodule(
+                    "resolveAccountIdEndpointModeConfig",
+                    null,
+                    AwsDependency.AWS_SDK_CORE,
+                    "/account-id-endpoint"
+                );
             }
         }
     }
@@ -75,21 +84,31 @@ public final class AddAccountIdEndpointModeRuntimeConfig implements TypeScriptIn
                     switch (target) {
                         case BROWSER:
                             runtimeConfigs.put("accountIdEndpointMode", writer -> {
-                                writer.addImportSubmodule("DEFAULT_ACCOUNT_ID_ENDPOINT_MODE", null,
+                                writer.addImportSubmodule(
+                                    "DEFAULT_ACCOUNT_ID_ENDPOINT_MODE",
+                                    null,
                                     AwsDependency.AWS_SDK_CORE,
-                                    "/account-id-endpoint");
+                                    "/account-id-endpoint"
+                                );
                                 writer.write("(() => Promise.resolve(DEFAULT_ACCOUNT_ID_ENDPOINT_MODE))");
                             });
                             break;
                         case NODE:
                             runtimeConfigs.put("accountIdEndpointMode", writer -> {
-                                writer.addImport("loadConfig", "loadNodeConfig",
-                                    TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                                writer.addImportSubmodule("NODE_ACCOUNT_ID_ENDPOINT_MODE_CONFIG_OPTIONS",
-                                    null, AwsDependency.AWS_SDK_CORE,
-                                    "/account-id-endpoint");
+                                writer.addImport(
+                                    "loadConfig",
+                                    "loadNodeConfig",
+                                    TypeScriptDependency.NODE_CONFIG_PROVIDER
+                                );
+                                writer.addImportSubmodule(
+                                    "NODE_ACCOUNT_ID_ENDPOINT_MODE_CONFIG_OPTIONS",
+                                    null,
+                                    AwsDependency.AWS_SDK_CORE,
+                                    "/account-id-endpoint"
+                                );
                                 writer.write(
-                                    "loadNodeConfig(NODE_ACCOUNT_ID_ENDPOINT_MODE_CONFIG_OPTIONS, loaderConfig)");
+                                    "loadNodeConfig(NODE_ACCOUNT_ID_ENDPOINT_MODE_CONFIG_OPTIONS, loaderConfig)"
+                                );
                             });
                             break;
                         default:
@@ -106,33 +125,27 @@ public final class AddAccountIdEndpointModeRuntimeConfig implements TypeScriptIn
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return List.of(
-        RuntimeClientPlugin.builder()
-            .inputConfig(
-                Symbol.builder()
-                    .namespace(
-                        AwsDependency.AWS_SDK_CORE.getPackageName() + "/account-id-endpoint", "/"
-                    )
-                    .name("AccountIdEndpointModeInputConfig")
-                    .build()
-            )
-            .resolvedConfig(
-                Symbol.builder()
-                    .namespace(
-                        AwsDependency.AWS_SDK_CORE.getPackageName() + "/account-id-endpoint", "/"
-                    )
-                    .name("AccountIdEndpointModeResolvedConfig")
-                    .build()
-            )
-            .resolveFunction(
-                Symbol.builder()
-                    .namespace(
-                        AwsDependency.AWS_SDK_CORE.getPackageName() + "/account-id-endpoint", "/"
-                    )
-                    .name("resolveAccountIdEndpointModeConfig")
-                    .build()
-            )
-            .servicePredicate((m, s) -> hasAccountIdEndpointParam(s))
-            .build()
+            RuntimeClientPlugin.builder()
+                .inputConfig(
+                    Symbol.builder()
+                        .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/account-id-endpoint", "/")
+                        .name("AccountIdEndpointModeInputConfig")
+                        .build()
+                )
+                .resolvedConfig(
+                    Symbol.builder()
+                        .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/account-id-endpoint", "/")
+                        .name("AccountIdEndpointModeResolvedConfig")
+                        .build()
+                )
+                .resolveFunction(
+                    Symbol.builder()
+                        .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/account-id-endpoint", "/")
+                        .name("resolveAccountIdEndpointModeConfig")
+                        .build()
+                )
+                .servicePredicate((m, s) -> hasAccountIdEndpointParam(s))
+                .build()
         );
     }
 
@@ -141,7 +154,7 @@ public final class AddAccountIdEndpointModeRuntimeConfig implements TypeScriptIn
         if (endpointRuleSetTrait.isPresent()) {
             RuleSetParameterFinder ruleSetParameterFinder = new RuleSetParameterFinder(service);
             if (ruleSetParameterFinder.getBuiltInParams().containsKey("AccountIdEndpointMode")) {
-              return true;
+                return true;
             }
         }
         return false;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -82,27 +82,32 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
 
     @Override
     public void addConfigInterfaceFields(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
     ) {
         if (isAwsService(settings, model)) {
-            writer.writeDocs("Unique service identifier.\n@internal")
-                    .write("serviceId?: string;\n");
-            writer.writeDocs("Enables IPv6/IPv4 dualstack endpoint.")
-                    .write("useDualstackEndpoint?: boolean | __Provider<boolean>;\n");
-            writer.writeDocs("Enables FIPS compatible endpoints.")
-                    .write("useFipsEndpoint?: boolean | __Provider<boolean>;\n");
+            writer.writeDocs("Unique service identifier.\n@internal").write("serviceId?: string;\n");
+            writer
+                .writeDocs("Enables IPv6/IPv4 dualstack endpoint.")
+                .write("useDualstackEndpoint?: boolean | __Provider<boolean>;\n");
+            writer
+                .writeDocs("Enables FIPS compatible endpoints.")
+                .write("useFipsEndpoint?: boolean | __Provider<boolean>;\n");
         }
         if (isSigV4Service(settings, model) || isAwsService(settings, model)) {
-            writer.writeDocs(isAwsService(settings, model)
-                    ? "The AWS region to which this client will send requests"
-                    : "The AWS region to use as signing region for AWS Auth")
+            writer
+                .writeDocs(
+                    isAwsService(settings, model)
+                        ? "The AWS region to which this client will send requests"
+                        : "The AWS region to use as signing region for AWS Auth"
+                )
                 .write("region?: string | __Provider<string>;\n");
         }
 
-        writer.writeDocs(
+        writer
+            .writeDocs(
                 """
                 Setting a client profile is similar to setting a value for the
                 AWS_PROFILE environment variable. Setting a profile on a client
@@ -118,16 +123,17 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                 configuration file, the client's profile (this value) will be
                 used unless a different profile is set in the credential
                 provider options.
-                """)
-                .write("profile?: string;\n");
+                """
+            )
+            .write("profile?: string;\n");
     }
 
     @Override
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            LanguageTarget target
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
     ) {
         ServiceShape service = settings.getService(model);
         Map<String, Consumer<TypeScriptWriter>> runtimeConfigs = new HashMap<>();
@@ -135,8 +141,11 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
             String serviceId = service.expectTrait(ServiceTrait.class).getSdkId();
             runtimeConfigs.put("serviceId", writer -> writer.write("$S", serviceId));
         } else {
-            LOGGER.info("Cannot generate a service ID for the client because no aws.api#Service "
-                + "trait was found on " + service.getId());
+            LOGGER.info(
+                "Cannot generate a service ID for the client because no aws.api#Service " +
+                    "trait was found on " +
+                    service.getId()
+            );
         }
         runtimeConfigs.putAll(getDefaultConfig(target, settings, model));
         runtimeConfigs.putAll(getEndpointConfigWriters(target, settings, model));
@@ -179,30 +188,34 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
     }
 
     private Map<String, Consumer<TypeScriptWriter>> getDefaultConfig(
-            LanguageTarget target,
-            TypeScriptSettings settings,
-            Model model
+        LanguageTarget target,
+        TypeScriptSettings settings,
+        Model model
     ) {
         if (isSigV4Service(settings, model) || isAwsService(settings, model)) {
             switch (target) {
                 case BROWSER:
                     return MapUtils.of("region", writer -> {
                         writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
-                        writer.addImport("invalidProvider", "invalidProvider",
-                            TypeScriptDependency.INVALID_DEPENDENCY);
+                        writer.addImport("invalidProvider", "invalidProvider", TypeScriptDependency.INVALID_DEPENDENCY);
                         writer.write("invalidProvider(\"Region is missing\")");
                     });
                 case NODE:
                     Map<String, Consumer<TypeScriptWriter>> nodeConfig = new HashMap<>();
                     nodeConfig.put("region", writer -> {
                         writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                        writer.addImport("loadConfig", "loadNodeConfig",
-                            TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                        writer.addImport("loadConfig", "loadNodeConfig", TypeScriptDependency.NODE_CONFIG_PROVIDER);
                         writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
-                        writer.addImport("NODE_REGION_CONFIG_OPTIONS", "NODE_REGION_CONFIG_OPTIONS",
-                            TypeScriptDependency.CONFIG_RESOLVER);
-                        writer.addImport("NODE_REGION_CONFIG_FILE_OPTIONS", "NODE_REGION_CONFIG_FILE_OPTIONS",
-                            TypeScriptDependency.CONFIG_RESOLVER);
+                        writer.addImport(
+                            "NODE_REGION_CONFIG_OPTIONS",
+                            "NODE_REGION_CONFIG_OPTIONS",
+                            TypeScriptDependency.CONFIG_RESOLVER
+                        );
+                        writer.addImport(
+                            "NODE_REGION_CONFIG_FILE_OPTIONS",
+                            "NODE_REGION_CONFIG_FILE_OPTIONS",
+                            TypeScriptDependency.CONFIG_RESOLVER
+                        );
                         writer.write(
                             """
                             loadNodeConfig(
@@ -214,12 +227,10 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                     });
                     if (!settings.useLegacyAuth()) {
                         nodeConfig.put("authSchemePreference", writer -> {
-                            writer.addImport("loadConfig", "loadNodeConfig",
-                                   TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                            writer.addImport("NODE_AUTH_SCHEME_PREFERENCE_OPTIONS", null,
-                                    AwsDependency.AWS_SDK_CORE);
+                            writer.addImport("loadConfig", "loadNodeConfig", TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                            writer.addImport("NODE_AUTH_SCHEME_PREFERENCE_OPTIONS", null, AwsDependency.AWS_SDK_CORE);
                             writer.write("loadNodeConfig(NODE_AUTH_SCHEME_PREFERENCE_OPTIONS, loaderConfig)");
-                          });
+                        });
                     }
                     return nodeConfig;
                 default:
@@ -230,9 +241,9 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
     }
 
     private Map<String, Consumer<TypeScriptWriter>> getEndpointConfigWriters(
-            LanguageTarget target,
-            TypeScriptSettings settings,
-            Model model
+        LanguageTarget target,
+        TypeScriptSettings settings,
+        Model model
     ) {
         if (!isAwsService(settings, model)) {
             return Collections.emptyMap();
@@ -240,41 +251,53 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
         switch (target) {
             case BROWSER:
                 return MapUtils.of(
-                        "useDualstackEndpoint", writer -> {
-                            writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
-                            writer.addImport("DEFAULT_USE_DUALSTACK_ENDPOINT", "DEFAULT_USE_DUALSTACK_ENDPOINT",
-                                    TypeScriptDependency.CONFIG_RESOLVER);
-                            writer.write("(() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT))");
-                        },
-                        "useFipsEndpoint", writer -> {
-                            writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
-                            writer.addImport("DEFAULT_USE_FIPS_ENDPOINT", "DEFAULT_USE_FIPS_ENDPOINT",
-                                    TypeScriptDependency.CONFIG_RESOLVER);
-                            writer.write("(() => Promise.resolve(DEFAULT_USE_FIPS_ENDPOINT))");
-                        }
+                    "useDualstackEndpoint",
+                    writer -> {
+                        writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
+                        writer.addImport(
+                            "DEFAULT_USE_DUALSTACK_ENDPOINT",
+                            "DEFAULT_USE_DUALSTACK_ENDPOINT",
+                            TypeScriptDependency.CONFIG_RESOLVER
+                        );
+                        writer.write("(() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT))");
+                    },
+                    "useFipsEndpoint",
+                    writer -> {
+                        writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
+                        writer.addImport(
+                            "DEFAULT_USE_FIPS_ENDPOINT",
+                            "DEFAULT_USE_FIPS_ENDPOINT",
+                            TypeScriptDependency.CONFIG_RESOLVER
+                        );
+                        writer.write("(() => Promise.resolve(DEFAULT_USE_FIPS_ENDPOINT))");
+                    }
                 );
             case NODE:
                 return MapUtils.of(
-                        "useDualstackEndpoint", writer -> {
-                            writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                            writer.addImport("loadConfig", "loadNodeConfig",
-                                    TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                            writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
-                            writer.addImport("NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS",
-                                    "NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS",
-                                    TypeScriptDependency.CONFIG_RESOLVER);
-                            writer.write("loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS, loaderConfig)");
-                        },
-                        "useFipsEndpoint", writer -> {
-                            writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                            writer.addImport("loadConfig", "loadNodeConfig",
-                                    TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                            writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
-                            writer.addImport("NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS",
-                                    "NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS",
-                                    TypeScriptDependency.CONFIG_RESOLVER);
-                            writer.write("loadNodeConfig(NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS, loaderConfig)");
-                        }
+                    "useDualstackEndpoint",
+                    writer -> {
+                        writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                        writer.addImport("loadConfig", "loadNodeConfig", TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                        writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
+                        writer.addImport(
+                            "NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS",
+                            "NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS",
+                            TypeScriptDependency.CONFIG_RESOLVER
+                        );
+                        writer.write("loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS, loaderConfig)");
+                    },
+                    "useFipsEndpoint",
+                    writer -> {
+                        writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                        writer.addImport("loadConfig", "loadNodeConfig", TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                        writer.addDependency(TypeScriptDependency.CONFIG_RESOLVER);
+                        writer.addImport(
+                            "NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS",
+                            "NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS",
+                            TypeScriptDependency.CONFIG_RESOLVER
+                        );
+                        writer.write("loadNodeConfig(NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS, loaderConfig)");
+                    }
                 );
             default:
                 return Collections.emptyMap();

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBodyChecksumGeneratorDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBodyChecksumGeneratorDependency.java
@@ -37,32 +37,34 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public class AddBodyChecksumGeneratorDependency implements TypeScriptIntegration {
+
     private static final Set<String> SERVICE_IDS = SetUtils.of("Glacier");
 
     @Override
     public void addConfigInterfaceFields(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
     ) {
         if (!needsBodyChecksumGeneratorDep(settings.getService(model))) {
             return;
         }
         writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.SMITHY_TYPES);
-        writer.writeDocs("Function that returns body checksums.\n"
-                        + "@internal");
-        writer.write("bodyChecksumGenerator?: (request: __HttpRequest, "
-                + "options: { sha256: __ChecksumConstructor | __HashConstructor; "
-                + "utf8Decoder: __Decoder }) => Promise<[string, string]>;\n");
-}
+        writer.writeDocs("Function that returns body checksums.\n" + "@internal");
+        writer.write(
+            "bodyChecksumGenerator?: (request: __HttpRequest, " +
+                "options: { sha256: __ChecksumConstructor | __HashConstructor; " +
+                "utf8Decoder: __Decoder }) => Promise<[string, string]>;\n"
+        );
+    }
 
     @Override
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            LanguageTarget target
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
     ) {
         if (!needsBodyChecksumGeneratorDep(settings.getService(model))) {
             return Collections.emptyMap();
@@ -72,15 +74,21 @@ public class AddBodyChecksumGeneratorDependency implements TypeScriptIntegration
             case NODE:
                 return MapUtils.of("bodyChecksumGenerator", writer -> {
                     writer.addDependency(AwsDependency.BODY_CHECKSUM_GENERATOR_NODE);
-                    writer.addImport("bodyChecksumGenerator", "bodyChecksumGenerator",
-                            AwsDependency.BODY_CHECKSUM_GENERATOR_NODE);
+                    writer.addImport(
+                        "bodyChecksumGenerator",
+                        "bodyChecksumGenerator",
+                        AwsDependency.BODY_CHECKSUM_GENERATOR_NODE
+                    );
                     writer.write("bodyChecksumGenerator");
                 });
             case BROWSER:
                 return MapUtils.of("bodyChecksumGenerator", writer -> {
                     writer.addDependency(AwsDependency.BODY_CHECKSUM_GENERATOR_BROWSER);
-                    writer.addImport("bodyChecksumGenerator", "bodyChecksumGenerator",
-                            AwsDependency.BODY_CHECKSUM_GENERATOR_BROWSER);
+                    writer.addImport(
+                        "bodyChecksumGenerator",
+                        "bodyChecksumGenerator",
+                        AwsDependency.BODY_CHECKSUM_GENERATOR_BROWSER
+                    );
                     writer.write("bodyChecksumGenerator");
                 });
             default:

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -23,10 +23,12 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public class AddBuiltinPlugins implements TypeScriptIntegration {
+
     @Override
     public List<String> runAfter() {
         return List.of(
-            software.amazon.smithy.typescript.codegen.integration.AddBuiltinPlugins.class.getCanonicalName());
+            software.amazon.smithy.typescript.codegen.integration.AddBuiltinPlugins.class.getCanonicalName()
+        );
     }
 
     @Override
@@ -46,8 +48,11 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                 .withConventions(AwsDependency.MIDDLEWARE_LOGGER.dependency, "Logger", HAS_MIDDLEWARE)
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.RECURSION_DETECTION_MIDDLEWARE.dependency,
-                    "RecursionDetection", HAS_MIDDLEWARE)
+                .withConventions(
+                    AwsDependency.RECURSION_DETECTION_MIDDLEWARE.dependency,
+                    "RecursionDetection",
+                    HAS_MIDDLEWARE
+                )
                 .build()
         );
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddCrossRegionCopyingPlugin.java
@@ -31,28 +31,37 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
 public class AddCrossRegionCopyingPlugin implements TypeScriptIntegration {
+
     private static final Map<String, Set<String>> PRESIGNED_URL_OPERATIONS_MAP = MapUtils.of(
-        "RDS", SetUtils.of(
+        "RDS",
+        SetUtils.of(
             "CopyDBClusterSnapshot",
             "CreateDBCluster",
             "CopyDBSnapshot",
             "CreateDBInstanceReadReplica",
-            "StartDBInstanceAutomatedBackupsReplication"),
-        "DocDB", SetUtils.of("CopyDBClusterSnapshot"),
-        "Neptune", SetUtils.of("CopyDBClusterSnapshot", "CreateDBCluster")
+            "StartDBInstanceAutomatedBackupsReplication"
+        ),
+        "DocDB",
+        SetUtils.of("CopyDBClusterSnapshot"),
+        "Neptune",
+        SetUtils.of("CopyDBClusterSnapshot", "CreateDBCluster")
     );
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
-        return PRESIGNED_URL_OPERATIONS_MAP.entrySet().stream().map((entry) -> {
-            String serviceId = entry.getKey();
-            Set<String> commands = entry.getValue();
-            return RuntimeClientPlugin.builder()
+        return PRESIGNED_URL_OPERATIONS_MAP.entrySet()
+            .stream()
+            .map(entry -> {
+                String serviceId = entry.getKey();
+                Set<String> commands = entry.getValue();
+                return RuntimeClientPlugin.builder()
                     .withConventions(AwsDependency.RDS_MIDDLEWARE.dependency, "CrossRegionPresignedUrl", HAS_MIDDLEWARE)
                     .operationPredicate(
-                            (m, s, o) -> commands.contains(o.getId().getName(s)) && testServiceId(s, serviceId))
+                        (m, s, o) -> commands.contains(o.getId().getName(s)) && testServiceId(s, serviceId)
+                    )
                     .build();
-        }).collect(Collectors.toList());
+            })
+            .collect(Collectors.toList());
     }
 
     private static boolean testServiceId(Shape serviceShape, String expectedId) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDefaultAwsEndpointRuleSet.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDefaultAwsEndpointRuleSet.java
@@ -16,11 +16,11 @@ import software.amazon.smithy.typescript.codegen.endpointsV2.AddDefaultEndpointR
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 
-
 /**
  * This replaces behavior from {@link EndpointGenerator}.
  */
 public class AddDefaultAwsEndpointRuleSet implements TypeScriptIntegration {
+
     private boolean usesDefaultAwsRegionalEndpoints = false;
 
     /**
@@ -56,10 +56,14 @@ public class AddDefaultAwsEndpointRuleSet implements TypeScriptIntegration {
             )
             .build();
 
-        RuntimeClientPlugin endpointPlugin = plugins.stream()
-            .filter(p -> p.getResolveFunction()
-                .map(r -> r.getAlias().equals("resolveEndpointConfig"))
-                .orElse(false))
+        RuntimeClientPlugin endpointPlugin = plugins
+            .stream()
+            .filter(p ->
+                p
+                    .getResolveFunction()
+                    .map(r -> r.getAlias().equals("resolveEndpointConfig"))
+                    .orElse(false)
+            )
             .findAny()
             .orElseThrow(() -> new IllegalStateException("Expected resolveEndpointConfig function in plugins."));
 
@@ -72,17 +76,19 @@ public class AddDefaultAwsEndpointRuleSet implements TypeScriptIntegration {
         Model.Builder modelBuilder = model.toBuilder();
 
         ServiceShape serviceShape = settings.getService(model);
-        if (!serviceShape.hasTrait(EndpointRuleSetTrait.class)
-            && AwsTraitsUtils.isAwsService(serviceShape)) {
+        if (!serviceShape.hasTrait(EndpointRuleSetTrait.class) && AwsTraitsUtils.isAwsService(serviceShape)) {
             // this branch is for models that identify as AWS services
             // but do not include an endpoint ruleset.
             usesDefaultAwsRegionalEndpoints = true;
             modelBuilder.removeShape(serviceShape.toShapeId());
             modelBuilder.addShape(
-                serviceShape.toBuilder()
-                    .addTrait(getDefaultRegionalEndpointRuleSet(
-                        serviceShape.expectTrait(ServiceTrait.class).getEndpointPrefix()
-                    ))
+                serviceShape
+                    .toBuilder()
+                    .addTrait(
+                        getDefaultRegionalEndpointRuleSet(
+                            serviceShape.expectTrait(ServiceTrait.class).getEndpointPrefix()
+                        )
+                    )
                     .build()
             );
         } else {
@@ -94,347 +100,351 @@ public class AddDefaultAwsEndpointRuleSet implements TypeScriptIntegration {
 
     private EndpointRuleSetTrait getDefaultRegionalEndpointRuleSet(String endpointPrefix) {
         return EndpointRuleSetTrait.builder()
-            .ruleSet(Node.parse("""
-{
-  "version": "1.0",
-  "parameters": {
-    "Region": {
-      "builtIn": "AWS::Region",
-      "required": false,
-      "documentation": "The AWS Region. This is a default regional AWS endpointRuleSet.",
-      "type": "String"
-    },
-    "UseDualStack": {
-      "builtIn": "AWS::UseDualStack",
-      "required": true,
-      "default": false,
-      "documentation": "Whether to use dual-stack.",
-      "type": "Boolean"
-    },
-    "UseFIPS": {
-      "builtIn": "AWS::UseFIPS",
-      "required": true,
-      "default": false,
-      "documentation": "Whether to use FIPS-compliant regional endpoint.",
-      "type": "Boolean"
-    },
-    "Endpoint": {
-      "builtIn": "SDK::Endpoint",
-      "required": false,
-      "documentation": "Override the endpoint.",
-      "type": "String"
-    }
-  },
-  "rules": [
-    {
-      "conditions": [
-        {
-          "fn": "isSet",
-          "argv": [
-            {
-              "ref": "Endpoint"
-            }
-          ]
-        }
-      ],
-      "rules": [
-        {
-          "conditions": [
-            {
-              "fn": "booleanEquals",
-              "argv": [
-                {
-                  "ref": "UseFIPS"
-                },
-                true
-              ]
-            }
-          ],
-          "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-          "type": "error"
-        },
-        {
-          "conditions": [
-            {
-              "fn": "booleanEquals",
-              "argv": [
-                {
-                  "ref": "UseDualStack"
-                },
-                true
-              ]
-            }
-          ],
-          "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-          "type": "error"
-        },
-        {
-          "conditions": [],
-          "endpoint": {
-            "url": {
-              "ref": "Endpoint"
-            },
-            "properties": {},
-            "headers": {}
-          },
-          "type": "endpoint"
-        }
-      ],
-      "type": "tree"
-    },
-    {
-      "conditions": [
-        {
-          "fn": "isSet",
-          "argv": [
-            {
-              "ref": "Region"
-            }
-          ]
-        }
-      ],
-      "rules": [
-        {
-          "conditions": [
-            {
-              "fn": "aws.partition",
-              "argv": [
-                {
-                  "ref": "Region"
-                }
-              ],
-              "assign": "PartitionResult"
-            }
-          ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "fn": "booleanEquals",
-                  "argv": [
+            .ruleSet(
+                Node.parse(
+                    """
                     {
-                      "ref": "UseFIPS"
-                    },
-                    true
-                  ]
-                },
-                {
-                  "fn": "booleanEquals",
-                  "argv": [
-                    {
-                      "ref": "UseDualStack"
-                    },
-                    true
-                  ]
-                }
-              ],
-              "rules": [
-                {
-                  "conditions": [
-                    {
-                      "fn": "booleanEquals",
-                      "argv": [
-                        true,
-                        {
-                          "fn": "getAttr",
-                          "argv": [
-                            {
-                              "ref": "PartitionResult"
-                            },
-                            "supportsFIPS"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "fn": "booleanEquals",
-                      "argv": [
-                        true,
-                        {
-                          "fn": "getAttr",
-                          "argv": [
-                            {
-                              "ref": "PartitionResult"
-                            },
-                            "supportsDualStack"
-                          ]
-                        }
-                      ]
-                    }
-                  ],
-                  "rules": [
-                    {
-                      "conditions": [],
-                      "endpoint": {
-                        "url": "https://%1$s-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                        "properties": {},
-                        "headers": {}
-                      },
-                      "type": "endpoint"
-                    }
-                  ],
-                  "type": "tree"
-                },
-                {
-                  "conditions": [],
-                  "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                  "type": "error"
-                }
-              ],
-              "type": "tree"
-            },
-            {
-              "conditions": [
-                {
-                  "fn": "booleanEquals",
-                  "argv": [
-                    {
-                      "ref": "UseFIPS"
-                    },
-                    true
-                  ]
-                }
-              ],
-              "rules": [
-                {
-                  "conditions": [
-                    {
-                      "fn": "booleanEquals",
-                      "argv": [
-                        {
-                          "fn": "getAttr",
-                          "argv": [
-                            {
-                              "ref": "PartitionResult"
-                            },
-                            "supportsFIPS"
-                          ]
+                      "version": "1.0",
+                      "parameters": {
+                        "Region": {
+                          "builtIn": "AWS::Region",
+                          "required": false,
+                          "documentation": "The AWS Region. This is a default regional AWS endpointRuleSet.",
+                          "type": "String"
                         },
-                        true
-                      ]
-                    }
-                  ],
-                  "rules": [
-                    {
-                      "conditions": [
+                        "UseDualStack": {
+                          "builtIn": "AWS::UseDualStack",
+                          "required": true,
+                          "default": false,
+                          "documentation": "Whether to use dual-stack.",
+                          "type": "Boolean"
+                        },
+                        "UseFIPS": {
+                          "builtIn": "AWS::UseFIPS",
+                          "required": true,
+                          "default": false,
+                          "documentation": "Whether to use FIPS-compliant regional endpoint.",
+                          "type": "Boolean"
+                        },
+                        "Endpoint": {
+                          "builtIn": "SDK::Endpoint",
+                          "required": false,
+                          "documentation": "Override the endpoint.",
+                          "type": "String"
+                        }
+                      },
+                      "rules": [
                         {
-                          "fn": "stringEquals",
-                          "argv": [
+                          "conditions": [
                             {
-                              "fn": "getAttr",
+                              "fn": "isSet",
                               "argv": [
                                 {
-                                  "ref": "PartitionResult"
-                                },
-                                "name"
+                                  "ref": "Endpoint"
+                                }
                               ]
-                            },
-                            "aws-us-gov"
-                          ]
-                        }
-                      ],
-                      "endpoint": {
-                        "url": "https://%1$s.{Region}.amazonaws.com",
-                        "properties": {},
-                        "headers": {}
-                      },
-                      "type": "endpoint"
-                    },
-                    {
-                      "conditions": [],
-                      "endpoint": {
-                        "url": "https://%1$s-fips.{Region}.{PartitionResult#dnsSuffix}",
-                        "properties": {},
-                        "headers": {}
-                      },
-                      "type": "endpoint"
-                    }
-                  ],
-                  "type": "tree"
-                },
-                {
-                  "conditions": [],
-                  "error": "FIPS is enabled but this partition does not support FIPS",
-                  "type": "error"
-                }
-              ],
-              "type": "tree"
-            },
-            {
-              "conditions": [
-                {
-                  "fn": "booleanEquals",
-                  "argv": [
-                    {
-                      "ref": "UseDualStack"
-                    },
-                    true
-                  ]
-                }
-              ],
-              "rules": [
-                {
-                  "conditions": [
-                    {
-                      "fn": "booleanEquals",
-                      "argv": [
-                        true,
-                        {
-                          "fn": "getAttr",
-                          "argv": [
+                            }
+                          ],
+                          "rules": [
                             {
-                              "ref": "PartitionResult"
+                              "conditions": [
+                                {
+                                  "fn": "booleanEquals",
+                                  "argv": [
+                                    {
+                                      "ref": "UseFIPS"
+                                    },
+                                    true
+                                  ]
+                                }
+                              ],
+                              "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                              "type": "error"
                             },
-                            "supportsDualStack"
-                          ]
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "booleanEquals",
+                                  "argv": [
+                                    {
+                                      "ref": "UseDualStack"
+                                    },
+                                    true
+                                  ]
+                                }
+                              ],
+                              "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                              "type": "error"
+                            },
+                            {
+                              "conditions": [],
+                              "endpoint": {
+                                "url": {
+                                  "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                              },
+                              "type": "endpoint"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [
+                            {
+                              "fn": "isSet",
+                              "argv": [
+                                {
+                                  "ref": "Region"
+                                }
+                              ]
+                            }
+                          ],
+                          "rules": [
+                            {
+                              "conditions": [
+                                {
+                                  "fn": "aws.partition",
+                                  "argv": [
+                                    {
+                                      "ref": "Region"
+                                    }
+                                  ],
+                                  "assign": "PartitionResult"
+                                }
+                              ],
+                              "rules": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "fn": "booleanEquals",
+                                      "argv": [
+                                        {
+                                          "ref": "UseFIPS"
+                                        },
+                                        true
+                                      ]
+                                    },
+                                    {
+                                      "fn": "booleanEquals",
+                                      "argv": [
+                                        {
+                                          "ref": "UseDualStack"
+                                        },
+                                        true
+                                      ]
+                                    }
+                                  ],
+                                  "rules": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "fn": "booleanEquals",
+                                          "argv": [
+                                            true,
+                                            {
+                                              "fn": "getAttr",
+                                              "argv": [
+                                                {
+                                                  "ref": "PartitionResult"
+                                                },
+                                                "supportsFIPS"
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "fn": "booleanEquals",
+                                          "argv": [
+                                            true,
+                                            {
+                                              "fn": "getAttr",
+                                              "argv": [
+                                                {
+                                                  "ref": "PartitionResult"
+                                                },
+                                                "supportsDualStack"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "rules": [
+                                        {
+                                          "conditions": [],
+                                          "endpoint": {
+                                            "url": "https://%1$s-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                            "properties": {},
+                                            "headers": {}
+                                          },
+                                          "type": "endpoint"
+                                        }
+                                      ],
+                                      "type": "tree"
+                                    },
+                                    {
+                                      "conditions": [],
+                                      "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                      "type": "error"
+                                    }
+                                  ],
+                                  "type": "tree"
+                                },
+                                {
+                                  "conditions": [
+                                    {
+                                      "fn": "booleanEquals",
+                                      "argv": [
+                                        {
+                                          "ref": "UseFIPS"
+                                        },
+                                        true
+                                      ]
+                                    }
+                                  ],
+                                  "rules": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "fn": "booleanEquals",
+                                          "argv": [
+                                            {
+                                              "fn": "getAttr",
+                                              "argv": [
+                                                {
+                                                  "ref": "PartitionResult"
+                                                },
+                                                "supportsFIPS"
+                                              ]
+                                            },
+                                            true
+                                          ]
+                                        }
+                                      ],
+                                      "rules": [
+                                        {
+                                          "conditions": [
+                                            {
+                                              "fn": "stringEquals",
+                                              "argv": [
+                                                {
+                                                  "fn": "getAttr",
+                                                  "argv": [
+                                                    {
+                                                      "ref": "PartitionResult"
+                                                    },
+                                                    "name"
+                                                  ]
+                                                },
+                                                "aws-us-gov"
+                                              ]
+                                            }
+                                          ],
+                                          "endpoint": {
+                                            "url": "https://%1$s.{Region}.amazonaws.com",
+                                            "properties": {},
+                                            "headers": {}
+                                          },
+                                          "type": "endpoint"
+                                        },
+                                        {
+                                          "conditions": [],
+                                          "endpoint": {
+                                            "url": "https://%1$s-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                            "properties": {},
+                                            "headers": {}
+                                          },
+                                          "type": "endpoint"
+                                        }
+                                      ],
+                                      "type": "tree"
+                                    },
+                                    {
+                                      "conditions": [],
+                                      "error": "FIPS is enabled but this partition does not support FIPS",
+                                      "type": "error"
+                                    }
+                                  ],
+                                  "type": "tree"
+                                },
+                                {
+                                  "conditions": [
+                                    {
+                                      "fn": "booleanEquals",
+                                      "argv": [
+                                        {
+                                          "ref": "UseDualStack"
+                                        },
+                                        true
+                                      ]
+                                    }
+                                  ],
+                                  "rules": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "fn": "booleanEquals",
+                                          "argv": [
+                                            true,
+                                            {
+                                              "fn": "getAttr",
+                                              "argv": [
+                                                {
+                                                  "ref": "PartitionResult"
+                                                },
+                                                "supportsDualStack"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "rules": [
+                                        {
+                                          "conditions": [],
+                                          "endpoint": {
+                                            "url": "https://%1$s.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                            "properties": {},
+                                            "headers": {}
+                                          },
+                                          "type": "endpoint"
+                                        }
+                                      ],
+                                      "type": "tree"
+                                    },
+                                    {
+                                      "conditions": [],
+                                      "error": "DualStack is enabled but this partition does not support DualStack",
+                                      "type": "error"
+                                    }
+                                  ],
+                                  "type": "tree"
+                                },
+                                {
+                                  "conditions": [],
+                                  "endpoint": {
+                                    "url": "https://%1$s.{Region}.{PartitionResult#dnsSuffix}",
+                                    "properties": {},
+                                    "headers": {}
+                                  },
+                                  "type": "endpoint"
+                                }
+                              ],
+                              "type": "tree"
+                            }
+                          ],
+                          "type": "tree"
+                        },
+                        {
+                          "conditions": [],
+                          "error": "Invalid Configuration: Missing Region",
+                          "type": "error"
                         }
                       ]
                     }
-                  ],
-                  "rules": [
-                    {
-                      "conditions": [],
-                      "endpoint": {
-                        "url": "https://%1$s.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                        "properties": {},
-                        "headers": {}
-                      },
-                      "type": "endpoint"
-                    }
-                  ],
-                  "type": "tree"
-                },
-                {
-                  "conditions": [],
-                  "error": "DualStack is enabled but this partition does not support DualStack",
-                  "type": "error"
-                }
-              ],
-              "type": "tree"
-            },
-            {
-              "conditions": [],
-              "endpoint": {
-                "url": "https://%1$s.{Region}.{PartitionResult#dnsSuffix}",
-                "properties": {},
-                "headers": {}
-              },
-              "type": "endpoint"
-            }
-          ],
-          "type": "tree"
-        }
-      ],
-      "type": "tree"
-    },
-    {
-      "conditions": [],
-      "error": "Invalid Configuration: Missing Region",
-      "type": "error"
-    }
-  ]
-}
-""".formatted(endpointPrefix)))
+                    """.formatted(endpointPrefix)
+                )
+            )
             .build();
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointsPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointsPlugin.java
@@ -17,6 +17,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 @Deprecated
 public class AddEndpointsPlugin implements TypeScriptIntegration {
+
     @Override
     public List<String> runAfter() {
         return List.of(AddBuiltinPlugins.class.getCanonicalName());

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointsV2ParameterNameMap.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEndpointsV2ParameterNameMap.java
@@ -24,20 +24,30 @@ import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegrati
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
-
 @SmithyInternalApi
 public class AddEndpointsV2ParameterNameMap implements TypeScriptIntegration {
+
     public static final Map<String, String> NAME_MAP = MapUtils.of(
-        "Region", "region",
-        "UseFIPS", "useFipsEndpoint",
-        "UseDualStack", "useDualstackEndpoint",
-        "ForcePathStyle", "forcePathStyle",
-        "Accelerate", "useAccelerateEndpoint",
-        "DisableMRAP", "disableMultiregionAccessPoints",
-        "DisableMultiRegionAccessPoints", "disableMultiregionAccessPoints",
-        "UseArnRegion", "useArnRegion",
-        "Endpoint", "endpoint",
-        "UseGlobalEndpoint", "useGlobalEndpoint"
+        "Region",
+        "region",
+        "UseFIPS",
+        "useFipsEndpoint",
+        "UseDualStack",
+        "useDualstackEndpoint",
+        "ForcePathStyle",
+        "forcePathStyle",
+        "Accelerate",
+        "useAccelerateEndpoint",
+        "DisableMRAP",
+        "disableMultiregionAccessPoints",
+        "DisableMultiRegionAccessPoints",
+        "disableMultiregionAccessPoints",
+        "UseArnRegion",
+        "useArnRegion",
+        "Endpoint",
+        "endpoint",
+        "UseGlobalEndpoint",
+        "useGlobalEndpoint"
     );
 
     public AddEndpointsV2ParameterNameMap() {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventStreamHandlingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventStreamHandlingDependency.java
@@ -55,41 +55,43 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.MIDDLEWARE_EVENTSTREAM.dependency,
-                                "EventStream", HAS_CONFIG)
-                        .servicePredicate(AddEventStreamHandlingDependency::hasEventStreamInput)
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.MIDDLEWARE_EVENTSTREAM.dependency,
-                                "EventStream", HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> hasEventStreamInput(m, o))
-                        .build()
+            RuntimeClientPlugin.builder()
+                .withConventions(AwsDependency.MIDDLEWARE_EVENTSTREAM.dependency, "EventStream", HAS_CONFIG)
+                .servicePredicate(AddEventStreamHandlingDependency::hasEventStreamInput)
+                .build(),
+            RuntimeClientPlugin.builder()
+                .withConventions(AwsDependency.MIDDLEWARE_EVENTSTREAM.dependency, "EventStream", HAS_MIDDLEWARE)
+                .operationPredicate((m, s, o) -> hasEventStreamInput(m, o))
+                .build()
         );
     }
 
     @Override
     public void addConfigInterfaceFields(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
     ) {
         if (hasEventStreamInput(model, settings.getService(model))) {
-            writer.addImport("EventStreamPayloadHandlerProvider", "__EventStreamPayloadHandlerProvider",
-                    TypeScriptDependency.AWS_SDK_TYPES);
-            writer.writeDocs("The function that provides necessary utilities for handling request event stream.\n"
-                            + "@internal");
+            writer.addImport(
+                "EventStreamPayloadHandlerProvider",
+                "__EventStreamPayloadHandlerProvider",
+                TypeScriptDependency.AWS_SDK_TYPES
+            );
+            writer.writeDocs(
+                "The function that provides necessary utilities for handling request event stream.\n" + "@internal"
+            );
             writer.write("eventStreamPayloadHandlerProvider?: __EventStreamPayloadHandlerProvider;\n");
         }
     }
 
     @Override
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            LanguageTarget target
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
     ) {
         ServiceShape service = settings.getService(model);
         if (!hasEventStreamInput(model, service)) {
@@ -99,8 +101,11 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
             case NODE:
                 return MapUtils.of("eventStreamPayloadHandlerProvider", writer -> {
                     writer.addDependency(AwsDependency.AWS_SDK_EVENTSTREAM_HANDLER_NODE);
-                    writer.addImport("eventStreamPayloadHandlerProvider", "eventStreamPayloadHandlerProvider",
-                            AwsDependency.AWS_SDK_EVENTSTREAM_HANDLER_NODE);
+                    writer.addImport(
+                        "eventStreamPayloadHandlerProvider",
+                        "eventStreamPayloadHandlerProvider",
+                        AwsDependency.AWS_SDK_EVENTSTREAM_HANDLER_NODE
+                    );
                     writer.write("eventStreamPayloadHandlerProvider");
                 });
             case BROWSER:
@@ -112,8 +117,7 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
                  */
                 return MapUtils.of("eventStreamPayloadHandlerProvider", writer -> {
                     writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
-                    writer.addImport("invalidFunction", "invalidFunction",
-                            TypeScriptDependency.INVALID_DEPENDENCY);
+                    writer.addImport("invalidFunction", "invalidFunction", TypeScriptDependency.INVALID_DEPENDENCY);
                     writer.openBlock("(() => ({", "}))", () -> {
                         writer.write("handle: invalidFunction(\"event stream request is not supported in browser.\"),");
                     });
@@ -126,11 +130,11 @@ public class AddEventStreamHandlingDependency implements TypeScriptIntegration {
                  */
                 return MapUtils.of("eventStreamPayloadHandlerProvider", writer -> {
                     writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
-                    writer.addImport("invalidFunction", "invalidFunction",
-                            TypeScriptDependency.INVALID_DEPENDENCY);
+                    writer.addImport("invalidFunction", "invalidFunction", TypeScriptDependency.INVALID_DEPENDENCY);
                     writer.openBlock("(() => ({", "}))", () -> {
-                        writer.write("handle: invalidFunction(\"event stream request "
-                                + "is not supported in ReactNative.\"),");
+                        writer.write(
+                            "handle: invalidFunction(\"event stream request " + "is not supported in ReactNative.\"),"
+                        );
                     });
                 });
             default:

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
@@ -34,12 +34,14 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
 public class AddHttp2Dependency implements TypeScriptIntegration {
+
     @Override
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            LanguageTarget target) {
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
+    ) {
         if (!isHttp2Applicable(settings.getService(model))) {
             return Collections.emptyMap();
         }
@@ -47,8 +49,11 @@ public class AddHttp2Dependency implements TypeScriptIntegration {
             case NODE:
                 return MapUtils.of("requestHandler", writer -> {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
-                    writer.addImport("NodeHttp2Handler", "RequestHandler",
-                            TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
+                    writer.addImport(
+                        "NodeHttp2Handler",
+                        "RequestHandler",
+                        TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER
+                    );
                     writer.openBlock("RequestHandler.create(config?.requestHandler ?? (async () => ({", "})))", () -> {
                         writer.write("...await defaultConfigProvider(),");
                         // TODO: remove this when root cause of #3809 is found
@@ -61,8 +66,10 @@ public class AddHttp2Dependency implements TypeScriptIntegration {
     }
 
     private static boolean isHttp2Applicable(ServiceShape service) {
-        List<String> eventStreamFlag = service.getTrait(AwsProtocolTrait.class)
-                .map(AwsProtocolTrait::getEventStreamHttp).orElse(ListUtils.of());
+        List<String> eventStreamFlag = service
+            .getTrait(AwsProtocolTrait.class)
+            .map(AwsProtocolTrait::getEventStreamHttp)
+            .orElse(ListUtils.of());
         return eventStreamFlag.contains("h2");
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
@@ -51,10 +51,10 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
 
     @Override
     public void addConfigInterfaceFields(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
     ) {
         if (!hasHttpChecksumTrait(model, settings.getService(model))) {
             return;
@@ -62,9 +62,11 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
 
         writer.addImport("Readable", "Readable", "stream");
         writer.addImport("StreamHasher", "__StreamHasher", TypeScriptDependency.SMITHY_TYPES);
-        writer.writeDocs("A function that, given a hash constructor and a stream, calculates the \n"
-                + "hash of the streamed value.\n"
-                + "@internal");
+        writer.writeDocs(
+            "A function that, given a hash constructor and a stream, calculates the \n" +
+                "hash of the streamed value.\n" +
+                "@internal"
+        );
         writer.write("streamHasher?: __StreamHasher<Readable> | __StreamHasher<Blob>;\n");
 
         writer.addImport("Hash", "__Hash", TypeScriptDependency.SMITHY_TYPES);
@@ -73,29 +75,37 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
         writer.addImport("Checksum", "__Checksum", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("ChecksumConstructor", "__ChecksumConstructor", TypeScriptDependency.SMITHY_TYPES);
 
-        writer.writeDocs("A constructor for a class implementing the {@link __Checksum} interface \n"
-                + "that computes MD5 hashes.\n"
-                + "@internal");
+        writer.writeDocs(
+            "A constructor for a class implementing the {@link __Checksum} interface \n" +
+                "that computes MD5 hashes.\n" +
+                "@internal"
+        );
         writer.write("md5?: __ChecksumConstructor | __HashConstructor;\n");
 
-        writer.writeDocs("A constructor for a class implementing the {@link __Checksum} interface \n"
-                + "that computes SHA1 hashes.\n"
-                + "@internal");
+        writer.writeDocs(
+            "A constructor for a class implementing the {@link __Checksum} interface \n" +
+                "that computes SHA1 hashes.\n" +
+                "@internal"
+        );
         writer.write("sha1?: __ChecksumConstructor | __HashConstructor;\n");
 
-        writer.addImport("GetAwsChunkedEncodingStream", "GetAwsChunkedEncodingStream",
-                TypeScriptDependency.AWS_SDK_TYPES);
-        writer.writeDocs("A function that returns Readable Stream which follows aws-chunked encoding stream.\n"
-                + "@internal");
+        writer.addImport(
+            "GetAwsChunkedEncodingStream",
+            "GetAwsChunkedEncodingStream",
+            TypeScriptDependency.AWS_SDK_TYPES
+        );
+        writer.writeDocs(
+            "A function that returns Readable Stream which follows aws-chunked encoding stream.\n" + "@internal"
+        );
         writer.write("getAwsChunkedEncodingStream?: GetAwsChunkedEncodingStream;\n");
     }
 
     @Override
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            LanguageTarget target
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
     ) {
         if (!hasHttpChecksumTrait(model, settings.getService(model))) {
             return Collections.emptyMap();
@@ -103,69 +113,88 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
 
         switch (target) {
             case SHARED:
-                return MapUtils.of(
-                    "getAwsChunkedEncodingStream", writer -> {
-                        writer.addDependency(TypeScriptDependency.UTIL_STREAM);
-                        writer.addImport("getAwsChunkedEncodingStream", "getAwsChunkedEncodingStream",
-                                TypeScriptDependency.UTIL_STREAM);
-                        writer.write("getAwsChunkedEncodingStream");
-                    }
-                );
+                return MapUtils.of("getAwsChunkedEncodingStream", writer -> {
+                    writer.addDependency(TypeScriptDependency.UTIL_STREAM);
+                    writer.addImport(
+                        "getAwsChunkedEncodingStream",
+                        "getAwsChunkedEncodingStream",
+                        TypeScriptDependency.UTIL_STREAM
+                    );
+                    writer.write("getAwsChunkedEncodingStream");
+                });
             case NODE:
                 return MapUtils.of(
-                    "streamHasher", writer -> {
+                    "streamHasher",
+                    writer -> {
                         writer.addDependency(TypeScriptDependency.STREAM_HASHER_NODE);
-                        writer.addImport("readableStreamHasher", "streamHasher",
-                                TypeScriptDependency.STREAM_HASHER_NODE);
+                        writer.addImport(
+                            "readableStreamHasher",
+                            "streamHasher",
+                            TypeScriptDependency.STREAM_HASHER_NODE
+                        );
                         writer.write("streamHasher");
                     },
-                    "md5", writer -> {
-                            writer.addDependency(TypeScriptDependency.AWS_SDK_TYPES);
-                            writer.addImport("HashConstructor", "__HashConstructor",
-                                    TypeScriptDependency.AWS_SDK_TYPES);
-                            writer.addImport("ChecksumConstructor", "__ChecksumConstructor",
-                                    TypeScriptDependency.AWS_SDK_TYPES);
-                            writer.write("Hash.bind(null, \"md5\")");
-                    },
-                    "sha1", writer -> {
+                    "md5",
+                    writer -> {
                         writer.addDependency(TypeScriptDependency.AWS_SDK_TYPES);
-                        writer.addImport("HashConstructor", "__HashConstructor",
-                                TypeScriptDependency.AWS_SDK_TYPES);
-                        writer.addImport("ChecksumConstructor", "__ChecksumConstructor",
-                                TypeScriptDependency.AWS_SDK_TYPES);
+                        writer.addImport("HashConstructor", "__HashConstructor", TypeScriptDependency.AWS_SDK_TYPES);
+                        writer.addImport(
+                            "ChecksumConstructor",
+                            "__ChecksumConstructor",
+                            TypeScriptDependency.AWS_SDK_TYPES
+                        );
+                        writer.write("Hash.bind(null, \"md5\")");
+                    },
+                    "sha1",
+                    writer -> {
+                        writer.addDependency(TypeScriptDependency.AWS_SDK_TYPES);
+                        writer.addImport("HashConstructor", "__HashConstructor", TypeScriptDependency.AWS_SDK_TYPES);
+                        writer.addImport(
+                            "ChecksumConstructor",
+                            "__ChecksumConstructor",
+                            TypeScriptDependency.AWS_SDK_TYPES
+                        );
                         writer.write("Hash.bind(null, \"sha1\")");
                     },
-                    "requestChecksumCalculation", writer -> {
+                    "requestChecksumCalculation",
+                    writer -> {
                         writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                        writer.addImport("loadConfig", "loadNodeConfig",
-                                    TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                        writer.addImport("NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS", null,
-                                    AwsDependency.FLEXIBLE_CHECKSUMS_MIDDLEWARE);
+                        writer.addImport("loadConfig", "loadNodeConfig", TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                        writer.addImport(
+                            "NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS",
+                            null,
+                            AwsDependency.FLEXIBLE_CHECKSUMS_MIDDLEWARE
+                        );
                         writer.write("loadNodeConfig(NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS, loaderConfig)");
                     },
-                    "responseChecksumValidation", writer -> {
+                    "responseChecksumValidation",
+                    writer -> {
                         writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                        writer.addImport("loadConfig", "loadNodeConfig",
-                                    TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                        writer.addImport("NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS", null,
-                                    AwsDependency.FLEXIBLE_CHECKSUMS_MIDDLEWARE);
+                        writer.addImport("loadConfig", "loadNodeConfig", TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                        writer.addImport(
+                            "NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS",
+                            null,
+                            AwsDependency.FLEXIBLE_CHECKSUMS_MIDDLEWARE
+                        );
                         writer.write("loadNodeConfig(NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS, loaderConfig)");
                     }
                 );
             case BROWSER:
                 return MapUtils.of(
-                    "streamHasher", writer -> {
+                    "streamHasher",
+                    writer -> {
                         writer.addDependency(TypeScriptDependency.STREAM_HASHER_BROWSER);
-                        writer.addImport("blobHasher", "streamHasher",
-                                TypeScriptDependency.STREAM_HASHER_BROWSER);
+                        writer.addImport("blobHasher", "streamHasher", TypeScriptDependency.STREAM_HASHER_BROWSER);
                         writer.write("streamHasher");
                     },
-                    "md5", writer -> {
+                    "md5",
+                    writer -> {
                         writer.addDependency(TypeScriptDependency.MD5_BROWSER);
                         writer.addImport("Md5", "Md5", TypeScriptDependency.MD5_BROWSER);
                         writer.write("Md5");
                     },
-                    "sha1", writer -> {
+                    "sha1",
+                    writer -> {
                         writer.addDependency(AwsDependency.AWS_CRYPTO_SHA1_BROWSER);
                         writer.addImport("Sha1", "Sha1", AwsDependency.AWS_CRYPTO_SHA1_BROWSER);
                         writer.write("Sha1");
@@ -180,16 +209,22 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
             RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.FLEXIBLE_CHECKSUMS_MIDDLEWARE.dependency, "FlexibleChecksums",
-                                         HAS_CONFIG)
-                        .servicePredicate((m, s) -> hasHttpChecksumTrait(m, s))
-                        .build(),
+                .withConventions(
+                    AwsDependency.FLEXIBLE_CHECKSUMS_MIDDLEWARE.dependency,
+                    "FlexibleChecksums",
+                    HAS_CONFIG
+                )
+                .servicePredicate((m, s) -> hasHttpChecksumTrait(m, s))
+                .build(),
             RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.FLEXIBLE_CHECKSUMS_MIDDLEWARE.dependency, "FlexibleChecksums",
-                                         HAS_MIDDLEWARE)
-                        .additionalPluginFunctionParamsSupplier((m, s, o) -> getPluginFunctionParams(m, s, o))
-                        .operationPredicate((m, s, o) -> hasHttpChecksumTrait(o))
-                        .build()
+                .withConventions(
+                    AwsDependency.FLEXIBLE_CHECKSUMS_MIDDLEWARE.dependency,
+                    "FlexibleChecksums",
+                    HAS_MIDDLEWARE
+                )
+                .additionalPluginFunctionParamsSupplier((m, s, o) -> getPluginFunctionParams(m, s, o))
+                .operationPredicate((m, s, o) -> hasHttpChecksumTrait(o))
+                .build()
         );
     }
 
@@ -202,25 +237,31 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
 
         HttpChecksumTrait httpChecksumTrait = operation.expectTrait(HttpChecksumTrait.class);
         params.put("requestChecksumRequired", httpChecksumTrait.isRequestChecksumRequired());
-        httpChecksumTrait.getRequestAlgorithmMember().ifPresent(requestAlgorithmMember -> {
-            Map<String, String> requestAlgorithmMemberMap = new TreeMap<String, String>();
-            requestAlgorithmMemberMap.put("name", requestAlgorithmMember);
+        httpChecksumTrait
+            .getRequestAlgorithmMember()
+            .ifPresent(requestAlgorithmMember -> {
+                Map<String, String> requestAlgorithmMemberMap = new TreeMap<String, String>();
+                requestAlgorithmMemberMap.put("name", requestAlgorithmMember);
 
-            // We know that input shape is structure, and contains requestAlgorithmMember.
-            StructureShape inputShape =  model.expectShape(operation.getInput().get(), StructureShape.class);
-            MemberShape requestAlgorithmMemberShape = inputShape.getAllMembers().get(requestAlgorithmMember);
+                // We know that input shape is structure, and contains requestAlgorithmMember.
+                StructureShape inputShape = model.expectShape(operation.getInput().get(), StructureShape.class);
+                MemberShape requestAlgorithmMemberShape = inputShape.getAllMembers().get(requestAlgorithmMember);
 
-            // Set requestAlgorithmMemberHttpHeader if HttpHeaderTrait is present.
-            requestAlgorithmMemberShape.getTrait(HttpHeaderTrait.class).ifPresent(httpHeaderTrait -> {
-                requestAlgorithmMemberMap.put("httpHeader", httpHeaderTrait.getValue());
+                // Set requestAlgorithmMemberHttpHeader if HttpHeaderTrait is present.
+                requestAlgorithmMemberShape
+                    .getTrait(HttpHeaderTrait.class)
+                    .ifPresent(httpHeaderTrait -> {
+                        requestAlgorithmMemberMap.put("httpHeader", httpHeaderTrait.getValue());
+                    });
+
+                params.put("requestAlgorithmMember", requestAlgorithmMemberMap);
             });
-
-            params.put("requestAlgorithmMember", requestAlgorithmMemberMap);
-        });
-        httpChecksumTrait.getRequestValidationModeMember().ifPresent(requestValidationModeMember -> {
-            params.put("requestValidationModeMember", requestValidationModeMember);
-            params.put("responseAlgorithms", httpChecksumTrait.getResponseAlgorithms());
-        });
+        httpChecksumTrait
+            .getRequestValidationModeMember()
+            .ifPresent(requestValidationModeMember -> {
+                params.put("requestValidationModeMember", requestValidationModeMember);
+                params.put("responseAlgorithms", httpChecksumTrait.getResponseAlgorithms());
+            });
 
         return params;
     }
@@ -230,10 +271,7 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
         return operation.hasTrait(HttpChecksumTrait.class);
     }
 
-    private static boolean hasHttpChecksumTrait(
-            Model model,
-            ServiceShape service
-    ) {
+    private static boolean hasHttpChecksumTrait(Model model, ServiceShape service) {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
         for (OperationShape operation : operations) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddNimbleCustomizations.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddNimbleCustomizations.java
@@ -41,7 +41,9 @@ public class AddNimbleCustomizations implements TypeScriptIntegration {
             return model;
         }
         Map<ShapeId, ShapeType> overWriteTypeMap = MapUtils.of(
-                ShapeId.from("com.amazonaws.nimble#StudioComponentConfiguration"), ShapeType.STRUCTURE);
+            ShapeId.from("com.amazonaws.nimble#StudioComponentConfiguration"),
+            ShapeType.STRUCTURE
+        );
         return ModelTransformer.create().changeShapeType(model, overWriteTypeMap);
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
@@ -27,9 +27,9 @@ import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
-
 @SmithyInternalApi
 public class AddOmitRetryHeadersDependency implements TypeScriptIntegration {
+
     private static final Set<String> SERVICE_IDS = SetUtils.of(
         "ConnectParticipant", // P43593766
         "DataBrew", // P55897945
@@ -40,14 +40,13 @@ public class AddOmitRetryHeadersDependency implements TypeScriptIntegration {
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
-                RuntimeClientPlugin.builder()
-                        .withConventions(TypeScriptDependency.MIDDLEWARE_RETRY.dependency, "OmitRetryHeaders",
-                                HAS_MIDDLEWARE)
-                        .servicePredicate((m, s) -> {
-                            String sdkId = s.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
-                            return SERVICE_IDS.contains(sdkId);
-                        })
-                        .build()
+            RuntimeClientPlugin.builder()
+                .withConventions(TypeScriptDependency.MIDDLEWARE_RETRY.dependency, "OmitRetryHeaders", HAS_MIDDLEWARE)
+                .servicePredicate((m, s) -> {
+                    String sdkId = s.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
+                    return SERVICE_IDS.contains(sdkId);
+                })
+                .build()
         );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmittedEndpointParams.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmittedEndpointParams.java
@@ -3,23 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- package software.amazon.smithy.aws.typescript.codegen;
+package software.amazon.smithy.aws.typescript.codegen;
 
- import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
- import software.amazon.smithy.typescript.codegen.endpointsV2.OmitEndpointParams;
- import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
- import software.amazon.smithy.utils.SetUtils;
- import software.amazon.smithy.utils.SmithyInternalApi;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
+import software.amazon.smithy.typescript.codegen.endpointsV2.OmitEndpointParams;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
- @SmithyInternalApi
- public class AddOmittedEndpointParams implements TypeScriptIntegration {
+@SmithyInternalApi
+public class AddOmittedEndpointParams implements TypeScriptIntegration {
 
-     @Override
-     public void customize(TypeScriptCodegenContext codegenContext) {
-         setParamForOmission();
-     }
+    @Override
+    public void customize(TypeScriptCodegenContext codegenContext) {
+        setParamForOmission();
+    }
 
-     private void setParamForOmission() {
-         OmitEndpointParams.addOmittedParams(SetUtils.of("AccountId"));
-     }
- }
+    private void setParamForOmission() {
+        OmitEndpointParams.addOmittedParams(SetUtils.of("AccountId"));
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocolConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocolConfig.java
@@ -30,12 +30,12 @@ import software.amazon.smithy.typescript.codegen.schema.SchemaGenerationAllowlis
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
-
 /**
  * Adds a protocol implementation to the runtime config.
  */
 @SmithyInternalApi
 public final class AddProtocolConfig implements TypeScriptIntegration {
+
     static {
         init();
     }
@@ -105,7 +105,8 @@ public final class AddProtocolConfig implements TypeScriptIntegration {
         }
         String namespace = settings.getService().getNamespace();
         String rpcTarget = settings.getService().getName();
-        String xmlns = settings.getService(model)
+        String xmlns = settings
+            .getService(model)
             .getTrait(XmlNamespaceTrait.class)
             .map(XmlNamespaceTrait::getUri)
             .orElse("");
@@ -114,135 +115,109 @@ public final class AddProtocolConfig implements TypeScriptIntegration {
         switch (target) {
             case SHARED:
                 if (Objects.equals(settings.getProtocol(), RestXmlTrait.ID)) {
-                    return MapUtils.of(
-                        "protocol", writer -> {
-                            writer.addImportSubmodule(
-                                "AwsRestXmlProtocol", null,
-                                AwsDependency.AWS_SDK_CORE, "/protocols");
-                            writer.write("""
-                                new AwsRestXmlProtocol({
-                                  defaultNamespace: $S,
-                                  xmlNamespace: $S,
-                                })""",
-                                namespace,
-                                xmlns
-                            );
-                        }
-                    );
+                    return MapUtils.of("protocol", writer -> {
+                        writer.addImportSubmodule("AwsRestXmlProtocol", null, AwsDependency.AWS_SDK_CORE, "/protocols");
+                        writer.write(
+                            """
+                            new AwsRestXmlProtocol({
+                              defaultNamespace: $S,
+                              xmlNamespace: $S,
+                            })""",
+                            namespace,
+                            xmlns
+                        );
+                    });
                 } else if (Objects.equals(settings.getProtocol(), AwsQueryTrait.ID)) {
-                    return MapUtils.of(
-                        "protocol", writer -> {
-                            writer.addImportSubmodule(
-                                "AwsQueryProtocol", null,
-                                AwsDependency.AWS_SDK_CORE, "/protocols");
-                            writer.write(
-                                """
-                                new AwsQueryProtocol({
-                                  defaultNamespace: $S,
-                                  xmlNamespace: $S,
-                                  version: $S,
-                                })""",
-                                namespace,
-                                xmlns,
-                                settings.getService(model).getVersion()
-                            );
-                        }
-                    );
+                    return MapUtils.of("protocol", writer -> {
+                        writer.addImportSubmodule("AwsQueryProtocol", null, AwsDependency.AWS_SDK_CORE, "/protocols");
+                        writer.write(
+                            """
+                            new AwsQueryProtocol({
+                              defaultNamespace: $S,
+                              xmlNamespace: $S,
+                              version: $S,
+                            })""",
+                            namespace,
+                            xmlns,
+                            settings.getService(model).getVersion()
+                        );
+                    });
                 } else if (Objects.equals(settings.getProtocol(), Ec2QueryTrait.ID)) {
-                    return MapUtils.of(
-                        "protocol", writer -> {
-                            writer.addImportSubmodule(
-                                "AwsEc2QueryProtocol", null,
-                                AwsDependency.AWS_SDK_CORE, "/protocols");
-                            writer.write(
-                                """
-                                new AwsEc2QueryProtocol({
-                                  defaultNamespace: $S,
-                                  xmlNamespace: $S,
-                                  version: $S,
-                                })""",
-                                namespace,
-                                xmlns,
-                                settings.getService(model).getVersion()
-                            );
-                        }
-                    );
+                    return MapUtils.of("protocol", writer -> {
+                        writer.addImportSubmodule(
+                            "AwsEc2QueryProtocol",
+                            null,
+                            AwsDependency.AWS_SDK_CORE,
+                            "/protocols"
+                        );
+                        writer.write(
+                            """
+                            new AwsEc2QueryProtocol({
+                              defaultNamespace: $S,
+                              xmlNamespace: $S,
+                              version: $S,
+                            })""",
+                            namespace,
+                            xmlns,
+                            settings.getService(model).getVersion()
+                        );
+                    });
                 } else if (Objects.equals(settings.getProtocol(), RestJson1Trait.ID)) {
-                    return MapUtils.of(
-                        "protocol", writer -> {
-                            writer.addImportSubmodule(
-                                "AwsRestJsonProtocol", null,
-                                AwsDependency.AWS_SDK_CORE, "/protocols");
-                            writer.write("new AwsRestJsonProtocol({ defaultNamespace: $S })", namespace);
-                        }
-                    );
+                    return MapUtils.of("protocol", writer -> {
+                        writer.addImportSubmodule(
+                            "AwsRestJsonProtocol",
+                            null,
+                            AwsDependency.AWS_SDK_CORE,
+                            "/protocols"
+                        );
+                        writer.write("new AwsRestJsonProtocol({ defaultNamespace: $S })", namespace);
+                    });
                 } else if (Objects.equals(settings.getProtocol(), AwsJson1_0Trait.ID)) {
-                    return MapUtils.of(
-                        "protocol", writer -> {
-                            writer.addImportSubmodule(
-                                "AwsJson1_0Protocol", null,
-                                AwsDependency.AWS_SDK_CORE, "/protocols");
-                            writer.openBlock(
-                                """
-                                    new AwsJson1_0Protocol({
-                                      defaultNamespace: $S,
-                                      serviceTarget: $S,
-                                      awsQueryCompatible: $L,""",
-                                """
-                                    })""",
-                                namespace,
-                                rpcTarget,
-                                awsQueryCompat,
-                                () -> {
-                                    if (CUSTOMIZATIONS.containsKey(settings.getService())) {
-                                        CUSTOMIZATIONS.get(settings.getService()).accept(writer);
-                                    }
-                                }
-                            );
-                        }
-                    );
+                    return MapUtils.of("protocol", writer -> {
+                        writer.addImportSubmodule("AwsJson1_0Protocol", null, AwsDependency.AWS_SDK_CORE, "/protocols");
+                        writer.openBlock("""
+                        new AwsJson1_0Protocol({
+                          defaultNamespace: $S,
+                          serviceTarget: $S,
+                          awsQueryCompatible: $L,""", """
+                        })""", namespace, rpcTarget, awsQueryCompat, () -> {
+                            if (CUSTOMIZATIONS.containsKey(settings.getService())) {
+                                CUSTOMIZATIONS.get(settings.getService()).accept(writer);
+                            }
+                        });
+                    });
                 } else if (Objects.equals(settings.getProtocol(), AwsJson1_1Trait.ID)) {
-                    return MapUtils.of(
-                        "protocol", writer -> {
-                            writer.addImportSubmodule(
-                                "AwsJson1_1Protocol", null,
-                                AwsDependency.AWS_SDK_CORE, "/protocols");
-                            writer.openBlock(
-                                """
-                                    new AwsJson1_1Protocol({
-                                      defaultNamespace: $S,
-                                      serviceTarget: $S,
-                                      awsQueryCompatible: $L,""",
-                                """
-                                    })""",
-                                namespace,
-                                rpcTarget,
-                                awsQueryCompat,
-                                () -> {
-                                    if (CUSTOMIZATIONS.containsKey(settings.getService())) {
-                                        CUSTOMIZATIONS.get(settings.getService()).accept(writer);
-                                    }
-                                }
-                            );
-                        }
-                    );
+                    return MapUtils.of("protocol", writer -> {
+                        writer.addImportSubmodule("AwsJson1_1Protocol", null, AwsDependency.AWS_SDK_CORE, "/protocols");
+                        writer.openBlock("""
+                        new AwsJson1_1Protocol({
+                          defaultNamespace: $S,
+                          serviceTarget: $S,
+                          awsQueryCompatible: $L,""", """
+                        })""", namespace, rpcTarget, awsQueryCompat, () -> {
+                            if (CUSTOMIZATIONS.containsKey(settings.getService())) {
+                                CUSTOMIZATIONS.get(settings.getService()).accept(writer);
+                            }
+                        });
+                    });
                 } else if (Objects.equals(settings.getProtocol(), Rpcv2CborTrait.ID)) {
-                    return MapUtils.of(
-                        "protocol", writer -> {
-                            writer.addImportSubmodule(
-                                "AwsSmithyRpcV2CborProtocol", null,
-                                AwsDependency.AWS_SDK_CORE, "/protocols");
-                            writer.write(
-                                """
-                                   new AwsSmithyRpcV2CborProtocol({
-                                     defaultNamespace: $S,
-                                     awsQueryCompatible: $L,
-                                   })""",
-                                namespace,
-                                awsQueryCompat
-                            );
-                        }
-                    );
+                    return MapUtils.of("protocol", writer -> {
+                        writer.addImportSubmodule(
+                            "AwsSmithyRpcV2CborProtocol",
+                            null,
+                            AwsDependency.AWS_SDK_CORE,
+                            "/protocols"
+                        );
+                        writer.write(
+                            """
+                            new AwsSmithyRpcV2CborProtocol({
+                              defaultNamespace: $S,
+                              awsQueryCompatible: $L,
+                            })""",
+                            namespace,
+                            awsQueryCompat
+                        );
+                    });
                 }
             case BROWSER:
             case NODE:

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocols.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddProtocols.java
@@ -29,9 +29,7 @@ public class AddProtocols implements TypeScriptIntegration {
 
     @Override
     public List<String> runAfter() {
-        return List.of(
-            software.amazon.smithy.typescript.codegen.protocols.AddProtocols.class.getCanonicalName()
-        );
+        return List.of(software.amazon.smithy.typescript.codegen.protocols.AddProtocols.class.getCanonicalName());
     }
 
     /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -71,6 +71,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class AddS3Config implements TypeScriptIntegration {
+
     private static final Logger LOGGER = Logger.getLogger(AddS3Config.class.getName());
 
     private static final Set<String> SSEC_INPUT_KEYS = SetUtils.of("SSECustomerKey", "CopySourceSSECustomerKey");
@@ -83,28 +84,27 @@ public final class AddS3Config implements TypeScriptIntegration {
         "ListBuckets"
     );
 
-    private static final String CRT_NOTIFICATION = "<p>Note: To supply the Multi-region Access Point (MRAP) to Bucket,"
-        + " you need to install the \"@aws-sdk/signature-v4-crt\" package to your project dependencies. \n"
-        + "For more information, please go to https://github.com/aws/aws-sdk-js-v3#known-issues</p>";
+    private static final String CRT_NOTIFICATION =
+        "<p>Note: To supply the Multi-region Access Point (MRAP) to Bucket," +
+        " you need to install the \"@aws-sdk/signature-v4-crt\" package to your project dependencies. \n" +
+        "For more information, please go to https://github.com/aws/aws-sdk-js-v3#known-issues</p>";
 
     /**
      * Remove the hostPrefix functionality by removing the endpoint traits.
      * Only applied if endpointRuleSet trait present on S3/S3Control services.
      */
     public static Shape removeHostPrefixTrait(Shape shape) {
-        return shape.asOperationShape()
+        return shape
+            .asOperationShape()
             .map(OperationShape::shapeToBuilder)
             .map((Object object) -> {
                 OperationShape.Builder builder = (OperationShape.Builder) object;
                 Trait trait = builder.getAllTraits().get(EndpointTrait.ID);
                 if (trait instanceof EndpointTrait endpointTrait) {
                     if (
-                        endpointTrait.getHostPrefix().equals(
-                            SmithyPattern.builder()
-                                .segments(List.of())
-                                .pattern("{AccountId}.")
-                                .build()
-                        )
+                        endpointTrait
+                            .getHostPrefix()
+                            .equals(SmithyPattern.builder().segments(List.of()).pattern("{AccountId}.").build())
                     ) {
                         builder.removeTrait(EndpointTrait.ID);
                     }
@@ -123,7 +123,8 @@ public final class AddS3Config implements TypeScriptIntegration {
      * - "Bucket" input member is a contextParam.
      */
     public static Shape removeUriBucketPrefix(Shape shape, Model model) {
-        return shape.asOperationShape()
+        return shape
+            .asOperationShape()
             .map(OperationShape::shapeToBuilder)
             .map((Object object) -> {
                 OperationShape.Builder builder = (OperationShape.Builder) object;
@@ -131,28 +132,18 @@ public final class AddS3Config implements TypeScriptIntegration {
                 if (trait instanceof HttpTrait httpTrait) {
                     String uri = httpTrait.getUri().toString();
 
-                    StructureShape input = model.expectShape(
-                        shape.asOperationShape().get().getInputShape()
-                    ).asStructureShape().orElseThrow(
-                        () -> new RuntimeException("operation must have input structure")
-                    );
+                    StructureShape input = model
+                        .expectShape(shape.asOperationShape().get().getInputShape())
+                        .asStructureShape()
+                        .orElseThrow(() -> new RuntimeException("operation must have input structure"));
 
                     boolean hasBucketPrefix = uri.startsWith("/{Bucket}");
                     Optional<MemberShape> bucket = input.getMember("Bucket");
                     boolean inputHasBucketMember = bucket.isPresent();
-                    boolean bucketIsContextParam = bucket
-                        .map(ms -> ms.getTrait(ContextParamTrait.class))
-                        .isPresent();
+                    boolean bucketIsContextParam = bucket.map(ms -> ms.getTrait(ContextParamTrait.class)).isPresent();
                     if (hasBucketPrefix && inputHasBucketMember && bucketIsContextParam) {
-                        String replaced = uri
-                            .replace("/{Bucket}/", "/")
-                            .replace("/{Bucket}", "/");
-                        builder.addTrait(
-                            httpTrait
-                                .toBuilder()
-                                .uri(UriPattern.parse(replaced))
-                                .build()
-                        );
+                        String replaced = uri.replace("/{Bucket}/", "/").replace("/{Bucket}", "/");
+                        builder.addTrait(httpTrait.toBuilder().uri(UriPattern.parse(replaced)).build());
                     }
                 }
                 return builder;
@@ -164,10 +155,7 @@ public final class AddS3Config implements TypeScriptIntegration {
 
     @Override
     public List<String> runAfter() {
-        return List.of(
-            new AddHttpSigningPlugin().name(),
-            AddBuiltinPlugins.class.getCanonicalName()
-        );
+        return List.of(new AddHttpSigningPlugin().name(), AddBuiltinPlugins.class.getCanonicalName());
     }
 
     @Override
@@ -186,19 +174,27 @@ public final class AddS3Config implements TypeScriptIntegration {
             if (NON_BUCKET_ENDPOINT_OPERATIONS.contains(operationShape.getId().getName(serviceShape))) {
                 continue;
             }
-            operationShape.getInput().ifPresent(inputShapeId -> {
-                StructureShape inputShape = model.expectShape(inputShapeId, StructureShape.class);
-                inputShape.getMember("Bucket").ifPresent(bucketMember -> {
-                    bucketMember.getTrait(DocumentationTrait.class).ifPresent(documentationTrait -> {
-                        StructureShape.Builder inputShapeBuilder = inputShape.toBuilder();
-                        MemberShape.Builder builder = MemberShape.shapeToBuilder(bucketMember);
-                        String newDocString = documentationTrait.getValue() + "\n" + CRT_NOTIFICATION;
-                        MemberShape newMemberShape = builder.addTrait(new DocumentationTrait(newDocString)).build();
-                        inputShapeBuilder.addMember(newMemberShape);
-                        inputShapes.add(inputShapeBuilder.build());
-                    });
+            operationShape
+                .getInput()
+                .ifPresent(inputShapeId -> {
+                    StructureShape inputShape = model.expectShape(inputShapeId, StructureShape.class);
+                    inputShape
+                        .getMember("Bucket")
+                        .ifPresent(bucketMember -> {
+                            bucketMember
+                                .getTrait(DocumentationTrait.class)
+                                .ifPresent(documentationTrait -> {
+                                    StructureShape.Builder inputShapeBuilder = inputShape.toBuilder();
+                                    MemberShape.Builder builder = MemberShape.shapeToBuilder(bucketMember);
+                                    String newDocString = documentationTrait.getValue() + "\n" + CRT_NOTIFICATION;
+                                    MemberShape newMemberShape = builder
+                                        .addTrait(new DocumentationTrait(newDocString))
+                                        .build();
+                                    inputShapeBuilder.addMember(newMemberShape);
+                                    inputShapes.add(inputShapeBuilder.build());
+                                });
+                        });
                 });
-            });
         }
         LOGGER.info("Patching " + inputShapes.size() + " input shapes with CRT notification");
 
@@ -208,15 +204,9 @@ public final class AddS3Config implements TypeScriptIntegration {
             // enforce that "com.amazonaws.s3#Expires" retains type=timestamp.
             // add a shape "com.amazonaws.s3#ExpiresString" of type=string.
             Shape expiresShape = model.getShape(ShapeId.from("com.amazonaws.s3#Expires")).get();
-            TimestampShape expiresTimestampShape = TimestampShape.builder()
-                .id(expiresShape.getId())
-                .build();
-            StringShape expiresStringShape = StringShape.builder()
-                .id("com.amazonaws.s3#ExpiresString")
-                .build();
-            modelBuilder
-                .removeShape(expiresShape.getId())
-                .addShapes(expiresTimestampShape, expiresStringShape);
+            TimestampShape expiresTimestampShape = TimestampShape.builder().id(expiresShape.getId()).build();
+            StringShape expiresStringShape = StringShape.builder().id("com.amazonaws.s3#ExpiresString").build();
+            modelBuilder.removeShape(expiresShape.getId()).addShapes(expiresTimestampShape, expiresStringShape);
 
             // ExpiresString customization part 2:
             // for any output shape member targeting Expires, add a member ExpiresString targeting ExpiresString.
@@ -229,12 +219,11 @@ public final class AddS3Config implements TypeScriptIntegration {
                     continue;
                 }
                 StructureShape structureShape = model.expectShape(
-                    operationShape.getOutputShape(), StructureShape.class
+                    operationShape.getOutputShape(),
+                    StructureShape.class
                 );
 
-                Set<Map.Entry<String, MemberShape>> memberEntries = structureShape
-                    .getAllMembers()
-                    .entrySet();
+                Set<Map.Entry<String, MemberShape>> memberEntries = structureShape.getAllMembers().entrySet();
                 StructureShape.Builder structureShapeBuilder = structureShape.toBuilder();
 
                 boolean isTargetingExpires = structureShape
@@ -251,49 +240,37 @@ public final class AddS3Config implements TypeScriptIntegration {
                         Optional<HttpHeaderTrait> httpHeader = memberShape.getTrait(HttpHeaderTrait.class);
                         Optional<DocumentationTrait> doc = memberShape.getTrait(DocumentationTrait.class);
 
-                        if (memberShape.getTarget().equals(expiresShape.getId())
-                            && httpHeader.isPresent()) {
+                        if (memberShape.getTarget().equals(expiresShape.getId()) && httpHeader.isPresent()) {
                             structureShapeBuilder
                                 .removeMember(memberName)
-                                .addMember(
-                                    memberName,
-                                    expiresTimestampShape.getId(),
-                                    (m) -> {
-                                        m
-                                            .addTrait(new DocumentationTrait("Deprecated in favor of ExpiresString."))
-                                            .addTrait(httpHeader.get())
-                                            .addTrait(DeprecatedTrait.builder().build());
-                                    }
-                                )
-                                .addMember(
-                                    "ExpiresString",
-                                    expiresStringShape.getId(),
-                                    (m) -> {
-                                        m.addTrait(new HttpHeaderTrait("ExpiresString"));
-                                        doc.ifPresent(m::addTrait);
-                                    }
-                                );
+                                .addMember(memberName, expiresTimestampShape.getId(), m -> {
+                                    m
+                                        .addTrait(new DocumentationTrait("Deprecated in favor of ExpiresString."))
+                                        .addTrait(httpHeader.get())
+                                        .addTrait(DeprecatedTrait.builder().build());
+                                })
+                                .addMember("ExpiresString", expiresStringShape.getId(), m -> {
+                                    m.addTrait(new HttpHeaderTrait("ExpiresString"));
+                                    doc.ifPresent(m::addTrait);
+                                });
                         } else {
                             // This is done to preserve the member order
                             // and insert ExpiresString adjacent to Expires.
                             structureShapeBuilder
                                 .removeMember(memberName)
-                                .addMember(memberName, memberShape.getTarget(), (m) -> {
+                                .addMember(memberName, memberShape.getTarget(), m -> {
                                     m.addTraits(memberShape.getAllTraits().values());
                                 });
                         }
                     }
-                    modelBuilder
-                        .addShape(structureShapeBuilder.build());
+                    modelBuilder.addShape(structureShapeBuilder.build());
                 }
             }
         }
 
         Model builtModel = modelBuilder.addShapes(inputShapes).build();
         if (hasRuleset) {
-            return ModelTransformer.create().mapShapes(
-                builtModel, (shape) -> removeUriBucketPrefix(shape, model)
-            );
+            return ModelTransformer.create().mapShapes(builtModel, shape -> removeUriBucketPrefix(shape, model));
         }
         return builtModel;
     }
@@ -309,19 +286,24 @@ public final class AddS3Config implements TypeScriptIntegration {
         if (!isS3(service)) {
             return;
         }
-        writer.writeDocs("Whether to escape request path when signing the request.")
+        writer
+            .writeDocs("Whether to escape request path when signing the request.")
             .write("signingEscapePath?: boolean;\n");
-        writer.writeDocs(
-                "Whether to override the request region with the region inferred from requested resource's ARN."
-                    + " Defaults to undefined.")
+        writer
+            .writeDocs(
+                "Whether to override the request region with the region inferred from requested resource's ARN." +
+                    " Defaults to undefined."
+            )
             .addImport("Provider", "Provider", TypeScriptDependency.SMITHY_TYPES)
             .write("useArnRegion?: boolean | undefined | Provider<boolean | undefined>;");
     }
 
     @Override
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-        TypeScriptSettings settings, Model model,
-        SymbolProvider symbolProvider, LanguageTarget target
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
     ) {
         if (!isS3(settings.getService(model))) {
             return Collections.emptyMap();
@@ -329,35 +311,42 @@ public final class AddS3Config implements TypeScriptIntegration {
         switch (target) {
             case SHARED:
                 return MapUtils.of(
-                    "signingEscapePath", writer -> {
+                    "signingEscapePath",
+                    writer -> {
                         writer.write("false");
                     },
-                    "useArnRegion", writer -> {
+                    "useArnRegion",
+                    writer -> {
                         writer.write("undefined");
                     }
                 );
             case NODE:
                 return MapUtils.of(
-                    "useArnRegion", writer -> {
-                        writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER)
-                        .addImport("loadConfig", "loadNodeConfig",
-                                TypeScriptDependency.NODE_CONFIG_PROVIDER)
-                        .addDependency(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE)
-                        .addImport("NODE_USE_ARN_REGION_CONFIG_OPTIONS", "NODE_USE_ARN_REGION_CONFIG_OPTIONS",
-                            AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE)
-                        .write("loadNodeConfig(NODE_USE_ARN_REGION_CONFIG_OPTIONS, loaderConfig)");
+                    "useArnRegion",
+                    writer -> {
+                        writer
+                            .addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER)
+                            .addImport("loadConfig", "loadNodeConfig", TypeScriptDependency.NODE_CONFIG_PROVIDER)
+                            .addDependency(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE)
+                            .addImport(
+                                "NODE_USE_ARN_REGION_CONFIG_OPTIONS",
+                                "NODE_USE_ARN_REGION_CONFIG_OPTIONS",
+                                AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE
+                            )
+                            .write("loadNodeConfig(NODE_USE_ARN_REGION_CONFIG_OPTIONS, loaderConfig)");
                     },
-                    "disableS3ExpressSessionAuth", writer -> {
-                        writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER)
-                        .addImport("loadConfig", "loadNodeConfig",
-                                TypeScriptDependency.NODE_CONFIG_PROVIDER)
-                        .addDependency(AwsDependency.S3_MIDDLEWARE)
-                        .addImport(
-                            "NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS",
-                            "NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS",
-                            AwsDependency.S3_MIDDLEWARE
-                        )
-                        .write("loadNodeConfig(NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS, loaderConfig)");
+                    "disableS3ExpressSessionAuth",
+                    writer -> {
+                        writer
+                            .addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER)
+                            .addImport("loadConfig", "loadNodeConfig", TypeScriptDependency.NODE_CONFIG_PROVIDER)
+                            .addDependency(AwsDependency.S3_MIDDLEWARE)
+                            .addImport(
+                                "NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS",
+                                "NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS",
+                                AwsDependency.S3_MIDDLEWARE
+                            )
+                            .write("loadNodeConfig(NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS, loaderConfig)");
                     }
                 );
             default:
@@ -369,18 +358,15 @@ public final class AddS3Config implements TypeScriptIntegration {
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "ValidateBucketName",
-                    HAS_MIDDLEWARE)
+                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "ValidateBucketName", HAS_MIDDLEWARE)
                 .servicePredicate((m, s) -> isS3(s))
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "CheckContentLengthHeader",
-                    HAS_MIDDLEWARE)
+                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "CheckContentLengthHeader", HAS_MIDDLEWARE)
                 .operationPredicate((m, s, o) -> isS3(s) && o.getId().getName(s).equals("PutObject"))
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "throw200Exceptions",
-                    HAS_MIDDLEWARE)
+                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "throw200Exceptions", HAS_MIDDLEWARE)
                 .operationPredicate((m, s, o) -> {
                     if (!isS3(s)) {
                         return false;
@@ -388,8 +374,11 @@ public final class AddS3Config implements TypeScriptIntegration {
                     Optional<ShapeId> output = o.getOutput();
                     if (output.isPresent()) {
                         Shape outputShape = m.expectShape(output.get());
-                        boolean hasStreamingBlobOutputPayload = outputShape.getAllMembers().values().stream().anyMatch(
-                            memberShape -> {
+                        boolean hasStreamingBlobOutputPayload = outputShape
+                            .getAllMembers()
+                            .values()
+                            .stream()
+                            .anyMatch(memberShape -> {
                                 boolean isPayload = memberShape.hasTrait(HttpPayloadTrait.class);
                                 if (!isPayload) {
                                     return false;
@@ -400,8 +389,7 @@ public final class AddS3Config implements TypeScriptIntegration {
                                     return false;
                                 }
                                 return shape.hasTrait(StreamingTrait.class);
-                            }
-                        );
+                            });
                         if (hasStreamingBlobOutputPayload) {
                             return false;
                         }
@@ -410,20 +398,16 @@ public final class AddS3Config implements TypeScriptIntegration {
                 })
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.ADD_EXPECT_CONTINUE.dependency, "AddExpectContinue",
-                    HAS_MIDDLEWARE)
+                .withConventions(AwsDependency.ADD_EXPECT_CONTINUE.dependency, "AddExpectContinue", HAS_MIDDLEWARE)
                 .servicePredicate((m, s) -> isS3(s))
                 .build(),
             RuntimeClientPlugin.builder()
                 .withConventions(AwsDependency.SSEC_MIDDLEWARE.dependency, "Ssec", HAS_MIDDLEWARE)
-                .operationPredicate((m, s, o) -> containsInputMembers(m, o, SSEC_INPUT_KEYS)
-                    && isS3(s))
+                .operationPredicate((m, s, o) -> containsInputMembers(m, o, SSEC_INPUT_KEYS) && isS3(s))
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.LOCATION_CONSTRAINT.dependency, "LocationConstraint",
-                    HAS_MIDDLEWARE)
-                .operationPredicate((m, s, o) -> o.getId().getName(s).equals("CreateBucket")
-                    && isS3(s))
+                .withConventions(AwsDependency.LOCATION_CONSTRAINT.dependency, "LocationConstraint", HAS_MIDDLEWARE)
+                .operationPredicate((m, s, o) -> o.getId().getName(s).equals("CreateBucket") && isS3(s))
                 .build(),
             RuntimeClientPlugin.builder()
                 .inputConfig(
@@ -442,19 +426,21 @@ public final class AddS3Config implements TypeScriptIntegration {
                     Symbol.builder()
                         .namespace(AwsDependency.S3_MIDDLEWARE.dependency.getPackageName(), "/")
                         .name("resolveS3Config")
-                        .addDependency(
-                            AwsDependency.S3_MIDDLEWARE.dependency
-                        )
+                        .addDependency(AwsDependency.S3_MIDDLEWARE.dependency)
                         .build(),
-                    (m, s, o) -> MapUtils.of(
-                        "session", Symbol.builder()
-                            .name("[() => this, CreateSessionCommand]")
-                            .addReference(Symbol.builder()
-                                .name("CreateSessionCommand")
-                                .namespace("./src/commands/CreateSessionCommand", "/")
-                                .build())
-                            .build()
-                    )
+                    (m, s, o) ->
+                        MapUtils.of(
+                            "session",
+                            Symbol.builder()
+                                .name("[() => this, CreateSessionCommand]")
+                                .addReference(
+                                    Symbol.builder()
+                                        .name("CreateSessionCommand")
+                                        .namespace("./src/commands/CreateSessionCommand", "/")
+                                        .build()
+                                )
+                                .build()
+                        )
                 )
                 .servicePredicate((m, s) -> isS3(s) && isEndpointsV2Service(s))
                 .build(),
@@ -463,36 +449,33 @@ public final class AddS3Config implements TypeScriptIntegration {
              * The second applies the middleware to bucket endpoint operations.
              */
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency, "BucketEndpoint",
-                    HAS_CONFIG)
+                .withConventions(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency, "BucketEndpoint", HAS_CONFIG)
                 .servicePredicate((m, s) -> isS3(s) && !isEndpointsV2Service(s))
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency, "BucketEndpoint",
-                    HAS_MIDDLEWARE)
-                .operationPredicate((m, s, o) -> !NON_BUCKET_ENDPOINT_OPERATIONS.contains(o.getId().getName(s))
-                    && isS3(s)
-                    && !isEndpointsV2Service(s)
-                    && containsInputMembers(m, o, BUCKET_ENDPOINT_INPUT_KEYS))
+                .withConventions(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE.dependency, "BucketEndpoint", HAS_MIDDLEWARE)
+                .operationPredicate(
+                    (m, s, o) ->
+                        !NON_BUCKET_ENDPOINT_OPERATIONS.contains(o.getId().getName(s)) &&
+                        isS3(s) &&
+                        !isEndpointsV2Service(s) &&
+                        containsInputMembers(m, o, BUCKET_ENDPOINT_INPUT_KEYS)
+                )
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "RegionRedirectMiddleware",
-                    HAS_MIDDLEWARE)
+                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "RegionRedirectMiddleware", HAS_MIDDLEWARE)
                 .servicePredicate((m, s) -> isS3(s))
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "S3ExpiresMiddleware",
-                    HAS_MIDDLEWARE)
+                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "S3ExpiresMiddleware", HAS_MIDDLEWARE)
                 .operationPredicate((m, s, o) -> isS3(s) && containsExpiresOutput(m, o))
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "S3Express",
-                    HAS_MIDDLEWARE)
+                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "S3Express", HAS_MIDDLEWARE)
                 .servicePredicate((m, s) -> isS3(s) && isEndpointsV2Service(s))
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "S3ExpressHttpSigning",
-                    HAS_MIDDLEWARE)
+                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "S3ExpressHttpSigning", HAS_MIDDLEWARE)
                 .servicePredicate((m, s) -> isS3(s) && isEndpointsV2Service(s))
                 .build()
         );
@@ -504,17 +487,16 @@ public final class AddS3Config implements TypeScriptIntegration {
         Set<String> expectedMemberNames
     ) {
         OperationIndex operationIndex = OperationIndex.of(model);
-        return operationIndex.getInput(operationShape)
+        return operationIndex
+            .getInput(operationShape)
             .filter(input -> input.getMemberNames().stream().anyMatch(expectedMemberNames::contains))
             .isPresent();
     }
 
-    private static boolean containsExpiresOutput(
-        Model model,
-        OperationShape operationShape
-    ) {
+    private static boolean containsExpiresOutput(Model model, OperationShape operationShape) {
         OperationIndex operationIndex = OperationIndex.of(model);
-        return operationIndex.getOutput(operationShape)
+        return operationIndex
+            .getOutput(operationShape)
             .filter(input -> input.getMemberNames().stream().anyMatch("Expires"::equals))
             .isPresent();
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddServiceCustomizationPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddServiceCustomizationPlugins.java
@@ -23,13 +23,12 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public class AddServiceCustomizationPlugins implements TypeScriptIntegration {
+
     private static final Set<String> ROUTE_53_ID_MEMBERS = Set.of("DelegationSetId", "HostedZoneId", "Id");
 
     @Override
     public List<String> runAfter() {
-        return List.of(
-            AddBuiltinPlugins.class.getCanonicalName()
-        );
+        return List.of(AddBuiltinPlugins.class.getCanonicalName());
     }
 
     @Override
@@ -37,42 +36,42 @@ public class AddServiceCustomizationPlugins implements TypeScriptIntegration {
         return List.of(
             // API Gateway
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.ACCEPT_HEADER.dependency, "AcceptHeader",
-                    HAS_MIDDLEWARE)
+                .withConventions(AwsDependency.ACCEPT_HEADER.dependency, "AcceptHeader", HAS_MIDDLEWARE)
                 .servicePredicate((m, s) -> testServiceId(s, "API Gateway"))
                 .build(),
             // Glacier
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.GLACIER_MIDDLEWARE.dependency,
-                    "Glacier", HAS_MIDDLEWARE)
+                .withConventions(AwsDependency.GLACIER_MIDDLEWARE.dependency, "Glacier", HAS_MIDDLEWARE)
                 .servicePredicate((m, s) -> testServiceId(s, "Glacier"))
                 .build(),
             // EC2
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.EC2_MIDDLEWARE.dependency,
-                    "CopySnapshotPresignedUrl", HAS_MIDDLEWARE)
-                .operationPredicate((m, s, o) -> o.getId().getName(s).equals("CopySnapshot")
-                    && testServiceId(s, "EC2"))
+                .withConventions(AwsDependency.EC2_MIDDLEWARE.dependency, "CopySnapshotPresignedUrl", HAS_MIDDLEWARE)
+                .operationPredicate((m, s, o) -> o.getId().getName(s).equals("CopySnapshot") && testServiceId(s, "EC2"))
                 .build(),
             // Machine Learning
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.MACHINELEARNING_MIDDLEWARE.dependency, "PredictEndpoint",
-                    HAS_MIDDLEWARE)
-                .operationPredicate((m, s, o) -> o.getId().getName(s).equals("Predict")
-                    && testServiceId(s, "Machine Learning"))
+                .withConventions(AwsDependency.MACHINELEARNING_MIDDLEWARE.dependency, "PredictEndpoint", HAS_MIDDLEWARE)
+                .operationPredicate(
+                    (m, s, o) -> o.getId().getName(s).equals("Predict") && testServiceId(s, "Machine Learning")
+                )
                 .build(),
             // Route 53
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.ROUTE53_MIDDLEWARE.dependency,
-                    "ChangeResourceRecordSets", HAS_MIDDLEWARE)
-                .operationPredicate((m, s, o) -> o.getId().getName(s).equals("ChangeResourceRecordSets")
-                    && testServiceId(s, "Route 53"))
+                .withConventions(
+                    AwsDependency.ROUTE53_MIDDLEWARE.dependency,
+                    "ChangeResourceRecordSets",
+                    HAS_MIDDLEWARE
+                )
+                .operationPredicate(
+                    (m, s, o) -> o.getId().getName(s).equals("ChangeResourceRecordSets") && testServiceId(s, "Route 53")
+                )
                 .build(),
             RuntimeClientPlugin.builder()
-                .withConventions(AwsDependency.ROUTE53_MIDDLEWARE.dependency, "IdNormalizer",
-                    HAS_MIDDLEWARE)
-                .operationPredicate((m, s, o) -> testInputContainsMember(m, o, ROUTE_53_ID_MEMBERS)
-                    && testServiceId(s, "Route 53"))
+                .withConventions(AwsDependency.ROUTE53_MIDDLEWARE.dependency, "IdNormalizer", HAS_MIDDLEWARE)
+                .operationPredicate(
+                    (m, s, o) -> testInputContainsMember(m, o, ROUTE_53_ID_MEMBERS) && testServiceId(s, "Route 53")
+                )
                 .build()
         );
     }
@@ -83,7 +82,8 @@ public class AddServiceCustomizationPlugins implements TypeScriptIntegration {
         Set<String> expectedMemberNames
     ) {
         OperationIndex operationIndex = OperationIndex.of(model);
-        return operationIndex.getInput(operationShape)
+        return operationIndex
+            .getInput(operationShape)
             .filter(input -> input.getMemberNames().stream().anyMatch(expectedMemberNames::contains))
             .isPresent();
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSqsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSqsDependency.java
@@ -45,47 +45,37 @@ public class AddSqsDependency implements TypeScriptIntegration {
 
     @Override
     public List<String> runAfter() {
-        return List.of(
-            AddBuiltinPlugins.class.getCanonicalName(),
-            AddDefaultEndpointRuleSet.class.getCanonicalName()
-        );
+        return List.of(AddBuiltinPlugins.class.getCanonicalName(), AddDefaultEndpointRuleSet.class.getCanonicalName());
     }
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "SendMessage",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("SendMessage")  && isSqs(s))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "SendMessageBatch",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("SendMessageBatch") && isSqs(s))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "ReceiveMessage",
-                                         HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("ReceiveMessage") && isSqs(s))
-                        .build(),
-                RuntimeClientPlugin.builder()
-                        .withConventions(
-                            AwsDependency.SQS_MIDDLEWARE.dependency,
-                            "QueueUrl",
-                            HAS_MIDDLEWARE, HAS_CONFIG
-                        )
-                        .servicePredicate((m, s) -> isSqs(s))
-                        .build()
+            RuntimeClientPlugin.builder()
+                .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "SendMessage", HAS_MIDDLEWARE)
+                .operationPredicate((m, s, o) -> o.getId().getName(s).equals("SendMessage") && isSqs(s))
+                .build(),
+            RuntimeClientPlugin.builder()
+                .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "SendMessageBatch", HAS_MIDDLEWARE)
+                .operationPredicate((m, s, o) -> o.getId().getName(s).equals("SendMessageBatch") && isSqs(s))
+                .build(),
+            RuntimeClientPlugin.builder()
+                .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "ReceiveMessage", HAS_MIDDLEWARE)
+                .operationPredicate((m, s, o) -> o.getId().getName(s).equals("ReceiveMessage") && isSqs(s))
+                .build(),
+            RuntimeClientPlugin.builder()
+                .withConventions(AwsDependency.SQS_MIDDLEWARE.dependency, "QueueUrl", HAS_MIDDLEWARE, HAS_CONFIG)
+                .servicePredicate((m, s) -> isSqs(s))
+                .build()
         );
     }
 
     @Override
     public void addConfigInterfaceFields(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
     ) {
         if (!isSqs(settings.getService(model))) {
             return;
@@ -95,17 +85,19 @@ public class AddSqsDependency implements TypeScriptIntegration {
         writer.addImport("HashConstructor", "__HashConstructor", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("Checksum", "__Checksum", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("ChecksumConstructor", "__ChecksumConstructor", TypeScriptDependency.SMITHY_TYPES);
-        writer.writeDocs("A constructor for a class implementing the {@link __Checksum} interface \n"
-                + "that computes MD5 hashes, or false to prevent MD5 computation.");
+        writer.writeDocs(
+            "A constructor for a class implementing the {@link __Checksum} interface \n" +
+                "that computes MD5 hashes, or false to prevent MD5 computation."
+        );
         writer.write("md5?: __ChecksumConstructor | __HashConstructor | false;\n");
     }
 
     @Override
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            LanguageTarget target
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
     ) {
         if (!isSqs(settings.getService(model))) {
             return Collections.emptyMap();
@@ -115,10 +107,8 @@ public class AddSqsDependency implements TypeScriptIntegration {
             case NODE:
                 return MapUtils.of("md5", writer -> {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_TYPES);
-                    writer.addImport("HashConstructor", "__HashConstructor",
-                            TypeScriptDependency.SMITHY_TYPES);
-                    writer.addImport("ChecksumConstructor", "__ChecksumConstructor",
-                            TypeScriptDependency.SMITHY_TYPES);
+                    writer.addImport("HashConstructor", "__HashConstructor", TypeScriptDependency.SMITHY_TYPES);
+                    writer.addImport("ChecksumConstructor", "__ChecksumConstructor", TypeScriptDependency.SMITHY_TYPES);
                     writer.write("Hash.bind(null, \"md5\")");
                 });
             case BROWSER:

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTokenAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTokenAuthPlugin.java
@@ -46,13 +46,13 @@ public final class AddTokenAuthPlugin implements TypeScriptIntegration {
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
             RuntimeClientPlugin.builder()
-                    .withConventions(AwsDependency.MIDDLEWARE_TOKEN.dependency, "Token", HAS_CONFIG)
-                    .servicePredicate((m, s) -> isHttpBearerAuthService(s))
-                    .build(),
+                .withConventions(AwsDependency.MIDDLEWARE_TOKEN.dependency, "Token", HAS_CONFIG)
+                .servicePredicate((m, s) -> isHttpBearerAuthService(s))
+                .build(),
             RuntimeClientPlugin.builder()
-                    .withConventions(AwsDependency.MIDDLEWARE_TOKEN.dependency, "Token", HAS_MIDDLEWARE)
-                    .servicePredicate((m, s) -> isHttpBearerAuthService(s))
-                    .build()
+                .withConventions(AwsDependency.MIDDLEWARE_TOKEN.dependency, "Token", HAS_MIDDLEWARE)
+                .servicePredicate((m, s) -> isHttpBearerAuthService(s))
+                .build()
         );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
@@ -50,21 +50,25 @@ public class AddTranscribeStreamingDependency implements TypeScriptIntegration {
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.TRANSCRIBE_STREAMING_MIDDLEWARE.dependency,
-                                "TranscribeStreaming", RuntimeClientPlugin.Convention.HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> isTranscribeStreaming(s)
-                            && AddEventStreamHandlingDependency.hasEventStreamInput(m, o))
-                        .build()
+            RuntimeClientPlugin.builder()
+                .withConventions(
+                    AwsDependency.TRANSCRIBE_STREAMING_MIDDLEWARE.dependency,
+                    "TranscribeStreaming",
+                    RuntimeClientPlugin.Convention.HAS_MIDDLEWARE
+                )
+                .operationPredicate(
+                    (m, s, o) -> isTranscribeStreaming(s) && AddEventStreamHandlingDependency.hasEventStreamInput(m, o)
+                )
+                .build()
         );
     }
 
     @Override
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            LanguageTarget target
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
     ) {
         ServiceShape service = settings.getService(model);
         if (!isTranscribeStreaming(service)) {
@@ -72,12 +76,17 @@ public class AddTranscribeStreamingDependency implements TypeScriptIntegration {
         }
 
         Map<String, Consumer<TypeScriptWriter>> transcribeStreamingHandlerConfig = MapUtils.of(
-                "eventStreamPayloadHandlerProvider", writer -> {
-                        writer.addDependency(AwsDependency.TRANSCRIBE_STREAMING_MIDDLEWARE);
-                        writer.addImport("eventStreamPayloadHandler", "eventStreamPayloadHandler",
-                            AwsDependency.TRANSCRIBE_STREAMING_MIDDLEWARE);
-                        writer.write("(() => eventStreamPayloadHandler)");
-                });
+            "eventStreamPayloadHandlerProvider",
+            writer -> {
+                writer.addDependency(AwsDependency.TRANSCRIBE_STREAMING_MIDDLEWARE);
+                writer.addImport(
+                    "eventStreamPayloadHandler",
+                    "eventStreamPayloadHandler",
+                    AwsDependency.TRANSCRIBE_STREAMING_MIDDLEWARE
+                );
+                writer.write("(() => eventStreamPayloadHandler)");
+            }
+        );
 
         switch (target) {
             case REACT_NATIVE:
@@ -93,5 +102,3 @@ public class AddTranscribeStreamingDependency implements TypeScriptIntegration {
         return serviceId.equals("Transcribe Streaming");
     }
 }
-
-

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
@@ -38,24 +38,29 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public class AddUserAgentDependency implements TypeScriptIntegration {
+
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.MIDDLEWARE_USER_AGENT.dependency, "UserAgent").build());
+            RuntimeClientPlugin.builder()
+                .withConventions(AwsDependency.MIDDLEWARE_USER_AGENT.dependency, "UserAgent")
+                .build()
+        );
     }
 
     @Override
     public void addConfigInterfaceFields(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
     ) {
         writer.addImport("Provider", "Provider", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("UserAgent", "__UserAgent", TypeScriptDependency.SMITHY_TYPES);
-        writer.writeDocs("The provider populating default tracking information to be sent with `user-agent`, "
-                + "`x-amz-user-agent` header\n@internal");
+        writer.writeDocs(
+            "The provider populating default tracking information to be sent with `user-agent`, " +
+                "`x-amz-user-agent` header\n@internal"
+        );
         writer.write("defaultUserAgentProvider?: Provider<__UserAgent>;\n");
     }
 
@@ -69,46 +74,60 @@ public class AddUserAgentDependency implements TypeScriptIntegration {
         switch (target) {
             case NODE:
                 return MapUtils.of(
-                        "defaultUserAgentProvider", writer -> {
-                            writer.addDependency(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.dependency);
-                            writer.addImport("createDefaultUserAgentProvider",
-                            "createDefaultUserAgentProvider", AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE);
-                            writer.addIgnoredDefaultImport("packageInfo", "./package.json",
-                                    "package.json will be imported from dist folders");
-                            writeDefaultUserAgentProvider(writer, settings, model);
-                        },
-                        "userAgentAppId", writer -> {
-                            writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                            writer.addImport("loadConfig", "loadNodeConfig",
-                                TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                            writer.addDependency(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE);
-                            writer.addImport("NODE_APP_ID_CONFIG_OPTIONS", "NODE_APP_ID_CONFIG_OPTIONS",
-                                AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE);
-                            writer.write(
-                                "loadNodeConfig(NODE_APP_ID_CONFIG_OPTIONS, loaderConfig)"
-                            );
-                        }
+                    "defaultUserAgentProvider",
+                    writer -> {
+                        writer.addDependency(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.dependency);
+                        writer.addImport(
+                            "createDefaultUserAgentProvider",
+                            "createDefaultUserAgentProvider",
+                            AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE
+                        );
+                        writer.addIgnoredDefaultImport(
+                            "packageInfo",
+                            "./package.json",
+                            "package.json will be imported from dist folders"
+                        );
+                        writeDefaultUserAgentProvider(writer, settings, model);
+                    },
+                    "userAgentAppId",
+                    writer -> {
+                        writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                        writer.addImport("loadConfig", "loadNodeConfig", TypeScriptDependency.NODE_CONFIG_PROVIDER);
+                        writer.addDependency(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE);
+                        writer.addImport(
+                            "NODE_APP_ID_CONFIG_OPTIONS",
+                            "NODE_APP_ID_CONFIG_OPTIONS",
+                            AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE
+                        );
+                        writer.write("loadNodeConfig(NODE_APP_ID_CONFIG_OPTIONS, loaderConfig)");
+                    }
                 );
             case BROWSER:
-                return MapUtils.of(
-                        "defaultUserAgentProvider", writer -> {
-                            writer.addDependency(AwsDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER.dependency);
-                            writer.addImport("createDefaultUserAgentProvider",
-                             "createDefaultUserAgentProvider", AwsDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER);
-                            writer.addIgnoredDefaultImport("packageInfo", "./package.json",
-                                    "package.json will be imported from dist folders");
-                            writeDefaultUserAgentProvider(writer, settings, model);
-                        }
-                );
+                return MapUtils.of("defaultUserAgentProvider", writer -> {
+                    writer.addDependency(AwsDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER.dependency);
+                    writer.addImport(
+                        "createDefaultUserAgentProvider",
+                        "createDefaultUserAgentProvider",
+                        AwsDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER
+                    );
+                    writer.addIgnoredDefaultImport(
+                        "packageInfo",
+                        "./package.json",
+                        "package.json will be imported from dist folders"
+                    );
+                    writeDefaultUserAgentProvider(writer, settings, model);
+                });
             default:
                 return Collections.emptyMap();
         }
     }
 
     private void writeDefaultUserAgentProvider(TypeScriptWriter writer, TypeScriptSettings settings, Model model) {
-        writer.write("createDefaultUserAgentProvider({"
+        writer.write(
+            "createDefaultUserAgentProvider({" +
                 // serviceId is optional in defaultUserAgent. serviceId exists only for AWS services
-                + (isAwsService(settings, model) ? "serviceId: clientSharedValues.serviceId, " : "")
-                + "clientVersion: packageInfo.version})");
+                (isAwsService(settings, model) ? "serviceId: clientSharedValues.serviceId, " : "") +
+                "clientVersion: packageInfo.version})"
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsCredentialProviderUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsCredentialProviderUtils.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
- package software.amazon.smithy.aws.typescript.codegen;
+package software.amazon.smithy.aws.typescript.codegen;
 
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -36,7 +36,6 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public enum AwsDependency implements Dependency {
-
     AWS_SDK_CORE(NORMAL_DEPENDENCY, "@aws-sdk/core"),
     MIDDLEWARE_SIGNING(NORMAL_DEPENDENCY, "@aws-sdk/middleware-signing"),
     MIDDLEWARE_TOKEN(NORMAL_DEPENDENCY, "@aws-sdk/middleware-token"),
@@ -61,11 +60,13 @@ public enum AwsDependency implements Dependency {
     /**
      * @deprecated use SmithyDependency.UUID.
      */
-    @Deprecated UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^9.0.1"),
+    @Deprecated
+    UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^9.0.1"),
     /**
      * @deprecated use SmithyDependency.UUID_TYPES.
      */
-    @Deprecated UUID_GENERATOR_TYPES(NORMAL_DEPENDENCY, "@types/uuid", "^9.0.1"),
+    @Deprecated
+    UUID_GENERATOR_TYPES(NORMAL_DEPENDENCY, "@types/uuid", "^9.0.1"),
     MIDDLEWARE_EVENTSTREAM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-eventstream"),
     AWS_SDK_EVENTSTREAM_HANDLER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/eventstream-handler-node"),
     TRANSCRIBE_STREAMING_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-transcribe-streaming"),
@@ -84,9 +85,12 @@ public enum AwsDependency implements Dependency {
     MIDDLEWARE_WEBSOCKET(NORMAL_DEPENDENCY, "@aws-sdk/middleware-websocket"),
 
     // Conditionally added when httpChecksum trait is present
-    @Deprecated MD5_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/md5-js", "3.374.0"),
-    @Deprecated STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node", "3.374.0"),
-    @Deprecated STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser", "3.374.0"),
+    @Deprecated
+    MD5_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/md5-js", "3.374.0"),
+    @Deprecated
+    STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node", "3.374.0"),
+    @Deprecated
+    STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser", "3.374.0"),
     FLEXIBLE_CHECKSUMS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-flexible-checksums"),
 
     // Conditionally added when auth trait is present
@@ -118,7 +122,6 @@ public enum AwsDependency implements Dependency {
         this.version = version;
     }
 
-
     @Override
     public List<SymbolDependency> getDependencies() {
         return Collections.singletonList(dependency);
@@ -130,11 +133,13 @@ public enum AwsDependency implements Dependency {
     }
 
     private static final class SdkVersion {
+
         private static final Map<String, String> VERSIONS;
 
         static {
-            String rawProperties =
-                    IoUtils.readUtf8Url(AwsDependency.class.getResource("sdkVersions.properties")).trim();
+            String rawProperties = IoUtils.readUtf8Url(
+                AwsDependency.class.getResource("sdkVersions.properties")
+            ).trim();
             Properties p = new Properties();
             try {
                 p.load(new StringReader(rawProperties));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
@@ -39,6 +39,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegration {
+
     @Override
     public void customize(TypeScriptCodegenContext codegenContext) {
         TypeScriptSettings settings = codegenContext.settings();
@@ -50,34 +51,36 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
     }
 
     private void writeAdditionalFiles(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory
     ) {
-        if (settings.generateClient()
-            && isAwsService(settings, model)
-            && settings.getService(model).hasTrait(EndpointRuleSetTrait.class)) {
-                writerFactory.accept(
-                    Paths.get(CodegenUtils.SOURCE_FOLDER, "endpoint", "endpointResolver.ts").toString(),
-                    writer -> {
-                        writer.addDependency(TypeScriptDependency.UTIL_ENDPOINTS);
-                        writer.addDependency(AwsDependency.UTIL_ENDPOINTS);
+        if (
+            settings.generateClient() &&
+            isAwsService(settings, model) &&
+            settings.getService(model).hasTrait(EndpointRuleSetTrait.class)
+        ) {
+            writerFactory.accept(
+                Paths.get(CodegenUtils.SOURCE_FOLDER, "endpoint", "endpointResolver.ts").toString(),
+                writer -> {
+                    writer.addDependency(TypeScriptDependency.UTIL_ENDPOINTS);
+                    writer.addDependency(AwsDependency.UTIL_ENDPOINTS);
 
-                        writer.addImport("customEndpointFunctions", null, TypeScriptDependency.UTIL_ENDPOINTS);
-                        writer.addImport("awsEndpointFunctions", null, AwsDependency.UTIL_ENDPOINTS);
-                        writer.write("customEndpointFunctions.aws = awsEndpointFunctions;");
-                    }
-                );
+                    writer.addImport("customEndpointFunctions", null, TypeScriptDependency.UTIL_ENDPOINTS);
+                    writer.addImport("awsEndpointFunctions", null, AwsDependency.UTIL_ENDPOINTS);
+                    writer.write("customEndpointFunctions.aws = awsEndpointFunctions;");
+                }
+            );
         }
     }
 
     @Override
     public void addConfigInterfaceFields(
-            TypeScriptSettings settings,
-            Model model,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
     ) {
         if (!settings.generateClient() || !isAwsService(settings, model)) {
             return;
@@ -92,17 +95,21 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
                     add("resolveClientEndpointParameters");
                     add("EndpointParameters");
                 }
-            }.forEach(name -> writer.addImport(
-                name,
-                null,
-                Paths.get(".", CodegenUtils.SOURCE_FOLDER, "endpoint/EndpointParameters").toString()
-            ));
+            }
+                .forEach(name ->
+                    writer.addImport(
+                        name,
+                        null,
+                        Paths.get(".", CodegenUtils.SOURCE_FOLDER, "endpoint/EndpointParameters").toString()
+                    )
+                );
 
             writer.addImport("EndpointV2", "__EndpointV2", TypeScriptDependency.SMITHY_TYPES);
         } else {
             writer.addImport("RegionInfoProvider", null, TypeScriptDependency.SMITHY_TYPES);
-            writer.writeDocs("Fetch related hostname, signing name or signing region with given region.\n"
-                + "@internal");
+            writer.writeDocs(
+                "Fetch related hostname, signing name or signing region with given region.\n" + "@internal"
+            );
             writer.write("regionInfoProvider?: RegionInfoProvider;\n");
         }
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_1.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsJsonRpc1_1.java
@@ -57,11 +57,9 @@ final class AwsJsonRpc1_1 extends JsonRpcProtocolGenerator {
         TypeScriptWriter writer = context.getWriter();
         writer.addImport("HeaderBag", "__HeaderBag", TypeScriptDependency.SMITHY_TYPES);
         String targetHeader = serviceShape.getId().getName(serviceShape) + ".${operation}";
-        writer.openBlock("function sharedHeaders(operation: string): __HeaderBag { return {", "}};",
-            () -> {
-                writer.write("'content-type': $S,", getDocumentContentType());
-                writer.write("'x-amz-target': `$L`,", targetHeader);
-            }
-        );
+        writer.openBlock("function sharedHeaders(operation: string): __HeaderBag { return {", "}};", () -> {
+            writer.write("'content-type': $S,", getDocumentContentType());
+            writer.write("'x-amz-target': `$L`,", targetHeader);
+        });
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -130,8 +130,9 @@ final class AwsProtocolUtils {
     static void generateJsonParseBodyWithQueryHeader(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
         writer.addImport("HeaderBag", "__HeaderBag", TypeScriptDependency.SMITHY_TYPES);
-        writer.write(IoUtils.readUtf8Resource(
-            AwsProtocolUtils.class, "populate-body-with-query-compatibility-code-stub.ts"));
+        writer.write(
+            IoUtils.readUtf8Resource(AwsProtocolUtils.class, "populate-body-with-query-compatibility-code-stub.ts")
+        );
     }
 
     /**
@@ -181,12 +182,21 @@ final class AwsProtocolUtils {
         TypeScriptWriter writer = context.getWriter();
 
         // Write a single function to handle combining a map in to a valid query string.
-        writer.addImport("extendedEncodeURIComponent", "__extendedEncodeURIComponent",
-            TypeScriptDependency.AWS_SMITHY_CLIENT);
-        writer.openBlock("const buildFormUrlencodedString = (formEntries: Record<string, string>): "
-                         + "string => Object.entries(formEntries).map(", ").join(\"&\");",
-            () -> writer.write("([key, value]) => __extendedEncodeURIComponent(key) + '=' + "
-                               + "__extendedEncodeURIComponent(value)"));
+        writer.addImport(
+            "extendedEncodeURIComponent",
+            "__extendedEncodeURIComponent",
+            TypeScriptDependency.AWS_SMITHY_CLIENT
+        );
+        writer.openBlock(
+            "const buildFormUrlencodedString = (formEntries: Record<string, string>): " +
+                "string => Object.entries(formEntries).map(",
+            ").join(\"&\");",
+            () ->
+                writer.write(
+                    "([key, value]) => __extendedEncodeURIComponent(key) + '=' + " +
+                        "__extendedEncodeURIComponent(value)"
+                )
+        );
         writer.write("");
     }
 
@@ -210,10 +220,7 @@ final class AwsProtocolUtils {
                 "[" + stringStore.var("Action") + "]: $L,",
                 stringStore.var(operation.getId().getName(serviceShape))
             );
-            writer.write(
-                "[" + stringStore.var("Version") + "]: $L,",
-                stringStore.var(serviceShape.getVersion())
-            );
+            writer.write("[" + stringStore.var("Version") + "]: $L,", stringStore.var(serviceShape.getVersion()));
         });
 
         return true;
@@ -259,7 +266,8 @@ final class AwsProtocolUtils {
             TypeScriptWriter writer = context.getWriter();
             writer.addImport("v4", "generateIdempotencyToken", TypeScriptDependency.SMITHY_UUID);
             writer.openBlock("if ($L === undefined) {", "}", inputLocation, () ->
-                writer.write("$L = generateIdempotencyToken();", inputLocation));
+                writer.write("$L = generateIdempotencyToken();", inputLocation)
+            );
         }
     }
 
@@ -285,17 +293,21 @@ final class AwsProtocolUtils {
     }
 
     static void generateProtocolTests(ProtocolGenerator generator, GenerationContext context) {
-        new HttpProtocolTestGenerator(context,
+        new HttpProtocolTestGenerator(
+            context,
             generator,
             AwsProtocolUtils::filterProtocolTests,
-            AwsProtocolUtils::filterMalformedRequestTests).run();
+            AwsProtocolUtils::filterMalformedRequestTests
+        ).run();
     }
 
     /**
      * @return map of error full shape id to alias strings having AwsQueryCompat error code.
      */
-    static Map<String, TreeSet<String>> getErrorAliases(GenerationContext context,
-                                                        Collection<OperationShape> operations) {
+    static Map<String, TreeSet<String>> getErrorAliases(
+        GenerationContext context,
+        Collection<OperationShape> operations
+    ) {
         Map<String, TreeSet<String>> aliases = new HashMap<>();
         ServiceShape service = context.getService();
         boolean awsQueryCompatible = service.hasTrait(AwsQueryCompatibleTrait.class);
@@ -330,12 +342,15 @@ final class AwsProtocolUtils {
         }
 
         // not implemented in server sdk.
-        if (SetUtils.of(
-            "SDKAppendedGzipAfterProvidedEncoding_restJson1",
-            "SDKAppliedContentEncoding_restJson1",
-            "RestJsonHttpPayloadWithUnsetUnion",
-            "RestJsonMustSupportParametersInContentType"
-        ).contains(testCase.getId()) && settings.generateServerSdk()) {
+        if (
+            SetUtils.of(
+                "SDKAppendedGzipAfterProvidedEncoding_restJson1",
+                "SDKAppliedContentEncoding_restJson1",
+                "RestJsonHttpPayloadWithUnsetUnion",
+                "RestJsonMustSupportParametersInContentType"
+            ).contains(testCase.getId()) &&
+            settings.generateServerSdk()
+        ) {
             return true;
         }
 
@@ -400,8 +415,10 @@ final class AwsProtocolUtils {
             return true;
         }
 
-        if (testCase.getId().equals("RestJsonStringPayloadNoContentType")
-            || testCase.getId().equals("RestJsonWithBodyExpectsApplicationJsonContentTypeNoHeaders")) {
+        if (
+            testCase.getId().equals("RestJsonStringPayloadNoContentType") ||
+            testCase.getId().equals("RestJsonWithBodyExpectsApplicationJsonContentTypeNoHeaders")
+        ) {
             return settings.generateServerSdk();
         }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -39,7 +39,6 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocolGenerator;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
-
 /**
  * Handles generating the aws.rest-xml protocol for services. It handles reading and
  * writing from document bodies, including generating any functions needed for
@@ -95,8 +94,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
 
     @Override
     protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes,
-            new XmlShapeDeserVisitor(context));
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes, new XmlShapeDeserVisitor(context));
     }
 
     @Override
@@ -111,9 +109,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
         writer.addDependency(AwsDependency.AWS_SDK_CORE);
         writer.addImport("loadRestXmlErrorCode", null, AwsDependency.AWS_SDK_CORE);
 
-        writer.write(
-            context.getStringStore().flushVariableDeclarationCode()
-        );
+        writer.write(context.getStringStore().flushVariableDeclarationCode());
     }
 
     @Override
@@ -136,9 +132,9 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
 
     @Override
     protected void serializeInputDocumentBody(
-            GenerationContext context,
-            OperationShape operation,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        OperationShape operation,
+        List<HttpBinding> documentBindings
     ) {
         serializeDocumentBody(context, documentBindings);
     }
@@ -151,26 +147,23 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
 
     @Override
     protected void serializeOutputDocumentBody(
-            GenerationContext context,
-            OperationShape operation,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        OperationShape operation,
+        List<HttpBinding> documentBindings
     ) {
         serializeDocumentBody(context, documentBindings);
     }
 
     @Override
     protected void serializeErrorDocumentBody(
-            GenerationContext context,
-            StructureShape error,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        StructureShape error,
+        List<HttpBinding> documentBindings
     ) {
         serializeDocumentBody(context, documentBindings);
     }
 
-    private void serializeDocumentBody(
-            GenerationContext context,
-            List<HttpBinding> documentBindings
-    ) {
+    private void serializeDocumentBody(GenerationContext context, List<HttpBinding> documentBindings) {
         // Short circuit when we have no bindings.
         TypeScriptWriter writer = context.getWriter();
         if (documentBindings.isEmpty()) {
@@ -190,9 +183,10 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
 
         // Handle the @xmlName trait for the input shape.
         StructureShape inputShape = context.getModel().expectShape(inputShapeId, StructureShape.class);
-        String nodeName = inputShape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse(inputShapeId.getName(serviceShape));
+        String nodeName = inputShape
+            .getTrait(XmlNameTrait.class)
+            .map(XmlNameTrait::getValue)
+            .orElse(inputShapeId.getName(serviceShape));
         writer.write("const bn = new __XmlNode($L);", context.getStringStore().var(nodeName));
 
         // Add @xmlNamespace value of the service to the root node,
@@ -222,35 +216,28 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
 
     @Override
     protected void serializeInputPayload(
-            GenerationContext context,
-            OperationShape operation,
-            HttpBinding payloadBinding
+        GenerationContext context,
+        OperationShape operation,
+        HttpBinding payloadBinding
     ) {
         serializePayload(context, payloadBinding);
     }
 
     @Override
     protected void serializeOutputPayload(
-            GenerationContext context,
-            OperationShape operation,
-            HttpBinding payloadBinding
+        GenerationContext context,
+        OperationShape operation,
+        HttpBinding payloadBinding
     ) {
         serializePayload(context, payloadBinding);
     }
 
     @Override
-    protected void serializeErrorPayload(
-            GenerationContext context,
-            StructureShape error,
-            HttpBinding payloadBinding
-    ) {
+    protected void serializeErrorPayload(GenerationContext context, StructureShape error, HttpBinding payloadBinding) {
         serializePayload(context, payloadBinding);
     }
 
-    private void serializePayload(
-            GenerationContext context,
-            HttpBinding payloadBinding
-    ) {
+    private void serializePayload(GenerationContext context, HttpBinding payloadBinding) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
         TypeScriptWriter writer = context.getWriter();
 
@@ -262,22 +249,26 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
         // Generate an if statement to set the body node if the member is set.
         writer.openBlock("if ($L !== undefined) {", "}", getFrom("input", memberName), () -> {
             Shape target = context.getModel().expectShape(member.getTarget());
-            writer.write("contents = $L;",
-                    getInputValue(context, Location.PAYLOAD, getFrom("input", memberName), member, target));
+            writer.write(
+                "contents = $L;",
+                getInputValue(context, Location.PAYLOAD, getFrom("input", memberName), member, target)
+            );
 
-            String targetName = target.getTrait(XmlNameTrait.class)
-                            .map(XmlNameTrait::getValue)
-                            .orElse(target.getId().getName());
+            String targetName = target
+                .getTrait(XmlNameTrait.class)
+                .map(XmlNameTrait::getValue)
+                .orElse(target.getId().getName());
             if (
-                member.hasTrait(XmlNameTrait.class)
-                && !member.getTrait(XmlNameTrait.class).get().getValue().equals(targetName)
+                member.hasTrait(XmlNameTrait.class) &&
+                !member.getTrait(XmlNameTrait.class).get().getValue().equals(targetName)
             ) {
                 writer.write("contents = contents.n($S);", member.getTrait(XmlNameTrait.class).get().getValue());
             }
 
             // XmlNode will serialize Structure and non-streaming Union payloads as XML documents.
-            if (target instanceof StructureShape
-                    || (target instanceof UnionShape && !target.hasTrait(StreamingTrait.class))
+            if (
+                target instanceof StructureShape ||
+                (target instanceof UnionShape && !target.hasTrait(StreamingTrait.class))
             ) {
                 // Start with the XML declaration.
                 String xmlDeclVar = context.getStringStore().var("<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>");
@@ -309,35 +300,32 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
 
     @Override
     protected void deserializeInputDocumentBody(
-            GenerationContext context,
-            OperationShape operation,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        OperationShape operation,
+        List<HttpBinding> documentBindings
     ) {
         deserializeDocumentBody(context, documentBindings);
     }
 
     @Override
     protected void deserializeOutputDocumentBody(
-            GenerationContext context,
-            OperationShape operation,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        OperationShape operation,
+        List<HttpBinding> documentBindings
     ) {
         deserializeDocumentBody(context, documentBindings);
     }
 
     @Override
     protected void deserializeErrorDocumentBody(
-            GenerationContext context,
-            StructureShape error,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        StructureShape error,
+        List<HttpBinding> documentBindings
     ) {
         deserializeDocumentBody(context, documentBindings);
     }
 
-    private void deserializeDocumentBody(
-            GenerationContext context,
-            List<HttpBinding> documentBindings
-    ) {
+    private void deserializeDocumentBody(GenerationContext context, List<HttpBinding> documentBindings) {
         SymbolProvider symbolProvider = context.getSymbolProvider();
         XmlShapeDeserVisitor shapeVisitor = new XmlShapeDeserVisitor(context);
 
@@ -357,10 +345,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
 
     @Override
     public void generateRequestSerializers(GenerationContext context) {
-        String serviceId = context.getService()
-            .getTrait(ServiceTrait.class)
-            .map(ServiceTrait::getSdkId)
-            .orElse("");
+        String serviceId = context.getService().getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
 
         if (serviceId.equals("S3")) {
             setContextParamDeduplicationParamControlSet(Collections.singleton("Bucket"));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
@@ -48,7 +48,10 @@ public final class AwsServiceIdIntegration implements TypeScriptIntegration {
 
     @Override
     public SymbolProvider decorateSymbolProvider(
-            Model model, TypeScriptSettings settings, SymbolProvider symbolProvider) {
+        Model model,
+        TypeScriptSettings settings,
+        SymbolProvider symbolProvider
+    ) {
         return shape -> {
             Symbol symbol = symbolProvider.toSymbol(shape);
 
@@ -59,24 +62,26 @@ public final class AwsServiceIdIntegration implements TypeScriptIntegration {
             // TODO: Should this WARNING be avoided somehow if client is not for an AWS service?
             // If the SDK service ID trait is present, use that, otherwise fall back to
             // the default naming strategy for the service.
-            return shape.getTrait(ServiceTrait.class)
-                    .map(ServiceTrait::getSdkId)
-                    .map(id -> updateServiceSymbol(symbol, id))
-                    .orElseGet(() -> {
-                        LOGGER.warning(String.format("No `%s` trait found on `%s`", ServiceTrait.ID, shape.getId()));
-                        return symbol;
-                    });
+            return shape
+                .getTrait(ServiceTrait.class)
+                .map(ServiceTrait::getSdkId)
+                .map(id -> updateServiceSymbol(symbol, id))
+                .orElseGet(() -> {
+                    LOGGER.warning(String.format("No `%s` trait found on `%s`", ServiceTrait.ID, shape.getId()));
+                    return symbol;
+                });
         };
     }
 
     private static Symbol updateServiceSymbol(Symbol symbol, String serviceId) {
-        String name = Arrays.asList(serviceId.split(" ")).stream()
-                .map(StringUtils::capitalize)
-                .collect(Collectors.joining("")) + "Client";
-        return symbol.toBuilder()
-                .name(name)
-                .namespace(Paths.get(".", CodegenUtils.SOURCE_FOLDER, name).toString(), "/")
-                .definitionFile(Paths.get(".", CodegenUtils.SOURCE_FOLDER, name + ".ts").toString())
-                .build();
+        String name =
+            Arrays.asList(serviceId.split(" ")).stream().map(StringUtils::capitalize).collect(Collectors.joining("")) +
+            "Client";
+        return symbol
+            .toBuilder()
+            .name(name)
+            .namespace(Paths.get(".", CodegenUtils.SOURCE_FOLDER, name).toString(), "/")
+            .definitionFile(Paths.get(".", CodegenUtils.SOURCE_FOLDER, name + ".ts").toString())
+            .build();
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsSmithyRpcV2Cbor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsSmithyRpcV2Cbor.java
@@ -22,20 +22,24 @@ import software.amazon.smithy.utils.IoUtils;
  * AWSQuery compatibility.
  */
 public final class AwsSmithyRpcV2Cbor extends SmithyRpcV2Cbor {
+
     @Override
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
         if (context.getService().hasTrait(AwsQueryCompatibleTrait.class)) {
             TypeScriptWriter writer = context.getWriter();
             writer.addImport("HeaderBag", "__HeaderBag", TypeScriptDependency.SMITHY_TYPES);
-            writer.write(IoUtils.readUtf8Resource(
-                AwsProtocolUtils.class, "populate-body-with-query-compatibility-code-stub.ts"));
+            writer.write(
+                IoUtils.readUtf8Resource(AwsProtocolUtils.class, "populate-body-with-query-compatibility-code-stub.ts")
+            );
         }
     }
 
     @Override
-    public Map<String, TreeSet<String>> getErrorAliases(GenerationContext context,
-                                                        Collection<OperationShape> operations) {
+    public Map<String, TreeSet<String>> getErrorAliases(
+        GenerationContext context,
+        Collection<OperationShape> operations
+    ) {
         return AwsProtocolUtils.getErrorAliases(context, operations);
     }
 
@@ -45,14 +49,18 @@ public final class AwsSmithyRpcV2Cbor extends SmithyRpcV2Cbor {
         writer.addImport("HeaderBag", "__HeaderBag", TypeScriptDependency.SMITHY_TYPES);
         writer.openBlock("const SHARED_HEADERS: __HeaderBag = {", "};", () -> {
             writer.write("'content-type': $S,", getDocumentContentType());
-            writer.write("""
+            writer.write(
+                """
                 "smithy-protocol": "rpc-v2-cbor",
                 "accept": "application/cbor",
-                """);
+                """
+            );
             if (context.getService().hasTrait(AwsQueryCompatibleTrait.class)) {
-                writer.write("""
+                writer.write(
+                    """
                     "x-amzn-query-mode": "true",
-                    """);
+                    """
+                );
             }
         });
     }
@@ -68,8 +76,10 @@ public final class AwsSmithyRpcV2Cbor extends SmithyRpcV2Cbor {
             writer.write("populateBodyWithQueryCompatibility(parsedOutput, output.headers);");
         }
         writer.addImportSubmodule(
-            "loadSmithyRpcV2CborErrorCode", null,
-            TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CBOR
+            "loadSmithyRpcV2CborErrorCode",
+            null,
+            TypeScriptDependency.SMITHY_CORE,
+            SmithyCoreSubmodules.CBOR
         );
         writer.write("const errorCode = loadSmithyRpcV2CborErrorCode(output, parsedOutput.body);");
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsTraitsUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsTraitsUtils.java
@@ -33,6 +33,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class AwsTraitsUtils {
+
     // SigV4a is not declared as a trait in existing services, so we need to hard code the following:
     // This should not be copied or made public outside of this class.
     private static final Set<ShapeId> ENDPOINT_RULESET_HTTP_AUTH_SCHEME_SERVICES = Set.of(

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DefaultsModeConfigGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DefaultsModeConfigGenerator.java
@@ -40,23 +40,25 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 final class DefaultsModeConfigGenerator {
 
-    static final String DEFAULTS_MODE_DOC_INTRODUCTION = "Option determining how certain default configuration options "
-    + "are resolved in the SDK. It can be one of the value listed below:\n";
+    static final String DEFAULTS_MODE_DOC_INTRODUCTION =
+        "Option determining how certain default configuration options " +
+        "are resolved in the SDK. It can be one of the value listed below:\n";
 
-    static final String INTERNAL_INTERFACES_BLOCK = ""
-    + "/**\n"
-    + " * @internal\n"
-    + " */\n"
-    + "export type ResolvedDefaultsMode = Exclude<DefaultsMode, \"auto\">;\n"
-    + "\n"
-    + "/**\n"
-    + " * @internal\n"
-    + " */\n"
-    + "export interface DefaultsModeConfigs {\n"
-    + "  retryMode?: string;\n"
-    + "  connectionTimeout?: number;\n"
-    + "  requestTimeout?: number;\n"
-    + "}\n";
+    static final String INTERNAL_INTERFACES_BLOCK =
+        "" +
+        "/**\n" +
+        " * @internal\n" +
+        " */\n" +
+        "export type ResolvedDefaultsMode = Exclude<DefaultsMode, \"auto\">;\n" +
+        "\n" +
+        "/**\n" +
+        " * @internal\n" +
+        " */\n" +
+        "export interface DefaultsModeConfigs {\n" +
+        "  retryMode?: string;\n" +
+        "  connectionTimeout?: number;\n" +
+        "  requestTimeout?: number;\n" +
+        "}\n";
 
     private DefaultsModeConfigGenerator() {}
 
@@ -68,28 +70,34 @@ final class DefaultsModeConfigGenerator {
 
         Path outputPath = Paths.get(args[0]);
         TypeScriptWriter writer = new TypeScriptWriter(outputPath.toString());
-        String defaultsConfigJson = IoUtils.readUtf8Resource(DefaultsModeConfigGenerator.class,
-                "sdk-default-configuration.json");
+        String defaultsConfigJson = IoUtils.readUtf8Resource(
+            DefaultsModeConfigGenerator.class,
+            "sdk-default-configuration.json"
+        );
         ObjectNode defaultsConfigData = Node.parse(defaultsConfigJson).expectObjectNode();
         ObjectNode baseNode = defaultsConfigData.expectObjectMember("base");
         ObjectNode modesNode = defaultsConfigData.expectObjectMember("modes");
 
         writer.writeDocs("@internal");
         writer.openBlock(
-            "export const loadConfigsForDefaultMode = (mode: ResolvedDefaultsMode): DefaultsModeConfigs => {", "}\n",
+            "export const loadConfigsForDefaultMode = (mode: ResolvedDefaultsMode): DefaultsModeConfigs => {",
+            "}\n",
             () -> {
                 writer.openBlock("switch (mode) {", "}", () -> {
-                    modesNode.getMembers().forEach((name, mode) -> {
-                        writer.write("case $S:", name.getValue());
-                        DefaultsMode defaultsMode = new DefaultsMode(baseNode, mode.expectObjectNode());
-                        writer.indent();
-                        defaultsMode.useWriter(writer);
-                        writer.dedent();
-                    });
+                    modesNode
+                        .getMembers()
+                        .forEach((name, mode) -> {
+                            writer.write("case $S:", name.getValue());
+                            DefaultsMode defaultsMode = new DefaultsMode(baseNode, mode.expectObjectNode());
+                            writer.indent();
+                            defaultsMode.useWriter(writer);
+                            writer.dedent();
+                        });
                     writer.write("default:");
                     writer.indent().write("return {};").dedent();
                 });
-        });
+            }
+        );
 
         ObjectNode docNode = defaultsConfigData.expectObjectMember("documentation").expectObjectMember("modes");
         List<String> defaultsModes = new LinkedList<String>();
@@ -102,9 +110,18 @@ final class DefaultsModeConfigGenerator {
         }
         defaultsModeDoc.append("\n@default \"legacy\"");
         writer.writeDocs(defaultsModeDoc.toString());
-        writer.write("export type DefaultsMode = $L;\n",
-                String.join(" | ", defaultsModes.stream().map((mod) -> {
-                        return "\"" + mod + "\""; }).collect(Collectors.toList())));
+        writer.write(
+            "export type DefaultsMode = $L;\n",
+            String.join(
+                " | ",
+                defaultsModes
+                    .stream()
+                    .map(mod -> {
+                        return "\"" + mod + "\"";
+                    })
+                    .collect(Collectors.toList())
+            )
+        );
         writer.write(INTERNAL_INTERFACES_BLOCK);
 
         boolean exists = outputPath.toFile().createNewFile();
@@ -127,6 +144,7 @@ final class DefaultsModeConfigGenerator {
     }
 
     private static final class DefaultsMode {
+
         private Optional<String> retryMode;
         private Optional<Number> connectTimeoutInMillis;
         private Optional<Number> httpRequestTimeoutInMillis;
@@ -139,26 +157,42 @@ final class DefaultsModeConfigGenerator {
 
         private DefaultsMode(ObjectNode base, ObjectNode mode) {
             this(base);
-            mode.getObjectMember("retryMode").ifPresent((overrideNode) -> {
-                overrideNode.getMembers().forEach((modifier, value) -> {
-                    String modifierName = modifier.getValue().toUpperCase();
-                    this.modifyRetryMode(Modifier.valueOf(modifierName), value.expectStringNode().getValue());
+            mode
+                .getObjectMember("retryMode")
+                .ifPresent(overrideNode -> {
+                    overrideNode
+                        .getMembers()
+                        .forEach((modifier, value) -> {
+                            String modifierName = modifier.getValue().toUpperCase();
+                            this.modifyRetryMode(Modifier.valueOf(modifierName), value.expectStringNode().getValue());
+                        });
                 });
-            });
-            mode.getObjectMember("connectTimeoutInMillis").ifPresent((overrideNode) -> {
-                overrideNode.getMembers().forEach((modifier, value) -> {
-                    String modifierName = modifier.getValue().toUpperCase();
-                    this.modifyConnectTimeoutInMillis(Modifier.valueOf(modifierName),
-                            value.expectNumberNode().getValue());
+            mode
+                .getObjectMember("connectTimeoutInMillis")
+                .ifPresent(overrideNode -> {
+                    overrideNode
+                        .getMembers()
+                        .forEach((modifier, value) -> {
+                            String modifierName = modifier.getValue().toUpperCase();
+                            this.modifyConnectTimeoutInMillis(
+                                Modifier.valueOf(modifierName),
+                                value.expectNumberNode().getValue()
+                            );
+                        });
                 });
-            });
-            mode.getObjectMember("httpRequestTimeoutInMillis").ifPresent((overrideNode) -> {
-                overrideNode.getMembers().forEach((modifier, value) -> {
-                    String modifierName = modifier.getValue().toUpperCase();
-                    this.modifyHttpRequestTimeoutInMillis(Modifier.valueOf(modifierName),
-                            value.expectNumberNode().getValue());
+            mode
+                .getObjectMember("httpRequestTimeoutInMillis")
+                .ifPresent(overrideNode -> {
+                    overrideNode
+                        .getMembers()
+                        .forEach((modifier, value) -> {
+                            String modifierName = modifier.getValue().toUpperCase();
+                            this.modifyHttpRequestTimeoutInMillis(
+                                Modifier.valueOf(modifierName),
+                                value.expectNumberNode().getValue()
+                            );
+                        });
                 });
-            });
         }
 
         private void modifyRetryMode(Modifier modifier, String val) {
@@ -166,7 +200,8 @@ final class DefaultsModeConfigGenerator {
                 this.retryMode = Optional.of(val);
             } else {
                 throw new CodegenException(
-                        String.format("Unexpected modifier to retryMode, expect \"override\", got %s", modifier.label));
+                    String.format("Unexpected modifier to retryMode, expect \"override\", got %s", modifier.label)
+                );
             }
         }
 
@@ -185,23 +220,25 @@ final class DefaultsModeConfigGenerator {
 
         private void modifyConnectTimeoutInMillis(Modifier modifier, Number val) {
             this.connectTimeoutInMillis = Optional.of(
-                    this.modifyNumber(this.connectTimeoutInMillis.orElse(null), modifier, val));
+                this.modifyNumber(this.connectTimeoutInMillis.orElse(null), modifier, val)
+            );
         }
 
         private void modifyHttpRequestTimeoutInMillis(Modifier modifier, Number val) {
             this.httpRequestTimeoutInMillis = Optional.of(
-                this.modifyNumber(this.httpRequestTimeoutInMillis.orElse(null), modifier, val));
+                this.modifyNumber(this.httpRequestTimeoutInMillis.orElse(null), modifier, val)
+            );
         }
 
         public void useWriter(TypeScriptWriter writer) {
             writer.openBlock("return {", "};", () -> {
-                this.retryMode.ifPresent((retryMode) -> {
+                this.retryMode.ifPresent(retryMode -> {
                     writer.write("retryMode: $S,", this.retryMode);
                 });
-                this.connectTimeoutInMillis.ifPresent((connectTimeoutInMillis) -> {
+                this.connectTimeoutInMillis.ifPresent(connectTimeoutInMillis -> {
                     writer.write("connectionTimeout: $L,", connectTimeoutInMillis);
                 });
-                this.httpRequestTimeoutInMillis.ifPresent((httpRequestTimeoutInMillis) -> {
+                this.httpRequestTimeoutInMillis.ifPresent(httpRequestTimeoutInMillis -> {
                     writer.write("requestTimeout: $L,", httpRequestTimeoutInMillis);
                 });
             });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -42,11 +42,11 @@ final class DocumentClientPaginationGenerator implements Runnable {
     private final String paginationType;
 
     DocumentClientPaginationGenerator(
-            Model model,
-            ServiceShape service,
-            OperationShape operation,
-            SymbolProvider symbolProvider,
-            TypeScriptWriter writer
+        Model model,
+        ServiceShape service,
+        OperationShape operation,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
     ) {
         this.writer = writer;
 
@@ -66,21 +66,28 @@ final class DocumentClientPaginationGenerator implements Runnable {
     @Override
     public void run() {
         // Import Service Types
-        Path commandFileLocation = Paths.get(".", DocumentClientUtils.CLIENT_COMMANDS_FOLDER,
-            DocumentClientUtils.getModifiedName(operationTypeName));
+        Path commandFileLocation = Paths.get(
+            ".",
+            DocumentClientUtils.CLIENT_COMMANDS_FOLDER,
+            DocumentClientUtils.getModifiedName(operationTypeName)
+        );
         writer.addRelativeImport(operationTypeName, operationTypeName, commandFileLocation);
         writer.addRelativeImport(inputTypeName, inputTypeName, commandFileLocation);
         writer.addRelativeImport(outputTypeName, outputTypeName, commandFileLocation);
         writer.addRelativeImport(
             DocumentClientUtils.CLIENT_NAME,
             DocumentClientUtils.CLIENT_NAME,
-            Paths.get(".", DocumentClientUtils.CLIENT_NAME));
+            Paths.get(".", DocumentClientUtils.CLIENT_NAME)
+        );
 
         // Import Pagination types
         writer.addImport("Paginator", "Paginator", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("createPaginator", "createPaginator", TypeScriptDependency.SMITHY_CORE);
-        writer.addRelativeImport(paginationType, paginationType,
-            Paths.get(".", getInterfaceFilelocation().replace(".ts", "")));
+        writer.addRelativeImport(
+            paginationType,
+            paginationType,
+            Paths.get(".", getInterfaceFilelocation().replace(".ts", ""))
+        );
 
         writer.writeDocs("@public");
         writer.write("export { Paginator }");
@@ -89,14 +96,21 @@ final class DocumentClientPaginationGenerator implements Runnable {
     }
 
     static String getOutputFilelocation(OperationShape operation) {
-        return String.format("%s%s/%s.ts", DocumentClientUtils.DOC_CLIENT_PREFIX,
+        return String.format(
+            "%s%s/%s.ts",
+            DocumentClientUtils.DOC_CLIENT_PREFIX,
             DocumentClientPaginationGenerator.PAGINATION_FOLDER,
-            DocumentClientUtils.getModifiedName(operation.getId().getName()) + "Paginator");
+            DocumentClientUtils.getModifiedName(operation.getId().getName()) + "Paginator"
+        );
     }
 
     static String getInterfaceFilelocation() {
-        return String.format("%s%s/%s.ts", DocumentClientUtils.DOC_CLIENT_PREFIX,
-            DocumentClientPaginationGenerator.PAGINATION_FOLDER, "Interfaces");
+        return String.format(
+            "%s%s/%s.ts",
+            DocumentClientUtils.DOC_CLIENT_PREFIX,
+            DocumentClientPaginationGenerator.PAGINATION_FOLDER,
+            "Interfaces"
+        );
     }
 
     static void generateServicePaginationInterfaces(TypeScriptWriter writer) {
@@ -105,35 +119,47 @@ final class DocumentClientPaginationGenerator implements Runnable {
         writer.addRelativeImport(
             DocumentClientUtils.CLIENT_NAME,
             DocumentClientUtils.CLIENT_NAME,
-            Paths.get(".", DocumentClientUtils.CLIENT_NAME));
+            Paths.get(".", DocumentClientUtils.CLIENT_NAME)
+        );
         writer.addRelativeImport(
             DocumentClientUtils.CLIENT_FULL_NAME,
             DocumentClientUtils.CLIENT_FULL_NAME,
-            Paths.get(".", DocumentClientUtils.CLIENT_FULL_NAME));
+            Paths.get(".", DocumentClientUtils.CLIENT_FULL_NAME)
+        );
 
         writer.writeDocs("@public");
         writer.write("export { PaginationConfiguration };");
         writer.write("");
 
         writer.writeDocs("@public");
-        writer.openBlock("export interface $LPaginationConfiguration extends PaginationConfiguration {",
-                "}", DocumentClientUtils.CLIENT_FULL_NAME, () -> {
-            writer.write("client: $L | $L;", DocumentClientUtils.CLIENT_FULL_NAME, DocumentClientUtils.CLIENT_NAME);
-        });
+        writer.openBlock(
+            "export interface $LPaginationConfiguration extends PaginationConfiguration {",
+            "}",
+            DocumentClientUtils.CLIENT_FULL_NAME,
+            () -> {
+                writer.write("client: $L | $L;", DocumentClientUtils.CLIENT_FULL_NAME, DocumentClientUtils.CLIENT_NAME);
+            }
+        );
     }
 
     private void writePager() {
         writer.writeDocs("@public");
-        writer.write("""
-export const paginate$1L: (
-  config: $2L,
-  input: $3L,
-  ...additionalArguments: any
-) => Paginator<$4L> = createPaginator<
-  $2L,
-  $3L,
-  $4L
->(DynamoDBDocumentClient, $1LCommand, "ExclusiveStartKey", "LastEvaluatedKey", "Limit");
-        """, operationName, paginationType, inputTypeName, outputTypeName);
+        writer.write(
+            """
+            export const paginate$1L: (
+              config: $2L,
+              input: $3L,
+              ...additionalArguments: any
+            ) => Paginator<$4L> = createPaginator<
+              $2L,
+              $3L,
+              $4L
+            >(DynamoDBDocumentClient, $1LCommand, "ExclusiveStartKey", "LastEvaluatedKey", "Limit");
+                    """,
+            operationName,
+            paginationType,
+            inputTypeName,
+            outputTypeName
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientUtils.java
@@ -33,6 +33,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
 final class DocumentClientUtils {
+
     static final String CLIENT_NAME = "DynamoDBDocumentClient";
     static final String CLIENT_FULL_NAME = "DynamoDBDocument";
     static final String CLIENT_CONFIG_NAME = getResolvedConfigTypeName(CLIENT_NAME);
@@ -52,17 +53,15 @@ final class DocumentClientUtils {
     }
 
     static String getModifiedName(String name) {
-      return name.replace("Items", "").replace("Item", "");
+        return name.replace("Items", "").replace("Item", "");
     }
 
-    static boolean containsAttributeValue(
-        Model model,
-        SymbolProvider symbolProvider,
-        OperationShape operation
-    ) {
+    static boolean containsAttributeValue(Model model, SymbolProvider symbolProvider, OperationShape operation) {
         OperationIndex operationIndex = OperationIndex.of(model);
-        if (containsAttributeValue(model, symbolProvider, operationIndex.getInput(operation))
-                || containsAttributeValue(model, symbolProvider, operationIndex.getOutput(operation))) {
+        if (
+            containsAttributeValue(model, symbolProvider, operationIndex.getInput(operation)) ||
+            containsAttributeValue(model, symbolProvider, operationIndex.getOutput(operation))
+        ) {
             return true;
         }
         return false;
@@ -73,108 +72,116 @@ final class DocumentClientUtils {
         SymbolProvider symbolProvider,
         Optional<StructureShape> optionalShape
     ) {
-      if (optionalShape.isPresent()) {
-        StructureShape structureShape = optionalShape.get();
-        for (MemberShape member : structureShape.getAllMembers().values()) {
-          if (containsAttributeValue(model, symbolProvider, member, new HashSet<String>())) {
-            return true;
-          }
+        if (optionalShape.isPresent()) {
+            StructureShape structureShape = optionalShape.get();
+            for (MemberShape member : structureShape.getAllMembers().values()) {
+                if (containsAttributeValue(model, symbolProvider, member, new HashSet<String>())) {
+                    return true;
+                }
+            }
         }
-      }
-      return false;
+        return false;
     }
 
     static boolean containsAttributeValue(
-          Model model,
-          SymbolProvider symbolProvider,
-          MemberShape member,
-          Set<String> parents
+        Model model,
+        SymbolProvider symbolProvider,
+        MemberShape member,
+        Set<String> parents
     ) {
-      Shape memberTarget = model.expectShape(member.getTarget());
-      if (memberTarget.isStructureShape()) {
-          if (!parents.contains(symbolProvider.toMemberName(member))) {
-              parents.add(symbolProvider.toMemberName(member));
-              Collection<MemberShape> structureMemberList = ((StructureShape) memberTarget).getAllMembers().values();
-              for (MemberShape structureMember : structureMemberList) {
-                  if (!parents.contains(symbolProvider.toMemberName(structureMember))
-                          && containsAttributeValue(model, symbolProvider, structureMember, parents)) {
-                      return true;
-                  }
-              }
-
-          }
-      } else if (memberTarget.isUnionShape()) {
-          if (symbolProvider.toSymbol(memberTarget).getName().equals("AttributeValue")) {
-              return true;
-          } else if (!parents.contains(symbolProvider.toMemberName(member))) {
-              parents.add(symbolProvider.toMemberName(member));
-              Collection<MemberShape> unionMemberList = ((UnionShape) memberTarget).getAllMembers().values();
-              for (MemberShape unionMember : unionMemberList) {
-                  if (!parents.contains(symbolProvider.toMemberName(unionMember))
-                          && containsAttributeValue(model, symbolProvider, unionMember, parents)) {
-                      return true;
-                  }
-              }
-          }
-      } else if (memberTarget.isMapShape()) {
-          MemberShape mapMember = ((MapShape) memberTarget).getValue();
-          if (containsAttributeValue(model, symbolProvider, mapMember, parents)) {
-              return true;
-          }
-      } else if (memberTarget instanceof CollectionShape) {
-          MemberShape collectionMember = ((CollectionShape) memberTarget).getMember();
-          if (containsAttributeValue(model, symbolProvider, collectionMember, parents)) {
-              return true;
-          }
-      }
-      return false;
+        Shape memberTarget = model.expectShape(member.getTarget());
+        if (memberTarget.isStructureShape()) {
+            if (!parents.contains(symbolProvider.toMemberName(member))) {
+                parents.add(symbolProvider.toMemberName(member));
+                Collection<MemberShape> structureMemberList = ((StructureShape) memberTarget).getAllMembers().values();
+                for (MemberShape structureMember : structureMemberList) {
+                    if (
+                        !parents.contains(symbolProvider.toMemberName(structureMember)) &&
+                        containsAttributeValue(model, symbolProvider, structureMember, parents)
+                    ) {
+                        return true;
+                    }
+                }
+            }
+        } else if (memberTarget.isUnionShape()) {
+            if (symbolProvider.toSymbol(memberTarget).getName().equals("AttributeValue")) {
+                return true;
+            } else if (!parents.contains(symbolProvider.toMemberName(member))) {
+                parents.add(symbolProvider.toMemberName(member));
+                Collection<MemberShape> unionMemberList = ((UnionShape) memberTarget).getAllMembers().values();
+                for (MemberShape unionMember : unionMemberList) {
+                    if (
+                        !parents.contains(symbolProvider.toMemberName(unionMember)) &&
+                        containsAttributeValue(model, symbolProvider, unionMember, parents)
+                    ) {
+                        return true;
+                    }
+                }
+            }
+        } else if (memberTarget.isMapShape()) {
+            MemberShape mapMember = ((MapShape) memberTarget).getValue();
+            if (containsAttributeValue(model, symbolProvider, mapMember, parents)) {
+                return true;
+            }
+        } else if (memberTarget instanceof CollectionShape) {
+            MemberShape collectionMember = ((CollectionShape) memberTarget).getMember();
+            if (containsAttributeValue(model, symbolProvider, collectionMember, parents)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static String getCommandDocs(String operationName) {
-        return "Accepts native JavaScript types instead of `AttributeValue`s, and calls\n"
-            + operationName + " operation from "
-            + "{@link @aws-sdk/client-dynamodb#"
-            + operationName
-            + "}.\n\n"
-            + "JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes \n"
-            + "required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.";
+        return (
+            "Accepts native JavaScript types instead of `AttributeValue`s, and calls\n" +
+            operationName +
+            " operation from " +
+            "{@link @aws-sdk/client-dynamodb#" +
+            operationName +
+            "}.\n\n" +
+            "JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes \n" +
+            "required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects."
+        );
     }
 
     static String getClientDocs() {
-        return "The document client simplifies working with items in Amazon DynamoDB by\n"
-        + "abstracting away the notion of attribute values. This abstraction annotates native\n"
-        + "JavaScript types supplied as input parameters, as well as converts annotated\n"
-        + "response data to native JavaScript types.\n\n"
-        + "## Marshalling Input and Unmarshalling Response Data\n\n"
-        + "The document client affords developers the use of native JavaScript types\n"
-        + "instead of `AttributeValue`s to simplify the JavaScript development\n"
-        + "experience with Amazon DynamoDB. JavaScript objects passed in as parameters\n"
-        + "are marshalled into `AttributeValue` shapes required by Amazon DynamoDB.\n"
-        + "Responses from DynamoDB are unmarshalled into plain JavaScript objects\n"
-        + "by the `DocumentClient`. The `DocumentClient` does not accept\n"
-        + "`AttributeValue`s in favor of native JavaScript types.\n\n"
-        + "|          JavaScript Type          | DynamoDB AttributeValue |\n"
-        + "| :-------------------------------: | ----------------------- |\n"
-        + "|              String               | S                       |\n"
-        + "|          Number / BigInt          | N                       |\n"
-        + "|              Boolean              | BOOL                    |\n"
-        + "|               null                | NULL                    |\n"
-        + "|               Array               | L                       |\n"
-        + "|              Object               | M                       |\n"
-        + "|   Set\\<Uint8Array, Blob, ...\\>    | BS                      |\n"
-        + "|       Set\\<Number, BigInt\\>       | NS                      |\n"
-        + "|           Set\\<String\\>           | SS                      |\n"
-        + "| Uint8Array, Buffer, File, Blob... | B                       |\n"
-        + "\n### Example\n\n"
-        + "Here is an example list which is sent to DynamoDB client in an operation:\n\n"
-        + "```json\n"
-        + "{ \"L\": [{ \"NULL\": true }, { \"BOOL\": false }, { \"N\": 1 }, { \"S\": \"two\" }] }\n"
-        + "```\n"
-        + "\nThe DynamoDB document client abstracts the attribute values as follows in\n"
-        + "both input and output:\n\n"
-        + "```json\n"
-        + "[null, false, 1, \"two\"]\n"
-        + "```\n\n"
-        + "@see {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb | @aws-sdk/client-dynamodb}";
+        return (
+            "The document client simplifies working with items in Amazon DynamoDB by\n" +
+            "abstracting away the notion of attribute values. This abstraction annotates native\n" +
+            "JavaScript types supplied as input parameters, as well as converts annotated\n" +
+            "response data to native JavaScript types.\n\n" +
+            "## Marshalling Input and Unmarshalling Response Data\n\n" +
+            "The document client affords developers the use of native JavaScript types\n" +
+            "instead of `AttributeValue`s to simplify the JavaScript development\n" +
+            "experience with Amazon DynamoDB. JavaScript objects passed in as parameters\n" +
+            "are marshalled into `AttributeValue` shapes required by Amazon DynamoDB.\n" +
+            "Responses from DynamoDB are unmarshalled into plain JavaScript objects\n" +
+            "by the `DocumentClient`. The `DocumentClient` does not accept\n" +
+            "`AttributeValue`s in favor of native JavaScript types.\n\n" +
+            "|          JavaScript Type          | DynamoDB AttributeValue |\n" +
+            "| :-------------------------------: | ----------------------- |\n" +
+            "|              String               | S                       |\n" +
+            "|          Number / BigInt          | N                       |\n" +
+            "|              Boolean              | BOOL                    |\n" +
+            "|               null                | NULL                    |\n" +
+            "|               Array               | L                       |\n" +
+            "|              Object               | M                       |\n" +
+            "|   Set\\<Uint8Array, Blob, ...\\>    | BS                      |\n" +
+            "|       Set\\<Number, BigInt\\>       | NS                      |\n" +
+            "|           Set\\<String\\>           | SS                      |\n" +
+            "| Uint8Array, Buffer, File, Blob... | B                       |\n" +
+            "\n### Example\n\n" +
+            "Here is an example list which is sent to DynamoDB client in an operation:\n\n" +
+            "```json\n" +
+            "{ \"L\": [{ \"NULL\": true }, { \"BOOL\": false }, { \"N\": 1 }, { \"S\": \"two\" }] }\n" +
+            "```\n" +
+            "\nThe DynamoDB document client abstracts the attribute values as follows in\n" +
+            "both input and output:\n\n" +
+            "```json\n" +
+            "[null, false, 1, \"two\"]\n" +
+            "```\n\n" +
+            "@see {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb | @aws-sdk/client-dynamodb}"
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/Ec2ShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/Ec2ShapeSerVisitor.java
@@ -48,6 +48,7 @@ import software.amazon.smithy.utils.StringUtils;
  */
 @SmithyInternalApi
 final class Ec2ShapeSerVisitor extends QueryShapeSerVisitor {
+
     Ec2ShapeSerVisitor(GenerationContext context) {
         super(context);
         serializeEmptyLists = false;
@@ -55,8 +56,9 @@ final class Ec2ShapeSerVisitor extends QueryShapeSerVisitor {
 
     @Override
     protected void serializeDocument(GenerationContext context, DocumentShape shape) {
-        throw new CodegenException(String.format(
-                "Cannot serialize Document types in the aws.ec2 protocol, shape: %s.", shape.getId()));
+        throw new CodegenException(
+            String.format("Cannot serialize Document types in the aws.ec2 protocol, shape: %s.", shape.getId())
+        );
     }
 
     @Override
@@ -69,10 +71,11 @@ final class Ec2ShapeSerVisitor extends QueryShapeSerVisitor {
 
         // Fall back to the capitalized @xmlName trait if present on the member,
         // otherwise use the capitalized default value.
-        return memberShape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .map(StringUtils::capitalize)
-                .orElseGet(() -> StringUtils.capitalize(defaultValue));
+        return memberShape
+            .getTrait(XmlNameTrait.class)
+            .map(XmlNameTrait::getValue)
+            .map(StringUtils::capitalize)
+            .orElseGet(() -> StringUtils.capitalize(defaultValue));
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
@@ -40,10 +40,12 @@ final class JsonMemberDeserVisitor extends MemberDeserVisitor {
     /**
      * @inheritDoc
      */
-    JsonMemberDeserVisitor(GenerationContext context,
-                           MemberShape memberShape,
-                           String dataSource,
-                           Format defaultTimestampFormat) {
+    JsonMemberDeserVisitor(
+        GenerationContext context,
+        MemberShape memberShape,
+        String dataSource,
+        Format defaultTimestampFormat
+    ) {
         super(context, dataSource, defaultTimestampFormat);
         this.dataSource = dataSource;
         this.context = context;
@@ -52,9 +54,7 @@ final class JsonMemberDeserVisitor extends MemberDeserVisitor {
         this.serdeElisionEnabled = !context.getSettings().generateServerSdk();
     }
 
-    JsonMemberDeserVisitor(GenerationContext context,
-                           String dataSource,
-                           Format defaultTimestampFormat) {
+    JsonMemberDeserVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
         this(context, null, dataSource, defaultTimestampFormat);
     }
 
@@ -88,7 +88,8 @@ final class JsonMemberDeserVisitor extends MemberDeserVisitor {
     }
 
     private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
-                shape.getType(), shape.getId()));
+        throw new CodegenException(
+            String.format("Cannot deserialize shape type %s on protocol, shape: %s.", shape.getType(), shape.getId())
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
@@ -42,6 +42,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 final class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
+
     private final boolean isAwsQueryCompat;
 
     /**
@@ -137,7 +138,8 @@ final class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
     }
 
     private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
-                shape.getType(), shape.getId()));
+        throw new CodegenException(
+            String.format("Cannot serialize shape type %s on protocol, shape: %s.", shape.getType(), shape.getId())
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -73,9 +73,7 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
         if (context.getService().hasTrait(AwsQueryCompatibleTrait.class)) {
             AwsProtocolUtils.generateJsonParseBodyWithQueryHeader(context);
         }
-        writer.write(
-            context.getStringStore().flushVariableDeclarationCode()
-        );
+        writer.write(context.getStringStore().flushVariableDeclarationCode());
     }
 
     @Override
@@ -84,8 +82,10 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     }
 
     @Override
-    public Map<String, TreeSet<String>> getErrorAliases(GenerationContext context,
-                                                        Collection<OperationShape> operations) {
+    public Map<String, TreeSet<String>> getErrorAliases(
+        GenerationContext context,
+        Collection<OperationShape> operations
+    ) {
         return AwsProtocolUtils.getErrorAliases(context, operations);
     }
 
@@ -102,25 +102,23 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     protected void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {
         boolean isAwsQueryCompat = context.getService().hasTrait(AwsQueryCompatibleTrait.class);
 
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes,
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(
+            context,
+            shapes,
             // AWS JSON does not support jsonName
-            new JsonShapeSerVisitor(
-                context,
-                (shape, name) -> name,
-                !isAwsQueryCompat && enableSerdeElision()
-            )
+            new JsonShapeSerVisitor(context, (shape, name) -> name, !isAwsQueryCompat && enableSerdeElision())
         );
     }
 
     @Override
     protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
         boolean disableDeserializationFunctionElision = DeserializerElisionDenyList.SDK_IDS.contains(
-            context.getService().getTrait(ServiceTrait.class)
-                .map(ServiceTrait::getSdkId)
-                .orElse(null)
+            context.getService().getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse(null)
         );
 
-        AwsProtocolUtils.generateDocumentBodyShapeSerde(context, shapes,
+        AwsProtocolUtils.generateDocumentBodyShapeSerde(
+            context,
+            shapes,
             // AWS JSON does not support jsonName
             new JsonShapeDeserVisitor(
                 context,
@@ -151,26 +149,26 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
         TypeScriptWriter writer = context.getWriter();
         writer.addImport("HeaderBag", "__HeaderBag", TypeScriptDependency.SMITHY_TYPES);
         String targetHeader = serviceShape.getId().getName(serviceShape) + ".${operation}";
-        writer.openBlock("function sharedHeaders(operation: string): __HeaderBag { return {", "}};",
-                () -> {
-                    writer.write("'content-type': $S,", getDocumentContentType());
-                    // AWS JSON RPC protocols use a combination of the service and operation shape names,
-                    // separated by a '.' character, for the target header.
-                    writer.write("'x-amz-target': `$L`,", targetHeader);
-                    if (serviceShape.hasTrait(AwsQueryCompatibleTrait.class)) {
-                        writer.write("""
-                            "x-amzn-query-mode": "true",
-                        """);
-                    }
-                }
-        );
+        writer.openBlock("function sharedHeaders(operation: string): __HeaderBag { return {", "}};", () -> {
+            writer.write("'content-type': $S,", getDocumentContentType());
+            // AWS JSON RPC protocols use a combination of the service and operation shape names,
+            // separated by a '.' character, for the target header.
+            writer.write("'x-amz-target': `$L`,", targetHeader);
+            if (serviceShape.hasTrait(AwsQueryCompatibleTrait.class)) {
+                writer.write(
+                    """
+                        "x-amzn-query-mode": "true",
+                    """
+                );
+            }
+        });
     }
 
     @Override
     protected void serializeInputDocument(
-            GenerationContext context,
-            OperationShape operation,
-            StructureShape inputStructure
+        GenerationContext context,
+        OperationShape operation,
+        StructureShape inputStructure
     ) {
         TypeScriptWriter writer = context.getWriter();
 
@@ -203,9 +201,9 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
 
     @Override
     protected void deserializeOutputDocument(
-            GenerationContext context,
-            OperationShape operation,
-            StructureShape outputStructure
+        GenerationContext context,
+        OperationShape operation,
+        StructureShape outputStructure
     ) {
         TypeScriptWriter writer = context.getWriter();
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/ProcessAwsQueryWaiters.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/ProcessAwsQueryWaiters.java
@@ -27,7 +27,6 @@ import software.amazon.smithy.waiters.Matcher;
 import software.amazon.smithy.waiters.WaitableTrait;
 import software.amazon.smithy.waiters.Waiter;
 
-
 @SmithyInternalApi
 public final class ProcessAwsQueryWaiters implements TypeScriptIntegration {
 
@@ -68,13 +67,12 @@ public final class ProcessAwsQueryWaiters implements TypeScriptIntegration {
 
                             String errorCode = matcherNode.expectStringMember("errorType").getValue();
                             if (errorCodeToShapeId.containsKey(errorCode)) {
-                                matcherNode = matcherNode.toBuilder()
-                                        .withMember("errorType", errorCodeToShapeId.get(errorCode))
-                                        .build();
+                                matcherNode = matcherNode
+                                    .toBuilder()
+                                    .withMember("errorType", errorCodeToShapeId.get(errorCode))
+                                    .build();
 
-                                acceptorNode = acceptorNode.toBuilder()
-                                        .withMember("matcher", matcherNode)
-                                        .build();
+                                acceptorNode = acceptorNode.toBuilder().withMember("matcher", matcherNode).build();
                             }
                         }
                         waiterBuilder.addAcceptor(Acceptor.fromNode(acceptorNode));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryMemberSerVisitor.java
@@ -38,8 +38,13 @@ final class QueryMemberSerVisitor extends DocumentMemberSerVisitor {
     }
 
     boolean visitSuppliesEntryList(Shape shape) {
-        return shape.isStructureShape() || shape.isUnionShape()
-                || shape.isMapShape() || shape.isListShape() || shape.isSetShape();
+        return (
+            shape.isStructureShape() ||
+            shape.isUnionShape() ||
+            shape.isMapShape() ||
+            shape.isListShape() ||
+            shape.isSetShape()
+        );
     }
 
     @Override
@@ -55,7 +60,8 @@ final class QueryMemberSerVisitor extends DocumentMemberSerVisitor {
     }
 
     private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
-                shape.getType(), shape.getId()));
+        throw new CodegenException(
+            String.format("Cannot serialize shape type %s on protocol, shape: %s.", shape.getType(), shape.getId())
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/QueryShapeSerVisitor.java
@@ -106,8 +106,9 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
 
     @Override
     protected void serializeDocument(GenerationContext context, DocumentShape shape) {
-        throw new CodegenException(String.format(
-                "Cannot serialize Document types in the aws.query protocol, shape: %s.", shape.getId()));
+        throw new CodegenException(
+            String.format("Cannot serialize Document types in the aws.query protocol, shape: %s.", shape.getId())
+        );
     }
 
     @Override
@@ -161,18 +162,19 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
     }
 
     private void serializeUnnamedMemberEntryList(
-            GenerationContext context,
-            Shape target,
-            String inputLocation,
-            String entryWrapper
+        GenerationContext context,
+        Shape target,
+        String inputLocation,
+        String entryWrapper
     ) {
         TypeScriptWriter writer = context.getWriter();
 
         QueryMemberSerVisitor inputVisitor = getMemberVisitor(inputLocation);
         // Map entries that supply entry lists need to have them joined properly.
         writer.write("const memberEntries = $L;", target.accept(inputVisitor));
-        writer.openBlock("Object.entries(memberEntries).forEach(([key, value]) => {", "});",
-                () -> writer.write("entries[`$L.$${key}`] = value;", entryWrapper));
+        writer.openBlock("Object.entries(memberEntries).forEach(([key, value]) => {", "});", () ->
+            writer.write("entries[`$L.$${key}`] = value;", entryWrapper)
+        );
     }
 
     @Override
@@ -183,30 +185,27 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
         writer.write("const entries: any = {};");
 
         // Serialize every member of the structure if present.
-        shape.getAllMembers().forEach((memberName, memberShape) -> {
-            String inputLocation = "input[" + stringStore.var(memberName) + "]";
+        shape
+            .getAllMembers()
+            .forEach((memberName, memberShape) -> {
+                String inputLocation = "input[" + stringStore.var(memberName) + "]";
 
-            // Handle if the member is an idempotency token that should be auto-filled.
-            AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
+                // Handle if the member is an idempotency token that should be auto-filled.
+                AwsProtocolUtils.writeIdempotencyAutofill(context, memberShape, inputLocation);
 
-            writer.openBlock(
-                "if ($1L != null) {",
-                "}",
-                inputLocation,
-                () -> {
+                writer.openBlock("if ($1L != null) {", "}", inputLocation, () -> {
                     serializeNamedMember(context, memberName, memberShape, inputLocation);
-                }
-            );
-        });
+                });
+            });
 
         writer.write("return entries");
     }
 
     private void serializeNamedMember(
-            GenerationContext context,
-            String memberName,
-            MemberShape memberShape,
-            String inputLocation
+        GenerationContext context,
+        String memberName,
+        MemberShape memberShape,
+        String inputLocation
     ) {
         // Grab the target shape so we can use a member serializer on it.
         Shape target = context.getModel().expectShape(memberShape.getTarget());
@@ -218,26 +217,28 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
             serializeNamedMemberEntryList(context, locationName, memberShape, target, inputVisitor, inputLocation);
         } else {
             serializeNamedMemberValue(
-                context, locationName,
-                "input[" + stringStore.var(memberName) + "]", memberShape, target
+                context,
+                locationName,
+                "input[" + stringStore.var(memberName) + "]",
+                memberShape,
+                target
             );
         }
     }
 
     private void serializeNamedMemberValue(
-            GenerationContext context,
-            String locationName,
-            String dataSource,
-            MemberShape memberShape,
-            Shape target
+        GenerationContext context,
+        String locationName,
+        String dataSource,
+        MemberShape memberShape,
+        Shape target
     ) {
         TypeScriptWriter writer = context.getWriter();
 
         // Handle @timestampFormat on members not just the targeted shape.
         String valueProvider = memberShape.hasTrait(TimestampFormatTrait.class)
-                ? AwsProtocolUtils.getInputTimestampValueProvider(context, memberShape,
-                        TIMESTAMP_FORMAT, dataSource)
-                : target.accept(getMemberVisitor(dataSource));
+            ? AwsProtocolUtils.getInputTimestampValueProvider(context, memberShape, TIMESTAMP_FORMAT, dataSource)
+            : target.accept(getMemberVisitor(dataSource));
 
         writer.write("entries[$L] = $L;", stringStore.var(locationName), valueProvider);
     }
@@ -252,18 +253,16 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
      */
     protected String getMemberSerializedLocationName(MemberShape memberShape, String defaultValue) {
         // Use the @xmlName trait if present on the member, otherwise use the member name.
-        return memberShape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse(defaultValue);
+        return memberShape.getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse(defaultValue);
     }
 
     private void serializeNamedMemberEntryList(
-            GenerationContext context,
-            String locationName,
-            MemberShape memberShape,
-            Shape target,
-            DocumentMemberSerVisitor inputVisitor,
-            String inputLocation
+        GenerationContext context,
+        String locationName,
+        MemberShape memberShape,
+        Shape target,
+        DocumentMemberSerVisitor inputVisitor,
+        String inputLocation
     ) {
         TypeScriptWriter writer = context.getWriter();
 
@@ -276,14 +275,9 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
         Shape targetShape = context.getModel().expectShape(memberShape.getTarget());
 
         if ((targetShape.isListShape() || targetShape.isSetShape()) && serializeEmptyLists) {
-            writer.openBlock(
-                "if ($L?.length === 0) {",
-                "}",
-                inputLocation,
-                () -> {
-                    writer.write("$L = []", PropertyAccessor.getFrom("entries", locationName));
-                }
-            );
+            writer.openBlock("if ($L?.length === 0) {", "}", inputLocation, () -> {
+                writer.write("$L = []", PropertyAccessor.getFrom("entries", locationName));
+            });
         }
 
         // Consolidate every entry in the list.
@@ -322,11 +316,13 @@ class QueryShapeSerVisitor extends DocumentShapeSerVisitor {
 
         // Visit over the union type, then get the right serialization for the member.
         writer.openBlock("$L.visit(input, {", "});", shape.getId().getName(serviceShape), () -> {
-            shape.getAllMembers().forEach((memberName, memberShape) -> {
-                writer.openBlock("$L: value => {", "},", memberName, () -> {
-                    serializeNamedMember(context, memberName, memberShape, "value");
+            shape
+                .getAllMembers()
+                .forEach((memberName, memberShape) -> {
+                    writer.openBlock("$L: value => {", "},", memberName, () -> {
+                        serializeNamedMember(context, memberName, memberShape, "value");
+                    });
                 });
-            });
 
             // Handle the unknown property.
             writer.openBlock("_: (name: string, value: any) => {", "}", () -> {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -60,6 +60,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
+
     /**
      * Creates a AWS JSON RPC protocol generator.
      */
@@ -68,8 +69,10 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
-    public Map<String, TreeSet<String>> getErrorAliases(GenerationContext context,
-                                                        Collection<OperationShape> operations) {
+    public Map<String, TreeSet<String>> getErrorAliases(
+        GenerationContext context,
+        Collection<OperationShape> operations
+    ) {
         return AwsProtocolUtils.getErrorAliases(context, operations);
     }
 
@@ -90,9 +93,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         writer.addDependency(AwsDependency.AWS_SDK_CORE);
         writer.addImport("loadRestJsonErrorCode", null, AwsDependency.AWS_SDK_CORE);
 
-        writer.write(
-            context.getStringStore().flushVariableDeclarationCode()
-        );
+        writer.write(context.getStringStore().flushVariableDeclarationCode());
     }
 
     @Override
@@ -105,10 +106,10 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         boolean isAwsQueryCompat = context.getService().hasTrait(AwsQueryCompatibleTrait.class);
         AwsProtocolUtils.generateDocumentBodyShapeSerde(
             context,
-            shapes, new JsonShapeSerVisitor(
+            shapes,
+            new JsonShapeSerVisitor(
                 context,
-                !context.getSettings().generateServerSdk()
-                    && !isAwsQueryCompat && enableSerdeElision()
+                !context.getSettings().generateServerSdk() && !isAwsQueryCompat && enableSerdeElision()
             )
         );
     }
@@ -116,9 +117,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     @Override
     protected void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {
         boolean disableDeserializationFunctionElision = DeserializerElisionDenyList.SDK_IDS.contains(
-            context.getService().getTrait(ServiceTrait.class)
-                .map(ServiceTrait::getSdkId)
-                .orElse(null)
+            context.getService().getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse(null)
         );
 
         AwsProtocolUtils.generateDocumentBodyShapeSerde(
@@ -126,8 +125,9 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
             shapes,
             new JsonShapeDeserVisitor(
                 context,
-                !context.getSettings().generateServerSdk()
-                    && !disableDeserializationFunctionElision && enableSerdeElision()
+                !context.getSettings().generateServerSdk() &&
+                    !disableDeserializationFunctionElision &&
+                    enableSerdeElision()
             )
         );
     }
@@ -150,9 +150,9 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected void serializeInputDocumentBody(
-            GenerationContext context,
-            OperationShape operation,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        OperationShape operation,
+        List<HttpBinding> documentBindings
     ) {
         // Short circuit when we have no bindings.
         TypeScriptWriter writer = context.getWriter();
@@ -165,9 +165,9 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected void serializeOutputDocumentBody(
-            GenerationContext context,
-            OperationShape operation,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        OperationShape operation,
+        List<HttpBinding> documentBindings
     ) {
         // Short circuit when we have no bindings.
         TypeScriptWriter writer = context.getWriter();
@@ -180,9 +180,9 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected void serializeErrorDocumentBody(
-            GenerationContext context,
-            StructureShape error,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        StructureShape error,
+        List<HttpBinding> documentBindings
     ) {
         // Short circuit when we have no bindings.
         TypeScriptWriter writer = context.getWriter();
@@ -195,9 +195,9 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected void serializeInputPayload(
-            GenerationContext context,
-            OperationShape operation,
-            HttpBinding payloadBinding
+        GenerationContext context,
+        OperationShape operation,
+        HttpBinding payloadBinding
     ) {
         super.serializeInputPayload(context, operation, payloadBinding);
         serializePayload(context, payloadBinding);
@@ -211,20 +211,16 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected void serializeOutputPayload(
-            GenerationContext context,
-            OperationShape operation,
-            HttpBinding payloadBinding
+        GenerationContext context,
+        OperationShape operation,
+        HttpBinding payloadBinding
     ) {
         super.serializeOutputPayload(context, operation, payloadBinding);
         serializePayload(context, payloadBinding);
     }
 
     @Override
-    protected void serializeErrorPayload(
-            GenerationContext context,
-            StructureShape error,
-            HttpBinding payloadBinding
-    ) {
+    protected void serializeErrorPayload(GenerationContext context, StructureShape error, HttpBinding payloadBinding) {
         super.serializeErrorPayload(context, error, payloadBinding);
         serializePayload(context, payloadBinding);
     }
@@ -244,36 +240,36 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected void deserializeInputDocumentBody(
-            GenerationContext context,
-            OperationShape operation,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        OperationShape operation,
+        List<HttpBinding> documentBindings
     ) {
         deserializeDocumentBody(context, documentBindings);
     }
 
     @Override
     protected void deserializeOutputDocumentBody(
-            GenerationContext context,
-            OperationShape operation,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        OperationShape operation,
+        List<HttpBinding> documentBindings
     ) {
         deserializeDocumentBody(context, documentBindings);
     }
 
     @Override
     protected void deserializeErrorDocumentBody(
-            GenerationContext context,
-            StructureShape error,
-            List<HttpBinding> documentBindings
+        GenerationContext context,
+        StructureShape error,
+        List<HttpBinding> documentBindings
     ) {
         deserializeDocumentBody(context, documentBindings);
     }
 
     @Override
     protected HttpBinding deserializeInputPayload(
-            GenerationContext context,
-            OperationShape operation,
-            HttpBinding payloadBinding
+        GenerationContext context,
+        OperationShape operation,
+        HttpBinding payloadBinding
     ) {
         HttpBinding returnedBinding = super.deserializeInputPayload(context, operation, payloadBinding);
         readPayload(context, payloadBinding);
@@ -282,9 +278,9 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected HttpBinding deserializeOutputPayload(
-            GenerationContext context,
-            OperationShape operation,
-            HttpBinding payloadBinding
+        GenerationContext context,
+        OperationShape operation,
+        HttpBinding payloadBinding
     ) {
         HttpBinding returnedBinding = super.deserializeOutputPayload(context, operation, payloadBinding);
         readPayload(context, payloadBinding);
@@ -293,19 +289,16 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected HttpBinding deserializeErrorPayload(
-            GenerationContext context,
-            StructureShape error,
-            HttpBinding payloadBinding
+        GenerationContext context,
+        StructureShape error,
+        HttpBinding payloadBinding
     ) {
         HttpBinding returnedBinding = super.deserializeErrorPayload(context, error, payloadBinding);
         readPayload(context, payloadBinding);
         return returnedBinding;
     }
 
-    protected void readPayload(
-            GenerationContext context,
-            HttpBinding payloadBinding
-    ) {
+    protected void readPayload(GenerationContext context, HttpBinding payloadBinding) {
         TypeScriptWriter writer = context.getWriter();
         Shape target = context.getModel().expectShape(payloadBinding.getMember().getTarget());
 
@@ -336,23 +329,29 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
                 String memberName = symbolProvider.toMemberName(memberShape);
                 String inputLocation = "input." + memberName;
                 // Use the jsonName trait value if present, otherwise use the member name.
-                String wireName = memberShape.getTrait(JsonNameTrait.class)
+                String wireName = memberShape
+                    .getTrait(JsonNameTrait.class)
                     .map(JsonNameTrait::getValue)
                     .orElseGet(binding::getLocationName);
                 boolean hasJsonName = memberShape.hasTrait(JsonNameTrait.class);
                 Shape target = context.getModel().expectShape(memberShape.getTarget());
 
                 // Handle @timestampFormat on members not just the targeted shape.
-                String valueProvider = "_ => " + (memberShape.hasTrait(TimestampFormatTrait.class)
-                    ? AwsProtocolUtils.getInputTimestampValueProvider(context, memberShape,
-                    getDocumentTimestampFormat(), "_")
-                    : target.accept(getMemberSerVisitor(context, "_")));
+                String valueProvider =
+                    "_ => " +
+                    (memberShape.hasTrait(TimestampFormatTrait.class)
+                        ? AwsProtocolUtils.getInputTimestampValueProvider(
+                              context,
+                              memberShape,
+                              getDocumentTimestampFormat(),
+                              "_"
+                          )
+                        : target.accept(getMemberSerVisitor(context, "_")));
 
                 if (hasJsonName) {
                     if (memberShape.hasTrait(IdempotencyTokenTrait.class)) {
                         writer.addImport("v4", "generateIdempotencyToken", TypeScriptDependency.SMITHY_UUID);
-                        writer.write("'$L': [true,_ => _ ?? generateIdempotencyToken(),`$L`],",
-                            wireName, memberName);
+                        writer.write("'$L': [true,_ => _ ?? generateIdempotencyToken(),`$L`],", wireName, memberName);
                     } else {
                         if (valueProvider.equals("_ => _")) {
                             writer.write("'$L': [,,`$L`],", wireName, memberName);
@@ -376,16 +375,15 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         });
     }
 
-    private ShapeVisitor<String> getMemberDeserVisitor(GenerationContext context,
-                                                       MemberShape memberShape,
-                                                       String dataSource) {
+    private ShapeVisitor<String> getMemberDeserVisitor(
+        GenerationContext context,
+        MemberShape memberShape,
+        String dataSource
+    ) {
         return new JsonMemberDeserVisitor(context, memberShape, dataSource, getDocumentTimestampFormat());
     }
 
-    private void serializePayload(
-        GenerationContext context,
-        HttpBinding payloadBinding
-    ) {
+    private void serializePayload(GenerationContext context, HttpBinding payloadBinding) {
         TypeScriptWriter writer = context.getWriter();
         MemberShape payloadMember = payloadBinding.getMember();
         Shape target = context.getModel().expectShape(payloadMember.getTarget());
@@ -393,8 +391,8 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         // When payload target is a structure or union but payload is not a stream, default
         // to an empty JSON body instead of an undefined body and make sure any structure or union
         // content ends up as a JSON string.
-        if (target instanceof StructureShape
-            || (target instanceof UnionShape && !target.hasTrait(StreamingTrait.class))
+        if (
+            target instanceof StructureShape || (target instanceof UnionShape && !target.hasTrait(StreamingTrait.class))
         ) {
             writer.openBlock("if (body === undefined) {", "}", () -> writer.write("body = {};"));
             writer.write("body = JSON.stringify(body);");
@@ -408,10 +406,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         return new JsonMemberSerVisitor(context, dataSource, getDocumentTimestampFormat());
     }
 
-    private void deserializeDocumentBody(
-        GenerationContext context,
-        List<HttpBinding> documentBindings
-    ) {
+    private void deserializeDocumentBody(GenerationContext context, List<HttpBinding> documentBindings) {
         TypeScriptWriter writer = context.getWriter();
         SymbolProvider symbolProvider = context.getSymbolProvider();
         writer.addImport("take", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
@@ -422,18 +417,23 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
                 // The name of the member to get from the input shape.
                 String memberName = symbolProvider.toMemberName(binding.getMember());
                 // Use the jsonName trait value if present, otherwise use the member name.
-                String wireName = binding.getMember().getTrait(JsonNameTrait.class)
+                String wireName = binding
+                    .getMember()
+                    .getTrait(JsonNameTrait.class)
                     .map(JsonNameTrait::getValue)
                     .orElseGet(binding::getLocationName);
                 boolean hasJsonName = binding.getMember().hasTrait(JsonNameTrait.class);
 
-                String valueExpression = target.accept(
-                    getMemberDeserVisitor(context, binding.getMember(), "_"));
+                String valueExpression = target.accept(getMemberDeserVisitor(context, binding.getMember(), "_"));
                 boolean isUnaryCall = UnaryFunctionCall.check(valueExpression);
                 if (hasJsonName) {
                     if (isUnaryCall) {
-                        writer.write("'$L': [, $L, `$L`],",
-                            memberName, UnaryFunctionCall.toRef(valueExpression), wireName);
+                        writer.write(
+                            "'$L': [, $L, `$L`],",
+                            memberName,
+                            UnaryFunctionCall.toRef(valueExpression),
+                            wireName
+                        );
                     } else {
                         writer.write("'$L': [, _ => $L, `$L`],", memberName, valueExpression, wireName);
                     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
@@ -48,16 +48,19 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 final class XmlMemberDeserVisitor extends DocumentMemberDeserVisitor {
+
     private final MemberShape memberShape;
 
     XmlMemberDeserVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
         this(context, null, dataSource, defaultTimestampFormat);
     }
 
-    XmlMemberDeserVisitor(GenerationContext context,
-                          MemberShape memberShape,
-                          String dataSource,
-                          Format defaultTimestampFormat) {
+    XmlMemberDeserVisitor(
+        GenerationContext context,
+        MemberShape memberShape,
+        String dataSource,
+        Format defaultTimestampFormat
+    ) {
         super(context, dataSource, defaultTimestampFormat);
         this.memberShape = memberShape;
     }
@@ -70,29 +73,33 @@ final class XmlMemberDeserVisitor extends DocumentMemberDeserVisitor {
 
     @Override
     public String byteShape(ByteShape shape) {
-        getContext().getWriter().addImport("strictParseByte", "__strictParseByte",
-            TypeScriptDependency.AWS_SMITHY_CLIENT);
+        getContext()
+            .getWriter()
+            .addImport("strictParseByte", "__strictParseByte", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__strictParseByte(" + getDataSource() + ") as number";
     }
 
     @Override
     public String shortShape(ShortShape shape) {
-        getContext().getWriter().addImport("strictParseShort", "__strictParseShort",
-            TypeScriptDependency.AWS_SMITHY_CLIENT);
+        getContext()
+            .getWriter()
+            .addImport("strictParseShort", "__strictParseShort", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__strictParseShort(" + getDataSource() + ") as number";
     }
 
     @Override
     public String integerShape(IntegerShape shape) {
-        getContext().getWriter().addImport("strictParseInt32", "__strictParseInt32",
-            TypeScriptDependency.AWS_SMITHY_CLIENT);
+        getContext()
+            .getWriter()
+            .addImport("strictParseInt32", "__strictParseInt32", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__strictParseInt32(" + getDataSource() + ") as number";
     }
 
     @Override
     public String longShape(LongShape shape) {
-        getContext().getWriter().addImport("strictParseLong", "__strictParseLong",
-            TypeScriptDependency.AWS_SMITHY_CLIENT);
+        getContext()
+            .getWriter()
+            .addImport("strictParseLong", "__strictParseLong", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__strictParseLong(" + getDataSource() + ") as number";
     }
 
@@ -124,13 +131,15 @@ final class XmlMemberDeserVisitor extends DocumentMemberDeserVisitor {
     }
 
     private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot deserialize shape type %s on protocol, shape: %s.",
-                shape.getType(), shape.getId()));
+        throw new CodegenException(
+            String.format("Cannot deserialize shape type %s on protocol, shape: %s.", shape.getType(), shape.getId())
+        );
     }
 
     private String deserializeFloat() {
-        getContext().getWriter().addImport("strictParseFloat", "__strictParseFloat",
-                TypeScriptDependency.AWS_SMITHY_CLIENT);
+        getContext()
+            .getWriter()
+            .addImport("strictParseFloat", "__strictParseFloat", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__strictParseFloat(" + getDataSource() + ") as number";
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberSerVisitor.java
@@ -52,6 +52,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 final class XmlMemberSerVisitor extends DocumentMemberSerVisitor {
+
     private final GenerationContext context;
     private final StringStore stringStore;
 
@@ -117,9 +118,10 @@ final class XmlMemberSerVisitor extends DocumentMemberSerVisitor {
 
     String getAsXmlText(Shape shape, String dataSource) {
         // Handle the @xmlName trait for the shape itself.
-        String nodeName = shape.getTrait(XmlNameTrait.class)
-                .map(XmlNameTrait::getValue)
-                .orElse(shape.getId().getName(context.getService()));
+        String nodeName = shape
+            .getTrait(XmlNameTrait.class)
+            .map(XmlNameTrait::getValue)
+            .orElse(shape.getId().getName(context.getService()));
 
         TypeScriptWriter writer = getContext().getWriter();
         writer.addImport("XmlNode", "__XmlNode", "@aws-sdk/xml-builder");
@@ -140,7 +142,8 @@ final class XmlMemberSerVisitor extends DocumentMemberSerVisitor {
     }
 
     private String unsupportedShape(Shape shape) {
-        throw new CodegenException(String.format("Cannot serialize shape type %s on protocol, shape: %s.",
-                shape.getType(), shape.getId()));
+        throw new CodegenException(
+            String.format("Cannot serialize shape type %s on protocol, shape: %s.", shape.getType(), shape.getId())
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddAwsDefaultSigningName.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddAwsDefaultSigningName.java
@@ -24,6 +24,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class AddAwsDefaultSigningName implements TypeScriptIntegration {
+
     private static final Logger LOGGER = Logger.getLogger(AddAwsDefaultSigningName.class.getName());
 
     /**
@@ -57,7 +58,8 @@ public final class AddAwsDefaultSigningName implements TypeScriptIntegration {
         // Set default name setting for service based on: SigV4 first, then the AWS Service trait
         try {
             settings.setDefaultSigningName(
-                service.getTrait(SigV4Trait.class)
+                service
+                    .getTrait(SigV4Trait.class)
                     .map(SigV4Trait::getName)
                     .orElseGet(() -> service.expectTrait(ServiceTrait.class).getArnNamespace())
             );
@@ -65,5 +67,4 @@ public final class AddAwsDefaultSigningName implements TypeScriptIntegration {
             LOGGER.warning("Unable to set service default signing name. A SigV4 or Service trait is needed.");
         }
     }
-
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSTSAuthCustomizations.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSTSAuthCustomizations.java
@@ -45,19 +45,19 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 @SuppressWarnings("AbbreviationAsWordInName")
 public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegration {
+
     static final String STS_ROLE_ASSUMERS_FILE = "defaultStsRoleAssumers";
 
     private static final Logger LOGGER = Logger.getLogger(AddSTSAuthCustomizations.class.getName());
-    private static final ShapeId STS_SERVICE =
-        ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615");
+    private static final ShapeId STS_SERVICE = ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615");
     private static final Set<ShapeId> OPTIONAL_AUTH_OPERATIONS = Set.of(
         ShapeId.from("com.amazonaws.sts#AssumeRoleWithWebIdentity"),
         ShapeId.from("com.amazonaws.sts#AssumeRoleWithSAML")
     );
     private static final String NO_TOUCH_NOTICE_PREFIX =
-        "// Please do not touch this file. It's generated from template in:\n"
-        + "// https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/smithy-aws-typescript-codegen/"
-        + "src/main/resources/software/amazon/smithy/aws/typescript/codegen/";
+        "// Please do not touch this file. It's generated from template in:\n" +
+        "// https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/smithy-aws-typescript-codegen/" +
+        "src/main/resources/software/amazon/smithy/aws/typescript/codegen/";
     private static final String STS_CLIENT_PREFIX = "sts-client-";
     private static final String ROLE_ASSUMERS_FILE = "defaultRoleAssumers";
     private static final String ROLE_ASSUMERS_TEST_FILE = "defaultRoleAssumers.spec";
@@ -72,9 +72,7 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
 
     @Override
     public List<String> runAfter() {
-        return List.of(
-            SupportSigV4Auth.class.getCanonicalName(),
-            AwsSdkCustomizeSigV4Auth.class.getCanonicalName());
+        return List.of(SupportSigV4Auth.class.getCanonicalName(), AwsSdkCustomizeSigV4Auth.class.getCanonicalName());
     }
 
     @Override
@@ -86,11 +84,16 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
         LOGGER.info("Backfilling STS auth operations with empty auth trait");
         for (ShapeId shapeId : OPTIONAL_AUTH_OPERATIONS) {
             LOGGER.info("Backfilling STS auth operation with empty auth trait: " + shapeId.toString());
-            model = model.toBuilder()
-                .addShape(model.expectShape(shapeId, OperationShape.class).toBuilder()
-                    .addTrait(new OptionalAuthTrait())
-                    .addTrait(new AuthTrait(Collections.emptySet()))
-                    .build())
+            model = model
+                .toBuilder()
+                .addShape(
+                    model
+                        .expectShape(shapeId, OperationShape.class)
+                        .toBuilder()
+                        .addTrait(new OptionalAuthTrait())
+                        .addTrait(new AuthTrait(Collections.emptySet()))
+                        .build()
+                )
                 .build();
         }
         return model;
@@ -105,15 +108,16 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
     ) {
         switch (target) {
             case NODE:
-                return MapUtils.of(
-                    "credentialDefaultProvider", writer -> {
-                        writer
-                            .addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE)
-                            .addImport("defaultProvider", "credentialDefaultProvider",
-                                AwsDependency.CREDENTIAL_PROVIDER_NODE)
-                            .write("credentialDefaultProvider");
-                    }
-                );
+                return MapUtils.of("credentialDefaultProvider", writer -> {
+                    writer
+                        .addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE)
+                        .addImport(
+                            "defaultProvider",
+                            "credentialDefaultProvider",
+                            AwsDependency.CREDENTIAL_PROVIDER_NODE
+                        )
+                        .write("credentialDefaultProvider");
+                });
             default:
                 return Collections.emptyMap();
         }
@@ -121,22 +125,28 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
 
     @Override
     public void customize(TypeScriptCodegenContext codegenContext) {
-        BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory =
-            codegenContext.writerDelegator()::useFileWriter;
+        BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory = codegenContext.writerDelegator()::useFileWriter;
         // src/defaultRoleAssumers.ts
         writerFactory.accept(CodegenUtils.SOURCE_FOLDER + "/" + ROLE_ASSUMERS_FILE + ".ts", writer -> {
             String resourceName = STS_CLIENT_PREFIX + ROLE_ASSUMERS_FILE + ".ts";
             writer
                 .pushState()
-                .putContext(Map.of(
-                    "noTouchNoticePrefix", NO_TOUCH_NOTICE_PREFIX,
-                    "resourceName", resourceName,
-                    "body", IoUtils.readUtf8Resource(AwsTraitsUtils.class, resourceName)
-                ))
-                .write("""
+                .putContext(
+                    Map.of(
+                        "noTouchNoticePrefix",
+                        NO_TOUCH_NOTICE_PREFIX,
+                        "resourceName",
+                        resourceName,
+                        "body",
+                        IoUtils.readUtf8Resource(AwsTraitsUtils.class, resourceName)
+                    )
+                )
+                .write(
+                    """
                     ${noTouchNoticePrefix:L}${resourceName:L}
                     ${body:L}
-                    """)
+                    """
+                )
                 .popState();
         });
         // src/defaultStsRoleAssumers.ts
@@ -144,15 +154,22 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
             String resourceName = STS_CLIENT_PREFIX + STS_ROLE_ASSUMERS_FILE + ".ts";
             writer
                 .pushState()
-                .putContext(Map.of(
-                    "noTouchNoticePrefix", NO_TOUCH_NOTICE_PREFIX,
-                    "resourceName", resourceName,
-                    "body", IoUtils.readUtf8Resource(AwsTraitsUtils.class, resourceName)
-                ))
-                .write("""
+                .putContext(
+                    Map.of(
+                        "noTouchNoticePrefix",
+                        NO_TOUCH_NOTICE_PREFIX,
+                        "resourceName",
+                        resourceName,
+                        "body",
+                        IoUtils.readUtf8Resource(AwsTraitsUtils.class, resourceName)
+                    )
+                )
+                .write(
+                    """
                     ${noTouchNoticePrefix:L}${resourceName:L}
                     ${body:L}
-                    """)
+                    """
+                )
                 .popState();
         });
         // src/index.ts
@@ -164,43 +181,60 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
             String resourceName = STS_CLIENT_PREFIX + ROLE_ASSUMERS_TEST_FILE + ".ts";
             writer
                 .pushState()
-                .putContext(Map.of(
-                    "noTouchNoticePrefix", NO_TOUCH_NOTICE_PREFIX,
-                    "resourceName", resourceName,
-                    "body", IoUtils.readUtf8Resource(AwsTraitsUtils.class, resourceName)
-                ))
-                .write("""
+                .putContext(
+                    Map.of(
+                        "noTouchNoticePrefix",
+                        NO_TOUCH_NOTICE_PREFIX,
+                        "resourceName",
+                        resourceName,
+                        "body",
+                        IoUtils.readUtf8Resource(AwsTraitsUtils.class, resourceName)
+                    )
+                )
+                .write(
+                    """
                     ${noTouchNoticePrefix:L}${resourceName:L}
                     ${body:L}
-                    """)
+                    """
+                )
                 .popState();
         });
 
-        codegenContext.writerDelegator().useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
-            ServiceShape service = codegenContext.settings().getService(codegenContext.model());
-            Symbol serviceSymbol = codegenContext.symbolProvider().toSymbol(service);
-            w.addRelativeImport(serviceSymbol.getName(), null,
-                Paths.get(".", serviceSymbol.getNamespace()));
-            w.addRelativeImport(serviceSymbol.getName() + "Config", null,
-                Paths.get(".", serviceSymbol.getNamespace()));
-            w.write("export interface StsAuthInputConfig {}\n");
-            w.openBlock("export interface StsAuthResolvedConfig {", "}\n", () -> w
-                .writeDocs("""
-                    Reference to STSClient class constructor.
-                    @internal""")
-                .addDependency(TypeScriptDependency.SMITHY_TYPES)
-                .addImport("Client", null, TypeScriptDependency.SMITHY_TYPES)
-                .write("stsClientCtor: new (clientConfig: any) => Client<any, any, any>;"));
-            w.openBlock("""
+        codegenContext
+            .writerDelegator()
+            .useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
+                ServiceShape service = codegenContext.settings().getService(codegenContext.model());
+                Symbol serviceSymbol = codegenContext.symbolProvider().toSymbol(service);
+                w.addRelativeImport(serviceSymbol.getName(), null, Paths.get(".", serviceSymbol.getNamespace()));
+                w.addRelativeImport(
+                    serviceSymbol.getName() + "Config",
+                    null,
+                    Paths.get(".", serviceSymbol.getNamespace())
+                );
+                w.write("export interface StsAuthInputConfig {}\n");
+                w.openBlock("export interface StsAuthResolvedConfig {", "}\n", () ->
+                    w
+                        .writeDocs(
+                            """
+                            Reference to STSClient class constructor.
+                            @internal"""
+                        )
+                        .addDependency(TypeScriptDependency.SMITHY_TYPES)
+                        .addImport("Client", null, TypeScriptDependency.SMITHY_TYPES)
+                        .write("stsClientCtor: new (clientConfig: any) => Client<any, any, any>;")
+                );
+                w.openBlock("""
                 export const resolveStsAuthConfig = <T>(
                   input: T & StsAuthInputConfig
                 ): T & StsAuthResolvedConfig => Object.assign(input, {
                 """, "});", () -> {
-                    w.write("""
+                    w.write(
+                        """
                         stsClientCtor: STSClient,
-                        """);
+                        """
+                    );
                 });
-        });
+            });
     }
 
     @Override
@@ -211,27 +245,40 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
     ) {
         ShapeId service = settings.getService();
         if (isSTSService(service)) {
-            HttpAuthScheme authScheme = supportedHttpAuthSchemesIndex.getHttpAuthScheme(SigV4Trait.ID).toBuilder()
+            HttpAuthScheme authScheme = supportedHttpAuthSchemesIndex
+                .getHttpAuthScheme(SigV4Trait.ID)
+                .toBuilder()
                 // Use `@aws-sdk/credential-provider-node` with `@aws-sdk/client-sts` as the
                 // default identity provider chain for Node.js
-                .putDefaultIdentityProvider(LanguageTarget.NODE, w -> w
-                    .write("""
+                .putDefaultIdentityProvider(LanguageTarget.NODE, w ->
+                    w.write(
+                        """
                         async (idProps) => await \
-                        credentialDefaultProvider(idProps?.__config || {})()"""))
-                .addResolveConfigFunction(ResolveConfigFunction.builder()
-                    .resolveConfigFunction(Symbol.builder()
-                        .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
-                        .name("resolveStsAuthConfig")
-                        .build())
-                    .inputConfig(Symbol.builder()
-                        .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
-                        .name("StsAuthInputConfig")
-                        .build())
-                    .resolvedConfig(Symbol.builder()
-                        .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
-                        .name("StsAuthResolvedConfig")
-                        .build())
-                    .build())
+                        credentialDefaultProvider(idProps?.__config || {})()"""
+                    )
+                )
+                .addResolveConfigFunction(
+                    ResolveConfigFunction.builder()
+                        .resolveConfigFunction(
+                            Symbol.builder()
+                                .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
+                                .name("resolveStsAuthConfig")
+                                .build()
+                        )
+                        .inputConfig(
+                            Symbol.builder()
+                                .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
+                                .name("StsAuthInputConfig")
+                                .build()
+                        )
+                        .resolvedConfig(
+                            Symbol.builder()
+                                .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
+                                .name("StsAuthResolvedConfig")
+                                .build()
+                        )
+                        .build()
+                )
                 .build();
             supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
         }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider.java
@@ -54,6 +54,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implements HttpAuthTypeScriptIntegration {
+
     private static final ShapeId SIGV4A_ID = ShapeId.from("aws.auth#sigv4a");
 
     /**
@@ -66,17 +67,12 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
 
     @Override
     public List<String> runBefore() {
-        return List.of(
-            AddHttpAuthSchemePlugin.class.getCanonicalName()
-        );
+        return List.of(AddHttpAuthSchemePlugin.class.getCanonicalName());
     }
 
     @Override
     public List<String> runAfter() {
-        return List.of(
-            SupportSigV4Auth.class.getCanonicalName(),
-            AwsSdkCustomizeSigV4Auth.class.getCanonicalName()
-        );
+        return List.of(SupportSigV4Auth.class.getCanonicalName(), AwsSdkCustomizeSigV4Auth.class.getCanonicalName());
     }
 
     @Override
@@ -105,7 +101,8 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
     public void customizeSupportedHttpAuthSchemes(
         SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex,
         Model model,
-        TypeScriptSettings settings) {
+        TypeScriptSettings settings
+    ) {
         if (!AwsTraitsUtils.isSigV4AsymmetricService(model, settings)) {
             return;
         }
@@ -114,16 +111,16 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
         if (supportedHttpAuthSchemesIndex.getHttpAuthScheme(SIGV4A_ID) == null) {
             ShapeId sigv4 = ShapeId.from("aws.auth#sigv4");
             HttpAuthScheme sigv4Scheme = supportedHttpAuthSchemesIndex.getHttpAuthScheme(sigv4);
-            supportedHttpAuthSchemesIndex.putHttpAuthScheme(SIGV4A_ID, sigv4Scheme.toBuilder()
-                .schemeId(SIGV4A_ID)
-                .traitId(sigv4)
-                .build());
+            supportedHttpAuthSchemesIndex.putHttpAuthScheme(
+                SIGV4A_ID,
+                sigv4Scheme.toBuilder().schemeId(SIGV4A_ID).traitId(sigv4).build()
+            );
         }
     }
 
     @Override
     public List<? extends CodeInterceptor<? extends CodeSection, TypeScriptWriter>> interceptors(
-            TypeScriptCodegenContext codegenContext
+        TypeScriptCodegenContext codegenContext
     ) {
         if (!AwsTraitsUtils.isSigV4AsymmetricService(codegenContext.model(), codegenContext.settings())) {
             return Collections.emptyList();
@@ -144,28 +141,29 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                     String serviceName = CodegenUtils.getServiceName(
                         s.getSettings(),
                         s.getModel(),
-                        s.getSymbolProvider());
+                        s.getSymbolProvider()
+                    );
                     ServiceIndex serviceIndex = ServiceIndex.of(s.getModel());
                     SupportedHttpAuthSchemesIndex authIndex = new SupportedHttpAuthSchemesIndex(
                         codegenContext.integrations(),
                         s.getModel(),
-                        s.getSettings());
+                        s.getSettings()
+                    );
                     TopDownIndex topDownIndex = TopDownIndex.of(s.getModel());
                     Map<ShapeId, HttpAuthScheme> effectiveHttpAuthSchemes =
                         AuthUtils.getAllEffectiveNoAuthAwareAuthSchemes(
                             s.getService(),
                             serviceIndex,
                             authIndex,
-                            topDownIndex);
+                            topDownIndex
+                        );
                     Map<String, HttpAuthSchemeParameter> httpAuthSchemeParameters =
                         AuthUtils.collectHttpAuthSchemeParameters(effectiveHttpAuthSchemes.values());
                     w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                     w.addImport("HttpAuthSchemeParameters", null, TypeScriptDependency.SMITHY_TYPES);
                     w.writeDocs("@internal");
                     w.openBlock("""
-                        interface _$LHttpAuthSchemeParameters extends HttpAuthSchemeParameters {""", "}\n",
-                        serviceName,
-                        () -> {
+                    interface _$LHttpAuthSchemeParameters extends HttpAuthSchemeParameters {""", "}\n", serviceName, () -> {
                         for (HttpAuthSchemeParameter parameter : httpAuthSchemeParameters.values()) {
                             w.write("$L?: $C;", parameter.name(), parameter.type());
                         }
@@ -173,10 +171,8 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                     w.addImport("EndpointParameters", null, EndpointsV2Generator.ENDPOINT_PARAMETERS_DEPENDENCY);
                     w.writeDocs("@internal");
                     w.openBlock("""
-                        export interface $LHttpAuthSchemeParameters extends \
-                        _$LHttpAuthSchemeParameters, EndpointParameters {""", "}",
-                        serviceName, serviceName,
-                        () -> {
+                    export interface $LHttpAuthSchemeParameters extends \
+                    _$LHttpAuthSchemeParameters, EndpointParameters {""", "}", serviceName, serviceName, () -> {
                         for (HttpAuthSchemeParameter parameter : httpAuthSchemeParameters.values()) {
                             w.write("$L?: $C;", parameter.name(), parameter.type());
                         }
@@ -198,24 +194,30 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                     String serviceName = CodegenUtils.getServiceName(
                         s.getSettings(),
                         s.getModel(),
-                        s.getSymbolProvider());
+                        s.getSymbolProvider()
+                    );
                     ServiceIndex serviceIndex = ServiceIndex.of(s.getModel());
                     SupportedHttpAuthSchemesIndex authIndex = new SupportedHttpAuthSchemesIndex(
                         codegenContext.integrations(),
                         s.getModel(),
-                        s.getSettings());
+                        s.getSettings()
+                    );
                     TopDownIndex topDownIndex = TopDownIndex.of(s.getModel());
                     Map<ShapeId, HttpAuthScheme> effectiveHttpAuthSchemes =
                         AuthUtils.getAllEffectiveNoAuthAwareAuthSchemes(
                             s.getService(),
                             serviceIndex,
                             authIndex,
-                            topDownIndex);
+                            topDownIndex
+                        );
                     Map<String, HttpAuthSchemeParameter> httpAuthSchemeParameters =
                         AuthUtils.collectHttpAuthSchemeParameters(effectiveHttpAuthSchemes.values());
                     Symbol serviceSymbol = s.getSymbolProvider().toSymbol(s.getService());
-                    w.addRelativeImport(serviceSymbol.getName() + "ResolvedConfig", null,
-                        Paths.get(".", serviceSymbol.getNamespace()));
+                    w.addRelativeImport(
+                        serviceSymbol.getName() + "ResolvedConfig",
+                        null,
+                        Paths.get(".", serviceSymbol.getNamespace())
+                    );
                     w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                     w.addImport("HandlerExecutionContext", null, TypeScriptDependency.SMITHY_TYPES);
                     w.addDependency(TypeScriptDependency.UTIL_MIDDLEWARE);
@@ -224,24 +226,29 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                     w.addImport("EndpointParameterInstructions", null, TypeScriptDependency.MIDDLEWARE_ENDPOINTS_V2);
                     w.addImport("resolveParams", null, TypeScriptDependency.MIDDLEWARE_ENDPOINTS_V2);
                     w.writeDocs("@internal");
-                    w.write("""
+                    w.write(
+                        """
                         interface EndpointRuleSetSmithyContext {
                           commandInstance?: {
                             constructor?: {
                               getEndpointParameterInstructions(): EndpointParameterInstructions;
                             };
                           };
-                        }""");
+                        }"""
+                    );
                     w.writeDocs("@internal");
-                    w.write("""
+                    w.write(
+                        """
                         interface EndpointRuleSetHttpAuthSchemeParametersProvider<
                           TConfig extends object,
                           TContext extends HandlerExecutionContext,
                           TParameters extends HttpAuthSchemeParameters & EndpointParameters,
                           TInput extends object
-                        > extends HttpAuthSchemeParametersProvider<TConfig, TContext, TParameters, TInput> {}""");
+                        > extends HttpAuthSchemeParametersProvider<TConfig, TContext, TParameters, TInput> {}"""
+                    );
                     w.writeDocs("@internal");
-                    w.write("""
+                    w.write(
+                        """
                         const createEndpointRuleSetHttpAuthSchemeParametersProvider =
                           <
                             TConfig extends object,
@@ -283,15 +290,14 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                                 config as Record<string, unknown>
                               );
                               return Object.assign(defaultParameters, endpointParameters) as TParameters;
-                            };""");
+                            };"""
+                    );
                     w.writeDocs("@internal");
                     w.openBlock("""
-                        const _default$LHttpAuthSchemeParametersProvider = async (\
-                        config: $LResolvedConfig, \
-                        context: HandlerExecutionContext, \
-                        input: object): Promise<_$LHttpAuthSchemeParameters> => {""", "};",
-                        serviceName, serviceSymbol.getName(), serviceName,
-                        () -> {
+                    const _default$LHttpAuthSchemeParametersProvider = async (\
+                    config: $LResolvedConfig, \
+                    context: HandlerExecutionContext, \
+                    input: object): Promise<_$LHttpAuthSchemeParameters> => {""", "};", serviceName, serviceSymbol.getName(), serviceName, () -> {
                         w.openBlock("return {", "};", () -> {
                             w.write("operation: getSmithyContext(context).operation as string,");
                             for (HttpAuthSchemeParameter parameter : httpAuthSchemeParameters.values()) {
@@ -300,12 +306,16 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                         });
                     });
                     w.writeDocs("@internal");
-                    w.write("""
+                    w.write(
+                        """
                         export const default$LHttpAuthSchemeParametersProvider: \
                         $LHttpAuthSchemeParametersProvider = createEndpointRuleSetHttpAuthSchemeParametersProvider(\
                         _default$LHttpAuthSchemeParametersProvider);
                         """,
-                        serviceName, serviceName, serviceName);
+                        serviceName,
+                        serviceName,
+                        serviceName
+                    );
                 }
             },
             new CodeInterceptor<HttpAuthSchemeProviderInterfaceCodeSection, TypeScriptWriter>() {
@@ -323,19 +333,27 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                     String serviceName = CodegenUtils.getServiceName(
                         s.getSettings(),
                         s.getModel(),
-                        s.getSymbolProvider());
+                        s.getSymbolProvider()
+                    );
                     w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                     w.addImport("HttpAuthSchemeProvider", null, TypeScriptDependency.SMITHY_TYPES);
                     w.writeDocs("@internal");
-                    w.write("""
-                    interface _$LHttpAuthSchemeProvider extends HttpAuthSchemeProvider<$LHttpAuthSchemeParameters> {}
-                    """, serviceName, serviceName);
+                    w.write(
+                        """
+                        interface _$LHttpAuthSchemeProvider extends HttpAuthSchemeProvider<$LHttpAuthSchemeParameters> {}
+                        """,
+                        serviceName,
+                        serviceName
+                    );
                     w.writeDocs("@internal");
-                    w.write("""
+                    w.write(
+                        """
                         export interface $LHttpAuthSchemeProvider extends \
                         HttpAuthSchemeProvider<$LHttpAuthSchemeParameters> {}
                         """,
-                        serviceName, serviceName);
+                        serviceName,
+                        serviceName
+                    );
                 }
             },
             new CodeInterceptor<DefaultHttpAuthSchemeProviderFunctionCodeSection, TypeScriptWriter>() {
@@ -353,37 +371,45 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                     String serviceName = CodegenUtils.getServiceName(
                         s.getSettings(),
                         s.getModel(),
-                        s.getSymbolProvider());
+                        s.getSymbolProvider()
+                    );
                     ServiceIndex serviceIndex = ServiceIndex.of(s.getModel());
                     TopDownIndex topDownIndex = TopDownIndex.of(s.getModel());
                     SupportedHttpAuthSchemesIndex authIndex = new SupportedHttpAuthSchemesIndex(
                         codegenContext.integrations(),
                         s.getModel(),
-                        s.getSettings());
+                        s.getSettings()
+                    );
                     Map<ShapeId, HttpAuthScheme> effectiveHttpAuthSchemes =
                         AuthUtils.getAllEffectiveNoAuthAwareAuthSchemes(
                             s.getService(),
                             serviceIndex,
                             authIndex,
-                            topDownIndex);
+                            topDownIndex
+                        );
                     w.writeDocs("@internal");
-                    w.write("""
+                    w.write(
+                        """
                         interface EndpointRuleSetHttpAuthSchemeProvider<
                           EndpointParametersT extends EndpointParameters,
                           HttpAuthSchemeParametersT extends HttpAuthSchemeParameters
-                        > extends HttpAuthSchemeProvider<EndpointParametersT & HttpAuthSchemeParametersT> { }""");
+                        > extends HttpAuthSchemeProvider<EndpointParametersT & HttpAuthSchemeParametersT> { }"""
+                    );
                     w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                     w.addImport("SignatureV4MultiRegion", null, AwsDependency.SIGNATURE_V4_MULTIREGION);
                     w.addImport("Logger", null, TypeScriptDependency.SMITHY_TYPES);
                     w.addImport("EndpointV2", null, TypeScriptDependency.SMITHY_TYPES);
                     w.writeDocs("@internal");
-                    w.write("""
+                    w.write(
+                        """
                         interface DefaultEndpointResolver<EndpointParametersT extends EndpointParameters> {
                           (params: EndpointParametersT, context?: { logger?: Logger; }): EndpointV2;
-                        }""");
+                        }"""
+                    );
                     w.addImport("HttpAuthSchemeId", null, TypeScriptDependency.SMITHY_TYPES);
                     w.writeDocs("@internal");
-                    w.write("""
+                    w.write(
+                        """
                         const createEndpointRuleSetHttpAuthSchemeProvider = <
                           EndpointParametersT extends EndpointParameters,
                           HttpAuthSchemeParametersT extends HttpAuthSchemeParameters
@@ -444,48 +470,63 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                           };
 
                           return endpointRuleSetHttpAuthSchemeProvider;
-                        }""");
+                        }"""
+                    );
                     w.writeDocs("@internal");
                     w.openBlock("""
-                        const _default$LHttpAuthSchemeProvider: _$LHttpAuthSchemeProvider = \
-                        (authParameters) => {""", "};",
-                        serviceName, serviceName, () -> {
+                    const _default$LHttpAuthSchemeProvider: _$LHttpAuthSchemeProvider = \
+                    (authParameters) => {""", "};", serviceName, serviceName, () -> {
                         w.write("const options: HttpAuthOption[] = [];");
                         w.openBlock("switch (authParameters.operation) {", "};", () -> {
                             var serviceAuthSchemes = serviceIndex.getEffectiveAuthSchemes(
-                                s.getService(), AuthSchemeMode.NO_AUTH_AWARE);
-                            serviceAuthSchemes.put(
-                                SIGV4A_ID, new DynamicTrait(SIGV4A_ID, ObjectNode.objectNode()));
+                                s.getService(),
+                                AuthSchemeMode.NO_AUTH_AWARE
+                            );
+                            serviceAuthSchemes.put(SIGV4A_ID, new DynamicTrait(SIGV4A_ID, ObjectNode.objectNode()));
                             for (OperationShape operationShape : topDownIndex.getContainedOperations(s.getService())) {
                                 ShapeId operationShapeId = operationShape.getId();
                                 var operationAuthSchemes = serviceIndex.getEffectiveAuthSchemes(
-                                    s.getService(), operationShapeId, AuthSchemeMode.NO_AUTH_AWARE);
+                                    s.getService(),
+                                    operationShapeId,
+                                    AuthSchemeMode.NO_AUTH_AWARE
+                                );
                                 operationAuthSchemes.put(
-                                    SIGV4A_ID, new DynamicTrait(SIGV4A_ID, ObjectNode.objectNode()));
+                                    SIGV4A_ID,
+                                    new DynamicTrait(SIGV4A_ID, ObjectNode.objectNode())
+                                );
                                 // Skip operation generation if operation auth schemes are equivalent to the default
                                 // service auth schemes.
                                 if (AuthUtils.areHttpAuthSchemesEqual(serviceAuthSchemes, operationAuthSchemes)) {
                                     continue;
                                 }
                                 w.openBlock("case $S: {", "};", operationShapeId.getName(), () -> {
-                                    operationAuthSchemes.keySet().forEach(shapeId -> {
-                                        w.write("options.push(create$LHttpAuthOption(authParameters));",
-                                            HttpAuthSchemeProviderGenerator.normalizeAuthSchemeName(shapeId));
-                                    });
+                                    operationAuthSchemes
+                                        .keySet()
+                                        .forEach(shapeId -> {
+                                            w.write(
+                                                "options.push(create$LHttpAuthOption(authParameters));",
+                                                HttpAuthSchemeProviderGenerator.normalizeAuthSchemeName(shapeId)
+                                            );
+                                        });
                                     w.write("break;");
                                 });
                             }
                             w.openBlock("default: {", "};", () -> {
-                                serviceAuthSchemes.keySet().forEach(shapeId -> {
-                                    w.write("options.push(create$LHttpAuthOption(authParameters));",
-                                        HttpAuthSchemeProviderGenerator.normalizeAuthSchemeName(shapeId));
-                                });
+                                serviceAuthSchemes
+                                    .keySet()
+                                    .forEach(shapeId -> {
+                                        w.write(
+                                            "options.push(create$LHttpAuthOption(authParameters));",
+                                            HttpAuthSchemeProviderGenerator.normalizeAuthSchemeName(shapeId)
+                                        );
+                                    });
                             });
                         });
                         w.write("return options;");
                     });
                     w.addImport("defaultEndpointResolver", null, EndpointsV2Generator.ENDPOINT_RESOLVER_DEPENDENCY);
-                    w.writeInline("""
+                    w.writeInline(
+                        """
                         /**
                          * @internal
                          */
@@ -493,15 +534,21 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                         createEndpointRuleSetHttpAuthSchemeProvider(\
                         defaultEndpointResolver, \
                         _default$LHttpAuthSchemeProvider, """,
-                        serviceName, serviceName, serviceName);
+                        serviceName,
+                        serviceName,
+                        serviceName
+                    );
                     w.openBlock("{", "});", () -> {
                         for (HttpAuthScheme scheme : effectiveHttpAuthSchemes.values()) {
-                            w.write("$S: create$LHttpAuthOption,",
+                            w.write(
+                                "$S: create$LHttpAuthOption,",
                                 scheme.getSchemeId(),
-                                HttpAuthSchemeProviderGenerator.normalizeAuthSchemeName(scheme.getSchemeId()));
+                                HttpAuthSchemeProviderGenerator.normalizeAuthSchemeName(scheme.getSchemeId())
+                            );
                         }
                     });
                 }
-            });
+            }
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/SupportSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/SupportSigV4Auth.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class SupportSigV4Auth implements HttpAuthTypeScriptIntegration {
+
     static final Symbol AWS_CREDENTIAL_IDENTITY = Symbol.builder()
         .name("AwsCredentialIdentity")
         .namespace(TypeScriptDependency.SMITHY_TYPES.getPackageName(), "/")
@@ -41,16 +42,20 @@ public final class SupportSigV4Auth implements HttpAuthTypeScriptIntegration {
         .name("credentials")
         .type(ConfigField.Type.MAIN)
         .docs(w -> w.write("The credentials used to sign requests."))
-        .inputType(Symbol.builder()
-            .name("AwsCredentialIdentity | AwsCredentialIdentityProvider")
-            .addReference(AWS_CREDENTIAL_IDENTITY)
-            .addReference(AWS_CREDENTIAL_IDENTITY_PROVIDER)
-            .build())
-        .resolvedType(Symbol.builder()
-            .name("AwsCredentialIdentityProvider")
-            .addReference(AWS_CREDENTIAL_IDENTITY)
-            .addReference(AWS_CREDENTIAL_IDENTITY_PROVIDER)
-            .build())
+        .inputType(
+            Symbol.builder()
+                .name("AwsCredentialIdentity | AwsCredentialIdentityProvider")
+                .addReference(AWS_CREDENTIAL_IDENTITY)
+                .addReference(AWS_CREDENTIAL_IDENTITY_PROVIDER)
+                .build()
+        )
+        .resolvedType(
+            Symbol.builder()
+                .name("AwsCredentialIdentityProvider")
+                .addReference(AWS_CREDENTIAL_IDENTITY)
+                .addReference(AWS_CREDENTIAL_IDENTITY_PROVIDER)
+                .build()
+        )
         .configFieldWriter(ConfigField::defaultMainConfigFieldWriter)
         .build();
     private static final Consumer<TypeScriptWriter> AWS_SIGV4_AUTH_SIGNER = w -> {
@@ -59,11 +64,13 @@ public final class SupportSigV4Auth implements HttpAuthTypeScriptIntegration {
         w.write("new SigV4Signer()");
     };
     private static final SymbolReference PROVIDER = SymbolReference.builder()
-        .symbol(Symbol.builder()
-            .name("Provider")
-            .namespace(TypeScriptDependency.SMITHY_TYPES.getPackageName(), "/")
-            .addDependency(TypeScriptDependency.SMITHY_TYPES)
-            .build())
+        .symbol(
+            Symbol.builder()
+                .name("Provider")
+                .namespace(TypeScriptDependency.SMITHY_TYPES.getPackageName(), "/")
+                .addDependency(TypeScriptDependency.SMITHY_TYPES)
+                .build()
+        )
         .alias("__Provider")
         .build();
 
@@ -77,63 +84,80 @@ public final class SupportSigV4Auth implements HttpAuthTypeScriptIntegration {
 
     @Override
     public Optional<HttpAuthScheme> getHttpAuthScheme() {
-        return Optional.of(HttpAuthScheme.builder()
+        return Optional.of(
+            HttpAuthScheme.builder()
                 .schemeId(ShapeId.from("aws.auth#sigv4"))
                 .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
                 .putDefaultSigner(LanguageTarget.SHARED, AWS_SIGV4_AUTH_SIGNER)
                 .addConfigField(CREDENTIALS_CONFIG_FIELD)
-                .addConfigField(ConfigField.builder()
-                    .name("region")
-                    .type(ConfigField.Type.AUXILIARY)
-                    .docs(w -> w.write("The AWS region to which this client will send requests."))
-                    .inputType(Symbol.builder()
-                        .name("string | __Provider<string>")
-                        .addReference(PROVIDER)
-                        .build())
-                    .resolvedType(Symbol.builder()
-                        .name("__Provider<string>")
-                        .addReference(PROVIDER)
-                        .build())
-                    .configFieldWriter(ConfigField::defaultAuxiliaryConfigFieldWriter)
-                    .build())
-                .addHttpAuthSchemeParameter(HttpAuthSchemeParameter.builder()
-                    .name("region")
-                    .type(w -> w.write("string"))
-                    .source(w -> {
-                        w.addDependency(TypeScriptDependency.UTIL_MIDDLEWARE);
-                        w.addImport("normalizeProvider", null, TypeScriptDependency.UTIL_MIDDLEWARE);
-                        w.openBlock("await normalizeProvider(config.region)() || (() => {", "})()", () -> {
-                            w.write("throw new Error(\"expected `region` to be configured for `aws.auth#sigv4`\");");
-                        });
-                    })
-                    .build())
-                .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
-                    .name("name")
-                    .type(HttpAuthOptionProperty.Type.SIGNING)
-                    .source(s -> w -> {
-                        w.write("$S", s.trait().toNode().expectObjectNode().getMember("name"));
-                    })
-                    .build())
-                .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
-                    .name("region")
-                    .type(HttpAuthOptionProperty.Type.SIGNING)
-                    .source(t -> w -> {
-                        w.write("authParameters.region");
-                    })
-                    .build())
-                .propertiesExtractor(s -> w -> w
-                    .write("""
-                        (config, context) => {
-                          return {
-                            /**
-                             * @internal
-                             */
-                            signingProperties: {
-                              context,
-                              sha256: (config as any).sha256,
-                            },
-                          };
-                        },"""))
-                .build());
+                .addConfigField(
+                    ConfigField.builder()
+                        .name("region")
+                        .type(ConfigField.Type.AUXILIARY)
+                        .docs(w -> w.write("The AWS region to which this client will send requests."))
+                        .inputType(Symbol.builder().name("string | __Provider<string>").addReference(PROVIDER).build())
+                        .resolvedType(Symbol.builder().name("__Provider<string>").addReference(PROVIDER).build())
+                        .configFieldWriter(ConfigField::defaultAuxiliaryConfigFieldWriter)
+                        .build()
+                )
+                .addHttpAuthSchemeParameter(
+                    HttpAuthSchemeParameter.builder()
+                        .name("region")
+                        .type(w -> w.write("string"))
+                        .source(w -> {
+                            w.addDependency(TypeScriptDependency.UTIL_MIDDLEWARE);
+                            w.addImport("normalizeProvider", null, TypeScriptDependency.UTIL_MIDDLEWARE);
+                            w.openBlock("await normalizeProvider(config.region)() || (() => {", "})()", () -> {
+                                w.write(
+                                    "throw new Error(\"expected `region` to be configured for `aws.auth#sigv4`\");"
+                                );
+                            });
+                        })
+                        .build()
+                )
+                .addHttpAuthOptionProperty(
+                    HttpAuthOptionProperty.builder()
+                        .name("name")
+                        .type(HttpAuthOptionProperty.Type.SIGNING)
+                        .source(
+                            s ->
+                                w -> {
+                                    w.write("$S", s.trait().toNode().expectObjectNode().getMember("name"));
+                                }
+                        )
+                        .build()
+                )
+                .addHttpAuthOptionProperty(
+                    HttpAuthOptionProperty.builder()
+                        .name("region")
+                        .type(HttpAuthOptionProperty.Type.SIGNING)
+                        .source(
+                            t ->
+                                w -> {
+                                    w.write("authParameters.region");
+                                }
+                        )
+                        .build()
+                )
+                .propertiesExtractor(
+                    s ->
+                        w ->
+                            w.write(
+                                """
+                                (config, context) => {
+                                  return {
+                                    /**
+                                     * @internal
+                                     */
+                                    signingProperties: {
+                                      context,
+                                      sha256: (config as any).sha256,
+                                    },
+                                  };
+                                },"""
+                            )
+                )
+                .build()
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/extensions/AwsRegionExtensionConfiguration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/extensions/AwsRegionExtensionConfiguration.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.typescript.codegen.extensions.ExtensionConfigurati
 import software.amazon.smithy.utils.Pair;
 
 public class AwsRegionExtensionConfiguration implements ExtensionConfigurationInterface {
+
     @Override
     public Pair<String, Dependency> name() {
         return Pair.of("AwsRegionExtensionConfiguration", AwsDependency.TYPES);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessor.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.aws.typescript.codegen.propertyaccess;
 import java.util.regex.Pattern;
 
 public final class PropertyAccessor {
+
     /**
      * Starts with alpha or underscore, and contains only alphanumeric and underscores.
      */

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/protocols/DeserializerElisionDenyList.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/protocols/DeserializerElisionDenyList.java
@@ -12,7 +12,6 @@ import software.amazon.smithy.utils.ListUtils;
  * Used to opt services out of deserializer elision.
  */
 public abstract class DeserializerElisionDenyList {
-    public static final List<String> SDK_IDS = ListUtils.of(
-        "SageMaker"
-    );
+
+    public static final List<String> SDK_IDS = ListUtils.of("SageMaker");
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/validation/UnaryFunctionCall.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/validation/UnaryFunctionCall.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
  * For handling expressions that may be unary function calls.
  */
 public final class UnaryFunctionCall {
+
     private static final Pattern CHECK_PATTERN = Pattern.compile("^(?!new ).+\\(((?!,).)*\\)$");
     private static final Pattern TO_REF_PATTERN = Pattern.compile("(.*)\\(.*\\)$");
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/visitor/MemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/visitor/MemberDeserVisitor.java
@@ -46,8 +46,8 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.typescript.codegen.knowledge.SerdeElisionIndex;
 
-
 public class MemberDeserVisitor implements ShapeVisitor<String> {
+
     protected SerdeElisionIndex serdeElisionIndex;
     protected boolean serdeElisionEnabled;
     protected GenerationContext context;
@@ -65,9 +65,7 @@ public class MemberDeserVisitor implements ShapeVisitor<String> {
         this.serdeElisionIndex = SerdeElisionIndex.of(context.getModel());
         this.context = context.copy();
         disableDeserializationFunctionElision = DeserializerElisionDenyList.SDK_IDS.contains(
-            context.getService().getTrait(ServiceTrait.class)
-                .map(ServiceTrait::getSdkId)
-                .orElse(null)
+            context.getService().getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse(null)
         );
     }
 
@@ -108,15 +106,17 @@ public class MemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public String floatShape(FloatShape shape) {
-        context.getWriter().addImport("limitedParseFloat32", "__limitedParseFloat32",
-            TypeScriptDependency.AWS_SMITHY_CLIENT);
+        context
+            .getWriter()
+            .addImport("limitedParseFloat32", "__limitedParseFloat32", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__limitedParseFloat32(" + dataSource + ")";
     }
 
     @Override
     public String doubleShape(DoubleShape shape) {
-        context.getWriter().addImport("limitedParseDouble", "__limitedParseDouble",
-            TypeScriptDependency.AWS_SMITHY_CLIENT);
+        context
+            .getWriter()
+            .addImport("limitedParseDouble", "__limitedParseDouble", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__limitedParseDouble(" + dataSource + ")";
     }
 
@@ -157,20 +157,21 @@ public class MemberDeserVisitor implements ShapeVisitor<String> {
         HttpBindingIndex httpIndex = HttpBindingIndex.of(context.getModel());
         TimestampFormatTrait.Format format;
         if (getMemberShape() == null) {
-            format = httpIndex.determineTimestampFormat(
-                shape, HttpBinding.Location.DOCUMENT, defaultTimestampFormat
-            );
+            format = httpIndex.determineTimestampFormat(shape, HttpBinding.Location.DOCUMENT, defaultTimestampFormat);
         } else {
             if (!shape.getId().equals(getMemberShape().getTarget())) {
                 throw new IllegalArgumentException(
                     String.format(
                         "Encountered timestamp shape %s that was not the target of member shape %s",
-                        shape.getId(), getMemberShape().getId()
+                        shape.getId(),
+                        getMemberShape().getId()
                     )
                 );
             }
             format = httpIndex.determineTimestampFormat(
-                getMemberShape(), HttpBinding.Location.DOCUMENT, defaultTimestampFormat
+                getMemberShape(),
+                HttpBinding.Location.DOCUMENT,
+                defaultTimestampFormat
             );
         }
 
@@ -181,7 +182,8 @@ public class MemberDeserVisitor implements ShapeVisitor<String> {
             shape,
             format,
             requiresNumericEpochSecondsInPayload(),
-            context.getSettings().generateClient());
+            context.getSettings().generateClient()
+        );
     }
 
     @Override
@@ -258,14 +260,11 @@ public class MemberDeserVisitor implements ShapeVisitor<String> {
         // Use the shape for the function name.
         Symbol symbol = context.getSymbolProvider().toSymbol(shape);
 
-        if (serdeElisionEnabled
-            && !disableDeserializationFunctionElision
-            && serdeElisionIndex.mayElide(shape)) {
+        if (serdeElisionEnabled && !disableDeserializationFunctionElision && serdeElisionIndex.mayElide(shape)) {
             context.getWriter().addImport("_json", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
             return "_json(" + customDataSource + ")";
         }
 
-        return ProtocolGenerator.getDeserFunctionShortName(symbol)
-                + "(" + customDataSource + ", context)";
+        return ProtocolGenerator.getDeserFunctionShortName(symbol) + "(" + customDataSource + ", context)";
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sdk-default-configuration.json
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sdk-default-configuration.json
@@ -16,8 +16,7 @@
         "override": 3100
       }
     },
-    "in-region": {
-    },
+    "in-region": {},
     "cross-region": {
       "connectTimeoutInMillis": {
         "override": 3100

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
@@ -99,14 +99,14 @@ describe("getDefaultRoleAssumer", () => {
     expect(mockHandle).toBeCalledTimes(1);
     // Validate request is signed by sourceCred1
     expect(mockHandle.mock.calls[0][0].headers?.authorization).toEqual(
-      expect.stringContaining("AWS4-HMAC-SHA256 Credential=key1/")
+      expect.stringContaining("AWS4-HMAC-SHA256 Credential=key1/"),
     );
     const sourceCred2 = { accessKeyId: "key2", secretAccessKey: "secrete1" };
     await roleAssumer(sourceCred2, params);
     // Validate request is signed by sourceCred2
     expect(mockHandle).toBeCalledTimes(2);
     expect(mockHandle.mock.calls[1][0].headers?.authorization).toEqual(
-      expect.stringContaining("AWS4-HMAC-SHA256 Credential=key2/")
+      expect.stringContaining("AWS4-HMAC-SHA256 Credential=key2/"),
     );
   });
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.ts
@@ -12,7 +12,7 @@ import { ServiceInputTypes, ServiceOutputTypes, STSClient, STSClientConfig } fro
 
 const getCustomizableStsClientCtor = (
   baseCtor: new (config: STSClientConfig) => STSClient,
-  customizations?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[]
+  customizations?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[],
 ) => {
   if (!customizations) return baseCtor;
   else
@@ -31,7 +31,7 @@ const getCustomizableStsClientCtor = (
  */
 export const getDefaultRoleAssumer = (
   stsOptions: STSRoleAssumerOptions = {},
-  stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[]
+  stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[],
 ): RoleAssumer => StsGetDefaultRoleAssumer(stsOptions, getCustomizableStsClientCtor(STSClient, stsPlugins));
 
 /**
@@ -39,7 +39,7 @@ export const getDefaultRoleAssumer = (
  */
 export const getDefaultRoleAssumerWithWebIdentity = (
   stsOptions: STSRoleAssumerOptions = {},
-  stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[]
+  stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[],
 ): RoleAssumerWithWebIdentity =>
   StsGetDefaultRoleAssumerWithWebIdentity(stsOptions, getCustomizableStsClientCtor(STSClient, stsPlugins));
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -26,7 +26,7 @@ export type STSRoleAssumerOptions = Pick<
  */
 export type RoleAssumer = (
   sourceCreds: AwsCredentialIdentity,
-  params: AssumeRoleCommandInput
+  params: AssumeRoleCommandInput,
 ) => Promise<AwsCredentialIdentity>;
 
 interface AssumedRoleUser {
@@ -63,7 +63,7 @@ const resolveRegion = async (
   _region: string | Provider<string> | undefined,
   _parentRegion: string | Provider<string> | undefined,
   credentialProviderLogger?: Logger,
-  loaderConfig: Parameters<typeof stsRegionDefaultResolver>[0] = {}
+  loaderConfig: Parameters<typeof stsRegionDefaultResolver>[0] = {},
 ): Promise<string> => {
   const region: string | undefined = typeof _region === "function" ? await _region() : _region;
   const parentRegion: string | undefined = typeof _parentRegion === "function" ? await _parentRegion() : _parentRegion;
@@ -74,7 +74,7 @@ const resolveRegion = async (
     "accepting first of:",
     `${region} (credential provider clientConfig)`,
     `${parentRegion} (contextual client)`,
-    `${stsDefaultRegion} (STS default: AWS_REGION, profile region, or us-east-1)`
+    `${stsDefaultRegion} (STS default: AWS_REGION, profile region, or us-east-1)`,
   );
   return region ?? parentRegion ?? stsDefaultRegion;
 };
@@ -85,7 +85,7 @@ const resolveRegion = async (
  */
 export const getDefaultRoleAssumer = (
   stsOptions: STSRoleAssumerOptions,
-  STSClient: new (options: STSClientConfig) => STSClient
+  STSClient: new (options: STSClientConfig) => STSClient,
 ): RoleAssumer => {
   let stsClient: STSClient;
   let closureSourceCreds: AwsCredentialIdentity;
@@ -107,7 +107,7 @@ export const getDefaultRoleAssumer = (
         {
           logger,
           profile,
-        }
+        },
       );
       const isCompatibleRequestHandler = !isH2(requestHandler);
 
@@ -147,7 +147,7 @@ export const getDefaultRoleAssumer = (
  * @internal
  */
 export type RoleAssumerWithWebIdentity = (
-  params: AssumeRoleWithWebIdentityCommandInput
+  params: AssumeRoleWithWebIdentityCommandInput,
 ) => Promise<AwsCredentialIdentity>;
 
 /**
@@ -156,7 +156,7 @@ export type RoleAssumerWithWebIdentity = (
  */
 export const getDefaultRoleAssumerWithWebIdentity = (
   stsOptions: STSRoleAssumerOptions,
-  STSClient: new (options: STSClientConfig) => STSClient
+  STSClient: new (options: STSClientConfig) => STSClient,
 ): RoleAssumerWithWebIdentity => {
   let stsClient: STSClient;
   return async (params) => {
@@ -176,7 +176,7 @@ export const getDefaultRoleAssumerWithWebIdentity = (
         {
           logger,
           profile,
-        }
+        },
       );
       const isCompatibleRequestHandler = !isH2(requestHandler);
 
@@ -233,7 +233,7 @@ export const decorateDefaultCredentialProvider =
       roleAssumer: getDefaultRoleAssumer(input, input.stsClientCtor as new (options: STSClientConfig) => STSClient),
       roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(
         input,
-        input.stsClientCtor as new (options: STSClientConfig) => STSClient
+        input.stsClientCtor as new (options: STSClientConfig) => STSClient,
       ),
       ...input,
     });

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPluginTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPluginTest.java
@@ -13,119 +13,188 @@ import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptClientCodegenPlugin;
 
 public class AddAwsAuthPluginTest {
+
     @Test
     public void awsClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("NotSame.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("NotSame.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#OriginalName"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .withMember("useLegacyAuth", Node.from(true))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#OriginalName"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .withMember("useLegacyAuth", Node.from(true))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check dependencies
-        assertThat(manifest.getFileString("package.json").get(),
-                containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName));
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName)
+        );
 
         // Check config interface fields
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("credentialDefaultProvider?"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), not(containsString("signingName")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("credentialDefaultProvider?")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            not(containsString("signingName"))
+        );
 
         // Check config files
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("Credential is missing"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), not(containsString("signingName:")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString("Credential is missing")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(),
+            not(containsString("signingName:"))
+        );
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveAwsAuthConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getAwsAuthPlugin"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("resolveAwsAuthConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("getAwsAuthPlugin")
+        );
     }
 
     @Test
     public void sigV4GenericClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("SsdkExampleSigV4.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("SsdkExampleSigV4.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#SsdkExampleSigV4"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .withMember("useLegacyAuth", Node.from(true))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#SsdkExampleSigV4"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .withMember("useLegacyAuth", Node.from(true))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check dependencies
-        assertThat(manifest.getFileString("package.json").get(),
-                containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName));
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName)
+        );
 
         // Check config interface fields
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("credentialDefaultProvider?"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("signingName?"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("credentialDefaultProvider?")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("signingName?")
+        );
 
         // Check config files
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("Credential is missing"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), containsString("signingName:"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString("Credential is missing")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(),
+            containsString("signingName:")
+        );
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("resolveSigV4AuthConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("getSigV4AuthPlugin"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("resolveSigV4AuthConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("getSigV4AuthPlugin")
+        );
     }
 
     @Test
     public void notSigV4GenericClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("SsdkExample.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("SsdkExample.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#SsdkExample"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .withMember("useLegacyAuth", Node.from(true))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#SsdkExample"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .withMember("useLegacyAuth", Node.from(true))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check dependencies
-        assertThat(manifest.getFileString("package.json").get(),
-                not(containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName)));
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            not(containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName))
+        );
 
         // Check config interface fields
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("credentialDefaultProvider?")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("signingName?")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            not(containsString("credentialDefaultProvider?"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            not(containsString("signingName?"))
+        );
 
         // Check config files
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
-                not(containsString("decorateDefaultCredentialProvider")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("Credential is missing")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), not(containsString("signingName:")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            not(containsString("decorateDefaultCredentialProvider"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            not(containsString("Credential is missing"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(),
+            not(containsString("signingName:"))
+        );
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("resolveSigV4AuthConfig")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("resolveAwsV4AuthConfig")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            not(containsString("resolveSigV4AuthConfig"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            not(containsString("resolveAwsV4AuthConfig"))
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
@@ -14,134 +14,255 @@ import software.amazon.smithy.typescript.codegen.TypeScriptClientCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 
 public class AddAwsRuntimeConfigTest {
+
     @Test
     public void awsClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("NotSame.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("NotSame.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                                  .withMember("service", Node.from("smithy.example#OriginalName"))
-                                  .withMember("package", Node.from("example"))
-                                  .withMember("packageVersion", Node.from("1.0.0"))
-                                  .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#OriginalName"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check dependencies
-        assertThat(manifest.getFileString("package.json").get(),
-                   containsString(TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName));
-        assertThat(manifest.getFileString("package.json").get(),
-                containsString(TypeScriptDependency.CONFIG_RESOLVER.packageName));
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            containsString(TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName)
+        );
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            containsString(TypeScriptDependency.CONFIG_RESOLVER.packageName)
+        );
 
         // Check config interface fields
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("serviceId?:"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("region?:"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("useDualstackEndpoint?:"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("useFipsEndpoint?:"));
-
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("serviceId?:")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("region?:")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("useDualstackEndpoint?:")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("useFipsEndpoint?:")
+        );
 
         // Check config files
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), containsString("serviceId: config?.serviceId ?? \"Not Same\""));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("region: config?.region ?? invalidProvider"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("region: config?.region ?? loadNodeConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString(
-                "useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT))"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString(
-                "useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS, loaderConfig)"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString(
-                "useFipsEndpoint: config?.useFipsEndpoint ?? (() => Promise.resolve(DEFAULT_USE_FIPS_ENDPOINT))"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString(
-                "useFipsEndpoint: config?.useFipsEndpoint ?? loadNodeConfig(NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS, loaderConfig),"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(),
+            containsString("serviceId: config?.serviceId ?? \"Not Same\"")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString("region: config?.region ?? invalidProvider")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            containsString("region: config?.region ?? loadNodeConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString(
+                "useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT))"
+            )
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            containsString(
+                "useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS, loaderConfig)"
+            )
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString(
+                "useFipsEndpoint: config?.useFipsEndpoint ?? (() => Promise.resolve(DEFAULT_USE_FIPS_ENDPOINT))"
+            )
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            containsString(
+                "useFipsEndpoint: config?.useFipsEndpoint ?? loadNodeConfig(NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS, loaderConfig),"
+            )
+        );
     }
 
     @Test
     public void sigV4GenericClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("SsdkExampleSigV4.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("SsdkExampleSigV4.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#SsdkExampleSigV4"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#SsdkExampleSigV4"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check dependencies
-        assertThat(manifest.getFileString("package.json").get(),
-                containsString(TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName));
-        assertThat(manifest.getFileString("package.json").get(),
-                containsString(TypeScriptDependency.CONFIG_RESOLVER.packageName));
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            containsString(TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName)
+        );
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            containsString(TypeScriptDependency.CONFIG_RESOLVER.packageName)
+        );
 
         // Check config interface fields
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), not(containsString("serviceId?:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("region?:"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), not(containsString("useDualstackEndpoint?:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), not(containsString("useFipsEndpoint?:")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            not(containsString("serviceId?:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("region?:")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            not(containsString("useDualstackEndpoint?:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            not(containsString("useFipsEndpoint?:"))
+        );
 
         // Check config files
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), not(containsString("serviceId:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("region: config?.region ?? invalidProvider"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("region: config?.region ?? loadNodeConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("useDualstackEndpoint:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("useDualstackEndpoint:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("useFipsEndpoint:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("useFipsEndpoint:")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(),
+            not(containsString("serviceId:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString("region: config?.region ?? invalidProvider")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            containsString("region: config?.region ?? loadNodeConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            not(containsString("useDualstackEndpoint:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            not(containsString("useDualstackEndpoint:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            not(containsString("useFipsEndpoint:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            not(containsString("useFipsEndpoint:"))
+        );
     }
 
     @Test
     public void notSigV4GenericClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("SsdkExample.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("SsdkExample.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#SsdkExample"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#SsdkExample"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check dependencies
-        assertThat(manifest.getFileString("package.json").get(),
-                containsString(TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName));
-        assertThat(manifest.getFileString("package.json").get(),
-                containsString(TypeScriptDependency.CONFIG_RESOLVER.packageName));
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            containsString(TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName)
+        );
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            containsString(TypeScriptDependency.CONFIG_RESOLVER.packageName)
+        );
 
         // Check config interface fields
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("serviceId?:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("region?:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("useDualstackEndpoint?:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("useFipsEndpoint?:")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            not(containsString("serviceId?:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            not(containsString("region?:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            not(containsString("useDualstackEndpoint?:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            not(containsString("useFipsEndpoint?:"))
+        );
 
         // Check config files
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), not(containsString("serviceId:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("region:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("region:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("useDualstackEndpoint:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("useDualstackEndpoint:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("useFipsEndpoint:")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("useFipsEndpoint:")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(),
+            not(containsString("serviceId:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            not(containsString("region:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            not(containsString("region:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            not(containsString("useDualstackEndpoint:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            not(containsString("useDualstackEndpoint:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            not(containsString("useFipsEndpoint:"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            not(containsString("useFipsEndpoint:"))
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPluginsTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPluginsTest.java
@@ -13,93 +13,163 @@ import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptClientCodegenPlugin;
 
 public class AddBuiltinPluginsTest {
+
     @Test
     public void awsClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("NotSame.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("NotSame.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#OriginalName"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#OriginalName"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveRegionConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveEndpointConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveRetryConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getRetryPlugin"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getContentLengthPlugin"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getHostHeaderPlugin"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getLoggerPlugin"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("resolveRegionConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("resolveEndpointConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("resolveRetryConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("getRetryPlugin")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("getContentLengthPlugin")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("getHostHeaderPlugin")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("getLoggerPlugin")
+        );
     }
 
     @Test
     public void sigV4GenericClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("SsdkExampleSigV4.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("SsdkExampleSigV4.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#SsdkExampleSigV4"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#SsdkExampleSigV4"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("resolveRegionConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("resolveEndpointConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("resolveRetryConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("getRetryPlugin"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("getContentLengthPlugin"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("getHostHeaderPlugin"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("getLoggerPlugin"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("resolveRegionConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("resolveEndpointConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("resolveRetryConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("getRetryPlugin")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("getContentLengthPlugin")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("getHostHeaderPlugin")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+            containsString("getLoggerPlugin")
+        );
     }
 
     @Test
     public void notSigV4GenericClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("SsdkExample.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("SsdkExample.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#SsdkExample"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#SsdkExample"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("resolveRegionConfig")));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("resolveEndpointConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("resolveRetryConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("getRetryPlugin"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("getContentLengthPlugin"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("getHostHeaderPlugin"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("getLoggerPlugin"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            not(containsString("resolveRegionConfig"))
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            containsString("resolveEndpointConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            containsString("resolveRetryConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            containsString("getRetryPlugin")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            containsString("getContentLengthPlugin")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            containsString("getHostHeaderPlugin")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(),
+            containsString("getLoggerPlugin")
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependencyTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependencyTest.java
@@ -13,85 +13,148 @@ import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptClientCodegenPlugin;
 
 public class AddUserAgentDependencyTest {
+
     @Test
     public void awsClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("NotSame.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("NotSame.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                                  .withMember("service", Node.from("smithy.example#OriginalName"))
-                                  .withMember("package", Node.from("example"))
-                                  .withMember("packageVersion", Node.from("1.0.0"))
-                                  .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#OriginalName"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check dependencies
-        assertThat(manifest.getFileString("package.json").get(),
-                   containsString(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName));
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            containsString(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName)
+        );
 
         // Check config interface fields
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("defaultUserAgentProvider?"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("defaultUserAgentProvider?")
+        );
 
         // Check config files
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("packageInfo.version"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("clientSharedValues.serviceId"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            containsString("defaultUserAgent")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            containsString("packageInfo.version")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            containsString("clientSharedValues.serviceId")
+        );
 
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("clientSharedValues.serviceId"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString("defaultUserAgent")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString("packageInfo.version")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString("clientSharedValues.serviceId")
+        );
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveUserAgentConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getUserAgentPlugin"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("resolveUserAgentConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(),
+            containsString("getUserAgentPlugin")
+        );
     }
 
     @Test
     public void genericClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("NonAwsService.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("NonAwsService.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#ExampleService"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#ExampleService"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         // Check dependencies
-        assertThat(manifest.getFileString("package.json").get(),
-                containsString(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName));
+        assertThat(
+            manifest.getFileString("package.json").get(),
+            containsString(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName)
+        );
 
         // Check config interface fields
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleServiceClient.ts").get(), containsString("defaultUserAgentProvider?"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleServiceClient.ts").get(),
+            containsString("defaultUserAgentProvider?")
+        );
 
         // Check config files
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("packageInfo.version"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("ClientSharedValues.serviceId")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            containsString("defaultUserAgent")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            containsString("packageInfo.version")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
+            not(containsString("ClientSharedValues.serviceId"))
+        );
 
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("ClientSharedValues.serviceId")));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString("defaultUserAgent")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            containsString("packageInfo.version")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(),
+            not(containsString("ClientSharedValues.serviceId"))
+        );
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleServiceClient.ts").get(), containsString("resolveUserAgentConfig"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleServiceClient.ts").get(), containsString("getUserAgentPlugin"));
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleServiceClient.ts").get(),
+            containsString("resolveUserAgentConfig")
+        );
+        assertThat(
+            manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleServiceClient.ts").get(),
+            containsString("getUserAgentPlugin")
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegrationTest.java
@@ -15,24 +15,27 @@ import software.amazon.smithy.typescript.codegen.TypeScriptServerCodegenPlugin;
 
 @Disabled
 public class AwsEndpointGeneratorIntegrationTest {
+
     @Test
     public void awsClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("NotSame.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("NotSame.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                                  .withMember("service", Node.from("smithy.example#OriginalName"))
-                                  .withMember("package", Node.from("example"))
-                                  .withMember("packageVersion", Node.from("1.0.0"))
-                                  .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#OriginalName"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         assertTrue(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/endpoints.ts").isPresent());
@@ -41,21 +44,23 @@ public class AwsEndpointGeneratorIntegrationTest {
     @Test
     public void genericClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("NonAwsService.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("NonAwsService.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#ExampleService"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#ExampleService"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
         new TypeScriptClientCodegenPlugin().execute(context);
 
         assertFalse(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/endpoints.ts").isPresent());
@@ -64,22 +69,24 @@ public class AwsEndpointGeneratorIntegrationTest {
     @Test
     public void serverSdk() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("SsdkExample.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("SsdkExample.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .pluginClassLoader(getClass().getClassLoader())
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#SsdkExample"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .withMember("disableDefaultValidation", Node.from(true))
-                        .build())
-                .build();
+            .pluginClassLoader(getClass().getClassLoader())
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#SsdkExample"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .withMember("disableDefaultValidation", Node.from(true))
+                    .build()
+            )
+            .build();
         new TypeScriptServerCodegenPlugin().execute(context);
 
         assertFalse(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/endpoints.ts").isPresent());

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegrationTest.java
@@ -15,23 +15,26 @@ import software.amazon.smithy.typescript.codegen.TypeScriptClientCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptServerCodegenPlugin;
 
 public class AwsPackageFixturesGeneratorIntegrationTest {
+
     @Test
     public void awsClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("NotSame.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("NotSame.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#OriginalName"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .build())
-                .build();
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#OriginalName"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
 
         new TypeScriptClientCodegenPlugin().execute(context);
 
@@ -39,30 +42,32 @@ public class AwsPackageFixturesGeneratorIntegrationTest {
         assertTrue(manifest.hasFile("README.md"));
 
         String readme = manifest.getFileString("README.md").get();
-        assertThat(readme, containsString("AWS SDK for JavaScript NotSame Client"));    // Description
-        assertThat(readme, containsString("`NotSameClient`"));  // Modular Client name
-        assertThat(readme, containsString("`GetFooCommand`"));  // Command name
-        assertThat(readme, containsString("AWS.NotSame"));      // v2 compatible client name
-        assertThat(readme, containsString("client.getFoo"));    // v2 compatible operation name                        
+        assertThat(readme, containsString("AWS SDK for JavaScript NotSame Client")); // Description
+        assertThat(readme, containsString("`NotSameClient`")); // Modular Client name
+        assertThat(readme, containsString("`GetFooCommand`")); // Command name
+        assertThat(readme, containsString("AWS.NotSame")); // v2 compatible client name
+        assertThat(readme, containsString("client.getFoo")); // v2 compatible operation name
     }
 
     @Test
     public void genericClient() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("SsdkExample.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("SsdkExample.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#SsdkExample"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .build())
-                .build();
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#SsdkExample"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .build()
+            )
+            .build();
 
         new TypeScriptClientCodegenPlugin().execute(context);
 
@@ -74,21 +79,23 @@ public class AwsPackageFixturesGeneratorIntegrationTest {
     @Test
     public void serverSdk() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("SsdkExample.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("SsdkExample.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         MockManifest manifest = new MockManifest();
         PluginContext context = PluginContext.builder()
-                .model(model)
-                .fileManifest(manifest)
-                .settings(Node.objectNodeBuilder()
-                        .withMember("service", Node.from("smithy.example#SsdkExample"))
-                        .withMember("package", Node.from("example"))
-                        .withMember("packageVersion", Node.from("1.0.0"))
-                        .withMember("disableDefaultValidation", Node.from(true))
-                        .build())
-                .build();
+            .model(model)
+            .fileManifest(manifest)
+            .settings(
+                Node.objectNodeBuilder()
+                    .withMember("service", Node.from("smithy.example#SsdkExample"))
+                    .withMember("package", Node.from("example"))
+                    .withMember("packageVersion", Node.from("1.0.0"))
+                    .withMember("disableDefaultValidation", Node.from(true))
+                    .build()
+            )
+            .build();
 
         new TypeScriptServerCodegenPlugin().execute(context);
 

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
@@ -16,13 +16,14 @@ import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 
 public class AwsServiceIdIntegrationTest {
+
     @Test
     public void testSomeLibraryMethod() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("NotSame.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("NotSame.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
         TypeScriptSettings settings = new TypeScriptSettings();
@@ -39,10 +40,10 @@ public class AwsServiceIdIntegrationTest {
     @Test
     public void testFirstNotCapitalizedServiceId() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("firstNotCapitalized.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("firstNotCapitalized.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
         TypeScriptSettings settings = new TypeScriptSettings();
@@ -53,17 +54,19 @@ public class AwsServiceIdIntegrationTest {
 
         assertThat(symbol.getName(), equalTo("FirstNotCapitalizedClient"));
         assertThat(symbol.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/FirstNotCapitalizedClient"));
-        assertThat(symbol.getDefinitionFile(),
-            equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/FirstNotCapitalizedClient.ts"));
+        assertThat(
+            symbol.getDefinitionFile(),
+            equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/FirstNotCapitalizedClient.ts")
+        );
     }
 
     @Test
     public void testRestNotCapitalizedServiceId() {
         Model model = Model.assembler()
-                .addImport(getClass().getResource("Restnotcapitalized.smithy"))
-                .discoverModels()
-                .assemble()
-                .unwrap();
+            .addImport(getClass().getResource("Restnotcapitalized.smithy"))
+            .discoverModels()
+            .assemble()
+            .unwrap();
         Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
         TypeScriptSettings settings = new TypeScriptSettings();
@@ -74,7 +77,9 @@ public class AwsServiceIdIntegrationTest {
 
         assertThat(symbol.getName(), equalTo("RestNotCapitalizedClient"));
         assertThat(symbol.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/RestNotCapitalizedClient"));
-        assertThat(symbol.getDefinitionFile(),
-            equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/RestNotCapitalizedClient.ts"));
+        assertThat(
+            symbol.getDefinitionFile(),
+            equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/RestNotCapitalizedClient.ts")
+        );
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessorTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessorTest.java
@@ -1,10 +1,11 @@
 package software.amazon.smithy.aws.typescript.codegen.propertyaccess;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.Test;
+
 class PropertyAccessorTest {
+
     @Test
     void getFrom() {
         assertEquals("output.fileSystemId", PropertyAccessor.getFrom("output", "fileSystemId"));

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/validation/UnaryFunctionCallTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/validation/UnaryFunctionCallTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 class UnaryFunctionCallTest {
+
     @Test
     void check() {
         assertEquals(false, UnaryFunctionCall.check(""));

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "kill-port": "^2.0.1",
     "lerna": "5.5.2",
     "lint-staged": "^10.0.1",
-    "prettier": "2.8.5",
+    "prettier": "^3.7.4",
+    "prettier-plugin-java": "^2.7.7",
     "rimraf": "3.0.2",
     "ts-jest": "29.1.1",
     "ts-loader": "9.4.2",
@@ -144,7 +145,7 @@
       "eslint --fix",
       "prettier --write"
     ],
-    "**/*.{ts,js,md,json}": "prettier --write"
+    "**/*.{ts,js,md,json,java}": "prettier --write"
   },
   "packageManager": "yarn@4.10.3"
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,13 @@
 module.exports = {
   // Custom
   printWidth: 120,
+  plugins: ["prettier-plugin-java"],
+  overrides: [
+    {
+      files: "*.java",
+      options: {
+        tabWidth: 4,
+      },
+    },
+  ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -25281,6 +25281,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chevrotain/cst-dts-gen@npm:11.0.3":
+  version: 11.0.3
+  resolution: "@chevrotain/cst-dts-gen@npm:11.0.3"
+  dependencies:
+    "@chevrotain/gast": "npm:11.0.3"
+    "@chevrotain/types": "npm:11.0.3"
+    lodash-es: "npm:4.17.21"
+  checksum: 10c0/9e945a0611386e4e08af34c2d0b3af36c1af08f726b58145f11310f2aeafcb2d65264c06ec65a32df6b6a65771e6a55be70580c853afe3ceb51487e506967104
+  languageName: node
+  linkType: hard
+
+"@chevrotain/gast@npm:11.0.3":
+  version: 11.0.3
+  resolution: "@chevrotain/gast@npm:11.0.3"
+  dependencies:
+    "@chevrotain/types": "npm:11.0.3"
+    lodash-es: "npm:4.17.21"
+  checksum: 10c0/54fc44d7b4a7b0323f49d957dd88ad44504922d30cb226d93b430b0e09925efe44e0726068581d777f423fabfb878a2238ed2c87b690c0c0014ebd12b6968354
+  languageName: node
+  linkType: hard
+
+"@chevrotain/regexp-to-ast@npm:11.0.3":
+  version: 11.0.3
+  resolution: "@chevrotain/regexp-to-ast@npm:11.0.3"
+  checksum: 10c0/6939c5c94fbfb8c559a4a37a283af5ded8e6147b184a7d7bcf5ad1404d9d663c78d81602bd8ea8458ec497358a9e1671541099c511835d0be2cad46f00c62b3f
+  languageName: node
+  linkType: hard
+
+"@chevrotain/types@npm:11.0.3":
+  version: 11.0.3
+  resolution: "@chevrotain/types@npm:11.0.3"
+  checksum: 10c0/72fe8f0010ebef848e47faea14a88c6fdc3cdbafaef6b13df4a18c7d33249b1b675e37b05cb90a421700c7016dae7cd4187ab6b549e176a81cea434f69cd2503
+  languageName: node
+  linkType: hard
+
+"@chevrotain/utils@npm:11.0.3":
+  version: 11.0.3
+  resolution: "@chevrotain/utils@npm:11.0.3"
+  checksum: 10c0/b31972d1b2d444eef1499cf9b7576fc1793e8544910de33a3c18e07c270cfad88067f175d0ee63e7bc604713ebed647f8190db45cc8311852cd2d4fe2ef14068
+  languageName: node
+  linkType: hard
+
 "@cnakazawa/watch@npm:^1.0.3":
   version: 1.0.4
   resolution: "@cnakazawa/watch@npm:1.0.4"
@@ -31114,7 +31156,8 @@ __metadata:
     kill-port: "npm:^2.0.1"
     lerna: "npm:5.5.2"
     lint-staged: "npm:^10.0.1"
-    prettier: "npm:2.8.5"
+    prettier: "npm:^3.7.4"
+    prettier-plugin-java: "npm:^2.7.7"
     rimraf: "npm:3.0.2"
     ts-jest: "npm:29.1.1"
     ts-loader: "npm:9.4.2"
@@ -31731,6 +31774,31 @@ __metadata:
   version: 2.1.1
   resolution: "check-error@npm:2.1.1"
   checksum: 10c0/979f13eccab306cf1785fa10941a590b4e7ea9916ea2a4f8c87f0316fc3eab07eabefb6e587424ef0f88cbcd3805791f172ea739863ca3d7ce2afc54641c7f0e
+  languageName: node
+  linkType: hard
+
+"chevrotain-allstar@npm:0.3.1":
+  version: 0.3.1
+  resolution: "chevrotain-allstar@npm:0.3.1"
+  dependencies:
+    lodash-es: "npm:^4.17.21"
+  peerDependencies:
+    chevrotain: ^11.0.0
+  checksum: 10c0/5cadedffd3114eb06b15fd3939bb1aa6c75412dbd737fe302b52c5c24334f9cb01cee8edc1d1067d98ba80dddf971f1d0e94b387de51423fc6cf3c5d8b7ef27a
+  languageName: node
+  linkType: hard
+
+"chevrotain@npm:11.0.3":
+  version: 11.0.3
+  resolution: "chevrotain@npm:11.0.3"
+  dependencies:
+    "@chevrotain/cst-dts-gen": "npm:11.0.3"
+    "@chevrotain/gast": "npm:11.0.3"
+    "@chevrotain/regexp-to-ast": "npm:11.0.3"
+    "@chevrotain/types": "npm:11.0.3"
+    "@chevrotain/utils": "npm:11.0.3"
+    lodash-es: "npm:4.17.21"
+  checksum: 10c0/ffd425fa321e3f17e9833d7f44cd39f2743f066e92ca74b226176080ca5d455f853fe9091cdfd86354bd899d85c08b3bdc3f55b267e7d07124b048a88349765f
   languageName: node
   linkType: hard
 
@@ -35669,6 +35737,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"java-parser@npm:3.0.1":
+  version: 3.0.1
+  resolution: "java-parser@npm:3.0.1"
+  dependencies:
+    chevrotain: "npm:11.0.3"
+    chevrotain-allstar: "npm:0.3.1"
+    lodash: "npm:4.17.21"
+  checksum: 10c0/9b60f1132b65785fe4f4c10785fc1638a4092aecf222f63706c119425d0ffb676b7229390abe289082cf837cd470df63f9b9383743d470816fa170240f8b1e22
+  languageName: node
+  linkType: hard
+
 "jayson@npm:^3.6.6":
   version: 3.7.0
   resolution: "jayson@npm:3.7.0"
@@ -37105,7 +37184,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.21":
+"lodash-es@npm:4.17.21, lodash-es@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash-es@npm:4.17.21"
   checksum: 10c0/fb407355f7e6cd523a9383e76e6b455321f0f153a6c9625e21a8827d10c54c2a2341bd2ae8d034358b60e07325e1330c14c224ff582d04612a46a4f0479ff2f2
@@ -39083,12 +39162,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.8.5":
-  version: 2.8.5
-  resolution: "prettier@npm:2.8.5"
-  bin:
-    prettier: bin-prettier.js
-  checksum: 10c0/32df014dadfa91a4f3250447078a335b93f5502ebfabf7236545edae34793d6ca5befb48b119e39ddaabfd131dbcba2ccaf081e658f73b3871dedadda3ab385a
+"prettier-plugin-java@npm:^2.7.7":
+  version: 2.7.7
+  resolution: "prettier-plugin-java@npm:2.7.7"
+  dependencies:
+    java-parser: "npm:3.0.1"
+  peerDependencies:
+    prettier: ^3.0.0
+  checksum: 10c0/0acf9ab0dcb39739f9dd80c880cc9d703d73abf62b807d213258d2424ffc7d6617be4d95dfed25e0af5856a13fc3e0b16c694e150e202d2a180d9c6c5d7f5bd8
   languageName: node
   linkType: hard
 
@@ -39098,6 +39179,15 @@ __metadata:
   bin:
     prettier: bin-prettier.js
   checksum: 10c0/463ea8f9a0946cd5b828d8cf27bd8b567345cf02f56562d5ecde198b91f47a76b7ac9eae0facd247ace70e927143af6135e8cf411986b8cb8478784a4d6d724a
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.7.4":
+  version: 3.7.4
+  resolution: "prettier@npm:3.7.4"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/9675d2cd08eacb1faf1d1a2dbfe24bfab6a912b059fc9defdb380a408893d88213e794a40a2700bd29b140eb3172e0b07c852853f6e22f16f3374659a1a13389
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue
paired with https://github.com/smithy-lang/smithy-typescript/pull/1808

### Description
Adds the java plugin for prettier, formats the files, and modifies the precommit hook to include java files.

### Additional context
Since we are a JS repo, we already have the base prettier tool installed. 
