### PR TITLE
chore(codegen): update release tag for 0.41.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Smithy AWS Typescript Codegen Changelog
 
-## 0.41.0 (2025-12-31)
+## 0.41.0 (2026-01-02)
 
 ### Features
 
-- Upgraded to smithy-typescript 0.41.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0410-2025-12-31))
+- Upgraded to smithy-typescript 0.41.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0410-2026-01-02))
+- Added `@aws-sdk/lib-*` package versions to `sdkVersions.properties` file ([#7616](https://github.com/aws/aws-sdk-js-v3/pull/7616))
 
 ## 0.40.0 (2025-12-22)
 

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -38,6 +38,8 @@ allprojects {
     }
     group = "software.amazon.smithy.typescript"
     version = "0.41.0"
+    // no-op change line to include latest commit(s) in 0.41.0.
+    // this can be removed on the next version bump.
 }
 
 // The root project doesn't produce a JAR.

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/650009c4ad66f78a779165db2a44e473e68e114d...eb9d0c639845ff9e8e94aa32ec97a3de315bc55a
-  SMITHY_TS_COMMIT: "eb9d0c639845ff9e8e94aa32ec97a3de315bc55a",
+  // https://github.com/smithy-lang/smithy-typescript/compare/eb9d0c639845ff9e8e94aa32ec97a3de315bc55a...29ccd13ee98634d1c6449f3b50ab377d1a515297
+  SMITHY_TS_COMMIT: "29ccd13ee98634d1c6449f3b50ab377d1a515297",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
update the commit associated with 0.41.0 to this one.

https://github.com/smithy-lang/smithy-typescript/compare/eb9d0c639845ff9e8e94aa32ec97a3de315bc55a...29ccd13ee98634d1c6449f3b50ab377d1a515297

related: https://github.com/smithy-lang/smithy-typescript/pull/1827