### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -8,7 +8,7 @@ jobs:
         permissions:
           issues: write
         steps:
-        - uses: aws-actions/closed-issue-message@v1
+        - uses: aws-actions/closed-issue-message@v2
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/commit-message-lint.yml
+++ b/.github/workflows/commit-message-lint.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+      - uses: wagoid/commitlint-github-action@v6
             
 

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@v6
         if: github.repository == 'aws/aws-sdk-js-v3'
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{secrets.PR_WORKFLOW_IAM_ROLE_ARN}}
           role-session-name: PullRequestBuildGitHubAction

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v6
+    - uses: aws-actions/stale-issue-cleanup@v7
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `aws-actions/closed-issue-message` | [`v1`](https://github.com/aws-actions/closed-issue-message/releases/tag/v1) | [`v2`](https://github.com/aws-actions/closed-issue-message/releases/tag/v2) | [Release](https://github.com/aws-actions/closed-issue-message/releases/tag/v2) | closed-issue-message.yml |
| `aws-actions/configure-aws-credentials` | [`v4`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4) | [`v6`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6) | [Release](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6) | pull-request-build.yml |
| `aws-actions/stale-issue-cleanup` | [`v6`](https://github.com/aws-actions/stale-issue-cleanup/releases/tag/v6) | [`v7`](https://github.com/aws-actions/stale-issue-cleanup/releases/tag/v7) | [Release](https://github.com/aws-actions/stale-issue-cleanup/releases/tag/v7) | stale_issues.yml |
| `dessant/lock-threads` | [`v2`](https://github.com/dessant/lock-threads/releases/tag/v2) | [`v6`](https://github.com/dessant/lock-threads/releases/tag/v6) | [Release](https://github.com/dessant/lock-threads/releases/tag/v6) | lock.yml |
| `wagoid/commitlint-github-action` | [`v4`](https://github.com/wagoid/commitlint-github-action/releases/tag/v4) | [`v6`](https://github.com/wagoid/commitlint-github-action/releases/tag/v6) | [Release](https://github.com/wagoid/commitlint-github-action/releases/tag/v6) | commit-message-lint.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
