### PR TITLE
fix(lib-dynamodb): clone middleware stack to support cacheMiddleware

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
@@ -192,15 +192,7 @@ final class DocumentBareBonesClientGenerator implements Runnable {
                 writer.write("super(client.config);");
                 writer.write("this.config = client.config;");
                 writer.write("this.config.translateConfig = translateConfig;");
-                writer.write("this.middlewareStack = client.middlewareStack;");
-                writer.write("""
-                             if (this.config?.cacheMiddleware) {
-                                 throw new Error(
-                                     "@aws-sdk/lib-dynamodb - cacheMiddleware=true is not compatible with the"
-                                       + " DynamoDBDocumentClient. This option must be set to false."
-                                 );
-                             }
-                             """);
+                writer.write("this.middlewareStack = client.middlewareStack.clone();");
                 writer.popState();
             }
         );

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.spec.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.spec.ts
@@ -1,0 +1,69 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+import { describe, expect, test as it } from "vitest";
+
+import { DynamoDBDocument } from "./DynamoDBDocument";
+import { DynamoDBDocumentClient } from "./DynamoDBDocumentClient";
+
+describe(DynamoDBDocumentClient.name, () => {
+  it("should allow initialization with cacheMiddleware: true", () => {
+    const dynamodb = new DynamoDB({
+      credentials: {} as any,
+      cacheMiddleware: true,
+    });
+    expect(() => {
+      DynamoDBDocumentClient.from(dynamodb);
+    }).not.toThrow();
+  });
+
+  it("should clone the middleware stack from the parent client", () => {
+    const dynamodb = new DynamoDB({
+      credentials: {} as any,
+    });
+    const docClient = DynamoDBDocumentClient.from(dynamodb);
+    expect(docClient.middlewareStack).not.toBe(dynamodb.middlewareStack);
+    expect(docClient.middlewareStack.identify()).toEqual(dynamodb.middlewareStack.identify());
+  });
+
+  it("should not affect parent client when middleware is added to document client", () => {
+    const dynamodb = new DynamoDB({
+      credentials: {} as any,
+    });
+    const parentEntryCount = dynamodb.middlewareStack.identify().length;
+    const docClient = DynamoDBDocumentClient.from(dynamodb);
+
+    docClient.middlewareStack.add((next) => (args) => next(args), {
+      name: "testMiddleware",
+      step: "initialize",
+    });
+
+    expect(dynamodb.middlewareStack.identify().length).toBe(parentEntryCount);
+    expect(docClient.middlewareStack.identify().length).toBe(parentEntryCount + 1);
+  });
+
+  it("should not affect document client when middleware is added to parent after creation", () => {
+    const dynamodb = new DynamoDB({
+      credentials: {} as any,
+    });
+    const docClient = DynamoDBDocumentClient.from(dynamodb);
+    const docEntryCount = docClient.middlewareStack.identify().length;
+
+    dynamodb.middlewareStack.add((next) => (args) => next(args), {
+      name: "lateParentMiddleware",
+      step: "initialize",
+    });
+
+    expect(docClient.middlewareStack.identify().length).toBe(docEntryCount);
+  });
+});
+
+describe(DynamoDBDocument.name, () => {
+  it("should allow initialization with cacheMiddleware: true", () => {
+    const dynamodb = new DynamoDB({
+      credentials: {} as any,
+      cacheMiddleware: true,
+    });
+    expect(() => {
+      DynamoDBDocument.from(dynamodb);
+    }).not.toThrow();
+  });
+});

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
@@ -1,30 +1,33 @@
 // smithy-typescript generated code
-import { Client as __Client } from "@smithy/smithy-client";
-import type { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
-
-import {
-  BatchExecuteStatementCommandInput,
-  BatchExecuteStatementCommandOutput,
-} from "./commands/BatchExecuteStatementCommand";
-import { BatchGetCommandInput, BatchGetCommandOutput } from "./commands/BatchGetCommand";
-import { BatchWriteCommandInput, BatchWriteCommandOutput } from "./commands/BatchWriteCommand";
-import { DeleteCommandInput, DeleteCommandOutput } from "./commands/DeleteCommand";
-import { ExecuteStatementCommandInput, ExecuteStatementCommandOutput } from "./commands/ExecuteStatementCommand";
-import { ExecuteTransactionCommandInput, ExecuteTransactionCommandOutput } from "./commands/ExecuteTransactionCommand";
-import { GetCommandInput, GetCommandOutput } from "./commands/GetCommand";
-import { PutCommandInput, PutCommandOutput } from "./commands/PutCommand";
-import { QueryCommandInput, QueryCommandOutput } from "./commands/QueryCommand";
-import { ScanCommandInput, ScanCommandOutput } from "./commands/ScanCommand";
-import { TransactGetCommandInput, TransactGetCommandOutput } from "./commands/TransactGetCommand";
-import { TransactWriteCommandInput, TransactWriteCommandOutput } from "./commands/TransactWriteCommand";
-import { UpdateCommandInput, UpdateCommandOutput } from "./commands/UpdateCommand";
-import {
+import type {
   DynamoDBClient,
   DynamoDBClientResolvedConfig,
   ServiceInputTypes as __ServiceInputTypes,
   ServiceOutputTypes as __ServiceOutputTypes,
 } from "@aws-sdk/client-dynamodb";
-import { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
+import type { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
+import { Client as __Client } from "@smithy/smithy-client";
+import type { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
+
+import type {
+  BatchExecuteStatementCommandInput,
+  BatchExecuteStatementCommandOutput,
+} from "./commands/BatchExecuteStatementCommand";
+import type { BatchGetCommandInput, BatchGetCommandOutput } from "./commands/BatchGetCommand";
+import type { BatchWriteCommandInput, BatchWriteCommandOutput } from "./commands/BatchWriteCommand";
+import type { DeleteCommandInput, DeleteCommandOutput } from "./commands/DeleteCommand";
+import type { ExecuteStatementCommandInput, ExecuteStatementCommandOutput } from "./commands/ExecuteStatementCommand";
+import type {
+  ExecuteTransactionCommandInput,
+  ExecuteTransactionCommandOutput,
+} from "./commands/ExecuteTransactionCommand";
+import type { GetCommandInput, GetCommandOutput } from "./commands/GetCommand";
+import type { PutCommandInput, PutCommandOutput } from "./commands/PutCommand";
+import type { QueryCommandInput, QueryCommandOutput } from "./commands/QueryCommand";
+import type { ScanCommandInput, ScanCommandOutput } from "./commands/ScanCommand";
+import type { TransactGetCommandInput, TransactGetCommandOutput } from "./commands/TransactGetCommand";
+import type { TransactWriteCommandInput, TransactWriteCommandOutput } from "./commands/TransactWriteCommand";
+import type { UpdateCommandInput, UpdateCommandOutput } from "./commands/UpdateCommand";
 
 /**
  * @public
@@ -33,7 +36,8 @@ export { __Client };
 /**
  * @public
  */
-export type ServiceInputTypes = __ServiceInputTypes
+export type ServiceInputTypes =
+  | __ServiceInputTypes
   | BatchExecuteStatementCommandInput
   | BatchGetCommandInput
   | BatchWriteCommandInput
@@ -51,7 +55,8 @@ export type ServiceInputTypes = __ServiceInputTypes
 /**
  * @public
  */
-export type ServiceOutputTypes = __ServiceOutputTypes
+export type ServiceOutputTypes =
+  | __ServiceOutputTypes
   | BatchExecuteStatementCommandOutput
   | BatchGetCommandOutput
   | BatchWriteCommandOutput
@@ -72,7 +77,7 @@ export type ServiceOutputTypes = __ServiceOutputTypes
 export type TranslateConfig = {
   marshallOptions?: marshallOptions;
   unmarshallOptions?: unmarshallOptions;
-}
+};
 
 /**
  * @public
@@ -129,21 +134,19 @@ export type DynamoDBDocumentClientResolvedConfig = DynamoDBClientResolvedConfig 
  *
  * @public
  */
-export class DynamoDBDocumentClient extends __Client<__HttpHandlerOptions, ServiceInputTypes, ServiceOutputTypes, DynamoDBDocumentClientResolvedConfig> {
+export class DynamoDBDocumentClient extends __Client<
+  __HttpHandlerOptions,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+  DynamoDBDocumentClientResolvedConfig
+> {
   readonly config: DynamoDBDocumentClientResolvedConfig;
 
-  protected constructor(client: DynamoDBClient, translateConfig?: TranslateConfig){
+  protected constructor(client: DynamoDBClient, translateConfig?: TranslateConfig) {
     super(client.config);
     this.config = client.config;
     this.config.translateConfig = translateConfig;
-    this.middlewareStack = client.middlewareStack;
-    if (this.config?.cacheMiddleware) {
-        throw new Error(
-            "@aws-sdk/lib-dynamodb - cacheMiddleware=true is not compatible with the"
-              + " DynamoDBDocumentClient. This option must be set to false."
-        );
-    }
-
+    this.middlewareStack = client.middlewareStack.clone();
   }
 
   static from(client: DynamoDBClient, translateConfig?: TranslateConfig) {


### PR DESCRIPTION
## Problem

`DynamoDBDocumentClient` shares the parent `DynamoDBClient`'s `middlewareStack` by direct reference:

```ts
this.middlewareStack = client.middlewareStack;
```

This means any middleware added to either client affects the other. Because of this, `cacheMiddleware: true` was explicitly blocked with a runtime error: Cached handlers on the parent could become stale if the document client mutated the shared stack.

## Solution

Clone the stack instead of sharing it:

```ts
this.middlewareStack = client.middlewareStack.clone();
```

This makes the two clients independent. The document client gets a snapshot of the parent's middleware at construction time, and subsequent mutations on either side don't cross over. The `cacheMiddleware` restriction is no longer needed and is removed.

The same change is applied to the codegen template (`DocumentBareBonesClientGenerator.java`) so that `yarn generate-clients` won't revert it.

## Testing

Added `DynamoDBDocumentClient.spec.ts` with 4 tests:

- `DynamoDBDocumentClient` allows initialization with `cacheMiddleware: true`
- `DynamoDBDocumentClient` clones the middleware stack (not same reference)
- Adding middleware to the document client does not affect the parent
- `DynamoDBDocument` (subclass) allows initialization with `cacheMiddleware: true`

## Benchmark Context

Total middleware stack rebuild cost (measured with a typical S3-like stack of 15 client middleware + 1 command middleware) with and without `cacheMiddleware`:

```
Requests     Uncached (ms)     With cacheMiddleware     Speedup
---------------------------------------------------------------
100          2.34              0.02 ms                  133x
1000         10.56             0.01 ms                  928x
3000         26.54             0.02 ms                  1468x
```

This PR doesn't change the default value of `cacheMiddleware` (still `false`), but it removes the blocker that prevented DynamoDB users from opting in.

## Behavioral Change

Previously, middleware added to the parent `DynamoDBClient` after creating a `DynamoDBDocumentClient` was visible to the document client (and vice versa) due to the shared reference. This is no longer the case — the two stacks are independent after construction.

This was never documented behavior, but it is _technically_ a breaking change: Post-construction middleware changes on one client no longer affect the other.

## Note on Shared Config

The constructor still shares the `config` object by reference (`this.config = client.config`) and mutates it (`this.config.translateConfig = translateConfig`). This means the parent `DynamoDBClient`'s resolved config ends up with a `translateConfig` property it never asked for. This is a pre-existing issue not introduced by this PR, but it means the "independence" story between the two clients is not yet complete. A follow-up could shallow-copy the config as well.
