### PR TITLE
chore(ci): use repo-specific IAM role for PR builds

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -8,7 +8,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IAM_ROLE_ARN: 'arn:aws:iam::088667348242:role/AwsSdkJsV3GitHubRole'
   DOWNLOAD_FOLDER: '.build-scripts/'
   SCRIPT_LOCATION: 'workflows/start-pull-request-build/pull-request-build-v1.sh'
 
@@ -25,7 +24,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.IAM_ROLE_ARN }}
+          role-to-assume: ${{secrets.PR_WORKFLOW_IAM_ROLE_ARN}}
           role-session-name: PullRequestBuildGitHubAction
           aws-region: us-west-2
           role-duration-seconds: 7200


### PR DESCRIPTION
### Issue
Internal JS-6097

### Description
Replace hardcoded IAM role ARN with GitHub secret to support repo-specific IAM roles for PR builds.

### Testing
CI

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
