### PR TITLE
chore(core): ensure package build order

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "3.957.0",
   "description": "Core functions & classes shared by multiple AWS SDK clients.",
   "scripts": {
-    "build": "yarn lint && concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build": "yarn lint && concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",
     "build:cjs": "node ../../scripts/compilation/inline core && rimraf ./dist-cjs/api-extractor-type-index.js",
     "build:es": "tsc -p tsconfig.es.json && rimraf ./dist-es/api-extractor-type-index.js",
     "build:include:deps": "yarn g:turbo run build -F=\"$npm_package_name\"",

--- a/packages/nested-clients/package.json
+++ b/packages/nested-clients/package.json
@@ -6,7 +6,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "scripts": {
-    "build": "yarn lint && concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build": "yarn lint && concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",
     "build:cjs": "node ../../scripts/compilation/inline nested-clients",
     "build:es": "tsc -p tsconfig.es.json",
     "build:include:deps": "yarn g:turbo run build -F=\"$npm_package_name\"",


### PR DESCRIPTION
### Issue
n/a

### Additional context
Some time ago the build order was changed from parallel types/es/cjs to types/es then cjs. This is to allow the cjs bundle to be built off the es artifact instead of the typescript source. 

The two submodule-containing packages didn't receive this change, though they happened to work because of the timings involved (building submodules takes longer for CJS so ES finished by that time anyway). 

This change ensures that the build order is correct and doesn't rely on a timing coincidence.

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

