### PR TITLE
fix(middleware-flexible-checksums): advise user on InvalidChunkSizeError

### DIFF
--- a/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.e2e.spec.ts
+++ b/packages/middleware-flexible-checksums/src/middleware-flexible-checksums.e2e.spec.ts
@@ -102,7 +102,8 @@ describe("S3 checksums", () => {
         })
         .catch((e) => {
           expect(String(e)).toContain(
-            "InvalidChunkSizeError: Only the last chunk is allowed to have a size less than 8192 bytes"
+            "InvalidChunkSizeError: Only the last chunk is allowed to have a size less than 8192 bytes. " +
+              "Set [requestStreamBufferSize=number e.g. 65_536] in client constructor to instruct AWS SDK to buffer your input stream."
           );
         });
       expect.hasAssertions();


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7596
https://github.com/aws/aws-sdk-js-v3/issues/6949
https://github.com/aws/aws-sdk-js-v3/issues/7509

### Description
Amazon S3 responds with 
> InvalidChunkSizeError: Only the last chunk is allowed to have a size less than 8192 bytes

To summarize the issue from when the feature was added: The error is thrown when checksums are enabled and the input stream (e.g. S3 PutObject) sends a chunk of size less than 8kb. Because of the transform applied by AWS Chunked Encoding, Node.js' http automatic buffering does not happen.

The JS SDK should append 
> InvalidChunkSizeError: Only the last chunk is allowed to have a size less than 8192 bytes. Set [requestStreamBufferSize=number e.g. 65_536] in client constructor to instruct AWS SDK to buffer your input stream.

To assist users towards one of the solutions provided by the SDK if they wish to use it. It is not automatically enabled for performance reasons.

### Testing
Updated e2e test.

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

