### PR TITLE
fix(codegen): strip empty self-closing HTML tags from documentation traits

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/SanitizeDocumentation.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/SanitizeDocumentation.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Sanitizes documentation traits by removing empty self-closing HTML tags
+ * such as {@code <p/>} that render as literal text in generated docs.
+ */
+@SmithyInternalApi
+public final class SanitizeDocumentation implements TypeScriptIntegration {
+
+    private static final Pattern EMPTY_SELF_CLOSING_TAGS = Pattern.compile("<\\s*(p|br|hr)\\s*/>");
+
+    @Override
+    public Model preprocessModel(Model model, TypeScriptSettings settings) {
+        List<Shape> modifiedShapes = new ArrayList<>();
+
+        for (Shape shape : model.toSet()) {
+            shape.getTrait(DocumentationTrait.class).ifPresent(trait -> {
+                String original = trait.getValue();
+                String sanitized = EMPTY_SELF_CLOSING_TAGS.matcher(original).replaceAll("");
+                if (!sanitized.equals(original)) {
+                    modifiedShapes.add(
+                        Shape.shapeToBuilder(shape)
+                            .addTrait(new DocumentationTrait(sanitized, trait.getSourceLocation()))
+                            .build()
+                    );
+                }
+            });
+        }
+
+        if (!modifiedShapes.isEmpty()) {
+            model = ModelTransformer.create().replaceShapes(model, modifiedShapes);
+        }
+
+        return model;
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -1,3 +1,4 @@
+software.amazon.smithy.aws.typescript.codegen.SanitizeDocumentation
 software.amazon.smithy.aws.typescript.codegen.AddEndpointsV2ParameterNameMap
 software.amazon.smithy.aws.typescript.codegen.AddAwsRuntimeConfig
 software.amazon.smithy.aws.typescript.codegen.AddAccountIdEndpointModeRuntimeConfig


### PR DESCRIPTION
Fixes #7477

## Problem

Several upstream AWS service models contain empty self-closing HTML tags like `<p/>` in their `smithy.api#documentation` trait values. These tags pass through code generation unmodified and render as literal text in:

- Generated `README.md` files (e.g. `clients/client-lambda/README.md`)
- JSDoc/TSDoc comments in generated TypeScript source (e.g. `LambdaClient.ts`)
- The published API reference at docs.aws.amazon.com

The Lambda client page is the one called out in the issue, but 30 service models are affected (RDS alone has 89 occurrences of `<p/>`).

## Solution

Adds a new `SanitizeDocumentation` codegen integration that runs as a `preprocessModel` step — before any code generation. It walks every shape in the Smithy model, finds `DocumentationTrait` values containing empty self-closing HTML tags (`<p/>`, `<br/>`, `<hr/>`), and strips them.

Because this operates on the model before codegen, it fixes all downstream outputs at once: READMEs, JSDoc in `.ts` files, and anything else that consumes the documentation trait. It's also resilient to future model updates that reintroduce these tags.

## Changes

- **New file:** `codegen/smithy-aws-typescript-codegen/src/main/java/.../SanitizeDocumentation.java`
  - Implements `TypeScriptIntegration.preprocessModel`
  - Uses a regex to match `<p/>`, `<br/>`, `<hr/>` (with optional whitespace)
  - Replaces affected shapes via `ModelTransformer.replaceShapes`
- **Modified:** `META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration`
  - Registers the new integration

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
