### PR TITLE
fix(middleware-user-agent): use retry strategy mode property instead of legacy fallback

### DIFF
--- a/packages-internal/middleware-user-agent/package.json
+++ b/packages-internal/middleware-user-agent/package.json
@@ -31,6 +31,7 @@
     "@smithy/core": "^3.23.8",
     "@smithy/protocol-http": "^5.3.11",
     "@smithy/types": "^4.13.0",
+    "@smithy/util-retry": "^4.2.11",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages-internal/middleware-user-agent/src/check-features.spec.ts
+++ b/packages-internal/middleware-user-agent/src/check-features.spec.ts
@@ -32,4 +32,23 @@ describe(checkFeatures.name, () => {
   it("should not throw an error if no fields are present", async () => {
     await checkFeatures({}, {}, {} as any);
   });
+
+  it.each([
+    ["standard", "RETRY_MODE_STANDARD", "E"],
+    ["adaptive", "RETRY_MODE_ADAPTIVE", "F"],
+  ] as const)("should set %s retry mode feature", async (mode, featureKey, featureValue) => {
+    const context = {} as AwsHandlerExecutionContext;
+    const config = { retryStrategy: async () => ({ mode }) };
+    await checkFeatures(context, config, { request: undefined, input: undefined });
+    expect(context.__aws_sdk_context?.features?.[featureKey]).toBe(featureValue);
+  });
+
+  it.each([["unknown"], [undefined]])("should not set any retry mode feature when mode is %s", async (mode) => {
+    const context = {} as AwsHandlerExecutionContext;
+    const config = { retryStrategy: async () => ({ ...(mode !== undefined && { mode }) }) };
+    await checkFeatures(context, config, { request: undefined, input: undefined });
+    expect(context.__aws_sdk_context?.features?.RETRY_MODE_STANDARD).toBeUndefined();
+    expect(context.__aws_sdk_context?.features?.RETRY_MODE_ADAPTIVE).toBeUndefined();
+    expect(context.__aws_sdk_context?.features?.RETRY_MODE_LEGACY).toBeUndefined();
+  });
 });

--- a/packages-internal/middleware-user-agent/src/check-features.ts
+++ b/packages-internal/middleware-user-agent/src/check-features.ts
@@ -6,13 +6,8 @@ import type {
   AwsSdkCredentialsFeatures,
 } from "@aws-sdk/types";
 import type { IHttpRequest } from "@smithy/protocol-http";
-import type {
-  AwsCredentialIdentityProvider,
-  BuildHandlerArguments,
-  Provider,
-  RetryStrategy,
-  RetryStrategyV2,
-} from "@smithy/types";
+import type { AwsCredentialIdentityProvider, BuildHandlerArguments, Provider } from "@smithy/types";
+import { RETRY_MODES } from "@smithy/util-retry";
 
 /**
  * @internal
@@ -20,7 +15,7 @@ import type {
 type PreviouslyResolved = Partial<{
   credentials?: AwsCredentialIdentityProvider;
   accountIdEndpointMode?: Provider<AccountIdEndpointMode>;
-  retryStrategy?: Provider<RetryStrategy | RetryStrategyV2>;
+  retryStrategy?: Provider<{ mode?: string }>;
 }>;
 
 /**
@@ -46,14 +41,15 @@ export async function checkFeatures(
 
   if (typeof config.retryStrategy === "function") {
     const retryStrategy = await config.retryStrategy();
-    if (typeof (retryStrategy as RetryStrategyV2).acquireInitialRetryToken === "function") {
-      if (retryStrategy.constructor?.name?.includes("Adaptive")) {
-        setFeature(context, "RETRY_MODE_ADAPTIVE", "F");
-      } else {
-        setFeature(context, "RETRY_MODE_STANDARD", "E");
+    if (typeof retryStrategy.mode === "string") {
+      switch (retryStrategy.mode) {
+        case RETRY_MODES.ADAPTIVE:
+          setFeature(context, "RETRY_MODE_ADAPTIVE", "F");
+          break;
+        case RETRY_MODES.STANDARD:
+          setFeature(context, "RETRY_MODE_STANDARD", "E");
+          break;
       }
-    } else {
-      setFeature(context, "RETRY_MODE_LEGACY", "D");
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24395,6 +24395,7 @@ __metadata:
     "@smithy/core": "npm:^3.23.8"
     "@smithy/protocol-http": "npm:^5.3.11"
     "@smithy/types": "npm:^4.13.0"
+    "@smithy/util-retry": "npm:^4.2.11"
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"


### PR DESCRIPTION
PR for running CI on https://github.com/aws/aws-sdk-js-v3/pull/7811