### PR TITLE
fix(compilation): disable Rollup externalLiveBindings to fix Jest auto-mocking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ test-schema: bundles
 test-integration: bundles
 	rm -rf ./clients/client-sso/node_modules/\@smithy # todo(yarn) incompatible redundant nesting.
 	node ./scripts/validation/no-generic-byte-arrays.js
+	node ./scripts/compilation/Inliner.spec.js
 	yarn g:vitest run -c vitest.config.integ.mts
 	make test-protocols
 	make test-types

--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -226,6 +226,7 @@ module.exports = class Inliner {
       format: "cjs",
       exports: "named",
       preserveModules: false,
+      externalLiveBindings: false,
     };
 
     const bundle = await rollup.rollup(inputOptions(variantExternalsForRollup));

--- a/scripts/compilation/Inliner.spec.js
+++ b/scripts/compilation/Inliner.spec.js
@@ -1,0 +1,54 @@
+const assert = require("assert");
+const path = require("path");
+const fs = require("fs");
+
+/**
+ * Verify that the Inliner's Rollup output uses eager bindings
+ * for external re-exports (externalLiveBindings: false).
+ *
+ * When externalLiveBindings is true (the default), Rollup emits:
+ *   Object.defineProperty(exports, k, { enumerable: true, get: function () { return ext[k]; } });
+ *
+ * These lazy getters break Jest's auto-mocking because jest.mock()
+ * snapshots exports at mock-creation time, before the getters resolve.
+ *
+ * With externalLiveBindings: false, Rollup emits:
+ *   exports[k] = ext[k];
+ *
+ * which Jest can auto-mock correctly.
+ *
+ * See: https://github.com/aws/aws-sdk-js-v3/issues/7748
+ */
+
+// Test 1: Verify the Inliner source contains externalLiveBindings: false
+const inlinerSource = fs.readFileSync(path.join(__dirname, "Inliner.js"), "utf-8");
+assert.ok(
+  inlinerSource.includes("externalLiveBindings: false"),
+  "Inliner.js must set externalLiveBindings: false in Rollup outputOptions"
+);
+
+// Test 2: If a built client-dynamodb dist-cjs/index.js exists, verify no lazy getter re-exports
+const dynamoIndexPath = path.join(__dirname, "..", "..", "clients", "client-dynamodb", "dist-cjs", "index.js");
+if (fs.existsSync(dynamoIndexPath)) {
+  const indexContents = fs.readFileSync(dynamoIndexPath, "utf-8");
+
+  // Match the lazy getter pattern Rollup emits with externalLiveBindings: true
+  const lazyGetterPattern = /Object\.defineProperty\(exports,\s*k,\s*\{[^}]*get:\s*function/g;
+  const matches = indexContents.match(lazyGetterPattern);
+
+  assert.strictEqual(
+    matches,
+    null,
+    "dist-cjs/index.js must not contain lazy Object.defineProperty getter re-exports. " +
+      "Found " +
+      (matches?.length ?? 0) +
+      " occurrences. " +
+      "Ensure externalLiveBindings: false is set in Rollup outputOptions."
+  );
+
+  console.log("PASS: dist-cjs/index.js has no lazy getter re-exports.");
+} else {
+  console.log("SKIP: client-dynamodb dist-cjs/index.js not found (not built).");
+}
+
+console.log("PASS: Inliner.js has externalLiveBindings: false.");


### PR DESCRIPTION
Fixes #7748

### Problem

When using `jest.mock("@aws-sdk/client-dynamodb")` (or any SDK client), Jest's auto-mock snapshots the module's exports at mock-creation time. However, the CJS dist bundle (`dist-cjs/index.js`) re-exports symbols from variant-external modules using lazy `Object.defineProperty` getters:

```js
Object.keys(schemas_0).forEach(function (k) {
  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k))
    Object.defineProperty(exports, k, {
      enumerable: true,
      get: function () { return schemas_0[k]; }
    });
});
```

These getters haven't resolved when Jest snapshots the exports, so all re-exported symbols (models, enums, exceptions from `schemas` and `errors` modules) become `undefined` in tests.

This affects any client that has react-native variant files, because the Inliner keeps variant files and their transitive dependencies as Rollup externals — and Rollup's default behavior is to use live-binding getters for external re-exports.

### Root Cause

The CJS inliner (`scripts/compilation/Inliner.js`) uses Rollup to bundle each client. Files with `.native.js` counterparts (e.g. `runtimeConfig`) are kept external so react-native bundlers can swap them. Their transitive `require()` targets (e.g. `schemas_0`, `errors`) are also externalized.

Rollup's default `externalLiveBindings: true` emits `Object.defineProperty` getters for these external re-exports. This is designed for ESM live-binding semantics, but is unnecessary for CJS and breaks Jest's auto-mocking.

### Solution

Set `externalLiveBindings: false` in the Rollup output options. This makes Rollup emit eager assignments instead:

```js
Object.keys(schemas_0).forEach(function (k) {
  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k))
    exports[k] = schemas_0[k];
});
```

This is semantically equivalent for CJS (live bindings only matter for ESM circular imports) and allows Jest to see all exports immediately when auto-mocking.

From the [Rollup documentation](https://rollupjs.org/configuration-options/#output-externallivebindings):
> When set to false, Rollup will not generate code to support live bindings for external imports but instead assume that exports do not change over time. This will enable Rollup to generate more optimized code.

### Changes

- `scripts/compilation/Inliner.js` — add `externalLiveBindings: false` to Rollup `outputOptions`
- `scripts/compilation/Inliner.spec.js` — new test verifying the option is set and output has no lazy getters