### PR TITLE
chore(scripts): script to get changed package list

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lint:dependencies": "node scripts/runtime-dependency-version-check/check-dependencies.js",
     "lint:api": "node scripts/validation/api-snapshot-validation.js",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
+    "pkg:changed": "node ./scripts/update-versions/getChangedPackages.mjs",
     "test:all": "yarn build:all && jest --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions && yarn test:integration",
     "test:ci": "lerna run test --since origin/main",
     "test:e2e": "make test-e2e && node ./tests/canary/canary",

--- a/scripts/update-versions/getChangedPackages.mjs
+++ b/scripts/update-versions/getChangedPackages.mjs
@@ -1,0 +1,63 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { spawnProcessReturnValue } from "../utils/spawn-process.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const root = join(__dirname, "..", "..");
+
+const lernaList = await spawnProcessReturnValue(
+  "yarn",
+  [
+    "run",
+    "--silent",
+    "lerna",
+    "list",
+    "--toposort", //dependencies come before dependents
+    "--loglevel",
+    "silent",
+    "--json",
+  ],
+  {
+    cwd: root,
+  }
+);
+const allPackages = JSON.parse(lernaList);
+
+const getWorkspaceVersion = async () => {
+  const lernaJson = await readFile(join(root, "lerna.json"), {
+    encoding: "utf-8",
+  });
+  return JSON.parse(lernaJson).version;
+};
+
+const workspaceVersion = await getWorkspaceVersion();
+
+const changedPackages = allPackages
+  .filter((pkg) => pkg.version === workspaceVersion && pkg.private === false)
+  .map((pkg) => {
+    return {
+      ...pkg,
+      location: relative(root, pkg.location),
+    };
+  });
+
+/*
+[
+  {
+    "name": "@aws-sdk/ec2-metadata-service",
+    "version": "3.964.0",
+    "private": false,
+    "location": "packages/ec2-metadata-service"
+  },
+  {
+    "name": "@aws-sdk/rds-signer",
+    "version": "3.964.0",
+    "private": false,
+    "location": "packages/rds-signer"
+  }
+]
+ */
+console.log(JSON.stringify(changedPackages, null, 2));


### PR DESCRIPTION
### Issue
internal JS-6432

### Description
Added a script to the repository that outputs a json list of changed packages to be published on the next release.
This list is currently generated externally with build scripts.

Giving the repository control over this list makes it easier to change how the list is generated (currently with lerna). 

```
[
  {
    "name": "@aws-sdk/ec2-metadata-service",
    "version": "3.964.0",
    "private": false,
    "location": "packages/ec2-metadata-service"
  },
  {
    "name": "@aws-sdk/rds-signer",
    "version": "3.964.0",
    "private": false,
    "location": "packages/rds-signer"
  }
]
```

### Testing
ran the script, verified output

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
