### PR TITLE
chore(build): set cjs->es dependency in turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,7 @@
     },
     "build:cjs": {
       "outputs": ["dist-cjs/**"],
-      "dependsOn": ["^build:types"]
+      "dependsOn": ["^build:types", "build:es"]
     },
     "build:docs": {
       "outputs": ["dist-cjs/**"],


### PR DESCRIPTION
### Issue
followup to https://github.com/aws/aws-sdk-js-v3/pull/7580

### Description
This adds `build:es` as a task dependency for `build:cjs`. This isn't really necessary, since the only build run in CI is the full build (types+cjs+es), but correct when running `build:cjs` with turbo, which may be manually run by developers. 