### PR TITLE
fix(client-ec2): fix ec2QueryName serialization

### DIFF
--- a/packages-internal/core/integ/ec2-query-name.integ.spec.ts
+++ b/packages-internal/core/integ/ec2-query-name.integ.spec.ts
@@ -1,0 +1,41 @@
+import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
+import { EC2 } from "@aws-sdk/client-ec2";
+import { describe, expect, test as it } from "vitest";
+
+describe("EC2", () => {
+  it("should serialize based on ec2QueryName if present", async () => {
+    const ec2 = new EC2({
+      region: "us-east-1",
+      credentials: {
+        accessKeyId: "INTEG",
+        secretAccessKey: "INTEG",
+      },
+    });
+    requireRequestsFrom(ec2).toMatch({
+      body(b) {
+        expect(b.split("&").sort()).toMatchObject([
+          "Action=RunInstances",
+          /^ClientToken=(.*?)$/,
+          "DryRun=true",
+          "MaxCount=1",
+          "MinCount=0",
+          "NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress=10.0.0.10",
+          "Version=2016-11-15",
+        ]);
+      },
+    });
+
+    await ec2.runInstances({
+      DryRun: true,
+      NetworkInterfaces: [
+        {
+          PrivateIpAddresses: [{ PrivateIpAddress: "10.0.0.10" }],
+        },
+      ],
+      MaxCount: 1,
+      MinCount: 0,
+    });
+
+    expect.assertions(1);
+  });
+});

--- a/packages-internal/core/src/submodules/protocols/query/AwsEc2QueryProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/query/AwsEc2QueryProtocol.ts
@@ -1,5 +1,5 @@
 import { AwsQueryProtocol } from "./AwsQueryProtocol";
-import { QuerySerializerSettings } from "./QuerySerializerSettings";
+import type { QuerySerializerSettings } from "./QuerySerializerSettings";
 
 /**
  * @public
@@ -17,6 +17,7 @@ export class AwsEc2QueryProtocol extends AwsQueryProtocol {
       capitalizeKeys: true,
       flattenLists: true,
       serializeEmptyLists: false,
+      ec2: true,
     };
     Object.assign(this.serializer.settings, ec2Settings);
   }

--- a/packages-internal/core/src/submodules/protocols/query/QuerySerializerSettings.ts
+++ b/packages-internal/core/src/submodules/protocols/query/QuerySerializerSettings.ts
@@ -4,4 +4,8 @@ export type QuerySerializerSettings = CodecSettings & {
   capitalizeKeys?: boolean;
   flattenLists?: boolean;
   serializeEmptyLists?: boolean;
+  /**
+   * Whether to read from ec2QueryName before xmlName.
+   */
+  ec2?: boolean;
 };


### PR DESCRIPTION
### Issue
D391251276

### Description
This fix is for a serialization error in the EC2 AWS SDK client `@aws-sdk/client-ec2`, affecting the `NetworkInterfaces.PrivateIpAddresses` and `NetworkInterfaces.Ipv6Addresses` properties in the following operations:

- RunInstances
- RequestSpotInstances
- RequestSpotFleet

The fix applies missing logic for using the ec2QueryName serialization trait.

### What SDK versions are affected?
`@aws-sdk/client-ec2` 

https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.930.0 through 
https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.988.0

### How do I acquire the fix?
If you are on versions v3.930.0 - v3.973.0, update `@aws-sdk/client-ec2` to the latest version. At this time: https://www.npmjs.com/package/@aws-sdk/client-ec2/v/3.989.0.

If you are on v3.974.0 or higher, you have a secondary option of running `npm up @aws-sdk/core` to bring in `@aws-sdk/core@3.973.9` or higher. Commit any resulting changes to your lockfile. Run `npm ls @aws-sdk/core` to confirm.

If you are on other versions, or you do not use the operations affected, no changes are needed.

### What EC2 operations are affected?

After running model analysis, we found a total of 17,731 shapes in the EC2 model. 6,914 have xmlName, and 5,529 have ec2QueryName serialization traits. A mismatch is defined as when the ec2QueryName does not match the capitalized form of the xmlName and also does not match the default member name.

Spec: https://smithy.io/2.0/aws/protocols/aws-ec2-query-protocol.html#aws-protocols-ec2queryname-trait

There are 2 mismatched member shapes.

```
1. com.amazonaws.ec2#InstanceNetworkInterfaceSpecification$Ipv6Addresses 

xmlName: ipv6AddressesSet ec2QueryName: Ipv6Addresses 
memberName: Ipv6Addresses

2. com.amazonaws.ec2#InstanceNetworkInterfaceSpecification$PrivateIpAddresses 

xmlName: privateIpAddressesSet ec2QueryName: PrivateIpAddresses 
memberName: PrivateIpAddresses
```

These values, in the context of the AWS SDK for JavaScript, appear here:

```ts
import { RequestSpotFleetCommand, RequestSpotInstancesCommand, RunInstancesCommand } from "@aws-sdk/client-ec2";

new RunInstancesCommand({
  MaxCount: 0,
  MinCount: 0,
  NetworkInterfaces: [
    {
      // here
      PrivateIpAddresses: [{ PrivateIpAddress: "xx" }],
      // here
      Ipv6Addresses: [{ Ipv6Address: "xx" }],
    },
  ],
});
new RequestSpotInstancesCommand({
  LaunchSpecification: {
    NetworkInterfaces: [
      {
        // here
        PrivateIpAddresses: [{ PrivateIpAddress: "xx" }],
        // here
        Ipv6Addresses: [{ Ipv6Address: "xx" }],
      },
    ],
  },
});
new RequestSpotFleetCommand({
  SpotFleetRequestConfig: {
    IamFleetRole: "",
    TargetCapacity: 0,
    LaunchSpecifications: [
      {
        NetworkInterfaces: [
          {
            // here
            PrivateIpAddresses: [{ PrivateIpAddress: "xx" }],
            // here
            Ipv6Addresses: [{ Ipv6Address: "xx" }],
          },
        ],
      },
    ],
  },
});
```


### Testing
new integ test

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [n/a] If you wrote E2E tests, are they resilient to concurrent I/O?
- [n/a ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
