### PR TITLE
test(credential-provider-login): change the expiration year for credentials to be valid

### DIFF
--- a/packages/credential-provider-login/src/LoginCredentialsFetcher.spec.ts
+++ b/packages/credential-provider-login/src/LoginCredentialsFetcher.spec.ts
@@ -52,7 +52,7 @@ const mockValidCreds = {
     secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
     sessionToken: "session-token",
     accountId: "123456789012",
-    expiresAt: "2026-01-01T00:00:00.000Z",
+    expiresAt: "3000-01-01T00:00:00.000Z",
   },
   clientId: "test-client-id",
   refreshToken: "test-refresh-token",
@@ -92,9 +92,6 @@ describe("LoginCredentialsFetcher", () => {
 
   it("should load cached credentials successfully", async () => {
     mockReadFile.mockResolvedValue(JSON.stringify(mockValidCreds));
-
-    const mockNow = new Date("2025-12-31T00:00:00.000Z").getTime();
-    vi.spyOn(Date, "now").mockReturnValue(mockNow);
 
     const fetcher = new LoginCredentialsFetcher(mockProfile);
     const result = await fetcher.loadCredentials();


### PR DESCRIPTION
### Issue
Internal P362267645

### Description
Update the expiration date of mock credentials to a future date

### Testing
CI

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
