### PR TITLE
chore(dynamodb-codec): remove peer dependency on client

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -38,7 +38,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@aws-sdk/client-dynamodb": "workspace:3.982.0"
+    "@aws-sdk/client-dynamodb": "workspace:^3.982.0"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "workspace:3.982.0",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -39,7 +39,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@aws-sdk/client-s3": "workspace:3.982.0"
+    "@aws-sdk/client-s3": "workspace:^3.982.0"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "workspace:3.982.0",

--- a/packages-internal/dynamodb-codec/package.json
+++ b/packages-internal/dynamodb-codec/package.json
@@ -36,9 +36,6 @@
     "premove": "4.0.0",
     "typescript": "~5.8.3"
   },
-  "peerDependencies": {
-    "@aws-sdk/client-dynamodb": "workspace:3.982.0"
-  },
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -34,7 +34,7 @@
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
-    "@aws-sdk/client-dynamodb": "workspace:3.982.0"
+    "@aws-sdk/client-dynamodb": "workspace:^3.982.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/scripts/update-versions/getUpdatedPackageJson.mjs
+++ b/scripts/update-versions/getUpdatedPackageJson.mjs
@@ -7,7 +7,7 @@ export const getUpdatedPackageJson = (packageJson, depToVersionHash) =>
     .reduce(
       (acc, sectionName) => ({
         ...acc,
-        [sectionName]: getUpdatedPackageJsonSection(packageJson[sectionName], depToVersionHash),
+        [sectionName]: getUpdatedPackageJsonSection(packageJson[sectionName], depToVersionHash, sectionName),
       }),
       packageJson
     );

--- a/scripts/update-versions/getUpdatedPackageJsonSection.mjs
+++ b/scripts/update-versions/getUpdatedPackageJsonSection.mjs
@@ -1,11 +1,17 @@
 // @ts-check
-export const getUpdatedPackageJsonSection = (section, depToVersionHash) =>
+export const getUpdatedPackageJsonSection = (section, depToVersionHash, sectionName) =>
   Object.entries(section)
     .filter(([key, value]) => key.startsWith("@aws-sdk/") && !value.startsWith("file:"))
     .reduce((acc, [key]) => {
       const newVersion = depToVersionHash[key];
       if (newVersion) {
-        acc[key] = newVersion;
+        if (sectionName === "peerDependencies") {
+          if (key.startsWith("@aws-sdk/")) {
+            acc[key] = newVersion.replace(/^(workspace:)?\^?(\d+\.\d+\.\d+)$/, "$1^$2");
+          }
+        } else {
+          acc[key] = newVersion;
+        }
       }
       return acc;
     }, section);

--- a/yarn.lock
+++ b/yarn.lock
@@ -23752,8 +23752,6 @@ __metadata:
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
-  peerDependencies:
-    "@aws-sdk/client-dynamodb": "workspace:3.982.0"
   languageName: unknown
   linkType: soft
 
@@ -23845,7 +23843,7 @@ __metadata:
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
   peerDependencies:
-    "@aws-sdk/client-dynamodb": "workspace:3.982.0"
+    "@aws-sdk/client-dynamodb": "workspace:^3.982.0"
   languageName: unknown
   linkType: soft
 
@@ -23870,7 +23868,7 @@ __metadata:
     typescript: "npm:~5.8.3"
     web-streams-polyfill: "npm:3.2.1"
   peerDependencies:
-    "@aws-sdk/client-s3": "workspace:3.982.0"
+    "@aws-sdk/client-s3": "workspace:^3.982.0"
   languageName: unknown
   linkType: soft
 
@@ -24728,7 +24726,7 @@ __metadata:
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
   peerDependencies:
-    "@aws-sdk/client-dynamodb": "workspace:3.982.0"
+    "@aws-sdk/client-dynamodb": "workspace:^3.982.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Issue
n/a

### Description
Removes the unnecessary peer dep in dynamodb-codec. It was likely copied over from util-dynamodb unintentionally.

Also adds `^` version ranges back to peer dependencies. 

### Testing
CI
