### PR TITLE
chore(scripts): script for setting * versions in workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "test:unit": "make test-unit",
     "test:versions": "jest --config tests/versions/jest.config.js tests/versions/index.spec.ts",
     "update:versions:default": "node ./scripts/update-versions/default.mjs",
-    "update:versions:current": "node ./scripts/update-versions/current.mjs"
+    "update:versions:current": "node ./scripts/update-versions/current.mjs",
+    "update:versions:preview": "node ./scripts/update-versions/preview.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/update-versions/getDepToDefaultVersionHash.mjs
+++ b/scripts/update-versions/getDepToDefaultVersionHash.mjs
@@ -1,6 +1,6 @@
 // @ts-check
-import { readFileSync } from "fs";
-import { basename, join } from "path";
+import { readFileSync } from "node:fs";
+import { basename, join } from "node:path";
 
 import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
 

--- a/scripts/update-versions/preview.mjs
+++ b/scripts/update-versions/preview.mjs
@@ -1,0 +1,16 @@
+// @ts-check
+
+// Updates versions for `@aws-sdk/*` local package interdependencies to `workspace:(actual version)`
+// or `workspace:^(actual version)` for free-range packages.
+
+import { basename } from "node:path";
+
+import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
+import { updateVersions } from "./updateVersions.mjs";
+
+updateVersions(
+  getWorkspacePaths().reduce((acc, workspacePath) => {
+    acc[`@aws-sdk/${basename(workspacePath)}`] = `*`;
+    return acc;
+  }, {})
+);


### PR DESCRIPTION
### Issue
V2122908547

### Description
script for setting `*` versions for the `@aws-sdk` monorepo workspace

### Testing
n/a

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
