### PR TITLE
test(client-sqs): validate request/response content-type in a queue

### DIFF
--- a/clients/client-sqs/test/SQS.e2e.spec.ts
+++ b/clients/client-sqs/test/SQS.e2e.spec.ts
@@ -1,30 +1,27 @@
 import { SQS } from "@aws-sdk/client-sqs";
 import { AwsJson1_0Protocol, AwsQueryProtocol } from "@aws-sdk/core";
-import { getHttpDebugLogPlugin } from "@aws-sdk/middleware-http-debug-log";
+import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { describe, expect, test as it } from "vitest";
 
-describe(
-  SQS.name,
-  () => {
-    const sqs = {
-      query: new SQS({
-        region: "us-west-2",
-        protocol: AwsQueryProtocol,
-      }),
-      json: new SQS({
-        region: "us-west-2",
-        protocol: AwsJson1_0Protocol,
-      }),
-    };
-
-    for (const client of Object.values(sqs)) {
-      client.middlewareStack.use(getHttpDebugLogPlugin("line headers body formatted"));
-
-      it(`can make requests with ${client.config.protocol.constructor.name}`, async () => {
-        const queues = await client.listQueues();
-        expect(queues.QueueUrls ?? []).toBeInstanceOf(Array);
-      });
+describe(SQS.name, () => {
+  it.each([
+    { output: "text/xml", input: "application/x-www-form-urlencoded", protocol: AwsQueryProtocol },
+    { output: "application/x-amz-json-1.0", input: "application/x-amz-json-1.0", protocol: AwsJson1_0Protocol },
+  ])(
+    "gets response with content-type=$output when request is content-type=$input with protocol $protocol.name",
+    async ({ input, output, protocol }) => {
+      const client = new SQS({ region: "us-west-2", protocol });
+      client.middlewareStack.add(
+        (next) => async (args: any) => {
+          expect((args.request as HttpRequest).headers["content-type"]).toBe(input);
+          const response = await next(args);
+          expect((response.response as HttpResponse).headers["content-type"]).toBe(output);
+          return response;
+        },
+        { step: "build" }
+      );
+      await client.listQueues({ MaxResults: 1 });
+      expect.assertions(2);
     }
-  },
-  60_000
-);
+  );
+});

--- a/clients/client-sqs/test/SQS.e2e.spec.ts
+++ b/clients/client-sqs/test/SQS.e2e.spec.ts
@@ -1,42 +1,39 @@
 import { SQS } from "@aws-sdk/client-sqs";
 import { AwsJson1_0Protocol, AwsQueryProtocol } from "@aws-sdk/core";
 import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
-import { beforeAll, afterAll, describe, expect, test as it } from "vitest";
+import { afterAll, describe, expect, test as it } from "vitest";
 
 describe(SQS.name, () => {
-  const region = "us-west-2";
-  const client = new SQS({ region });
-  const QueueName = `aws-sdk-js-${crypto.randomUUID()}`;
-  let QueueUrl: string;
-
-  beforeAll(async () => {
-    const response = await client.createQueue({ QueueName });
-    QueueUrl = response.QueueUrl!;
-  });
-
-  it.each([
+  describe.each([
     { output: "text/xml", input: "application/x-www-form-urlencoded", protocol: AwsQueryProtocol },
     { output: "application/x-amz-json-1.0", input: "application/x-amz-json-1.0", protocol: AwsJson1_0Protocol },
   ])(
     "gets response with content-type=$output when request is content-type=$input with protocol $protocol.name",
-    async ({ input, output, protocol }) => {
-      const client = new SQS({ region, protocol });
-      client.middlewareStack.add(
-        (next) => async (args: any) => {
-          expect((args.request as HttpRequest).headers["content-type"]).toBe(input);
-          const response = await next(args);
-          expect((response.response as HttpResponse).headers["content-type"]).toBe(output);
-          return response;
-        },
-        { step: "build" }
-      );
-      const response = await client.getQueueUrl({ QueueName });
-      expect(response.QueueUrl).toEqual(QueueUrl);
-      expect.assertions(3);
+    ({ input, output, protocol }) => {
+      const client = new SQS({ region: "us-west-2", protocol });
+      let QueueUrl: string;
+
+      it("run createQueue", async () => {
+        client.middlewareStack.add(
+          (next) => async (args: any) => {
+            expect((args.request as HttpRequest).headers["content-type"]).toBe(input);
+            const response = await next(args);
+            expect((response.response as HttpResponse).headers["content-type"]).toBe(output);
+            return response;
+          },
+          { step: "build" }
+        );
+        const response = await client.createQueue({ QueueName: `aws-sdk-js-${crypto.randomUUID()}` });
+        QueueUrl = response.QueueUrl!;
+        expect(typeof QueueUrl).toBe("string");
+        expect.assertions(3);
+      });
+
+      afterAll(async () => {
+        await client.deleteQueue({ QueueUrl }).catch(() => {
+          // Ignore errors during cleanup (e.g. if queue creation fails)
+        });
+      });
     }
   );
-
-  afterAll(async () => {
-    await client.deleteQueue({ QueueUrl });
-  });
 });

--- a/clients/client-sqs/test/SQS.e2e.spec.ts
+++ b/clients/client-sqs/test/SQS.e2e.spec.ts
@@ -1,16 +1,26 @@
 import { SQS } from "@aws-sdk/client-sqs";
 import { AwsJson1_0Protocol, AwsQueryProtocol } from "@aws-sdk/core";
 import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
-import { describe, expect, test as it } from "vitest";
+import { beforeAll, afterAll, describe, expect, test as it } from "vitest";
 
 describe(SQS.name, () => {
+  const region = "us-west-2";
+  const client = new SQS({ region });
+  const QueueName = `aws-sdk-js-${crypto.randomUUID()}`;
+  let QueueUrl: string;
+
+  beforeAll(async () => {
+    const response = await client.createQueue({ QueueName });
+    QueueUrl = response.QueueUrl!;
+  });
+
   it.each([
     { output: "text/xml", input: "application/x-www-form-urlencoded", protocol: AwsQueryProtocol },
     { output: "application/x-amz-json-1.0", input: "application/x-amz-json-1.0", protocol: AwsJson1_0Protocol },
   ])(
     "gets response with content-type=$output when request is content-type=$input with protocol $protocol.name",
     async ({ input, output, protocol }) => {
-      const client = new SQS({ region: "us-west-2", protocol });
+      const client = new SQS({ region, protocol });
       client.middlewareStack.add(
         (next) => async (args: any) => {
           expect((args.request as HttpRequest).headers["content-type"]).toBe(input);
@@ -20,9 +30,13 @@ describe(SQS.name, () => {
         },
         { step: "build" }
       );
-      const response = await client.listQueues({ MaxResults: 1 });
-      expect(response.$metadata.httpStatusCode).toEqual(200);
+      const response = await client.getQueueUrl({ QueueName });
+      expect(response.QueueUrl).toEqual(QueueUrl);
       expect.assertions(3);
     }
   );
+
+  afterAll(async () => {
+    await client.deleteQueue({ QueueUrl });
+  });
 });

--- a/clients/client-sqs/test/SQS.e2e.spec.ts
+++ b/clients/client-sqs/test/SQS.e2e.spec.ts
@@ -20,8 +20,9 @@ describe(SQS.name, () => {
         },
         { step: "build" }
       );
-      await client.listQueues({ MaxResults: 1 });
-      expect.assertions(2);
+      const response = await client.listQueues({ MaxResults: 1 });
+      expect(response.$metadata.httpStatusCode).toEqual(200);
+      expect.assertions(3);
     }
   );
 });


### PR DESCRIPTION
### Issue
* Noticed while examining e2e test output in JS-6477
* Alternative to https://github.com/aws/aws-sdk-js-v3/pull/7656

### Description
Validates request/response content-type in a queue.

### Testing

#### Before

Prints lot of debug statements, and doesn't check for content-type used by protocol.

```console
$ client-sqs> yarn test:e2e test/SQS.e2e.spec.ts

 RUN  v3.2.4 /local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-sqs

stdout | test/SQS.e2e.spec.ts > SQS > can make requests with AwsQueryProtocol
200 POST SQSClient ListQueuesCommand
    https://sqs.us-west-2.amazonaws.com/
    >>== Request Headers: {
      "content-type": "application/x-www-form-urlencoded",
      "content-length": "36",
      "x-amz-user-agent": "aws-sdk-js/3.968.0",
      "user-agent": "aws-sdk-js/3.968.0 ua/2.1 os/linux#5.10.247-246.989.amzn2int.x86_64 lang/js md/nodejs#20.19.0 api/sqs#3.968.0 m/E,w,v",
...
 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  02:36:01
   Duration  599ms (transform 100ms, setup 0ms, collect 174ms, tests 169ms, environment 0ms, prepare 91ms)
```

#### After

Doesn't print debug statements, and checks for content-type used by protocol.
Also creates a

```console
$ client-sqs> yarn test:e2e test/SQS.e2e.spec.ts
...
 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  04:10:07
   Duration  753ms (transform 99ms, setup 0ms, collect 167ms, tests 319ms, environment 0ms, prepare 81ms)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
