### PR TITLE
test(util-user-agent-node): add integration test

### DIFF
--- a/packages-internal/util-user-agent-node/package.json
+++ b/packages-internal/util-user-agent-node/package.json
@@ -10,7 +10,9 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
     "test": "yarn g:vitest run",
-    "test:watch": "yarn g:vitest watch"
+    "test:integration": "yarn g:vitest run -c vitest.config.integ.mts",
+    "test:watch": "yarn g:vitest watch",
+    "test:integration:watch": "yarn g:vitest watch -c vitest.config.integ.mts"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages-internal/util-user-agent-node/src/util-user-agent-node.integ.spec.ts
+++ b/packages-internal/util-user-agent-node/src/util-user-agent-node.integ.spec.ts
@@ -1,0 +1,21 @@
+import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
+import { S3 } from "@aws-sdk/client-s3";
+import { version as sdkVersion } from "@aws-sdk/client-s3/package.json";
+import { platform, release } from "os";
+import { versions } from "process";
+import { describe, test as it } from "vitest";
+const { version: tscVersion } = await import("typescript");
+
+describe("util-user-agent-node", () => {
+  it("populates user agent string", async () => {
+    const client = new S3({ region: "us-west-2" });
+    requireRequestsFrom(client).toMatch({
+      headers: {
+        "user-agent": `aws-sdk-js/${sdkVersion} ua/2.1 os/${platform()}#${release()} lang/js md/nodejs#${
+          versions.node
+        } api/s3#${sdkVersion} m/E,g`,
+      },
+    });
+    await client.listBuckets();
+  });
+});

--- a/packages-internal/util-user-agent-node/vitest.config.integ.mts
+++ b/packages-internal/util-user-agent-node/vitest.config.integ.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.integ.spec.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
### Issue
Split from https://github.com/aws/aws-sdk-js-v3/pull/7783

### Description
Adds integration test in util-user-agent-node

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
