### PR TITLE
fix(middleware-websocket): establish stream pipeline prior to continuing with request

### DIFF
--- a/lib/lib-storage/src/chunks/getDataReadableStream.spec.ts
+++ b/lib/lib-storage/src/chunks/getDataReadableStream.spec.ts
@@ -1,6 +1,4 @@
 import { describe, expect, test as it } from "vitest";
-// polyfill exposes the same ReadableStream API as web, allowing easy testing
-import { ReadableStream } from "web-streams-polyfill";
 
 import { byteLength } from "../byteLength";
 import { RawDataPart as DataPart } from "../Upload";

--- a/packages-internal/middleware-websocket/package.json
+++ b/packages-internal/middleware-websocket/package.json
@@ -42,8 +42,7 @@
     "mock-socket": "9.1.5",
     "premove": "4.0.0",
     "typescript": "~5.8.3",
-    "vitest-websocket-mock": "0.2.3",
-    "web-streams-polyfill": "3.2.1"
+    "vitest-websocket-mock": "0.2.3"
   },
   "engines": {
     "node": ">= 14.0.0"

--- a/packages-internal/middleware-websocket/src/EventStreamPayloadHandler.spec.ts
+++ b/packages-internal/middleware-websocket/src/EventStreamPayloadHandler.spec.ts
@@ -1,7 +1,6 @@
 import { EventStreamCodec } from "@smithy/eventstream-codec";
 import { Decoder, Encoder, FinalizeHandler, FinalizeHandlerArguments, HttpRequest, MessageSigner } from "@smithy/types";
 import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
-import { ReadableStream, TransformStream } from "web-streams-polyfill";
 
 import { EventStreamPayloadHandler } from "./EventStreamPayloadHandler";
 import { getEventSigningTransformStream } from "./get-event-signing-stream";
@@ -129,6 +128,51 @@ describe(EventStreamPayloadHandler.name, () => {
     );
   });
 
+  it("should start piping regardless of whether the downstream resolves", async () => {
+    const authorization =
+      "AWS4-HMAC-SHA256 Credential=AKID/20200510/us-west-2/foo/aws4_request, SignedHeaders=host, Signature=1234567890";
+    const originalPayload = new TransformStream();
+    const mockRequest = {
+      body: originalPayload.readable,
+      headers: { authorization },
+    } as any;
+    const handler = new EventStreamPayloadHandler({
+      messageSigner: () => Promise.resolve(mockSigner),
+      utf8Decoder: mockUtf8Decoder,
+      utf8Encoder: mockUtf8encoder,
+    });
+
+    const sourceStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(Buffer.from("Some Data"));
+        controller.close();
+      },
+    });
+    sourceStream.pipeThrough(originalPayload);
+
+    (mockNextHandler as any).mockImplementationOnce(async (args: FinalizeHandlerArguments<any>) => {
+      const handledRequest = args.request as HttpRequest;
+
+      const reader = handledRequest.body.getReader();
+      const { value } = await reader.read();
+      const collected = Buffer.from(value).toString("utf8");
+
+      // this means the stream is flowing without this downstream middleware
+      // having resolved yet.
+      expect(collected).toEqual("Some Data");
+
+      return Promise.resolve({ output: { handledRequest } });
+    });
+
+    const {
+      output: { handledRequest },
+    } = await handler.handle(mockNextHandler, {
+      request: mockRequest,
+      input: {},
+    });
+    expect(handledRequest.body).not.toBe(originalPayload);
+  });
+
   it("should start piping to request payload through event signer if downstream middleware returns", async () => {
     const authorization =
       "AWS4-HMAC-SHA256 Credential=AKID/20200510/us-west-2/foo/aws4_request, SignedHeaders=host, Signature=1234567890";
@@ -178,5 +222,81 @@ describe(EventStreamPayloadHandler.name, () => {
 
     const collectedData = Buffer.concat(chunks).toString("utf8");
     expect(collectedData).toEqual("Some Data");
+  });
+
+  /**
+   * This test doesn't test our code. It is a reminder of how web streams work.
+   */
+  it("cancelling the readable side of a TransformStream propagates through its pipeline", async () => {
+    const transform1 = new TransformStream();
+    const transform2 = new TransformStream();
+
+    const source = new ReadableStream({
+      async start(controller) {
+        controller.enqueue(Buffer.from("Some Data"));
+        controller.enqueue(Buffer.from("Some More Data"));
+        controller.close();
+      },
+    });
+
+    source.pipeThrough(transform1).pipeThrough(transform2);
+
+    const read: Uint8Array[] = [];
+
+    const reader = transform2.readable.getReader();
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      read.push(value);
+      await reader.cancel();
+    }
+
+    expect(read).toEqual([Buffer.from("Some Data")]);
+  });
+
+  it("if the handler's downstream throws, the stream's cancel method is called", async () => {
+    const authorization =
+      "AWS4-HMAC-SHA256 Credential=AKID/20200510/us-west-2/foo/aws4_request, SignedHeaders=host, Signature=1234567890";
+
+    const sourceStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(Buffer.from("Some data"));
+        controller.enqueue(Buffer.from("Some more data"));
+        controller.close();
+      },
+    });
+    sourceStream.cancel = vi.fn();
+
+    const mockRequest = {
+      body: sourceStream,
+      headers: { authorization },
+    } as any;
+
+    const handler = new EventStreamPayloadHandler({
+      messageSigner: () => Promise.resolve(mockSigner),
+      utf8Decoder: mockUtf8Decoder,
+      utf8Encoder: mockUtf8encoder,
+    });
+
+    (mockNextHandler as any).mockImplementationOnce(() => {
+      return Promise.reject(new Error("test error"));
+    });
+
+    let err: any;
+    try {
+      await handler.handle(mockNextHandler, {
+        request: mockRequest,
+        input: {},
+      });
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err.message).toEqual("test error");
+    expect(sourceStream.locked).toBe(true);
+    expect(sourceStream.cancel).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages-internal/middleware-websocket/src/eventstream-payload-handler-provider.ts
+++ b/packages-internal/middleware-websocket/src/eventstream-payload-handler-provider.ts
@@ -2,7 +2,9 @@ import { Decoder, Encoder, EventStreamPayloadHandlerProvider, MessageSigner, Pro
 
 import { EventStreamPayloadHandler } from "./EventStreamPayloadHandler";
 
-/** NodeJS event stream utils provider */
+/**
+ * @internal
+ */
 export const eventStreamPayloadHandlerProvider: EventStreamPayloadHandlerProvider = (options: {
   utf8Encoder: Encoder;
   utf8Decoder: Decoder;

--- a/packages-internal/middleware-websocket/src/get-event-signing-stream.spec.ts
+++ b/packages-internal/middleware-websocket/src/get-event-signing-stream.spec.ts
@@ -2,7 +2,6 @@ import { EventStreamCodec } from "@smithy/eventstream-codec";
 import { Message, MessageHeaders, SignedMessage } from "@smithy/types";
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
 import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
-import { TransformStream } from "web-streams-polyfill";
 
 import { getEventSigningTransformStream } from "./get-event-signing-stream";
 

--- a/packages-internal/middleware-websocket/src/websocket-fetch-handler.ts
+++ b/packages-internal/middleware-websocket/src/websocket-fetch-handler.ts
@@ -202,8 +202,12 @@ export class WebSocketFetchHandler {
 
     const send = async (): Promise<void> => {
       try {
-        for await (const inputChunk of data) {
-          socket.send(inputChunk);
+        for await (const chunk of data) {
+          if (socket.readyState >= WebSocket.CLOSING) {
+            break;
+          } else {
+            socket.send(chunk);
+          }
         }
       } catch (err) {
         // We don't throw the error here because the send()'s returned

--- a/yarn.lock
+++ b/yarn.lock
@@ -24318,7 +24318,6 @@ __metadata:
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
     vitest-websocket-mock: "npm:0.2.3"
-    web-streams-polyfill: "npm:3.2.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Issue
internal P374793336

### Description
This mirrors the change from https://github.com/aws/aws-sdk-js-v3/pull/6311, in which the event stream payload handler should establish the request stream pipeline without waiting for the request to resolve.

### Testing
added unit tests


