### PR TITLE
Update package.json

### DIFF
--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -4,7 +4,7 @@
   "description": "XML utilities for the AWS SDK",
   "dependencies": {
     "@smithy/types": "^4.12.0",
-    "fast-xml-parser": "5.3.4",
+    "fast-xml-parser": "~5.3.4",
     "tslib": "^2.6.2"
   },
   "scripts": {


### PR DESCRIPTION
added a hook to take latest fast-xml-parser as 5.3.4 is high vulernable 5.3.5 needs to be adopter

### Issue
Issue number, if available, prefixed with "#"

### Description
What does this implement/fix? Explain your changes.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
