### PR TITLE
fix(util-user-agent): remove legacy label for pre-SRA retries

### DIFF
--- a/packages/middleware-user-agent/src/check-features-repro.spec.ts
+++ b/packages/middleware-user-agent/src/check-features-repro.spec.ts
@@ -1,0 +1,56 @@
+import { AwsHandlerExecutionContext } from "@aws-sdk/types";
+import { describe, expect, test as it, vi } from "vitest";
+
+import { checkFeatures } from "./check-features";
+
+describe("checkFeatures reproduction for pre-SRA retries", () => {
+  it("should return 'E' (RETRY_MODE_STANDARD) for pre-SRA standard retry", async () => {
+    const config = {
+      retryStrategy: async () =>
+        ({
+          // Mocking a pre-SRA retry strategy (no acquireInitialRetryToken)
+          retry: vi.fn(),
+        } as any),
+    };
+
+    const context = {
+      __aws_sdk_context: { features: {} },
+    } as AwsHandlerExecutionContext;
+
+    await checkFeatures(context, config, {
+      request: undefined,
+      input: undefined,
+    });
+
+    // Should return "E" (Standard), NOT "D" (Legacy)
+    expect(context.__aws_sdk_context?.features?.RETRY_MODE_STANDARD).toBe("E");
+    expect(context.__aws_sdk_context?.features?.RETRY_MODE_LEGACY).toBeUndefined();
+  });
+
+  it("should return 'F' (RETRY_MODE_ADAPTIVE) for pre-SRA adaptive retry", async () => {
+    const adaptiveMock = {
+      retry: vi.fn(),
+    };
+    // Force the constructor name to identify as Adaptive
+    Object.defineProperty(adaptiveMock, "constructor", {
+      value: { name: "AdaptiveRetryStrategy" },
+    });
+
+    const config = {
+      retryStrategy: async () => adaptiveMock as any,
+    };
+
+    const context = {
+      __aws_sdk_context: { features: {} },
+    } as AwsHandlerExecutionContext;
+
+    await checkFeatures(context, config, {
+      request: undefined,
+      input: undefined,
+    });
+
+    // Should return "F" (Adaptive), NOT "D" (Legacy)
+    expect(context.__aws_sdk_context?.features?.RETRY_MODE_ADAPTIVE).toBe("F");
+    expect(context.__aws_sdk_context?.features?.RETRY_MODE_LEGACY).toBeUndefined();
+  });
+});

--- a/packages/middleware-user-agent/src/check-features.ts
+++ b/packages/middleware-user-agent/src/check-features.ts
@@ -53,7 +53,11 @@ export async function checkFeatures(
         setFeature(context, "RETRY_MODE_STANDARD", "E");
       }
     } else {
-      setFeature(context, "RETRY_MODE_LEGACY", "D");
+      if (retryStrategy.constructor?.name?.includes("Adaptive")) {
+        setFeature(context, "RETRY_MODE_ADAPTIVE", "F");
+      } else {
+        setFeature(context, "RETRY_MODE_STANDARD", "E");
+      }
     }
   }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where pre-SRA (standard and adaptive) retry modes were incorrectly attributed as "Legacy" (feature ID `D`) in the User-Agent header.

With this change, pre-SRA retry modes are correctly identified:
- Standard Mode: `E`
- Adaptive Mode: `F`

And the Legacy `D` tag is removed when these modes are active.

## Issue links

Fixes #7574

## Testing

Added a new test file `packages/middleware-user-agent/src/check-features-repro.spec.ts` to verify that:
1. `standard` retry mode without SRA produces feature `E` and not `D`.
2. `adaptive` retry mode without SRA produces feature `F` and not `D`.