### PR TITLE
fix(core/protocols): $unknown union member support

### DIFF
--- a/packages/core/src/submodules/protocols/UnionSerde.ts
+++ b/packages/core/src/submodules/protocols/UnionSerde.ts
@@ -1,0 +1,38 @@
+/**
+ * Helper for identifying unknown union members during deserialization.
+ */
+export class UnionSerde {
+  private keys: Set<string>;
+
+  public constructor(private from: any, private to: any) {
+    this.keys = new Set(Object.keys(this.from).filter((k) => k !== "__type"));
+  }
+
+  /**
+   * Marks the key as being a known member.
+   * @param key - to mark.
+   */
+  public mark(key: string): void {
+    this.keys.delete(key);
+  }
+
+  /**
+   * @returns whether only one key remains unmarked and nothing has been written,
+   * implying the object is a union.
+   */
+  public hasUnknown(): boolean {
+    return this.keys.size === 1 && Object.keys(this.to).length === 0;
+  }
+
+  /**
+   * Writes the unknown key-value pair, if present, into the $unknown property
+   * of the union object.
+   */
+  public writeUnknown(): void {
+    if (this.hasUnknown()) {
+      const k = this.keys.values().next().value as string;
+      const v = this.from[k];
+      this.to.$unknown = [k, v];
+    }
+  }
+}

--- a/packages/core/src/submodules/protocols/json/JsonShapeSerializer.spec.ts
+++ b/packages/core/src/submodules/protocols/json/JsonShapeSerializer.spec.ts
@@ -2,7 +2,7 @@ import { NumericValue } from "@smithy/core/serde";
 import type { TimestampEpochSecondsSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
-import { createNestingWidget, nestingWidget, widget } from "../test-schema.spec";
+import { createNestingWidget, nestingWidget, unionStruct, widget } from "../test-schema.spec";
 import { SinglePassJsonShapeSerializer } from "./experimental/SinglePassJsonShapeSerializer";
 import { JsonShapeSerializer } from "./JsonShapeSerializer";
 
@@ -29,6 +29,22 @@ describe(JsonShapeSerializer.name, () => {
     expect(serialization).toEqual(
       `{"blob":"AAAAAQ==","timestamp":0,"bigint":10000000000000000000000054321,"bigdecimal":0.10000000000000000000000054321}`
     );
+  });
+
+  it("serializes $unknown union members", () => {
+    serializer1.write(unionStruct, {
+      union: {
+        $unknown: [
+          "unknownKey",
+          {
+            timestamp: new Date(0),
+            blob: new Uint8Array([0, 1, 2, 3]),
+          },
+        ],
+      },
+    });
+    const serialization = serializer1.flush();
+    expect(serialization).toEqual(`{"union":{"unknownKey":{"timestamp":0,"blob":"AAECAw=="}}}`);
   });
 
   describe("performance baseline indicator", () => {

--- a/packages/core/src/submodules/protocols/json/JsonShapeSerializer.ts
+++ b/packages/core/src/submodules/protocols/json/JsonShapeSerializer.ts
@@ -2,6 +2,7 @@ import { determineTimestampFormat } from "@smithy/core/protocols";
 import { NormalizedSchema } from "@smithy/core/schema";
 import { dateToUtcString, generateIdempotencyToken, LazyJsonString, NumericValue } from "@smithy/core/serde";
 import type {
+  DocumentSchema,
   Schema,
   ShapeSerializer,
   TimestampDateTimeSchema,
@@ -79,6 +80,13 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
             const jsonName = memberSchema.getMergedTraits().jsonName;
             const targetKey = this.settings.jsonName ? jsonName ?? memberName : memberName;
             out[targetKey] = serializableValue;
+          }
+        }
+        if (ns.isUnionSchema() && Object.keys(out).length === 0) {
+          const { $unknown } = value as any;
+          if (Array.isArray($unknown)) {
+            const [k, v] = $unknown;
+            out[k] = this._write(15 satisfies DocumentSchema, v);
           }
         }
         return out;

--- a/packages/core/src/submodules/protocols/query/QueryShapeSerializer.spec.ts
+++ b/packages/core/src/submodules/protocols/query/QueryShapeSerializer.spec.ts
@@ -2,20 +2,15 @@ import { NumericValue } from "@smithy/core/serde";
 import type { TimestampDateTimeSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
-import { widget } from "../test-schema.spec";
+import { unionStruct, unionStructControl, widget } from "../test-schema.spec";
 import { QueryShapeSerializer } from "./QueryShapeSerializer";
 
 describe(QueryShapeSerializer.name, () => {
-  it("serializes data to Query", async () => {
-    const serializer = new QueryShapeSerializer({
-      timestampFormat: { default: 5 satisfies TimestampDateTimeSchema, useTrait: true },
-    });
-    serializer.setSerdeContext({
-      base64Encoder: (input: Uint8Array) => {
-        return Buffer.from(input).toString("base64");
-      },
-    } as any);
+  const serializer = new QueryShapeSerializer({
+    timestampFormat: { default: 5 satisfies TimestampDateTimeSchema, useTrait: true },
+  });
 
+  it("serializes data to Query", async () => {
     const data = {
       timestamp: new Date(0),
       bigint: 10000000000000000000000054321n,
@@ -27,5 +22,42 @@ describe(QueryShapeSerializer.name, () => {
     expect(serialization).toEqual(
       `&blob=AAAAAQ%3D%3D&timestamp=0&bigint=10000000000000000000000054321&bigdecimal=0.10000000000000000000000054321`
     );
+  });
+
+  it("serializes $unknown union members", () => {
+    {
+      serializer.write(unionStruct, {
+        union: {
+          $unknown: [
+            "unknownKey",
+            {
+              timestamp: new Date(0),
+              blob: new Uint8Array([0, 1, 2, 3]),
+            },
+          ],
+        },
+      });
+      const serialization = String(serializer.flush()).replaceAll(/&/g, "\n&");
+      expect(serialization).toEqual(`
+&union.unknownKey.entry.1.key=timestamp
+&union.unknownKey.entry.1.value=1970-01-01T00%3A00%3A00Z
+&union.unknownKey.entry.2.key=blob
+&union.unknownKey.entry.2.value=AAECAw%3D%3D`);
+    }
+    {
+      serializer.write(unionStructControl, {
+        union: {
+          $unknown: [
+            "unknownKey",
+            {
+              timestamp: new Date(0),
+              blob: new Uint8Array([0, 1, 2, 3]),
+            },
+          ],
+        },
+      });
+      const serialization = serializer.flush();
+      expect(serialization).toEqual(``);
+    }
   });
 });

--- a/packages/core/src/submodules/protocols/test-schema.spec.ts
+++ b/packages/core/src/submodules/protocols/test-schema.spec.ts
@@ -7,6 +7,7 @@ import type {
   StaticListSchema,
   StaticOperationSchema,
   StaticStructureSchema,
+  StaticUnionSchema,
   StringSchema,
   TimestampDefaultSchema,
   TimestampEpochSecondsSchema,
@@ -122,3 +123,21 @@ export const context = {
     };
   },
 } as any;
+
+export const unionStruct = [
+  3,
+  "ns",
+  "UnionStruct",
+  0,
+  ["union"],
+  [[4, "ns", "Union", 0, ["string", "timestamp", "blob"], [0, 7, 21]] satisfies StaticUnionSchema],
+] satisfies StaticStructureSchema;
+
+export const unionStructControl = [
+  3,
+  "ns",
+  "UnionStruct",
+  0,
+  ["union"],
+  [[3, "ns", "Union", 0, ["string", "timestamp", "blob"], [0, 7, 21]] satisfies StaticStructureSchema],
+] satisfies StaticStructureSchema;

--- a/packages/core/src/submodules/protocols/xml/XmlShapeSerializer.spec.ts
+++ b/packages/core/src/submodules/protocols/xml/XmlShapeSerializer.spec.ts
@@ -2,7 +2,7 @@ import { NumericValue } from "@smithy/core/serde";
 import type { TimestampDateTimeSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
-import { createNestingWidget, nestingWidget, widget } from "../test-schema.spec";
+import { createNestingWidget, nestingWidget, unionStruct, unionStructControl, widget } from "../test-schema.spec";
 import { simpleFormatXml } from "./simpleFormatXml";
 import { XmlShapeSerializer } from "./XmlShapeSerializer";
 
@@ -18,7 +18,7 @@ describe(XmlShapeSerializer.name, () => {
     },
   } as any);
 
-  it("serializes data to Query", async () => {
+  it("serializes data to XML", async () => {
     const data = {
       timestamp: new Date(0),
       bigint: 10000000000000000000000054321n,
@@ -41,6 +41,27 @@ describe(XmlShapeSerializer.name, () => {
     0.10000000000000000000000054321
   </bigdecimal>
 </Struct>`);
+  });
+
+  it("serializes $unknown union members", () => {
+    {
+      serializer.write(unionStruct, {
+        union: {
+          $unknown: ["UK", "UV"],
+        },
+      });
+      const serialization = serializer.flush();
+      expect(serialization).toEqual(`<UnionStruct xmlns="namespace"><union><UK>UV</UK></union></UnionStruct>`);
+    }
+    {
+      serializer.write(unionStructControl, {
+        union: {
+          $unknown: ["UK", "UV"],
+        },
+      });
+      const serialization = serializer.flush();
+      expect(serialization).toEqual(`<UnionStruct xmlns="namespace"><union/></UnionStruct>`);
+    }
   });
 
   describe("performance baseline indicator", () => {


### PR DESCRIPTION
### Issue
follows https://github.com/smithy-lang/smithy-typescript/pull/1820

### Description
supports usage of the `$unknown` field for serializing and deserializing unmodeled union members in schema-serde mode.

### Testing
new unit tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

