### PR TITLE
fix(client-config-service): correct RecorderStatus enum values to match API response

### DIFF
--- a/clients/client-config-service/src/commands/DescribeConfigurationRecorderStatusCommand.ts
+++ b/clients/client-config-service/src/commands/DescribeConfigurationRecorderStatusCommand.ts
@@ -63,7 +63,7 @@ export interface DescribeConfigurationRecorderStatusCommandOutput extends Descri
  * //       lastStartTime: new Date("TIMESTAMP"),
  * //       lastStopTime: new Date("TIMESTAMP"),
  * //       recording: true || false,
- * //       lastStatus: "Pending" || "Success" || "Failure" || "NotApplicable",
+ * //       lastStatus: "PENDING" || "SUCCESS" || "FAILURE" || "NOT_APPLICABLE",
  * //       lastErrorCode: "STRING_VALUE",
  * //       lastErrorMessage: "STRING_VALUE",
  * //       lastStatusChangeTime: new Date("TIMESTAMP"),

--- a/clients/client-config-service/src/models/enums.ts
+++ b/clients/client-config-service/src/models/enums.ts
@@ -826,10 +826,10 @@ export type ConfigurationRecorderFilterName =
  * @enum
  */
 export const RecorderStatus = {
-  Failure: "Failure",
-  NotApplicable: "NotApplicable",
-  Pending: "Pending",
-  Success: "Success",
+  Failure: "FAILURE",
+  NotApplicable: "NOT_APPLICABLE",
+  Pending: "PENDING",
+  Success: "SUCCESS",
 } as const;
 /**
  * @public

--- a/codegen/sdk-codegen/aws-models/config-service.json
+++ b/codegen/sdk-codegen/aws-models/config-service.json
@@ -11245,25 +11245,25 @@
         "Pending": {
           "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#enumValue": "Pending"
+            "smithy.api#enumValue": "PENDING"
           }
         },
         "Success": {
           "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#enumValue": "Success"
+            "smithy.api#enumValue": "SUCCESS"
           }
         },
         "Failure": {
           "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#enumValue": "Failure"
+            "smithy.api#enumValue": "FAILURE"
           }
         },
         "NotApplicable": {
           "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#enumValue": "NotApplicable"
+            "smithy.api#enumValue": "NOT_APPLICABLE"
           }
         }
       }


### PR DESCRIPTION
## Problem

The `RecorderStatus` enum in `@aws-sdk/client-config-service` defines values in TitleCase:

```ts
export const RecorderStatus = {
  Failure: "Failure",
  NotApplicable: "NotApplicable",
  Pending: "Pending",
  Success: "Success",
} as const;
```

However, the actual AWS Config API returns UPPER_SNAKE_CASE values: `"SUCCESS"`, `"FAILURE"`, `"PENDING"`, `"NOT_APPLICABLE"`. This means comparisons like `status === RecorderStatus.Success` never match the real API response.

## Solution

This PR updates the enum values in the Smithy service model (`codegen/sdk-codegen/aws-models/config-service.json`) to change `smithy.api#enumValue` from TitleCase to UPPER_SNAKE_CASE. The other changes are auto-generated from that change.

The enum keys remain unchanged (e.g., `RecorderStatus.Success`), so existing code using the keys will continue to work, but the values they resolve to now match what the API actually returns.