### PR TITLE
fix(nested-clients): add bundler instructions for browser credential clients

### DIFF
--- a/packages-internal/nested-clients/package.json
+++ b/packages-internal/nested-clients/package.json
@@ -93,8 +93,10 @@
     "dist-*/**"
   ],
   "browser": {
+    "./dist-es/submodules/cognito-identity/runtimeConfig": "./dist-es/submodules/cognito-identity/runtimeConfig.browser",
     "./dist-es/submodules/signin/runtimeConfig": "./dist-es/submodules/signin/runtimeConfig.browser",
     "./dist-es/submodules/sso-oidc/runtimeConfig": "./dist-es/submodules/sso-oidc/runtimeConfig.browser",
+    "./dist-es/submodules/sso/runtimeConfig": "./dist-es/submodules/sso/runtimeConfig.browser",
     "./dist-es/submodules/sts/runtimeConfig": "./dist-es/submodules/sts/runtimeConfig.browser"
   },
   "react-native": {},

--- a/scripts/validation/submodules-linter.js
+++ b/scripts/validation/submodules-linter.js
@@ -41,6 +41,10 @@ for (const submodulePackage of submodulePackages) {
         }
       }
       // package.json metadata.
+      const pushPkgJson = () => {
+        fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(pkgJson, null, 2) + "\n");
+      };
+
       if (!pkgJson.exports[`./${submodule}`]) {
         errors.push(`${submodule} submodule is missing exports statement in package.json`);
         pkgJson.exports[`./${submodule}`] = {
@@ -50,14 +54,23 @@ for (const submodulePackage of submodulePackages) {
           import: `./dist-es/submodules/${submodule}/index.js`,
           require: `./dist-cjs/submodules/${submodule}/index.js`,
         };
-        fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(pkgJson, null, 2) + "\n");
+        pushPkgJson();
+      }
+      if (submodulePackage === "nested-clients") {
+        if (!pkgJson.browser[`./dist-es/submodules/${submodule}/runtimeConfig`]) {
+          pkgJson.browser[
+            `./dist-es/submodules/${submodule}/runtimeConfig`
+          ] = `./dist-es/submodules/${submodule}/runtimeConfig.browser`;
+          errors.push(`${submodule} is missing browser replacement directive.`);
+        }
+        pushPkgJson();
       }
       if (!pkgJson.files.includes(`./${submodule}.js`) || !pkgJson.files.includes(`./${submodule}.d.ts`)) {
         pkgJson.files.push(`./${submodule}.js`);
         pkgJson.files.push(`./${submodule}.d.ts`);
         errors.push(`package.json files array missing ${submodule}.js compatibility redirect file.`);
         pkgJson.files = [...new Set(pkgJson.files)].sort();
-        fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(pkgJson, null, 2) + "\n");
+        pushPkgJson();
       }
       // tsconfig metadata.
       for (const [kind, tsconfig] of Object.entries(tsconfigs)) {


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7807

### Description
Sets bundler replacement directive for runtimeConfig files in nested clients.

### Testing
added validation script

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
