### PR TITLE
fix(cloudfront-signer): url-encode special characters in URL path

### DIFF
--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -383,6 +383,46 @@ describe("getSignedUrl", () => {
       expect(verifySignature(signatureQueryParam, policy)).toBeTruthy();
     });
   });
+
+  it("should URL-encode spaces in the path", () => {
+    const urlWithSpaces = "https://d111111abcdef8.cloudfront.net/private content/My File.pdf";
+    const result = getSignedUrl({
+      url: urlWithSpaces,
+      keyPairId,
+      dateLessThan,
+      privateKey,
+      passphrase,
+    });
+    expect(result).toContain("private%20content/My%20File.pdf");
+    expect(result).not.toContain("private content");
+    expect(result).not.toContain("My File.pdf");
+  });
+
+  it("should URL-encode special characters in the path while preserving path structure", () => {
+    const urlWithSpecialChars = "https://d111111abcdef8.cloudfront.net/path with spaces/file[1].pdf";
+    const result = getSignedUrl({
+      url: urlWithSpecialChars,
+      keyPairId,
+      dateLessThan,
+      privateKey,
+      passphrase,
+    });
+    expect(result).toContain("path%20with%20spaces");
+    expect(result).not.toContain("path with spaces");
+  });
+
+  it("should not double-encode already-encoded URLs", () => {
+    const alreadyEncodedUrl = "https://d111111abcdef8.cloudfront.net/private%20content/My%20File.pdf";
+    const result = getSignedUrl({
+      url: alreadyEncodedUrl,
+      keyPairId,
+      dateLessThan,
+      privateKey,
+      passphrase,
+    });
+    expect(result).toContain("private%20content/My%20File.pdf");
+    expect(result).not.toContain("%2520");
+  });
 });
 
 describe("getSignedCookies", () => {

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -407,8 +407,8 @@ describe("getSignedUrl", () => {
       privateKey,
       passphrase,
     });
-    expect(result).toContain("path%20with%20spaces");
-    expect(result).not.toContain("path with spaces");
+    expect(result).toContain("file%5B1%5D.pdf");
+    expect(result).not.toContain("file[1].pdf");
   });
 
   it("should not double-encode already-encoded URLs", () => {

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -143,18 +143,7 @@ export function getSignedUrl({
     .map(([key, value]) => `${extendedEncodeURIComponent(key)}=${extendedEncodeURIComponent(value)}`)
     .join("&");
 
-  function encodeBaseUrlQuery(url: string) {
-    if (url.includes("?")) {
-      const [hostAndPath, query] = url.split("?");
-      const params = [...new URLSearchParams(query).entries()]
-        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-        .join("&");
-      return `${hostAndPath}?${params}`;
-    }
-    return url;
-  }
-
-  const urlString = encodeBaseUrlQuery(baseUrl!) + startFlag + params;
+  const urlString = encodeUrlPath(baseUrl!) + startFlag + params;
 
   return getResource(urlString);
 }
@@ -246,6 +235,53 @@ interface CloudfrontAttributes {
   Policy?: string;
   "Key-Pair-Id": string;
   Signature: string;
+}
+
+/**
+ * Encodes the path and query of a URL string without normalizing `.` or `..` segments.
+ * Already percent-encoded sequences are preserved (no double-encoding).
+ * @internal
+ */
+function encodeUrlPath(url: string): string {
+  const protocolEnd = url.indexOf("//");
+  if (protocolEnd === -1) {
+    return url;
+  }
+  const authorityStart = protocolEnd + 2;
+  const pathStart = url.indexOf("/", authorityStart);
+  if (pathStart === -1) {
+    return url;
+  }
+
+  const origin = url.slice(0, pathStart);
+  const rest = url.slice(pathStart);
+
+  // Split path from query string
+  const queryIndex = rest.indexOf("?");
+  const rawPath = queryIndex === -1 ? rest : rest.slice(0, queryIndex);
+  const rawQuery = queryIndex === -1 ? "" : rest.slice(queryIndex);
+
+  // Encode each path segment individually, preserving `/` and already-encoded `%XX`.
+  const encodedPath = rawPath.replace(/[^/]+/g, (segment) => {
+    // Decode first to avoid double-encoding, then re-encode.
+    try {
+      return encodeURIComponent(decodeURIComponent(segment));
+    } catch {
+      // If decoding fails (malformed percent sequence), encode as-is.
+      return encodeURIComponent(segment);
+    }
+  });
+
+  // Re-encode query parameters if present
+  let encodedQuery = "";
+  if (rawQuery) {
+    const params = [...new URLSearchParams(rawQuery.slice(1)).entries()]
+      .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+      .join("&");
+    encodedQuery = `?${params}`;
+  }
+
+  return origin + encodedPath + encodedQuery;
 }
 
 /**

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -275,10 +275,9 @@ function encodeUrlPath(url: string): string {
   // Re-encode query parameters if present
   let encodedQuery = "";
   if (rawQuery) {
-    const params = [...new URLSearchParams(rawQuery.slice(1)).entries()]
-      .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-      .join("&");
-    encodedQuery = `?${params}`;
+    for (const [key, value] of new URLSearchParams(rawQuery.slice(1)).entries()) {
+      encodedQuery += `${encodedQuery ? "&" : "?"}${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+    }
   }
 
   return origin + encodedPath + encodedQuery;


### PR DESCRIPTION
Fixes #7571

## Problem

After PR #7237 (`fix(cloudfront-signer): do not use URL Object`), the CloudFront URL signer stopped URL-encoding spaces and other special characters in the URL path. PR #7237 correctly fixed an issue where `new URL()` was normalizing `.` and `..` path segments, but the switch to raw string manipulation also removed the implicit URL-encoding that `new URL()` provided.

This means URLs like `https://example.cloudfront.net/My File.pdf` are returned with unencoded spaces, producing invalid URLs.

## Solution

Added an `encodeUrlPath` helper function that:

1. Parses the URL into origin, path, and query components using string operations (no `new URL()`)
2. Encodes each path segment individually with `encodeURIComponent`, preserving `/` separators
3. Decodes before re-encoding to prevent double-encoding of already percent-encoded sequences (e.g., `%20` stays `%20`, not `%2520`)
4. Re-encodes query parameters using `URLSearchParams`

This replaces the previous `encodeBaseUrlQuery` function which only handled query parameter encoding but not path encoding.

The fix preserves the behavior from PR #7237: As confirmed by the tests, `.` and `..` path segments are not normalized.