### PR TITLE
fix(credential-provider-node): open credential provider lock after failed chain

### DIFF
--- a/packages-internal/credential-provider-node/src/runtime/memoize-chain.ts
+++ b/packages-internal/credential-provider-node/src/runtime/memoize-chain.ts
@@ -44,16 +44,22 @@ export function memoizeChain(
     } else if (!credentials || treatAsExpired?.(credentials!)) {
       if (credentials) {
         if (!passiveLock) {
-          passiveLock = chain(options).then((c) => {
-            credentials = c;
-            passiveLock = undefined;
-          });
+          passiveLock = chain(options)
+            .then((c) => {
+              credentials = c;
+            })
+            .finally(() => {
+              passiveLock = undefined;
+            });
         }
       } else {
-        activeLock = chain(options).then((c) => {
-          credentials = c;
-          activeLock = undefined;
-        });
+        activeLock = chain(options)
+          .then((c) => {
+            credentials = c;
+          })
+          .finally(() => {
+            activeLock = undefined;
+          });
         return provider(options);
       }
     }


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7690

### Description
This allows the credential provider functions returned by `fromNodeProviderChain()` to reattempt credential resolution if failing to do so.

### Testing
new unit test

### Checklist
- [n/a] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?