### PR TITLE
chore(codegen): downgrade spotless to 7.2.1

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -27,7 +27,8 @@ plugins {
     jacoco
     id("com.github.spotbugs") version "6.3.0"
     id("org.jreleaser") version "1.21.0"
-    id("com.diffplug.spotless") version "8.1.0"
+    // spotless 8.x is incompatible with jreleaser 1.x (see https://github.com/jreleaser/jreleaser/issues/1989)
+    id("com.diffplug.spotless") version "7.2.1"
 }
 
 allprojects {

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/934fd271bef22c7751e0c59615cf1639dd609c3c...de08d556d19c8500d88249f80b81f71131cc3138
-  SMITHY_TS_COMMIT: "de08d556d19c8500d88249f80b81f71131cc3138",
+  // https://github.com/smithy-lang/smithy-typescript/compare/de08d556d19c8500d88249f80b81f71131cc3138...46c6eef6b80338f8acb560ba826519ade474ec5e
+  SMITHY_TS_COMMIT: "46c6eef6b80338f8acb560ba826519ade474ec5e",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
* Internal JS-6423
* smithy-ts changes https://github.com/smithy-lang/smithy-typescript/pull/1818

### Description
Downgrades spotless to 7.2.1, since 8.x is not compatible with jreleaser 1.x

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
