### PR TITLE
chore(util-locate-window): undo unpublished version increment

### DIFF
--- a/packages-internal/util-locate-window/package.json
+++ b/packages-internal/util-locate-window/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-sdk/util-locate-window",
-  "version": "3.965.1",
+  "version": "3.965.0",
   "scripts": {
     "build": "concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",
     "build:cjs": "node ../../scripts/compilation/inline util-locate-window",


### PR DESCRIPTION
### Issue
P367664067

### Description
The 3.965.1 increment was made by the free-range versioning system that is still WIP. It was not published, so it could be removed.
