### PR TITLE
test(credential-provider-login): mock Date for determinism

### DIFF
--- a/packages/credential-provider-login/src/LoginCredentialsFetcher.spec.ts
+++ b/packages/credential-provider-login/src/LoginCredentialsFetcher.spec.ts
@@ -93,6 +93,9 @@ describe("LoginCredentialsFetcher", () => {
   it("should load cached credentials successfully", async () => {
     mockReadFile.mockResolvedValue(JSON.stringify(mockValidCreds));
 
+    const mockNow = new Date("2025-12-31T00:00:00.000Z").getTime();
+    vi.spyOn(Date, "now").mockReturnValue(mockNow);
+
     const fetcher = new LoginCredentialsFetcher(mockProfile);
     const result = await fetcher.loadCredentials();
 


### PR DESCRIPTION
### Issue
Internal JS-6439

### Description
mocks Date for determinism in a test running against a hardcoded expiry date

### Testing
```console
 ✓ src/fromLoginCredentials.spec.ts (5 tests) 5ms
 ✓ src/LoginCredentialsFetcher.spec.ts (16 tests) 14ms

 Test Files  2 passed (2)
      Tests  21 passed (21)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
