### PR TITLE
fix(deps): bump fast-xml-parser from 5.2.5 to 5.3.4

### DIFF
--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -4,7 +4,7 @@
   "description": "XML builder for the AWS SDK",
   "dependencies": {
     "@smithy/types": "^4.12.0",
-    "fast-xml-parser": "5.2.5",
+    "fast-xml-parser": "5.3.4",
     "tslib": "^2.6.2"
   },
   "scripts": {

--- a/private/aws-protocoltests-restxml-schema/package.json
+++ b/private/aws-protocoltests-restxml-schema/package.json
@@ -60,7 +60,7 @@
     "@smithy/util-stream": "^4.5.10",
     "@smithy/util-utf8": "^4.2.0",
     "entities": "2.2.0",
-    "fast-xml-parser": "5.2.5",
+    "fast-xml-parser": "5.3.4",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -62,7 +62,7 @@
     "@smithy/util-utf8": "^4.2.0",
     "@smithy/uuid": "^1.1.0",
     "entities": "2.2.0",
-    "fast-xml-parser": "5.2.5",
+    "fast-xml-parser": "5.3.4",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,7 +1168,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:5.2.5"
+    fast-xml-parser: "npm:5.3.4"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -1228,7 +1228,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:5.2.5"
+    fast-xml-parser: "npm:5.3.4"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -24912,7 +24912,7 @@ __metadata:
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
-    fast-xml-parser: "npm:5.2.5"
+    fast-xml-parser: "npm:5.3.4"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -33901,14 +33901,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.2.5":
-  version: 5.2.5
-  resolution: "fast-xml-parser@npm:5.2.5"
+"fast-xml-parser@npm:5.3.4":
+  version: 5.3.4
+  resolution: "fast-xml-parser@npm:5.3.4"
   dependencies:
     strnum: "npm:^2.1.0"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/d1057d2e790c327ccfc42b872b91786a4912a152d44f9507bf053f800102dfb07ece3da0a86b33ff6a0caa5a5cad86da3326744f6ae5efb0c6c571d754fe48cd
+  checksum: 10c0/d77866ca860ad185153e12f6ba12274d32026319ad8064e4681342b8a8e1ffad3f1f98daf04d77239fb12eb1d906ee7185fd328deda74529680e8dae0f3e9327
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR updates `fast-xml-parser` from 5.2.5 to 5.3.4 to fix **CVE-2026-25128** (High Severity).

### Vulnerability Details
- **CVE**: CVE-2026-25128
- **Advisory**: https://github.com/advisories/GHSA-37qj-frw5-hhjh
- **Severity**: High
- **Issue**: RangeError DoS Numeric Entities Bug
- **Affected versions**: 4.3.6 - 5.3.3
- **Fixed in**: 5.3.4

### Changes
Updates `fast-xml-parser` to 5.3.4 in all packages that depend on it:
- `packages-internal/xml-builder`
- `private/aws-protocoltests-restxml`
- `private/aws-protocoltests-restxml-schema`

### Note
The existing Dependabot PRs (#7695, #7696, #7697, #7698) fail CI because they only update individual package.json files without updating yarn.lock. This PR includes the yarn.lock update and updates all affected packages to maintain version consistency across the monorepo.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.