### PR TITLE
fix(protocols): handle missing error.Error in queryCompat mode

### DIFF
--- a/packages-internal/core/src/submodules/protocols/ProtocolLib.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/ProtocolLib.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test as it } from "vitest";
+
+import { ProtocolLib } from "./ProtocolLib";
+import { ServiceException } from "@smithy/smithy-client";
+
+describe("ProtocolLib", () => {
+  describe("decorateServiceException", () => {
+    describe("queryCompat mode", () => {
+      it("should handle missing error.Error gracefully when x-amzn-query-error header is absent", () => {
+        // When queryCompat=true but x-amzn-query-error header is absent,
+        // error.Error is undefined. The method should not throw TypeError.
+        const lib = new ProtocolLib(true);
+
+        const exception = Object.assign(new Error("AccessDeniedException"), {
+          $fault: "client" as const,
+          $metadata: {
+            httpStatusCode: 403,
+            requestId: "test-request-id",
+          },
+        }) as ServiceException;
+
+        const additions = {
+          message: "User is not authorized to perform this action",
+          // Note: no Error property since x-amzn-query-error header was absent
+        };
+
+        // Should not throw TypeError: Cannot read properties of undefined (reading 'Type')
+        const result = lib.decorateServiceException(exception, additions);
+
+        // Verify the exception is properly decorated (error should not crash)
+        expect(result.$fault).toBe("client");
+        expect(result.$metadata.requestId).toBe("test-request-id");
+        expect(result.RequestId).toBe("test-request-id");
+
+        // error.Error should be created with undefined values for Type and Code
+        // when setQueryCompatError was not called (header absent)
+        expect(result.Error).toBeDefined();
+        expect(result.Error.Type).toBeUndefined();
+        expect(result.Error.Code).toBeUndefined();
+      });
+
+      it("should properly populate error.Error when x-amzn-query-error header is present", () => {
+        const lib = new ProtocolLib(true);
+
+        const exception = Object.assign(new Error("AccessDeniedException"), {
+          $fault: "client" as const,
+          $metadata: {
+            httpStatusCode: 403,
+            requestId: "test-request-id",
+          },
+        }) as ServiceException;
+
+        const additions = {
+          message: "User is not authorized to perform this action",
+          Error: {
+            Code: "AccessDeniedException",
+            Type: "Sender",
+            Message: "User is not authorized to perform this action",
+          },
+        };
+
+        const result = lib.decorateServiceException(exception, additions);
+
+        expect(result.Error).toBeDefined();
+        expect(result.Error.Code).toBe("AccessDeniedException");
+        expect(result.Error.Type).toBe("Sender");
+        expect(result.Error.Message).toBe("User is not authorized to perform this action");
+      });
+
+      it("should use Message from additions when error.Error is missing", () => {
+        const lib = new ProtocolLib(true);
+
+        const exception = Object.assign(new Error("ValidationException"), {
+          $fault: "client" as const,
+          $metadata: {
+            httpStatusCode: 400,
+            requestId: "test-request-id-2",
+          },
+          Message: "Invalid input parameter",
+        }) as ServiceException;
+
+        const additions = {
+          Message: "Invalid input parameter",
+        };
+
+        const result = lib.decorateServiceException(exception, additions);
+
+        // The message property is set from Message
+        expect(result.message).toBe("Invalid input parameter");
+        expect(result.Error.Message).toBe("Invalid input parameter");
+      });
+    });
+
+    describe("non-queryCompat mode", () => {
+      it("should delegate to decorateServiceException without modification", () => {
+        const lib = new ProtocolLib(false);
+
+        const exception = Object.assign(new Error("SomeError"), {
+          $fault: "server" as const,
+          $metadata: {
+            httpStatusCode: 500,
+          },
+        }) as ServiceException;
+
+        const additions = {
+          message: "Server error occurred",
+        };
+
+        const result = lib.decorateServiceException(exception, additions);
+
+        // In non-queryCompat mode, Error property should not be set
+        expect((result as any).Error).toBeUndefined();
+        expect((result as any).RequestId).toBeUndefined();
+      });
+    });
+  });
+
+  describe("setQueryCompatError", () => {
+    it("should set Error property when x-amzn-query-error header is present", () => {
+      const lib = new ProtocolLib(true);
+
+      const output: Record<string, any> = {
+        message: "Access denied",
+      };
+
+      const response = {
+        statusCode: 403,
+        headers: {
+          "x-amzn-query-error": "AccessDeniedException;Sender",
+        },
+        body: undefined,
+      };
+
+      lib.setQueryCompatError(output, response);
+
+      expect(output.Error).toBeDefined();
+      expect(output.Error.Code).toBe("AccessDeniedException");
+      expect(output.Error.Type).toBe("Sender");
+      expect(output.Error.Message).toBe("Access denied");
+    });
+
+    it("should not set Error property when x-amzn-query-error header is absent", () => {
+      const lib = new ProtocolLib(true);
+
+      const output: Record<string, any> = {
+        message: "Access denied",
+      };
+
+      const response = {
+        statusCode: 403,
+        headers: {},
+        body: undefined,
+      };
+
+      lib.setQueryCompatError(output, response);
+
+      expect(output.Error).toBeUndefined();
+    });
+  });
+});

--- a/packages-internal/core/src/submodules/protocols/ProtocolLib.ts
+++ b/packages-internal/core/src/submodules/protocols/ProtocolLib.ts
@@ -117,9 +117,9 @@ export class ProtocolLib {
 
       error.Error = {
         ...error.Error,
-        Type: error.Error.Type,
-        Code: error.Error.Code,
-        Message: error.Error.message ?? error.Error.Message ?? msg,
+        Type: error.Error?.Type,
+        Code: error.Error?.Code,
+        Message: error.Error?.message ?? error.Error?.Message ?? msg,
       };
 
       const reqId = error.$metadata.requestId;


### PR DESCRIPTION
## Summary

When an `awsQueryCompatible` client (e.g., CloudWatchClient) receives an error response that does not include the `x-amzn-query-error` header, `ProtocolLib.decorateServiceException()` throws:

```
TypeError: Cannot read properties of undefined (reading 'Type')
```

This destroys the structured ServiceException - the caller receives a raw TypeError with no error name, no message from the response body, and no `$fault`.

### Root Cause

In `ProtocolLib.ts#decorateServiceException`, the `queryCompat` branch unconditionally accesses `error.Error.Type`, `error.Error.Code`, and `error.Error.Message`. But `error.Error` is only set by `setQueryCompatError()` when the `x-amzn-query-error` response header is present. If the header is absent, `error.Error` is undefined and the property access throws.

### When does the header go missing?

The `x-amzn-query-error` header is a service-side response to the `x-amzn-query-mode: true` request header. It can be absent when a proxy or gateway doesn't forward the `x-amzn-query-mode` request header.

## Changes

- Added optional chaining (`?.`) to gracefully handle undefined `error.Error`
- Added test coverage for `ProtocolLib.decorateServiceException` and `setQueryCompatError`

## Test Plan

- [x] Added 6 unit tests covering:
  - Missing `error.Error` (header absent) - verifies no TypeError is thrown
  - Present `error.Error` (header present) - verifies normal behavior unchanged
  - Message fallback when `error.Error` is missing
  - Non-queryCompat mode behavior
  - `setQueryCompatError` with and without header
- [x] All new tests pass: `yarn test src/submodules/protocols/ProtocolLib.spec.ts`
- [x] Existing protocol tests pass

Fixes #7756

---

*Generated with [Claude Code](https://claude.ai/code)*