### PR TITLE
fix(s3-presigned-post): use starts-with condition for fields containing ${filename}

### DIFF
--- a/packages/s3-presigned-post/src/createPresignedPost.spec.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.spec.ts
@@ -1,6 +1,6 @@
 import { defaultEndpointResolver } from "@aws-sdk/client-s3/src/endpoint/endpointResolver";
 import { createScope, getSigningKey } from "@smithy/signature-v4";
-import { HttpRequest, SourceData } from "@smithy/types";
+import type { HttpRequest, SourceData } from "@smithy/types";
 import { afterAll, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import {
@@ -104,6 +104,25 @@ describe("createPresignedPost", () => {
     });
     const { conditions } = JSON.parse(mockS3Client.config.utf8Decoder.mock.calls[0] as any);
     expect(conditions).toContainEqual(["starts-with", "$key", "path/to/"]);
+  });
+
+  it("should use starts-with condition for fields containing ${filename}", async () => {
+    //@ts-ignore mock s3 client
+    const { fields } = await createPresignedPost(mockS3Client, {
+      Bucket,
+      Key: "uploads/${filename}",
+      Fields: {
+        success_action_redirect: "https://example.com/success?file=${filename}",
+      },
+    });
+    const { conditions } = JSON.parse(mockS3Client.config.utf8Decoder.mock.calls[0] as any);
+    // Field containing ${filename} should get a starts-with condition, not an exact match
+    expect(conditions).toContainEqual(["starts-with", "$success_action_redirect", "https://example.com/success?file="]);
+    expect(conditions).not.toContainEqual({
+      success_action_redirect: "https://example.com/success?file=${filename}",
+    });
+    // The field value itself should still contain ${filename} for S3 to substitute
+    expect(fields.success_action_redirect).toBe("https://example.com/success?file=${filename}");
   });
 
   it("should default expiration at 3600 seconds later", async () => {

--- a/packages/s3-presigned-post/src/createPresignedPost.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.ts
@@ -1,12 +1,10 @@
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import type { S3Client } from "@aws-sdk/client-s3";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { formatUrl } from "@aws-sdk/util-format-url";
-import {
-  EndpointParameterInstructionsSupplier,
-  getEndpointFromInstructions,
-  toEndpointV1,
-} from "@smithy/middleware-endpoint";
+import type { EndpointParameterInstructionsSupplier } from "@smithy/middleware-endpoint";
+import { getEndpointFromInstructions, toEndpointV1 } from "@smithy/middleware-endpoint";
 import { createScope, getSigningKey } from "@smithy/signature-v4";
-import { ChecksumConstructor, HashConstructor, SourceData } from "@smithy/types";
+import type { ChecksumConstructor, HashConstructor, SourceData } from "@smithy/types";
 import { toHex } from "@smithy/util-hex-encoding";
 import { toUint8Array } from "@smithy/util-utf8";
 
@@ -18,7 +16,7 @@ import {
   SIGNATURE_QUERY_PARAM,
   TOKEN_QUERY_PARAM,
 } from "./constants";
-import { Conditions as PolicyEntry } from "./types";
+import type { Conditions as PolicyEntry } from "./types";
 
 type Fields = Record<string, string>;
 
@@ -74,10 +72,14 @@ export const createPresignedPost = async (
     conditionsSet.add(stringifiedCondition);
   }
 
-  for (const [k,v] of Object.entries(fields)) {
-    conditionsSet.add(JSON.stringify({ [k]: v }))
-  }  
-  
+  for (const [k, v] of Object.entries(fields)) {
+    if (typeof v === "string" && v.includes("${filename}")) {
+      conditionsSet.add(JSON.stringify(["starts-with", `$${k}`, v.substring(0, v.lastIndexOf("${filename}"))]));
+    } else {
+      conditionsSet.add(JSON.stringify({ [k]: v }));
+    }
+  }
+
   if (Key.endsWith("${filename}")) {
     conditionsSet.add(JSON.stringify(["starts-with", "$key", Key.substring(0, Key.lastIndexOf("${filename}"))]));
   } else {


### PR DESCRIPTION
Fixes #7191

### Problem

When using `createPresignedPost()` with `${filename}` in a field value (e.g. `success_action_redirect`), S3 rejects the upload with `AccessDenied`. 

S3 supports `${filename}` variable substitution in POST uploads — at upload time, S3 replaces `${filename}` with the actual uploaded filename. However, the SDK generates an exact-match policy condition for all fields:

```json
{"success_action_redirect": "https://example.com/success?file=${filename}"}
```

When S3 substitutes `${filename}` with the real filename (e.g. `test.txt`), the field value becomes `https://example.com/success?file=test.txt`, which no longer matches the exact condition, causing a policy violation.

The SDK already handles this correctly for the `Key` field (line 82), but not for other fields.

### Solution

Extend the existing `${filename}` detection to all user-provided `Fields`. When a field value contains `${filename}`, generate a `starts-with` condition instead of an exact match:

```json
["starts-with", "$success_action_redirect", "https://example.com/success?file="]
```

This allows S3 to substitute `${filename}` freely while still enforcing that the field value starts with the expected prefix.

### Changes

- `packages/s3-presigned-post/src/createPresignedPost.ts` — check field values for `${filename}` and emit `starts-with` conditions
- `packages/s3-presigned-post/src/createPresignedPost.spec.ts` — add test for `${filename}` in field values

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
