### PR TITLE
chore(codegen): bump codegen version to 0.45.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.45.0 (2026-02-19)
+
+### Chores
+
+- Upgraded to smithy-typescript 0.45.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0450-2026-02-19))
+
 ## 0.44.0 (2026-02-06)
 
 ### Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -37,7 +37,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.44.0"
+    version = "0.45.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.44.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.45.0")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/0076b3f7bb55ad1656178f8cfad890b006c92c1a...d714b0b39bbf3850b72fdfdbba696e5ef6c35ede
-  SMITHY_TS_COMMIT: "d714b0b39bbf3850b72fdfdbba696e5ef6c35ede",
+  // https://github.com/smithy-lang/smithy-typescript/compare/d714b0b39bbf3850b72fdfdbba696e5ef6c35ede...877898b947e4b782abe1f5707bbc205d6fa50df4
+  SMITHY_TS_COMMIT: "877898b947e4b782abe1f5707bbc205d6fa50df4",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
Internal JS-6640

### Description
Bumps codegen version to 0.45.0

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
