### PR TITLE
fix(core/protocols): custom behavior for __type in structure

### DIFF
--- a/packages/core/src/submodules/protocols/json/JsonShapeDeserializer.spec.ts
+++ b/packages/core/src/submodules/protocols/json/JsonShapeDeserializer.spec.ts
@@ -179,6 +179,27 @@ describe(JsonShapeDeserializer.name, () => {
     }
   });
 
+  it("deserializes extra document members when encountering __type", async () => {
+    expect(
+      await deserializer.read(
+        nestingWidget,
+        JSON.stringify({
+          blob: "AAAA",
+          nested: {
+            __type: "ns#Other",
+            __field__: "xyz",
+          },
+        })
+      )
+    ).toEqual({
+      blob: new Uint8Array([0, 0, 0]),
+      nested: {
+        __field__: "xyz",
+        __type: "ns#Other",
+      },
+    });
+  });
+
   describe("performance baseline indicator", () => {
     const serializer = new JsonShapeSerializer({
       jsonName: true,

--- a/packages/core/src/submodules/protocols/json/JsonShapeSerializer.spec.ts
+++ b/packages/core/src/submodules/protocols/json/JsonShapeSerializer.spec.ts
@@ -31,6 +31,17 @@ describe(JsonShapeSerializer.name, () => {
     );
   });
 
+  it("serializes extra document members when encountering __type", async () => {
+    const data = {
+      __type: "ns#PlateOfFood",
+      pasta: "Macaroni",
+      cheese: "cheddar",
+    };
+    serializer1.write(widget, data);
+    const serialization = serializer1.flush();
+    expect(serialization).toEqual(`{"__type":"ns#PlateOfFood","pasta":"Macaroni","cheese":"cheddar"}`);
+  });
+
   it("serializes $unknown union members", () => {
     serializer1.write(unionStruct, {
       union: {

--- a/packages/core/src/submodules/protocols/schema-testing/schema-documents.spec.ts
+++ b/packages/core/src/submodules/protocols/schema-testing/schema-documents.spec.ts
@@ -145,6 +145,7 @@ describe("schema conversion tests for serializations, data objects, and document
 
       // 2. data object document back to data object
       const dataObjectFromDocument = await deserializer.readObject(subjectSchema, documentFromDataObject);
+      delete dataObjectFromDocument.__type;
       expect(dataObjectFromDocument).toEqual(canonicalDataObject);
 
       // 3. data object from serialization document


### PR DESCRIPTION
### Issue
V2073227955

### Description
Treats unknown keys as Document types if a structure input or output contains __type. 

### Testing
new unit tests and CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [x] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?