### PR TITLE
test(middleware-websocket): improve integ test for websocket

### DIFF
--- a/packages-internal/middleware-websocket/src/WebSocketFetchHandler.ts
+++ b/packages-internal/middleware-websocket/src/WebSocketFetchHandler.ts
@@ -5,7 +5,6 @@ import type { HttpRequest } from "@smithy/protocol-http";
 import { HttpResponse } from "@smithy/protocol-http";
 import type { Logger, Provider, RequestHandler, RequestHandlerMetadata } from "@smithy/types";
 import { fromBase64 } from "@smithy/util-base64";
-import { fromUtf8 } from "@smithy/util-utf8";
 
 import { isWebSocketRequest } from "./utils";
 

--- a/packages-internal/middleware-websocket/vitest.config.integ.mts
+++ b/packages-internal/middleware-websocket/vitest.config.integ.mts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["**/*.integ.spec.ts"],
-    environment: "node",
+    environment: "happy-dom",
   },
 });


### PR DESCRIPTION
### Issue
follows https://github.com/aws/aws-sdk-js-v3/pull/7704

### Testing
This PR improves the integ test for websockets using BedrockRuntime bidirectional event stream.

- websocket server messages are now interspersed, arriving before, during, and after the client messages
- the test asserts that all of these events are observable by the operation's response AsyncIterable as long as the input AsyncIterable is held open