### PR TITLE
fix(util-arn-parser): omissions for S3 arn building

### DIFF
--- a/packages/util-arn-parser/src/index.spec.ts
+++ b/packages/util-arn-parser/src/index.spec.ts
@@ -69,13 +69,66 @@ describe("builder", () => {
     resource: "accesspoint:myendpoint",
   };
 
-  it("should build valid ARN object to string", () => {
-    expect(build(builderArn)).toBe("arn:aws:s3:us-east-1:123456789012:accesspoint:myendpoint");
+  const nonS3BuilderArn = {
+    service: "sns",
+    region: "us-east-1",
+    accountId: "123456789012",
+    resource: "myTopic",
+  };
+
+  it("should build valid S3 ARN object to string with omitted region and accountId", () => {
+    expect(build(builderArn)).toBe("arn:aws:s3:::accesspoint:myendpoint");
   });
 
-  ["service", "region", "accountId", "resource"].forEach((option) => {
-    it(`should throw if "${option}" is missing`, () => {
-      expect(() => build({ ...builderArn, [option]: undefined })).toThrow(new Error("Input ARN object is invalid"));
+  it("should build valid S3 bucket ARN", () => {
+    expect(
+      build({
+        service: "s3",
+        region: "us-east-1",
+        accountId: "123456789012",
+        resource: "a-bucket",
+      })
+    ).toBe("arn:aws:s3:::a-bucket");
+  });
+
+  it("should build valid S3 object ARN", () => {
+    expect(
+      build({
+        service: "s3",
+        region: "us-east-1",
+        accountId: "123456789012",
+        resource: "a-bucket/key-name",
+      })
+    ).toBe("arn:aws:s3:::a-bucket/key-name");
+  });
+
+  it("should build valid non-S3 ARN object to string", () => {
+    expect(build(nonS3BuilderArn)).toBe("arn:aws:sns:us-east-1:123456789012:myTopic");
+  });
+
+  it("should throw if service is missing", () => {
+    expect(() => build({ ...builderArn, service: undefined as any })).toThrow(new Error("Input ARN object is invalid"));
+  });
+
+  it("should throw if resource is missing", () => {
+    expect(() => build({ ...builderArn, resource: undefined as any })).toThrow(
+      new Error("Input ARN object is invalid")
+    );
+  });
+
+  ["region", "accountId"].forEach((option) => {
+    it(`should throw if "${option}" is missing for non-S3 services`, () => {
+      expect(() => build({ ...nonS3BuilderArn, [option]: undefined as any })).toThrow(
+        new Error("Input ARN object is invalid")
+      );
     });
+  });
+
+  it("should not throw if region is missing for S3 service", () => {
+    expect(() => build({ ...builderArn, region: undefined as any })).not.toThrow();
+  });
+
+  it("should not throw if accountId is missing for S3 service", () => {
+    expect(() => build({ ...builderArn, accountId: undefined as any })).not.toThrow();
   });
 });

--- a/packages/util-arn-parser/src/index.ts
+++ b/packages/util-arn-parser/src/index.ts
@@ -43,7 +43,15 @@ type buildOptions = Omit<ARN, "partition"> & { partition?: string };
  */
 export const build = (arnObject: buildOptions): string => {
   const { partition = "aws", service, region, accountId, resource } = arnObject;
-  if ([service, region, accountId, resource].some((segment) => typeof segment !== "string")) {
+  if ([service, resource].some((segment) => typeof segment !== "string")) {
+    throw new Error("Input ARN object is invalid");
+  }
+  // S3 ARNs omit region and account ID (https://docs.aws.amazon.com/quicksight/latest/APIReference/qs-arn-format.html)
+  if (service === "s3") {
+    return `arn:${partition}:${service}:::${resource}`;
+  }
+
+  if ([region, accountId].some((segment) => typeof segment !== "string")) {
     throw new Error("Input ARN object is invalid");
   }
   return `arn:${partition}:${service}:${region}:${accountId}:${resource}`;


### PR DESCRIPTION
### Issue
#7621 

### Description
Account for service (S3) specific arn format

### Testing
```console
 ✓ src/index.spec.ts (13 tests) 5ms
   ✓ validate > should validate whether input is a qualified resource ARN 1ms
   ✓ parser > should parse valid resource ARNs 1ms
   ✓ parser > should throw at invalid ARN strings 1ms
   ✓ builder > should build valid S3 ARN object to string with omitted region and accountId 0ms
   ✓ builder > should build valid S3 bucket ARN 0ms
   ✓ builder > should build valid S3 object ARN 0ms
   ✓ builder > should build valid non-S3 ARN object to string 0ms
   ✓ builder > should throw if service is missing 0ms
   ✓ builder > should throw if resource is missing 0ms
   ✓ builder > should throw if "region" is missing for non-S3 services 0ms
   ✓ builder > should throw if "accountId" is missing for non-S3 services 0ms
   ✓ builder > should not throw if region is missing for S3 service 0ms
   ✓ builder > should not throw if accountId is missing for S3 service 0ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
