### PR TITLE
fix(util-dynamodb): replace InstanceType that resolves to any in NativeAttributeValue

### DIFF
--- a/packages/util-dynamodb/src/models.spec.ts
+++ b/packages/util-dynamodb/src/models.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import type { NativeAttributeValue } from "./models";
+
+describe("NativeAttributeValue type", () => {
+  it("should not resolve to any (should reject values not in the union)", () => {
+    // This test validates that NativeAttributeValue is not `any`.
+    // If the type were `any`, assigning a symbol would be allowed at compile time.
+    // With a proper union type, symbols are not assignable to NativeAttributeValue.
+    //
+    // We verify at runtime that the known members of the union are accepted.
+    const stringVal: NativeAttributeValue = "hello";
+    const numberVal: NativeAttributeValue = 42;
+    const boolVal: NativeAttributeValue = true;
+    const nullVal: NativeAttributeValue = null;
+    const undefinedVal: NativeAttributeValue = undefined;
+    const mapVal: NativeAttributeValue = { key: "value" };
+    const listVal: NativeAttributeValue = [1, "two", true];
+    const setVal: NativeAttributeValue = new Set([1, 2, 3]);
+    const binaryVal: NativeAttributeValue = new Uint8Array([1, 2, 3]);
+    const classInstance: NativeAttributeValue = new Date();
+
+    expect(stringVal).toBe("hello");
+    expect(numberVal).toBe(42);
+    expect(boolVal).toBe(true);
+    expect(nullVal).toBe(null);
+    expect(undefinedVal).toBe(undefined);
+    expect(mapVal).toEqual({ key: "value" });
+    expect(listVal).toEqual([1, "two", true]);
+    expect(setVal).toEqual(new Set([1, 2, 3]));
+    expect(binaryVal).toEqual(new Uint8Array([1, 2, 3]));
+    expect(classInstance).toBeInstanceOf(Date);
+  });
+});

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -18,7 +18,7 @@ export type NativeAttributeValue =
   | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[]
   | Set<number | bigint | NumberValue | string | NativeAttributeBinary | undefined>
-  | InstanceType<{ new (...args: any[]): any }>; // accepts any class instance with options.convertClassInstanceToMap
+  | object; // accepts any class instance with options.convertClassInstanceToMap
 
 /**
  * @public


### PR DESCRIPTION
Fixes #7526

## Problem

The `NativeAttributeValue` type in `@aws-sdk/util-dynamodb` resolves to `any` in IDEs and type checking. This is because the union includes:

```ts
InstanceType<{ new (...args: any[]): any }>
```

which TypeScript evaluates to `any`, poisoning the entire union type. As a result, users get no type validation when using `NativeAttributeValue`.

## Solution

Replace `InstanceType<{ new (...args: any[]): any }>` with `object`.

The intent of that union member was to accept class instances when `convertClassInstanceToMap` is enabled. At the type level, class instances are `object`s, so `object` correctly represents this without collapsing the union to `any`.

The `object` type in TypeScript represents all non-primitive values, which includes class instances, plain objects, arrays, etc. Since the other union members already cover arrays, records, and Sets specifically, the `object` member serves as the catch-all for class instances as originally intended.