### PR TITLE
chore(ci): remove deprecated --es-module-specifier-resolution=node

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:packages": "node ./scripts/turbo build -F=./packages/*",
     "build:protocols": "node ./scripts/turbo build -F=./private/aws-protocoltests-*",
     "build:server-protocols": "node ./scripts/turbo build -F=./private/*-server",
-    "build:types:downlevel": "node --es-module-specifier-resolution=node ./scripts/downlevel-dts",
+    "build:types:downlevel": "node ./scripts/downlevel-dts/index.mjs",
     "clean": "yarn clear-build-cache && yarn clear-build-info && lerna clean",
     "clear-build-docs": "rimraf ./clients/*/docs/ ./dist/docs/clients/*/docs/ ./clientDocs",
     "clear-build-cache": "rimraf ./packages/*/dist-* ./clients/*/dist-* ./lib/*/dist-* ./private/*/dist-*",
@@ -52,8 +52,8 @@
     "test:size": "node ./tests/bundlers/runner/run.mjs",
     "test:unit": "make test-unit",
     "test:versions": "jest --config tests/versions/jest.config.js tests/versions/index.spec.ts",
-    "update:versions:default": "node --es-module-specifier-resolution=node ./scripts/update-versions/default.mjs",
-    "update:versions:current": "node --es-module-specifier-resolution=node ./scripts/update-versions/current.mjs"
+    "update:versions:default": "node ./scripts/update-versions/default.mjs",
+    "update:versions:current": "node ./scripts/update-versions/current.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/downlevel-dts/index.mjs
+++ b/scripts/downlevel-dts/index.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import parallelLimit from "async/parallelLimit";
+import parallelLimit from "async/parallelLimit.js";
 import { cpus } from "os";
 import yargs from "yargs";
 


### PR DESCRIPTION
### Issue
* Internal JS-6457
* `es-module-specifier-resolution=node` was removed in node 19 https://github.com/nodejs/node/issues/45108

### Description
Removes deprecated --es-module-specifier-resolution=node

### Testing

#### Before

Error thrown for `yarn build:types:downlevel` in node 20.

```console
$ node -v
v20.19.0

$ yarn build:types:downlevel
node:internal/modules/cjs/loader:1215
  throw err;
  ^

Error: Cannot find module '/local/home/trivikr/workspace/aws-sdk-js-v3/scripts/downlevel-dts'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1212:15)
    at Module._load (node:internal/modules/cjs/loader:1043:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:164:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.19.0
```

#### After

No error thrown for `yarn build:types:downlevel` in node 20.

```console
$ node -v
v20.19.0

$ yarn build:types:downlevel
```

Also verified that other commands work in node 20:

- `yarn update:versions:default`
- `yarn update:versions:current`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
