### PR TITLE
fix(client-sts): warn sts default region only when used

### DIFF
--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -58,9 +58,8 @@ const getAccountIdFromAssumedRoleUser = (assumedRoleUser?: AssumedRoleUser) => {
 };
 
 /**
- * @internal
- *
  * Default to the parent client region or us-east-1 if no region is specified.
+ * @internal
  */
 const resolveRegion = async (
   _region: string | Provider<string> | undefined,
@@ -70,7 +69,9 @@ const resolveRegion = async (
 ): Promise<string> => {
   const region: string | undefined = typeof _region === "function" ? await _region() : _region;
   const parentRegion: string | undefined = typeof _parentRegion === "function" ? await _parentRegion() : _parentRegion;
-  const stsDefaultRegion = await stsRegionDefaultResolver(loaderConfig)();
+  let stsDefaultRegion = "";
+
+  const resolvedRegion = region ?? parentRegion ?? (stsDefaultRegion = await stsRegionDefaultResolver(loaderConfig)());
 
   credentialProviderLogger?.debug?.(
     "@aws-sdk/client-sts::resolveRegion",
@@ -79,7 +80,8 @@ const resolveRegion = async (
     `${parentRegion} (contextual client)`,
     `${stsDefaultRegion} (STS default: AWS_REGION, profile region, or us-east-1)`
   );
-  return region ?? parentRegion ?? stsDefaultRegion;
+
+  return resolvedRegion;
 };
 
 /**

--- a/clients/client-sts/test/defaultRoleAssumers.spec.ts
+++ b/clients/client-sts/test/defaultRoleAssumers.spec.ts
@@ -3,7 +3,7 @@
 import { NodeHttp2Handler, NodeHttpHandler, streamCollector } from "@smithy/node-http-handler";
 import { HttpResponse } from "@smithy/protocol-http";
 import { Readable } from "stream";
-import { beforeAll, beforeEach, describe, expect, test as it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import type { AssumeRoleCommandInput } from "../src/commands/AssumeRoleCommand";
 import { AssumeRoleWithWebIdentityCommandInput } from "../src/commands/AssumeRoleWithWebIdentityCommand";
@@ -240,6 +240,53 @@ describe("getDefaultRoleAssumer", () => {
     expect(customMiddlewareFunction).toHaveBeenCalledTimes(2); // make sure the middleware is not added to stack multiple times.
     expect(customMiddlewareFunction).toHaveBeenNthCalledWith(1, expect.objectContaining({ input: params }));
     expect(customMiddlewareFunction).toHaveBeenNthCalledWith(2, expect.objectContaining({ input: params }));
+  });
+
+  describe("resolveRegion", () => {
+    let envRegion: string | undefined;
+    let envDefaultRegion: string | undefined;
+
+    beforeAll(async () => {
+      envRegion = process.env.AWS_REGION;
+      envDefaultRegion = process.env.AWS_DEFAULT_REGION;
+      delete process.env.AWS_REGION;
+      delete process.env.AWS_DEFAULT_REGION;
+    });
+
+    afterAll(async () => {
+      process.env.AWS_REGION = envRegion;
+      process.env.AWS_DEFAULT_REGION = envDefaultRegion;
+    });
+
+    it("should not call stsRegionDefaultResolver unless no region was configured on the client and provider", async () => {
+      vi.spyOn(console, "warn");
+      const sourceCred = { accessKeyId: "key", secretAccessKey: "secret" };
+      const params: AssumeRoleCommandInput = {
+        RoleArn: "arn:aws:foo",
+        RoleSessionName: "session",
+      };
+      {
+        const roleAssumer = getDefaultRoleAssumer({
+          region: async () => "us-west-2",
+        });
+        await roleAssumer(sourceCred, params);
+        expect(console.warn).not.toHaveBeenCalled();
+      }
+      {
+        const roleAssumer = getDefaultRoleAssumer({
+          parentClientConfig: {
+            region: async () => "us-west-2",
+          },
+        });
+        await roleAssumer(sourceCred, params);
+        expect(console.warn).not.toHaveBeenCalled();
+      }
+      {
+        const roleAssumer = getDefaultRoleAssumer({});
+        await roleAssumer(sourceCred, params);
+        expect(console.warn).toHaveBeenCalledTimes(1);
+      }
+    });
   });
 });
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -55,9 +55,8 @@ const getAccountIdFromAssumedRoleUser = (assumedRoleUser?: AssumedRoleUser) => {
 };
 
 /**
- * @internal
- *
  * Default to the parent client region or us-east-1 if no region is specified.
+ * @internal
  */
 const resolveRegion = async (
   _region: string | Provider<string> | undefined,
@@ -67,7 +66,9 @@ const resolveRegion = async (
 ): Promise<string> => {
   const region: string | undefined = typeof _region === "function" ? await _region() : _region;
   const parentRegion: string | undefined = typeof _parentRegion === "function" ? await _parentRegion() : _parentRegion;
-  const stsDefaultRegion = await stsRegionDefaultResolver(loaderConfig)();
+  let stsDefaultRegion = "";
+
+  const resolvedRegion = region ?? parentRegion ?? (stsDefaultRegion = await stsRegionDefaultResolver(loaderConfig)());
 
   credentialProviderLogger?.debug?.(
     "@aws-sdk/client-sts::resolveRegion",
@@ -76,7 +77,8 @@ const resolveRegion = async (
     `${parentRegion} (contextual client)`,
     `${stsDefaultRegion} (STS default: AWS_REGION, profile region, or us-east-1)`
   );
-  return region ?? parentRegion ?? stsDefaultRegion;
+
+  return resolvedRegion;
 };
 
 /**

--- a/packages/nested-clients/src/submodules/sts/defaultStsRoleAssumers.ts
+++ b/packages/nested-clients/src/submodules/sts/defaultStsRoleAssumers.ts
@@ -58,9 +58,8 @@ const getAccountIdFromAssumedRoleUser = (assumedRoleUser?: AssumedRoleUser) => {
 };
 
 /**
- * @internal
- *
  * Default to the parent client region or us-east-1 if no region is specified.
+ * @internal
  */
 const resolveRegion = async (
   _region: string | Provider<string> | undefined,
@@ -70,7 +69,9 @@ const resolveRegion = async (
 ): Promise<string> => {
   const region: string | undefined = typeof _region === "function" ? await _region() : _region;
   const parentRegion: string | undefined = typeof _parentRegion === "function" ? await _parentRegion() : _parentRegion;
-  const stsDefaultRegion = await stsRegionDefaultResolver(loaderConfig)();
+  let stsDefaultRegion = "";
+
+  const resolvedRegion = region ?? parentRegion ?? (stsDefaultRegion = await stsRegionDefaultResolver(loaderConfig)());
 
   credentialProviderLogger?.debug?.(
     "@aws-sdk/client-sts::resolveRegion",
@@ -79,7 +80,8 @@ const resolveRegion = async (
     `${parentRegion} (contextual client)`,
     `${stsDefaultRegion} (STS default: AWS_REGION, profile region, or us-east-1)`
   );
-  return region ?? parentRegion ?? stsDefaultRegion;
+
+  return resolvedRegion;
 };
 
 /**


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7576

### Description
Fix incorrectly emitted warning in some cases where a region was set on the client but the warning thinks the final fallback STS region was used.

### Testing
manual testing, new unit test
