### PR TITLE
chore(scripts): override smithy partitions

### DIFF
--- a/scripts/utils/spawn-process.js
+++ b/scripts/utils/spawn-process.js
@@ -1,7 +1,34 @@
 // @ts-check
 const { spawn } = require("node:child_process");
+const { join } = require("node:path");
 
 const spawnProcess = async (command, args = [], options = {}) => {
+  // set AWS_PARTITIONS_FILE_OVERRIDE for gradle commands to ensure
+  // Smithy uses the SDK's up-to-date partitions.json instead of its bundled version.
+  if (command === "./gradlew") {
+    const hasPartitionsOverride = options.env && options.env.AWS_PARTITIONS_FILE_OVERRIDE;
+    if (!hasPartitionsOverride) {
+      options = {
+        ...options,
+        env: {
+          ...process.env,
+          ...(options.env || {}),
+          AWS_PARTITIONS_FILE_OVERRIDE: join(
+            __dirname,
+            "..",
+            "..",
+            "packages-internal",
+            "util-endpoints",
+            "src",
+            "lib",
+            "aws",
+            "partitions.json"
+          ),
+        },
+      };
+    }
+  }
+
   const childProcess = spawn(command, args, options);
 
   childProcess.stdout?.pipe(process.stdout);


### PR DESCRIPTION
### Issue
Internal JS-6400

### Description
Env override for partitions, to use the copy that exists in the SDK and is updated by awstools instead of the partitions that come bundled with smithy.

### Testing
clients are generated successfully

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
