### PR TITLE
fix(middleware-user-agent): use retry strategy mode property instead of legacy fallback

### DIFF
--- a/packages-internal/middleware-user-agent/package.json
+++ b/packages-internal/middleware-user-agent/package.json
@@ -31,6 +31,7 @@
     "@smithy/core": "^3.23.8",
     "@smithy/protocol-http": "^5.3.11",
     "@smithy/types": "^4.13.0",
+    "@smithy/util-retry": "^4.2.11",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages-internal/middleware-user-agent/src/check-features.spec.ts
+++ b/packages-internal/middleware-user-agent/src/check-features.spec.ts
@@ -32,4 +32,23 @@ describe(checkFeatures.name, () => {
   it("should not throw an error if no fields are present", async () => {
     await checkFeatures({}, {}, {} as any);
   });
+
+  it.each([
+    ["standard", "RETRY_MODE_STANDARD", "E"],
+    ["adaptive", "RETRY_MODE_ADAPTIVE", "F"],
+  ] as const)("should set %s retry mode feature", async (mode, featureKey, featureValue) => {
+    const context = {} as AwsHandlerExecutionContext;
+    const config = { retryStrategy: async () => ({ mode }) };
+    await checkFeatures(context, config, { request: undefined, input: undefined });
+    expect(context.__aws_sdk_context?.features?.[featureKey]).toBe(featureValue);
+  });
+
+  it.each([["unknown"], [undefined]])("should not set any retry mode feature when mode is %s", async (mode) => {
+    const context = {} as AwsHandlerExecutionContext;
+    const config = { retryStrategy: async () => ({ ...(mode !== undefined && { mode }) }) };
+    await checkFeatures(context, config, { request: undefined, input: undefined });
+    expect(context.__aws_sdk_context?.features?.RETRY_MODE_STANDARD).toBeUndefined();
+    expect(context.__aws_sdk_context?.features?.RETRY_MODE_ADAPTIVE).toBeUndefined();
+    expect(context.__aws_sdk_context?.features?.RETRY_MODE_LEGACY).toBeUndefined();
+  });
 });

--- a/packages-internal/middleware-user-agent/src/check-features.ts
+++ b/packages-internal/middleware-user-agent/src/check-features.ts
@@ -6,13 +6,8 @@ import type {
   AwsSdkCredentialsFeatures,
 } from "@aws-sdk/types";
 import type { IHttpRequest } from "@smithy/protocol-http";
-import type {
-  AwsCredentialIdentityProvider,
-  BuildHandlerArguments,
-  Provider,
-  RetryStrategy,
-  RetryStrategyV2,
-} from "@smithy/types";
+import type { AwsCredentialIdentityProvider, BuildHandlerArguments, Provider } from "@smithy/types";
+import { RETRY_MODES } from "@smithy/util-retry";
 
 /**
  * @internal
@@ -20,7 +15,7 @@ import type {
 type PreviouslyResolved = Partial<{
   credentials?: AwsCredentialIdentityProvider;
   accountIdEndpointMode?: Provider<AccountIdEndpointMode>;
-  retryStrategy?: Provider<RetryStrategy | RetryStrategyV2>;
+  retryStrategy?: Provider<{ mode?: string }>;
 }>;
 
 /**
@@ -46,14 +41,15 @@ export async function checkFeatures(
 
   if (typeof config.retryStrategy === "function") {
     const retryStrategy = await config.retryStrategy();
-    if (typeof (retryStrategy as RetryStrategyV2).acquireInitialRetryToken === "function") {
-      if (retryStrategy.constructor?.name?.includes("Adaptive")) {
-        setFeature(context, "RETRY_MODE_ADAPTIVE", "F");
-      } else {
-        setFeature(context, "RETRY_MODE_STANDARD", "E");
+    if (typeof retryStrategy.mode === "string") {
+      switch (retryStrategy.mode) {
+        case RETRY_MODES.ADAPTIVE:
+          setFeature(context, "RETRY_MODE_ADAPTIVE", "F");
+          break;
+        case RETRY_MODES.STANDARD:
+          setFeature(context, "RETRY_MODE_STANDARD", "E");
+          break;
       }
-    } else {
-      setFeature(context, "RETRY_MODE_LEGACY", "D");
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24395,6 +24395,7 @@ __metadata:
     "@smithy/core": "npm:^3.23.8"
     "@smithy/protocol-http": "npm:^5.3.11"
     "@smithy/types": "npm:^4.13.0"
+    "@smithy/util-retry": "npm:^4.2.11"
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"


### PR DESCRIPTION
Fixes #7574

### Problem

The `checkFeatures` function in `middleware-user-agent` incorrectly attributes pre-SRA retry strategies as "legacy" (`D`) in the user-agent feature metadata. It does this by checking for `acquireInitialRetryToken` (a `RetryStrategyV2`-only method), and if absent, assumes the retry mode is legacy.

"Legacy" refers to AWS SDK for JavaScript v2 retry behavior, which does not exist in v3. Pre-SRA retry strategies in this SDK are still either standard or adaptive — they just implement the older `RetryStrategy` interface instead of `RetryStrategyV2`.

### Solution

All retry strategies in v3 (both SRA and pre-SRA) expose a `mode` property set to either `"standard"` or `"adaptive"`. The fix replaces the `acquireInitialRetryToken` type-check branching with a single `mode` property check, which correctly identifies the retry mode regardless of which interface the strategy implements.

Before:
```ts
if (typeof (retryStrategy as RetryStrategyV2).acquireInitialRetryToken === "function") {
  if (retryStrategy.constructor?.name?.includes("Adaptive")) {
    setFeature(context, "RETRY_MODE_ADAPTIVE", "F");
  } else {
    setFeature(context, "RETRY_MODE_STANDARD", "E");
  }
} else {
  setFeature(context, "RETRY_MODE_LEGACY", "D"); // wrong for v3 pre-SRA strategies
}
```

After:
```ts
if (typeof retryStrategy.mode === "string" && retryStrategy.mode.includes("adaptive")) {
  setFeature(context, "RETRY_MODE_ADAPTIVE", "F");
} else {
  setFeature(context, "RETRY_MODE_STANDARD", "E");
}
```

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
