### PR TITLE
feat(client-iam): default region to us-east-1 for global IAM service

### DIFF
--- a/clients/client-iam/src/runtimeConfig.browser.ts
+++ b/clients/client-iam/src/runtimeConfig.browser.ts
@@ -6,7 +6,6 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { createDefaultUserAgentProvider } from "@aws-sdk/util-user-agent-browser";
 import { DEFAULT_USE_DUALSTACK_ENDPOINT, DEFAULT_USE_FIPS_ENDPOINT } from "@smithy/config-resolver";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
-import { invalidProvider } from "@smithy/invalid-dependency";
 import { loadConfigsForDefaultMode } from "@smithy/smithy-client";
 import { calculateBodyLength } from "@smithy/util-body-length-browser";
 import { resolveDefaultsModeConfig } from "@smithy/util-defaults-mode-browser";
@@ -31,7 +30,7 @@ export const getRuntimeConfig = (config: IAMClientConfig) => {
     credentialDefaultProvider: config?.credentialDefaultProvider ?? ((_: unknown) => () => Promise.reject(new Error("Credential is missing"))),
     defaultUserAgentProvider: config?.defaultUserAgentProvider ?? createDefaultUserAgentProvider({serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version}),
     maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
-    region: config?.region ?? invalidProvider("Region is missing"),
+    region: config?.region ?? "us-east-1",
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
     sha256: config?.sha256 ?? Sha256,

--- a/clients/client-iam/src/runtimeConfig.ts
+++ b/clients/client-iam/src/runtimeConfig.ts
@@ -46,10 +46,16 @@ export const getRuntimeConfig = (config: IAMClientConfig) => {
     credentialDefaultProvider: config?.credentialDefaultProvider ?? credentialDefaultProvider,
     defaultUserAgentProvider: config?.defaultUserAgentProvider ?? createDefaultUserAgentProvider({serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version}),
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
-    region: config?.region ?? loadNodeConfig(
-        NODE_REGION_CONFIG_OPTIONS,
-        {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
-    ),
+    region: config?.region ?? (async () => {
+      try {
+        return await loadNodeConfig(
+          NODE_REGION_CONFIG_OPTIONS,
+          {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
+        )();
+      } catch (e) {
+        return "us-east-1";
+      }
+    }),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??

--- a/clients/client-iam/test/default-region.spec.ts
+++ b/clients/client-iam/test/default-region.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getRuntimeConfig } from "../src/runtimeConfig";
+
+describe("IAM default region", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    // Clear any region-related env vars
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_DEFAULT_REGION;
+    delete process.env.AMAZON_REGION;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should default to us-east-1 when no region is configured", async () => {
+    const config = getRuntimeConfig({
+      // Explicitly pass no region, and override profile to avoid loading from ~/.aws/config
+      profile: "__test_no_region_profile__",
+    });
+    // The region field should be a provider that resolves to us-east-1
+    const region = typeof config.region === "function" ? await config.region() : config.region;
+    expect(region).toBe("us-east-1");
+  });
+
+  it("should use the provided region when explicitly set", async () => {
+    const config = getRuntimeConfig({
+      region: "eu-west-1",
+    });
+    const region = typeof config.region === "function" ? await config.region() : config.region;
+    expect(region).toBe("eu-west-1");
+  });
+
+  it("should use the region from environment when set", async () => {
+    process.env.AWS_REGION = "ap-southeast-1";
+    const config = getRuntimeConfig({});
+    const region = typeof config.region === "function" ? await config.region() : config.region;
+    expect(region).toBe("ap-southeast-1");
+  });
+});

--- a/scripts/generate-clients/customizations/iam-global-region.js
+++ b/scripts/generate-clients/customizations/iam-global-region.js
@@ -1,0 +1,46 @@
+const fs = require("fs");
+const path = require("path");
+
+const root = path.join(__dirname, "..", "..", "..");
+
+const runtimeConfigTs = path.join(root, "clients", "client-iam", "src", "runtimeConfig.ts");
+const runtimeConfigBrowserTs = path.join(root, "clients", "client-iam", "src", "runtimeConfig.browser.ts");
+
+/**
+ * IAM is a global service. The region parameter is only used to determine
+ * the AWS partition for endpoint resolution. When no region is configured,
+ * default to us-east-1 so users don't need to specify a region for the
+ * standard aws partition.
+ *
+ * @see https://github.com/aws/aws-sdk-js-v3/issues/6343
+ */
+module.exports = function () {
+  // Node.js runtime config: wrap region loader to fall back to us-east-1
+  let nodeConfig = fs.readFileSync(runtimeConfigTs, "utf-8");
+  nodeConfig = nodeConfig.replace(
+    /region: config\?\.region \?\? loadNodeConfig\(\s*NODE_REGION_CONFIG_OPTIONS,\s*\{\.\.\.NODE_REGION_CONFIG_FILE_OPTIONS, \.\.\.loaderConfig\}\s*\)/,
+    `region: config?.region ?? (async () => {
+      try {
+        return await loadNodeConfig(
+          NODE_REGION_CONFIG_OPTIONS,
+          {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
+        )();
+      } catch (e) {
+        return "us-east-1";
+      }
+    })`
+  );
+  fs.writeFileSync(runtimeConfigTs, nodeConfig);
+
+  // Browser runtime config: replace invalidProvider with default region
+  let browserConfig = fs.readFileSync(runtimeConfigBrowserTs, "utf-8");
+  browserConfig = browserConfig.replace(
+    `region: config?.region ?? invalidProvider("Region is missing")`,
+    `region: config?.region ?? "us-east-1"`
+  );
+  // Remove unused invalidProvider import if no other usage remains
+  if (!browserConfig.includes("invalidProvider(") || browserConfig.match(/invalidProvider\(/g).length === 0) {
+    browserConfig = browserConfig.replace(/import \{ invalidProvider \} from "@smithy\/invalid-dependency";\n/, "");
+  }
+  fs.writeFileSync(runtimeConfigBrowserTs, browserConfig);
+};

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -124,6 +124,7 @@ const {
     }
 
     require("./customizations/workspaces-thin-client")();
+    require("./customizations/iam-global-region")();
 
     if (!protocolTestsOnly && !globs) {
       await generateNestedClients();

--- a/scripts/generate-clients/single-service.js
+++ b/scripts/generate-clients/single-service.js
@@ -23,6 +23,10 @@ const { solo } = yargs(process.argv.slice(2))
       require("./customizations/workspaces-thin-client")();
     }
 
+    if (solo === "iam") {
+      require("./customizations/iam-global-region")();
+    }
+
     if (solo === "sts" || solo === "sso-oidc" || solo === "signin") {
       const generateNestedClients = require("./nested-clients/generate-nested-clients");
       await generateNestedClients();


### PR DESCRIPTION
Closes #6343

### Problem

When creating an `IAMClient` without specifying a region, the SDK throws `"Region is missing"`. This is confusing because IAM is a global service — it always routes to a global endpoint (`iam.global.api.aws`) regardless of which region you specify. The region is only used internally to determine the AWS partition (aws, aws-cn, aws-us-gov).

Users coming from AWS SDK v2 (where `new AWS.IAM()` worked without a region) or from the AWS CLI (where `aws iam list-users` works without a region) are surprised by this behavior.

### Solution

Added a post-codegen customization script (`scripts/generate-clients/customizations/iam-global-region.js`) that modifies the generated runtime configs to default the region to `us-east-1` when no region is configured. The customization is invoked from both `single-service.js` and `index.js`, so it survives codegen regeneration.

The customization applies to both runtime configs:

- **Node.js** (`runtimeConfig.ts`): Wraps the region config loader in a try/catch that falls back to `"us-east-1"` when no region is found in env vars or shared config
- **Browser** (`runtimeConfig.browser.ts`): Replaces `invalidProvider("Region is missing")` with `"us-east-1"`

The `us-east-1` default is appropriate because:
1. IAM's endpoint ruleset uses the region solely to determine the partition via `aws.partition(Region)`
2. `us-east-1` maps to the `aws` partition, which routes to `iam.global.api.aws`
3. Users targeting `aws-cn` or `aws-us-gov` partitions will always have a region configured (since all services in those partitions are regional)

This follows the same post-codegen customization pattern used by `workspaces-thin-client.js`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
