### PR TITLE
chore: bump fast-xml-parser to ^5.3.6 (CVE-2026-26278)

### DIFF
--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -4,7 +4,7 @@
   "description": "XML utilities for the AWS SDK",
   "dependencies": {
     "@smithy/types": "^4.12.0",
-    "fast-xml-parser": "5.3.4",
+    "fast-xml-parser": "^5.3.6",
     "tslib": "^2.6.2"
   },
   "scripts": {

--- a/private/aws-protocoltests-restxml-schema/package.json
+++ b/private/aws-protocoltests-restxml-schema/package.json
@@ -62,7 +62,7 @@
     "@smithy/util-stream": "^4.5.12",
     "@smithy/util-utf8": "^4.2.0",
     "entities": "2.2.0",
-    "fast-xml-parser": "5.3.4",
+    "fast-xml-parser": "^5.3.6",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -64,7 +64,7 @@
     "@smithy/util-utf8": "^4.2.0",
     "@smithy/uuid": "^1.1.0",
     "entities": "2.2.0",
-    "fast-xml-parser": "5.3.4",
+    "fast-xml-parser": "^5.3.6",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,7 +1167,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:5.3.4"
+    fast-xml-parser: "npm:^5.3.6"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -1227,7 +1227,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:5.3.4"
+    fast-xml-parser: "npm:^5.3.6"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -24854,7 +24854,7 @@ __metadata:
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
-    fast-xml-parser: "npm:5.3.4"
+    fast-xml-parser: "npm:^5.3.6"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -33843,14 +33843,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.3.4":
-  version: 5.3.4
-  resolution: "fast-xml-parser@npm:5.3.4"
+"fast-xml-parser@npm:^5.3.6":
+  version: 5.3.6
+  resolution: "fast-xml-parser@npm:5.3.6"
   dependencies:
-    strnum: "npm:^2.1.0"
+    strnum: "npm:^2.1.2"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/d77866ca860ad185153e12f6ba12274d32026319ad8064e4681342b8a8e1ffad3f1f98daf04d77239fb12eb1d906ee7185fd328deda74529680e8dae0f3e9327
+  checksum: 10c0/0150cc0566f327a76115de8b11628d717fb179010ed9bb77c52e579a7e6055a0f92f42f83678a6f1ec5b74411faec09713cb1f9b94bc687068ad86884a9199fa
   languageName: node
   linkType: hard
 
@@ -40505,10 +40505,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "strnum@npm:2.1.1"
-  checksum: 10c0/1f9bd1f9b4c68333f25c2b1f498ea529189f060cd50aa59f1876139c994d817056de3ce57c12c970f80568d75df2289725e218bd9e3cdf73cd1a876c9c102733
+"strnum@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "strnum@npm:2.1.2"
+  checksum: 10c0/4e04753b793540d79cd13b2c3e59e298440477bae2b853ab78d548138385193b37d766d95b63b7046475d68d44fb1fca692f0a3f72b03f4168af076c7b246df9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context                                                                                                                                                                                       

fast-xml-parser was pinned to an exact version (5.3.4) and affected by CVE-2026-26278, a denial-of-service vulnerability via unlimited entity expansion affecting versions 4.1.3–5.3.5.

### Changes

- Bumped fast-xml-parser to ^5.3.6 (patched version) in packages-internal/xml-builder, private/aws-protocoltests-restxml, and private/aws-protocoltests-restxml-schema

- Switched from an exact pin to a caret range to allow compatible patch/minor updates going forward

### Consequences

Loosening from an exact pin to ^5.3.6 means future patch and minor releases will be automatically picked up, allowing future security fixes to land in downstream projects without manual intervention in the AWS SDK packages. The tradeoff is reduced reproducibility and a small risk of unexpected breakage if fast-xml-parser ships a behavioral change in a minor version. The package was previously pinned exactly, suggesting this was a concern.

<!--
### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
-->
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
