### PR TITLE
chore(scripts): use $npm_package_name in `build:include:deps` script

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -66,12 +66,9 @@ const mergeManifest = async (fromContent = {}, toContent = {}, parentKey = "root
         delete fromContent[name]["typedoc"];
       }
 
-      if (name === "build" && parentKey === "scripts") {
-        // build CJS after ES because of rollup inliner.
-        fromContent[name] = `concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs`;
-      }
-
-      if (name === "scripts" && !fromContent[name]["build:include:deps"]) {
+      if (name === "scripts") {
+        // build CJS after types and ES because of rollup inliner.
+        fromContent[name]["build"] = `concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs`;
         fromContent[name]["build:include:deps"] = `yarn g:turbo run build -F="$npm_package_name"`;
       }
 


### PR DESCRIPTION
### Description
- The `build:include:deps` script was being generated with hardcoded package names (e.g. @aws-sdk/weather-legacy-auth) instead of using the `$npm_package_name`, causing unnecessary diffs in pacakge.json when running `generate-clients`.
- build script was incorrectly placed inside the `Object` type check, but build script values are strings and not objects, so that script was never executed. Modified it to place it inside the scripts object check.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
