### PR TITLE
chore: make PR template checklist easier to edit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,13 +7,15 @@ What does this implement/fix? Explain your changes.
 ### Testing
 How was this change tested?
 
-### Additional context
-Add any other context about the PR here.
-
 ### Checklist
-- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`).
-- [ ] If you wrote E2E tests, are they resilient to concurrent I/O?
-- [ ] If adding new public functions, did you add the `@public` tag and enable doc generation on the package?
+- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
+  - [ ] It's not a feature.
+- [ ] My E2E tests are resilient to concurrent i/o.
+  - [ ] I didn't write any E2E tests.
+- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
+  - [ ] I didn't add any public functions.
+- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
+  - [ ] No streams here.
 
 ---
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
### Issue
internal JS-6642

### Description
This adds alternate "no" options to the PR checklist template so it's easier to interact with without needing to edit out the non-applicable checklist items

I also removed the context section because it's rarely used separately from the description.

It looks like this:
----

### Issue
Issue number, if available, prefixed with "#"

### Description
What does this implement/fix? Explain your changes.

### Testing
How was this change tested?

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.