### PR TITLE
chore(build): disable snapshot write/compare

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test-integration: bundles
 	yarn g:vitest run -c vitest.config.integ.mts
 	make test-protocols
 	make test-types
-	make snapshot-compare
+	# make snapshot-compare
 	make test-indices
 	make test-endpoints
 

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -135,11 +135,11 @@ const {
       env: { ...process.env },
     });
 
-    await spawnProcess("make", ["snapshot-write"], {
-      cwd: REPO_ROOT,
-      stdio: "inherit",
-      env: { ...process.env },
-    });
+    // await spawnProcess("make", ["snapshot-write"], {
+    //   cwd: REPO_ROOT,
+    //   stdio: "inherit",
+    //   env: { ...process.env },
+    // });
 
     require("../runtime-dependency-version-check/runtime-dep-version-check");
     await spawnProcess("yarn", ["install", "--no-immutable"], {


### PR DESCRIPTION
### Issue
P386875383

### Description
Turn off snapshot testing temporarily.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
