### PR TITLE
chore: fix build versioning

### DIFF
--- a/scripts/update-versions/bumpReleaseCandidates.mjs
+++ b/scripts/update-versions/bumpReleaseCandidates.mjs
@@ -9,7 +9,7 @@
 import { independentPackagesConfig, linkedPackagesConfig, overwriteLerna, runLernaVersion } from "./lib/release.mjs";
 
 overwriteLerna(linkedPackagesConfig);
-await runLernaVersion();
+await runLernaVersion(true);
 
 overwriteLerna(independentPackagesConfig);
 await runLernaVersion();

--- a/scripts/update-versions/lib/release.mjs
+++ b/scripts/update-versions/lib/release.mjs
@@ -30,8 +30,8 @@ export const independentPackagesConfig = {
 /**
  * Execute `lerna version`.
  */
-export const runLernaVersion = async () =>
-  spawnProcess("yarn", [
+export const runLernaVersion = async (useNewLinkedVersion = false) => {
+  await spawnProcess("yarn", [
     "lerna",
     "version",
     "--exact",
@@ -41,6 +41,10 @@ export const runLernaVersion = async () =>
     "--no-commit-hooks",
     "--yes",
   ]);
+  if (useNewLinkedVersion) {
+    lernaConfig.version = await getWorkspaceVersion();
+  }
+};
 
 /**
  * Returns the output of `lerna list`.


### PR DESCRIPTION
### Issue
P367504818

### Description
The new release script missed updating the workspace lerna.json version prior to committing the versioning changes.

### Testing
Ran `yarn lerna:version` locally.

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?