### PR TITLE
test(core): reduce nesting depth of test structures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test-endpoints:
 
 test-e2e: bundles
 	yarn g:vitest run -c vitest.config.e2e.mts --retry=4 --test-timeout=60000
-	yarn g:vitest run -c vitest.config.browser.e2e.mts --retry=4
+	yarn g:vitest run -c vitest.config.browser.e2e.mts --retry=4 --test-timeout=60000
 	make test-bundlers
 
 test-bundlers:

--- a/packages/core/src/submodules/protocols/cbor/CborCodec.spec.ts
+++ b/packages/core/src/submodules/protocols/cbor/CborCodec.spec.ts
@@ -13,7 +13,7 @@ describe("performance baseline indicator", () => {
     const objects = [];
 
     // warmup
-    for (let i = 0; i < 13; ++i) {
+    for (let i = 0; i < 10; ++i) {
       const o = createNestingWidget(2 ** i);
       objects.push(o);
       serializer.write(nestingWidget, o);
@@ -46,7 +46,7 @@ describe("performance baseline indicator", () => {
     const strings = [];
 
     // warmup
-    for (let i = 0; i < 12; ++i) {
+    for (let i = 0; i < 10; ++i) {
       const o = createNestingWidget(2 ** i);
       serializer.write(nestingWidget, o);
       const json = serializer.flush();

--- a/packages/core/src/submodules/protocols/json/AwsJson1_1Protocol.spec.ts
+++ b/packages/core/src/submodules/protocols/json/AwsJson1_1Protocol.spec.ts
@@ -133,7 +133,7 @@ describe(AwsJson1_1Protocol, () => {
       const timings: string[] = [];
       const objects = [];
 
-      for (let i = 0; i < 12; ++i) {
+      for (let i = 0; i < 10; ++i) {
         const o = createNestingWidget(2 ** i);
         objects.push(o);
       }

--- a/packages/core/src/submodules/protocols/json/JsonShapeDeserializer.spec.ts
+++ b/packages/core/src/submodules/protocols/json/JsonShapeDeserializer.spec.ts
@@ -195,7 +195,7 @@ describe(JsonShapeDeserializer.name, () => {
       const strings = [];
 
       // warmup
-      for (let i = 0; i < 12; ++i) {
+      for (let i = 0; i < 10; ++i) {
         const o = createNestingWidget(2 ** i);
         serializer.write(nestingWidget, o);
         const json = serializer.flush();

--- a/packages/core/src/submodules/protocols/json/JsonShapeSerializer.spec.ts
+++ b/packages/core/src/submodules/protocols/json/JsonShapeSerializer.spec.ts
@@ -54,7 +54,7 @@ describe(JsonShapeSerializer.name, () => {
         const objects = [];
 
         // warmup
-        for (let i = 0; i < 12; ++i) {
+        for (let i = 0; i < 10; ++i) {
           const o = createNestingWidget(2 ** i);
           objects.push(o);
           serializer.write(nestingWidget, o);

--- a/packages/core/src/submodules/protocols/xml/XmlShapeDeserializer.spec.ts
+++ b/packages/core/src/submodules/protocols/xml/XmlShapeDeserializer.spec.ts
@@ -64,7 +64,7 @@ describe(XmlShapeDeserializer.name, () => {
       const strings = [];
 
       // warmup
-      for (let i = 0; i < 12; ++i) {
+      for (let i = 0; i < 10; ++i) {
         const o = createNestingWidget(2 ** i);
         serializer.write(nestingWidget, o);
         const json = serializer.flush();

--- a/packages/core/src/submodules/protocols/xml/XmlShapeSerializer.spec.ts
+++ b/packages/core/src/submodules/protocols/xml/XmlShapeSerializer.spec.ts
@@ -70,7 +70,7 @@ describe(XmlShapeSerializer.name, () => {
       const objects = [];
 
       // warmup
-      for (let i = 0; i < 13; ++i) {
+      for (let i = 0; i < 10; ++i) {
         const o = createNestingWidget(2 ** i);
         objects.push(o);
         serializer.write(nestingWidget, o);


### PR DESCRIPTION
### Issue
internal P364285277

### Description
reduce nesting depth of generated test objects as the high end can in rare cases cause a stack overflow

### Testing
ci

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [x] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?