### PR TITLE
fix(eventstream-handler-node): fix uncatchable error in stream pipeline

### DIFF
--- a/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.spec.ts
+++ b/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.spec.ts
@@ -238,7 +238,6 @@ describe(EventStreamPayloadHandler.name, () => {
       return Promise.resolve({ output: {} });
     });
 
-    // Expect the pipeline error to be caught and wrapped
     try {
       await handler.handle(mockNextHandler, {
         request: mockRequest,

--- a/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.ts
+++ b/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.ts
@@ -74,14 +74,16 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
       systemClockOffsetProvider: this.systemClockOffsetProvider,
     });
 
-    // this promise is used in a race against the http layer's response below
+    // this promise rejects on pipeline error, resolves after http layer completes
+    // this is used in a race against the http layer's response below
+    let resolvePipeline: () => void;
     const pipelineError = new Promise<FinalizeHandlerOutput<any>>((resolve, reject) => {
+      resolvePipeline = () => resolve(undefined as any);
       pipeline(payloadStream, signingStream, request.body, (err: NodeJS.ErrnoException | null) => {
         if (err) {
           reject(new Error(`Pipeline error in @aws-sdk/eventstream-handler-node: ${err.message}`, { cause: err }));
-        } else {
-          resolve(undefined as any); // won't win race, but prevents GC issues
         }
+        // it resolves after next(args) completes
       });
     });
 
@@ -95,6 +97,9 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
       // because of the previous connection.
       request.body.end();
       throw e;
+    } finally {
+      // for stream pipeline promise
+      resolvePipeline!();
     }
 
     return result;


### PR DESCRIPTION
### Issue
#7496 
https://github.com/aws/aws-sdk-js-v3/issues/7706

### Description
fixes issue where `ERR_STREAM_PREMATURE_CLOSE` and other pipeline errors in `@aws-sdk/eventstream-handler-node` would crash the Node.js process when connections closed prematurely (e.g., expired credentials). Changed pipeline callback to reject a Promise instead of throwing, making errors catchable via `Promise.race`. 

### Testing
Unit test case added
```console
 ✓ src/EventSigningStream.spec.ts (1 test) 6ms
 ✓ src/EventStreamPayloadHandler.spec.ts (7 tests) 26ms

 Test Files  2 passed (2)
      Tests  8 passed (8)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
