### PR TITLE
test(client-rds): make securityGroupName unique

### DIFF
--- a/clients/client-rds/test/rds-features.e2e.spec.ts
+++ b/clients/client-rds/test/rds-features.e2e.spec.ts
@@ -25,7 +25,7 @@ describe(RDS.name, () => {
 
   describe("Describe DB security group", () => {
     it("should create security group, describe it, and verify structure", async () => {
-      dbSecurityGroupName = `aws-sdk-js-rds-e2e`;
+      dbSecurityGroupName = `aws-sdk-js-rds-e2e-${Date.now()}`;
 
       const expectedDescription = "Test security group for e2e tests";
 


### PR DESCRIPTION
### Issue
Internal V2057675810

### Description
Update securityGroupName with a timestamp to make it unique.

### Testing
```
> yarn test:e2e
✓ test/rds-features.e2e.spec.ts (3 tests) 2642ms
   ✓ RDS > Describe DB security group > should create security group, describe it, and verify structure  654ms
   ✓ RDS > Error handling > should get InvalidParameterValue with 400 status for empty security group name 75ms
   ✓ RDS > Paginating responses > should paginate describeReservedDBInstancesOfferings with more than one page  1799ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
