### PR TITLE
test(client-sqs): use unique queue prefix

### DIFF
--- a/clients/client-sqs/test/sqs-queues-features.e2e.spec.ts
+++ b/clients/client-sqs/test/sqs-queues-features.e2e.spec.ts
@@ -49,24 +49,26 @@ describe("SQS Queues", () => {
   });
 
   describe("Creating and deleting queues", () => {
+    const prefix = `aws-sdk-${Date.now()}-`;
+
     it("should create queues and eventually list them", async () => {
       // Create first queue
       const createResult1 = await client.createQueue({
-        QueueName: `aws-js-sdk-${Date.now()}`,
+        QueueName: `${prefix}-q1`,
       });
       const queueUrl1 = createResult1.QueueUrl!;
       createdQueues.push(queueUrl1);
 
       // Create second queue
       const createResult2 = await client.createQueue({
-        QueueName: `aws-js-sdk-${Date.now() + 1}`,
+        QueueName: `${prefix}-q2`,
       });
       const queueUrl2 = createResult2.QueueUrl!;
       createdQueues.push(queueUrl2);
 
       // Wait for queues to be eventually consistent and available in list
       const listResult = await eventually(
-        () => client.listQueues({ QueueNamePrefix: "aws-js-sdk-" }),
+        () => client.listQueues({ QueueNamePrefix: prefix }),
         (result) => {
           const queueUrls = result.QueueUrls || [];
           return createdQueues.every((createdQueue) => queueUrls.includes(createdQueue));


### PR DESCRIPTION
### Issue
JS-6689

### Testing
This makes the queue prefix unique. The test has been flaking lately.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
