### PR TITLE
test(client-sqs): increase eventually function timeout to 60s

### DIFF
--- a/clients/client-sqs/test/sqs-queues-features.e2e.spec.ts
+++ b/clients/client-sqs/test/sqs-queues-features.e2e.spec.ts
@@ -7,7 +7,7 @@ async function eventually<T>(
   condition: (result: T) => boolean,
   options: { delay?: number; backoff?: number; maxTime?: number } = {}
 ): Promise<T> {
-  const { delay: initialDelay = 0, backoff = 500, maxTime = 5 } = options;
+  const { delay: initialDelay = 0, backoff = 500, maxTime = 60 } = options;
 
   let delay = initialDelay;
   const started = Date.now();
@@ -71,7 +71,6 @@ describe("SQS Queues", () => {
           const queueUrls = result.QueueUrls || [];
           return createdQueues.every((createdQueue) => queueUrls.includes(createdQueue));
         },
-        { maxTime: 15 }
       );
 
       // Check that created queues exist in the list


### PR DESCRIPTION
### Issue
Internal P358780234

### Description
The `eventually` function had a default `maxTime` of 5 s, but SQS can take longer than this for newly created queues to appear in `listQueues()` results. Increased the default timeout from 5 s to 60 s in the `eventually` function.


### Testing
`yarn test:e2e`

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
