### PR TITLE
test(clients): ignore prettifying automated snapshot test code

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,9 @@ CHANGELOG.md
 **/*/report.md
 clients/**/src
 clients/**/README.md
+clients/**/test/index-objects.spec.mjs
+clients/**/test/index-types.ts
+clients/**/test/snapshots.integ.spec.ts
 private/**
 !private/aws-client-api-test/src/**/*
 packages/nested-clients/src/submodules/*/endpoint/ruleset.ts

--- a/clients/client-appconfigdata/test/snapshots.integ.spec.ts
+++ b/clients/client-appconfigdata/test/snapshots.integ.spec.ts
@@ -16,27 +16,25 @@ const Client = AppConfigDataClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "AppConfigDataClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("AppConfigDataClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [GetLatestConfiguration$, GetLatestConfigurationCommand],
         [StartConfigurationSession$, StartConfigurationSessionCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-bedrock-runtime/test/snapshots.integ.spec.ts
+++ b/clients/client-bedrock-runtime/test/snapshots.integ.spec.ts
@@ -32,21 +32,20 @@ const Client = BedrockRuntimeClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "BedrockRuntimeClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("BedrockRuntimeClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [ApplyGuardrail$, ApplyGuardrailCommand],
         [Converse$, ConverseCommand],
         [ConverseStream$, ConverseStreamCommand],
@@ -58,9 +57,8 @@ describe(
         [ListAsyncInvokes$, ListAsyncInvokesCommand],
         [StartAsyncInvoke$, StartAsyncInvokeCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-cloudwatch/test/snapshots.integ.spec.ts
+++ b/clients/client-cloudwatch/test/snapshots.integ.spec.ts
@@ -98,21 +98,20 @@ const Client = CloudWatchClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "CloudWatchClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("CloudWatchClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [DeleteAlarmMuteRule$, DeleteAlarmMuteRuleCommand],
         [DeleteAlarms$, DeleteAlarmsCommand],
         [DeleteAnomalyDetector$, DeleteAnomalyDetectorCommand],
@@ -157,9 +156,8 @@ describe(
         [TagResource$, TagResourceCommand],
         [UntagResource$, UntagResourceCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-cognito-identity/test/snapshots.integ.spec.ts
+++ b/clients/client-cognito-identity/test/snapshots.integ.spec.ts
@@ -58,21 +58,20 @@ const Client = CognitoIdentityClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "CognitoIdentityClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("CognitoIdentityClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [CreateIdentityPool$, CreateIdentityPoolCommand],
         [DeleteIdentities$, DeleteIdentitiesCommand],
         [DeleteIdentityPool$, DeleteIdentityPoolCommand],
@@ -97,9 +96,8 @@ describe(
         [UntagResource$, UntagResourceCommand],
         [UpdateIdentityPool$, UpdateIdentityPoolCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-dynamodb-streams/test/snapshots.integ.spec.ts
+++ b/clients/client-dynamodb-streams/test/snapshots.integ.spec.ts
@@ -20,29 +20,27 @@ const Client = DynamoDBStreamsClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "DynamoDBStreamsClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("DynamoDBStreamsClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [DescribeStream$, DescribeStreamCommand],
         [GetRecords$, GetRecordsCommand],
         [GetShardIterator$, GetShardIteratorCommand],
         [ListStreams$, ListStreamsCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-dynamodb/test/snapshots.integ.spec.ts
+++ b/clients/client-dynamodb/test/snapshots.integ.spec.ts
@@ -126,21 +126,20 @@ const Client = DynamoDBClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "DynamoDBClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("DynamoDBClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [BatchExecuteStatement$, BatchExecuteStatementCommand],
         [BatchGetItem$, BatchGetItemCommand],
         [BatchWriteItem$, BatchWriteItemCommand],
@@ -199,9 +198,8 @@ describe(
         [UpdateTableReplicaAutoScaling$, UpdateTableReplicaAutoScalingCommand],
         [UpdateTimeToLive$, UpdateTimeToLiveCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-ec2/test/snapshots.integ.spec.ts
+++ b/clients/client-ec2/test/snapshots.integ.spec.ts
@@ -1524,21 +1524,20 @@ const Client = EC2Client;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "EC2Client" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("EC2Client" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [AcceptAddressTransfer$, AcceptAddressTransferCommand],
         [AcceptCapacityReservationBillingOwnership$, AcceptCapacityReservationBillingOwnershipCommand],
         [AcceptReservedInstancesExchangeQuote$, AcceptReservedInstancesExchangeQuoteCommand],
@@ -1638,17 +1637,11 @@ describe(
         [CreateLaunchTemplateVersion$, CreateLaunchTemplateVersionCommand],
         [CreateLocalGatewayRoute$, CreateLocalGatewayRouteCommand],
         [CreateLocalGatewayRouteTable$, CreateLocalGatewayRouteTableCommand],
-        [
-          CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociation$,
-          CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
-        ],
+        [CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociation$, CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand],
         [CreateLocalGatewayRouteTableVpcAssociation$, CreateLocalGatewayRouteTableVpcAssociationCommand],
         [CreateLocalGatewayVirtualInterface$, CreateLocalGatewayVirtualInterfaceCommand],
         [CreateLocalGatewayVirtualInterfaceGroup$, CreateLocalGatewayVirtualInterfaceGroupCommand],
-        [
-          CreateMacSystemIntegrityProtectionModificationTask$,
-          CreateMacSystemIntegrityProtectionModificationTaskCommand,
-        ],
+        [CreateMacSystemIntegrityProtectionModificationTask$, CreateMacSystemIntegrityProtectionModificationTaskCommand],
         [CreateManagedPrefixList$, CreateManagedPrefixListCommand],
         [CreateNatGateway$, CreateNatGatewayCommand],
         [CreateNetworkAcl$, CreateNetworkAclCommand],
@@ -1739,10 +1732,7 @@ describe(
         [DeleteLaunchTemplateVersions$, DeleteLaunchTemplateVersionsCommand],
         [DeleteLocalGatewayRoute$, DeleteLocalGatewayRouteCommand],
         [DeleteLocalGatewayRouteTable$, DeleteLocalGatewayRouteTableCommand],
-        [
-          DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociation$,
-          DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
-        ],
+        [DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociation$, DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand],
         [DeleteLocalGatewayRouteTableVpcAssociation$, DeleteLocalGatewayRouteTableVpcAssociationCommand],
         [DeleteLocalGatewayVirtualInterface$, DeleteLocalGatewayVirtualInterfaceCommand],
         [DeleteLocalGatewayVirtualInterfaceGroup$, DeleteLocalGatewayVirtualInterfaceGroupCommand],
@@ -1898,10 +1888,7 @@ describe(
         [DescribeLaunchTemplates$, DescribeLaunchTemplatesCommand],
         [DescribeLaunchTemplateVersions$, DescribeLaunchTemplateVersionsCommand],
         [DescribeLocalGatewayRouteTables$, DescribeLocalGatewayRouteTablesCommand],
-        [
-          DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations$,
-          DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand,
-        ],
+        [DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations$, DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand],
         [DescribeLocalGatewayRouteTableVpcAssociations$, DescribeLocalGatewayRouteTableVpcAssociationsCommand],
         [DescribeLocalGateways$, DescribeLocalGatewaysCommand],
         [DescribeLocalGatewayVirtualInterfaceGroups$, DescribeLocalGatewayVirtualInterfaceGroupsCommand],
@@ -1976,10 +1963,7 @@ describe(
         [DescribeTrunkInterfaceAssociations$, DescribeTrunkInterfaceAssociationsCommand],
         [DescribeVerifiedAccessEndpoints$, DescribeVerifiedAccessEndpointsCommand],
         [DescribeVerifiedAccessGroups$, DescribeVerifiedAccessGroupsCommand],
-        [
-          DescribeVerifiedAccessInstanceLoggingConfigurations$,
-          DescribeVerifiedAccessInstanceLoggingConfigurationsCommand,
-        ],
+        [DescribeVerifiedAccessInstanceLoggingConfigurations$, DescribeVerifiedAccessInstanceLoggingConfigurationsCommand],
         [DescribeVerifiedAccessInstances$, DescribeVerifiedAccessInstancesCommand],
         [DescribeVerifiedAccessTrustProviders$, DescribeVerifiedAccessTrustProvidersCommand],
         [DescribeVolumeAttribute$, DescribeVolumeAttributeCommand],
@@ -2311,9 +2295,8 @@ describe(
         [UpdateSecurityGroupRuleDescriptionsIngress$, UpdateSecurityGroupRuleDescriptionsIngressCommand],
         [WithdrawByoipCidr$, WithdrawByoipCidrCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-iam/test/snapshots.integ.spec.ts
+++ b/clients/client-iam/test/snapshots.integ.spec.ts
@@ -364,21 +364,20 @@ const Client = IAMClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "IAMClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("IAMClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [AcceptDelegationRequest$, AcceptDelegationRequestCommand],
         [AddClientIDToOpenIDConnectProvider$, AddClientIDToOpenIDConnectProviderCommand],
         [AddRoleToInstanceProfile$, AddRoleToInstanceProfileCommand],
@@ -556,9 +555,8 @@ describe(
         [UploadSigningCertificate$, UploadSigningCertificateCommand],
         [UploadSSHPublicKey$, UploadSSHPublicKeyCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-rds/test/snapshots.integ.spec.ts
+++ b/clients/client-rds/test/snapshots.integ.spec.ts
@@ -338,21 +338,20 @@ const Client = RDSClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "RDSClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("RDSClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [AddRoleToDBCluster$, AddRoleToDBClusterCommand],
         [AddRoleToDBInstance$, AddRoleToDBInstanceCommand],
         [AddSourceIdentifierToSubscription$, AddSourceIdentifierToSubscriptionCommand],
@@ -517,9 +516,8 @@ describe(
         [SwitchoverGlobalCluster$, SwitchoverGlobalClusterCommand],
         [SwitchoverReadReplica$, SwitchoverReadReplicaCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-route-53/test/snapshots.integ.spec.ts
+++ b/clients/client-route-53/test/snapshots.integ.spec.ts
@@ -154,21 +154,20 @@ const Client = Route53Client;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "Route53Client" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("Route53Client" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [ActivateKeySigningKey$, ActivateKeySigningKeyCommand],
         [AssociateVPCWithHostedZone$, AssociateVPCWithHostedZoneCommand],
         [ChangeCidrCollection$, ChangeCidrCollectionCommand],
@@ -241,9 +240,8 @@ describe(
         [UpdateTrafficPolicyComment$, UpdateTrafficPolicyCommentCommand],
         [UpdateTrafficPolicyInstance$, UpdateTrafficPolicyInstanceCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-s3-control/test/snapshots.integ.spec.ts
+++ b/clients/client-s3-control/test/snapshots.integ.spec.ts
@@ -206,21 +206,20 @@ const Client = S3ControlClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "S3ControlClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("S3ControlClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [AssociateAccessGrantsIdentityCenter$, AssociateAccessGrantsIdentityCenterCommand],
         [CreateAccessGrant$, CreateAccessGrantCommand],
         [CreateAccessGrantsInstance$, CreateAccessGrantsInstanceCommand],
@@ -319,9 +318,8 @@ describe(
         [UpdateJobStatus$, UpdateJobStatusCommand],
         [UpdateStorageLensGroup$, UpdateStorageLensGroupCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-s3/test/snapshots.integ.spec.ts
+++ b/clients/client-s3/test/snapshots.integ.spec.ts
@@ -226,21 +226,20 @@ const Client = S3Client;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "S3Client" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("S3Client" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [AbortMultipartUpload$, AbortMultipartUploadCommand],
         [CompleteMultipartUpload$, CompleteMultipartUploadCommand],
         [CopyObject$, CopyObjectCommand],
@@ -349,9 +348,8 @@ describe(
         [UploadPartCopy$, UploadPartCopyCommand],
         [WriteGetObjectResponse$, WriteGetObjectResponseCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-s3tables/test/snapshots.integ.spec.ts
+++ b/clients/client-s3tables/test/snapshots.integ.spec.ts
@@ -110,21 +110,20 @@ const Client = S3TablesClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "S3TablesClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("S3TablesClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [CreateNamespace$, CreateNamespaceCommand],
         [CreateTable$, CreateTableCommand],
         [CreateTableBucket$, CreateTableBucketCommand],
@@ -175,9 +174,8 @@ describe(
         [UntagResource$, UntagResourceCommand],
         [UpdateTableMetadataLocation$, UpdateTableMetadataLocationCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-sagemaker-runtime-http2/test/snapshots.integ.spec.ts
+++ b/clients/client-sagemaker-runtime-http2/test/snapshots.integ.spec.ts
@@ -14,26 +14,24 @@ const Client = SageMakerRuntimeHTTP2Client;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "SageMakerRuntimeHTTP2Client" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("SageMakerRuntimeHTTP2Client" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [InvokeEndpointWithBidirectionalStream$, InvokeEndpointWithBidirectionalStreamCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-secrets-manager/test/snapshots.integ.spec.ts
+++ b/clients/client-secrets-manager/test/snapshots.integ.spec.ts
@@ -58,21 +58,20 @@ const Client = SecretsManagerClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "SecretsManagerClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("SecretsManagerClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [BatchGetSecretValue$, BatchGetSecretValueCommand],
         [CancelRotateSecret$, CancelRotateSecretCommand],
         [CreateSecret$, CreateSecretCommand],
@@ -97,9 +96,8 @@ describe(
         [UpdateSecretVersionStage$, UpdateSecretVersionStageCommand],
         [ValidateResourcePolicy$, ValidateResourcePolicyCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-signin/test/snapshots.integ.spec.ts
+++ b/clients/client-signin/test/snapshots.integ.spec.ts
@@ -10,24 +10,24 @@ const Client = SigninClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "SigninClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([[CreateOAuth2Token$, CreateOAuth2TokenCommand]]),
-    });
+describe("SigninClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
+        [CreateOAuth2Token$, CreateOAuth2TokenCommand],
+      ]),
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-sqs/test/snapshots.integ.spec.ts
+++ b/clients/client-sqs/test/snapshots.integ.spec.ts
@@ -58,21 +58,20 @@ const Client = SQSClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "SQSClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("SQSClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [AddPermission$, AddPermissionCommand],
         [CancelMessageMoveTask$, CancelMessageMoveTaskCommand],
         [ChangeMessageVisibility$, ChangeMessageVisibilityCommand],
@@ -97,9 +96,8 @@ describe(
         [TagQueue$, TagQueueCommand],
         [UntagQueue$, UntagQueueCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-sso-oidc/test/snapshots.integ.spec.ts
+++ b/clients/client-sso-oidc/test/snapshots.integ.spec.ts
@@ -20,29 +20,27 @@ const Client = SSOOIDCClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "SSOOIDCClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("SSOOIDCClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [CreateToken$, CreateTokenCommand],
         [CreateTokenWithIAM$, CreateTokenWithIAMCommand],
         [RegisterClient$, RegisterClientCommand],
         [StartDeviceAuthorization$, StartDeviceAuthorizationCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-sso/test/snapshots.integ.spec.ts
+++ b/clients/client-sso/test/snapshots.integ.spec.ts
@@ -20,29 +20,27 @@ const Client = SSOClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "SSOClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("SSOClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [GetRoleCredentials$, GetRoleCredentialsCommand],
         [ListAccountRoles$, ListAccountRolesCommand],
         [ListAccounts$, ListAccountsCommand],
         [Logout$, LogoutCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);

--- a/clients/client-sts/test/snapshots.integ.spec.ts
+++ b/clients/client-sts/test/snapshots.integ.spec.ts
@@ -34,21 +34,20 @@ const Client = STSClient;
 
 const mode = (process.env.SNAPSHOT_MODE as "write" | "compare") ?? "write";
 
-describe(
-  "STSClient" + ` (${mode})`,
-  () => {
-    const runner = new SnapshotRunner({
-      snapshotDirPath: join(__dirname, "snapshots"),
-      Client,
-      mode,
-      testCase(caseName: string, run: () => Promise<void>) {
-        it(caseName, run);
-      },
-      assertions(caseName: string, expected: string, actual: string): Promise<void> {
-        expect(actual).toEqual(expected);
-        return Promise.resolve();
-      },
-      schemas: new Map<any, any>([
+describe("STSClient" + ` (${mode})`, () => {
+  const runner = new SnapshotRunner({
+    snapshotDirPath: join(__dirname, "snapshots"),
+    Client,
+    mode,
+    testCase(caseName: string, run: () => Promise<void>) {
+      it(caseName, run);
+    },
+    assertions(caseName: string, expected: string, actual: string): Promise<void> {
+      expect(actual).toEqual(expected);
+      return Promise.resolve();
+    },
+    schemas:
+      new Map<any, any>([
         [AssumeRole$, AssumeRoleCommand],
         [AssumeRoleWithSAML$, AssumeRoleWithSAMLCommand],
         [AssumeRoleWithWebIdentity$, AssumeRoleWithWebIdentityCommand],
@@ -61,9 +60,8 @@ describe(
         [GetSessionToken$, GetSessionTokenCommand],
         [GetWebIdentityToken$, GetWebIdentityTokenCommand],
       ]),
-    });
 
-    runner.run();
-  },
-  30_000
-);
+  });
+
+  runner.run();
+}, 30_000);


### PR DESCRIPTION
### Issue
N/A

### Description
Ignores prettifying automated snapshot test code

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
