### PR TITLE
fix(core): handle empty error response body in AwsQuery protocol deserialization

### DIFF
--- a/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.spec.ts
@@ -1,7 +1,8 @@
 import { TypeRegistry } from "@smithy/core/schema";
 import { HttpResponse } from "@smithy/protocol-http";
-import { ServiceException, ServiceExceptionOptions } from "@smithy/smithy-client";
-import { StaticErrorSchema } from "@smithy/types";
+import type { ServiceExceptionOptions } from "@smithy/smithy-client";
+import { ServiceException } from "@smithy/smithy-client";
+import type { StaticErrorSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
 import { context } from "../test-schema.spec";
@@ -124,5 +125,48 @@ describe(AwsQueryProtocol.name, () => {
     expect(actual.Type).toEqual(expected.Type);
     expect(actual.Code).toEqual(expected.Code);
     expect(actual.Error).toEqual(expected.Error);
+  });
+});
+
+it("should not crash when error response body is empty", async () => {
+  const httpResponse = new HttpResponse({
+    statusCode: 500,
+    headers: {
+      "content-type": "text/xml",
+    },
+    body: Buffer.from(""),
+  });
+
+  const protocol = new AwsQueryProtocol({
+    version: "1999-12-31",
+    defaultNamespace: "com.amazonaws.giraffes",
+    xmlNamespace: "ns",
+  });
+
+  const actual = await protocol
+    .deserializeResponse(
+      {
+        namespace: "ns",
+        name: "Empty",
+        traits: 0,
+        input: "unit" as const,
+        output: [3, "ns", "EmptyOutput", 0, [], []],
+      },
+      context,
+      httpResponse
+    )
+    .catch((e) => {
+      return e;
+    });
+
+  // The error should be a proper ServiceException, not a raw TypeError
+  expect(actual).toBeDefined();
+  expect(actual).not.toBeInstanceOf(TypeError);
+  expect(actual.$metadata.httpStatusCode).toBe(500);
+  expect(actual.message).toBe("Unknown");
+  expect(actual.Error).toEqual({
+    Type: undefined,
+    Code: undefined,
+    Message: "Unknown",
   });
 });

--- a/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.ts
@@ -146,7 +146,7 @@ export class AwsQueryProtocol extends RpcProtocol {
     metadata: ResponseMetadata
   ): Promise<never> {
     const errorIdentifier = this.loadQueryErrorCode(response, dataObject) ?? "Unknown";
-    const errorData = this.loadQueryError(dataObject);
+    const errorData = this.loadQueryError(dataObject) ?? {};
     const message = this.loadQueryErrorMessage(dataObject);
     errorData.message = message;
     errorData.Error = {


### PR DESCRIPTION
## fix(core): handle empty error response body in AwsQuery protocol deserialization

Fixes #7749

### Problem

When an AWS Query protocol service (e.g. SQS) returns an HTTP 500 with an empty or malformed XML body, the SDK throws a raw `TypeError: Cannot set properties of undefined` instead of a proper `ServiceException`.

The root cause is in `AwsQueryProtocol.handleError()`: `loadQueryError(dataObject)` returns `undefined` when the parsed body has no `Error`, `Errors`, or `Errors[0].Error` fields. The code then immediately tries to set `errorData.message = message` on the `undefined` value, crashing before the error can be properly constructed.

This also affects EC2 Query protocol clients since `AwsEc2QueryProtocol` inherits `handleError` from `AwsQueryProtocol`.

### Solution

Default the return value of `loadQueryError()` to an empty object (`?? {}`) so that property assignment and access on `errorData` succeeds even when the response body is empty. The error is then constructed normally with `Type: undefined`, `Code: undefined`, and `Message: "Unknown"`.

### Changes

- `packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.ts` — add `?? {}` fallback for `loadQueryError()` result
- `packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.spec.ts` — add test for empty error response body