### PR TITLE
fix(util-endpoints): cache compiled RegExp in partition lookup

### DIFF
--- a/packages-internal/util-endpoints/src/lib/aws/partition.ts
+++ b/packages-internal/util-endpoints/src/lib/aws/partition.ts
@@ -35,6 +35,19 @@ let selectedPartitionsInfo: PartitionsInfo = partitionsInfo;
 let selectedUserAgentPrefix = "";
 
 /**
+ * Compiled regex cache for regionRegex strings.
+ * Avoids re-creating RegExp objects on every partition() call.
+ */
+const regionRegexCache: Record<string, RegExp> = {};
+
+const getRegionRegex = (regionRegex: string): RegExp => {
+  if (!regionRegexCache[regionRegex]) {
+    regionRegexCache[regionRegex] = new RegExp(regionRegex);
+  }
+  return regionRegexCache[regionRegex];
+};
+
+/**
  * Evaluates a single string argument value as a region, and matches the
  * string value to an AWS partition.
  * The matcher MUST always return a successful object describing the partition
@@ -58,7 +71,7 @@ export const partition = (value: string): EndpointPartition => {
   // Check for region that matches a regionRegex pattern.
   for (const partition of partitions) {
     const { regionRegex, outputs } = partition;
-    if (new RegExp(regionRegex).test(value)) {
+    if (getRegionRegex(regionRegex).test(value)) {
       return {
         ...outputs,
       };
@@ -87,6 +100,9 @@ export const partition = (value: string): EndpointPartition => {
 export const setPartitionInfo = (partitionsInfo: PartitionsInfo, userAgentPrefix = "") => {
   selectedPartitionsInfo = partitionsInfo;
   selectedUserAgentPrefix = userAgentPrefix;
+  for (const key in regionRegexCache) {
+    delete regionRegexCache[key];
+  }
 };
 
 /**


### PR DESCRIPTION
## Problem

The `partition()` function in `@aws-sdk/util-endpoints` is called during endpoint resolution on every API request. On each call, it constructs a new `RegExp` object from the `regionRegex` string for every partition entry:

```ts
if (new RegExp(regionRegex).test(value)) {
```

Since the partition data (and therefore the regex strings) are static between `setPartitionInfo()` calls, this repeated compilation is unnecessary work on the hot path.

## Solution

Introduce a simple `Record<string, RegExp>` cache that stores compiled `RegExp` objects keyed by their source string. A helper function `getRegionRegex()` returns the cached regex or compiles and caches it on first encounter.

```ts
const regionRegexCache: Record<string, RegExp> = {};

const getRegionRegex = (regionRegex: string): RegExp => {
  if (!regionRegexCache[regionRegex]) {
    regionRegexCache[regionRegex] = new RegExp(regionRegex);
  }
  return regionRegexCache[regionRegex];
};
```

The cache is keyed by the regex string itself, so it naturally handles `setPartitionInfo()` swapping in different partition data. The cache is cleared inside `setPartitionInfo()` so stale entries from a previous partition configuration don't accumulate as dead weight.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
