### PR TITLE
test(core/protocols): add integration test for hostPrefix

### DIFF
--- a/packages/core/integ/disable-host-prefix.integ.spec.ts
+++ b/packages/core/integ/disable-host-prefix.integ.spec.ts
@@ -1,0 +1,37 @@
+import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
+import { Location } from "@aws-sdk/client-location";
+import { describe, test as it } from "vitest";
+
+describe("disableHostPrefix", () => {
+  const region = "us-west-2";
+
+  it("should have a host prefix", async () => {
+    const loc = new Location({
+      region,
+      credentials: {
+        accessKeyId: "INTEG",
+        secretAccessKey: "INTEG",
+      },
+      disableHostPrefix: false,
+    });
+    requireRequestsFrom(loc).toMatch({
+      hostname: `geofencing.geo.${region}.amazonaws.com`,
+    });
+    await loc.listGeofences();
+  });
+
+  it("should allow disabling host prefix", async () => {
+    const loc = new Location({
+      region,
+      credentials: {
+        accessKeyId: "INTEG",
+        secretAccessKey: "INTEG",
+      },
+      disableHostPrefix: true,
+    });
+    requireRequestsFrom(loc).toMatch({
+      hostname: `geo.${region}.amazonaws.com`,
+    });
+    await loc.listGeofences();
+  });
+});


### PR DESCRIPTION
### Issue
Adds test coverage for https://github.com/smithy-lang/smithy-typescript/pull/1833

### Description
Adds an integration test for `disableHostPrefix`, a configuration field that exists on all clients.

### Testing
New integration test

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
