### PR TITLE
fix(xhr-http-handler): fix import delcaration of event emitter

### DIFF
--- a/packages/xhr-http-handler/src/xhr-http-handler.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.ts
@@ -2,7 +2,8 @@ import type { HttpHandler, HttpRequest } from "@smithy/protocol-http";
 import { HttpResponse } from "@smithy/protocol-http";
 import { buildQueryString } from "@smithy/querystring-builder";
 import type { HttpHandlerOptions, Provider } from "@smithy/types";
-import { EventEmitter } from "node:events";
+// eslint-disable-next-line n/prefer-node-protocol
+import { EventEmitter } from "events";
 
 import { requestTimeout as requestTimeoutFn } from "./request-timeout";
 


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7812

### Description
Make an exception for the `node:` lint rule for the event emitter package used in browsers.

### Testing
CI, e2e smoke test will be added to https://github.com/aws/aws-sdk-js-v3/pull/7808 later.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
