### PR TITLE
fix(lib-dynamodb): conditionally clone middleware stack when cacheMiddleware is enabled

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
@@ -192,15 +192,15 @@ final class DocumentBareBonesClientGenerator implements Runnable {
                 writer.write("super(client.config);");
                 writer.write("this.config = client.config;");
                 writer.write("this.config.translateConfig = translateConfig;");
+                writer.write("if (this.config.cacheMiddleware) {");
+                writer.indent();
+                writer.write("this.middlewareStack = client.middlewareStack.clone();");
+                writer.dedent();
+                writer.write("} else {");
+                writer.indent();
                 writer.write("this.middlewareStack = client.middlewareStack;");
-                writer.write("""
-                             if (this.config?.cacheMiddleware) {
-                                 throw new Error(
-                                     "@aws-sdk/lib-dynamodb - cacheMiddleware=true is not compatible with the"
-                                       + " DynamoDBDocumentClient. This option must be set to false."
-                                 );
-                             }
-                             """);
+                writer.dedent();
+                writer.write("}");
                 writer.popState();
             }
         );

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.spec.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.spec.ts
@@ -1,0 +1,82 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+import { describe, expect, test as it } from "vitest";
+
+import { DynamoDBDocument } from "./DynamoDBDocument";
+import { DynamoDBDocumentClient } from "./DynamoDBDocumentClient";
+
+describe(DynamoDBDocumentClient.name, () => {
+  describe("default (cacheMiddleware: false)", () => {
+    it("should share the middleware stack with the parent client", () => {
+      const dynamodb = new DynamoDB({ credentials: {} as any });
+      const docClient = DynamoDBDocumentClient.from(dynamodb);
+      expect(docClient.middlewareStack).toBe(dynamodb.middlewareStack);
+    });
+  });
+
+  describe("cacheMiddleware: true", () => {
+    it("should allow initialization without throwing", () => {
+      const dynamodb = new DynamoDB({
+        credentials: {} as any,
+        cacheMiddleware: true,
+      });
+      expect(() => {
+        DynamoDBDocumentClient.from(dynamodb);
+      }).not.toThrow();
+    });
+
+    it("should clone the middleware stack from the parent client", () => {
+      const dynamodb = new DynamoDB({
+        credentials: {} as any,
+        cacheMiddleware: true,
+      });
+      const docClient = DynamoDBDocumentClient.from(dynamodb);
+      expect(docClient.middlewareStack).not.toBe(dynamodb.middlewareStack);
+      expect(docClient.middlewareStack.identify()).toEqual(dynamodb.middlewareStack.identify());
+    });
+
+    it("should not affect parent when middleware is added to document client", () => {
+      const dynamodb = new DynamoDB({
+        credentials: {} as any,
+        cacheMiddleware: true,
+      });
+      const parentEntryCount = dynamodb.middlewareStack.identify().length;
+      const docClient = DynamoDBDocumentClient.from(dynamodb);
+
+      docClient.middlewareStack.add(
+        (next: any) => (args: any) => next(args),
+        { name: "testMiddleware", step: "initialize" }
+      );
+
+      expect(dynamodb.middlewareStack.identify().length).toBe(parentEntryCount);
+      expect(docClient.middlewareStack.identify().length).toBe(parentEntryCount + 1);
+    });
+
+    it("should not affect document client when middleware is added to parent after creation", () => {
+      const dynamodb = new DynamoDB({
+        credentials: {} as any,
+        cacheMiddleware: true,
+      });
+      const docClient = DynamoDBDocumentClient.from(dynamodb);
+      const docEntryCount = docClient.middlewareStack.identify().length;
+
+      dynamodb.middlewareStack.add(
+        (next: any) => (args: any) => next(args),
+        { name: "lateParentMiddleware", step: "initialize" }
+      );
+
+      expect(docClient.middlewareStack.identify().length).toBe(docEntryCount);
+    });
+  });
+});
+
+describe(DynamoDBDocument.name, () => {
+  it("should allow initialization with cacheMiddleware: true", () => {
+    const dynamodb = new DynamoDB({
+      credentials: {} as any,
+      cacheMiddleware: true,
+    });
+    expect(() => {
+      DynamoDBDocument.from(dynamodb);
+    }).not.toThrow();
+  });
+});

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
@@ -1,30 +1,33 @@
 // smithy-typescript generated code
-import { Client as __Client } from "@smithy/smithy-client";
-import type { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
-
-import {
-  BatchExecuteStatementCommandInput,
-  BatchExecuteStatementCommandOutput,
-} from "./commands/BatchExecuteStatementCommand";
-import { BatchGetCommandInput, BatchGetCommandOutput } from "./commands/BatchGetCommand";
-import { BatchWriteCommandInput, BatchWriteCommandOutput } from "./commands/BatchWriteCommand";
-import { DeleteCommandInput, DeleteCommandOutput } from "./commands/DeleteCommand";
-import { ExecuteStatementCommandInput, ExecuteStatementCommandOutput } from "./commands/ExecuteStatementCommand";
-import { ExecuteTransactionCommandInput, ExecuteTransactionCommandOutput } from "./commands/ExecuteTransactionCommand";
-import { GetCommandInput, GetCommandOutput } from "./commands/GetCommand";
-import { PutCommandInput, PutCommandOutput } from "./commands/PutCommand";
-import { QueryCommandInput, QueryCommandOutput } from "./commands/QueryCommand";
-import { ScanCommandInput, ScanCommandOutput } from "./commands/ScanCommand";
-import { TransactGetCommandInput, TransactGetCommandOutput } from "./commands/TransactGetCommand";
-import { TransactWriteCommandInput, TransactWriteCommandOutput } from "./commands/TransactWriteCommand";
-import { UpdateCommandInput, UpdateCommandOutput } from "./commands/UpdateCommand";
-import {
+import type {
   DynamoDBClient,
   DynamoDBClientResolvedConfig,
   ServiceInputTypes as __ServiceInputTypes,
   ServiceOutputTypes as __ServiceOutputTypes,
 } from "@aws-sdk/client-dynamodb";
-import { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
+import type { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
+import { Client as __Client } from "@smithy/smithy-client";
+import type { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
+
+import type {
+  BatchExecuteStatementCommandInput,
+  BatchExecuteStatementCommandOutput,
+} from "./commands/BatchExecuteStatementCommand";
+import type { BatchGetCommandInput, BatchGetCommandOutput } from "./commands/BatchGetCommand";
+import type { BatchWriteCommandInput, BatchWriteCommandOutput } from "./commands/BatchWriteCommand";
+import type { DeleteCommandInput, DeleteCommandOutput } from "./commands/DeleteCommand";
+import type { ExecuteStatementCommandInput, ExecuteStatementCommandOutput } from "./commands/ExecuteStatementCommand";
+import type {
+  ExecuteTransactionCommandInput,
+  ExecuteTransactionCommandOutput,
+} from "./commands/ExecuteTransactionCommand";
+import type { GetCommandInput, GetCommandOutput } from "./commands/GetCommand";
+import type { PutCommandInput, PutCommandOutput } from "./commands/PutCommand";
+import type { QueryCommandInput, QueryCommandOutput } from "./commands/QueryCommand";
+import type { ScanCommandInput, ScanCommandOutput } from "./commands/ScanCommand";
+import type { TransactGetCommandInput, TransactGetCommandOutput } from "./commands/TransactGetCommand";
+import type { TransactWriteCommandInput, TransactWriteCommandOutput } from "./commands/TransactWriteCommand";
+import type { UpdateCommandInput, UpdateCommandOutput } from "./commands/UpdateCommand";
 
 /**
  * @public
@@ -33,7 +36,8 @@ export { __Client };
 /**
  * @public
  */
-export type ServiceInputTypes = __ServiceInputTypes
+export type ServiceInputTypes =
+  | __ServiceInputTypes
   | BatchExecuteStatementCommandInput
   | BatchGetCommandInput
   | BatchWriteCommandInput
@@ -51,7 +55,8 @@ export type ServiceInputTypes = __ServiceInputTypes
 /**
  * @public
  */
-export type ServiceOutputTypes = __ServiceOutputTypes
+export type ServiceOutputTypes =
+  | __ServiceOutputTypes
   | BatchExecuteStatementCommandOutput
   | BatchGetCommandOutput
   | BatchWriteCommandOutput
@@ -72,7 +77,7 @@ export type ServiceOutputTypes = __ServiceOutputTypes
 export type TranslateConfig = {
   marshallOptions?: marshallOptions;
   unmarshallOptions?: unmarshallOptions;
-}
+};
 
 /**
  * @public
@@ -125,25 +130,40 @@ export type DynamoDBDocumentClientResolvedConfig = DynamoDBClientResolvedConfig 
  * [null, false, 1, "two"]
  * ```
  *
+ * ## Middleware Stack Behavior
+ *
+ * By default, the document client shares the middleware stack of the parent
+ * `DynamoDBClient` by reference. Middleware added to either client will affect
+ * both.
+ *
+ * When `cacheMiddleware: true` is set on the parent `DynamoDBClient`, the
+ * document client clones the middleware stack at construction time, making the
+ * two clients independent. This is required because cached middleware handlers
+ * on a shared stack would become stale if either side mutated it.
+ *
  * @see {@link https://www.npmjs.com/package/@aws-sdk/client-dynamodb | @aws-sdk/client-dynamodb}
  *
  * @public
  */
-export class DynamoDBDocumentClient extends __Client<__HttpHandlerOptions, ServiceInputTypes, ServiceOutputTypes, DynamoDBDocumentClientResolvedConfig> {
+export class DynamoDBDocumentClient extends __Client<
+  __HttpHandlerOptions,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+  DynamoDBDocumentClientResolvedConfig
+> {
   readonly config: DynamoDBDocumentClientResolvedConfig;
 
-  protected constructor(client: DynamoDBClient, translateConfig?: TranslateConfig){
+  protected constructor(client: DynamoDBClient, translateConfig?: TranslateConfig) {
     super(client.config);
     this.config = client.config;
     this.config.translateConfig = translateConfig;
-    this.middlewareStack = client.middlewareStack;
-    if (this.config?.cacheMiddleware) {
-        throw new Error(
-            "@aws-sdk/lib-dynamodb - cacheMiddleware=true is not compatible with the"
-              + " DynamoDBDocumentClient. This option must be set to false."
-        );
+    if (this.config.cacheMiddleware) {
+      // Clone the stack so cached handlers on the parent don't go stale
+      // when the document client adds its own middleware.
+      this.middlewareStack = client.middlewareStack.clone();
+    } else {
+      this.middlewareStack = client.middlewareStack;
     }
-
   }
 
   static from(client: DynamoDBClient, translateConfig?: TranslateConfig) {

--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -32,14 +32,14 @@ import { afterAll, beforeAll, describe, expect, test as it, vi } from "vitest";
 // expected running time: table creation (~20s) + operations 10s
 
 describe(DynamoDBDocument.name, () => {
-  it("should deny initialization with cacheMiddleware: true", () => {
+  it("should allow initialization with cacheMiddleware: true", () => {
     const dynamodb = new DynamoDB({
       credentials: {} as any,
       cacheMiddleware: true,
     });
     expect(() => {
       DynamoDBDocument.from(dynamodb);
-    }).toThrow();
+    }).not.toThrow();
   });
 });
 


### PR DESCRIPTION
Previously: https://github.com/aws/aws-sdk-js-v3/pull/7762

Currently, setting `cacheMiddleware: true` on `DynamoDBDocumentClient` causes a runtime error.

With this PR, that setting causes the middleware stack from the parent to be cloned, allowing it to be cached. When `cacheMiddleware` is `false` (the default), the existing shared-reference behavior is preserved.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
