### PR TITLE
chore(xml-builder): single-pass XML escape for escapeElement and escapeAttribute

### DIFF
--- a/packages-internal/xml-builder/src/escape-attribute.ts
+++ b/packages-internal/xml-builder/src/escape-attribute.ts
@@ -1,8 +1,17 @@
+const ATTR_ESCAPE_RE = /[&<>"]/g;
+
+const ATTR_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+};
+
 /**
  * @internal
  *
  * Escapes characters that can not be in an XML attribute.
  */
 export function escapeAttribute(value: string): string {
-  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return value.replace(ATTR_ESCAPE_RE, (ch) => ATTR_ESCAPE_MAP[ch]);
 }

--- a/packages-internal/xml-builder/src/escape-element.spec.ts
+++ b/packages-internal/xml-builder/src/escape-element.spec.ts
@@ -7,4 +7,8 @@ describe("escape-element", () => {
     const value = "abc 123 &<>\"'%\n\r\u0085\u2028";
     expect(escapeElement(value)).toBe("abc 123 &amp;&lt;&gt;&quot;&apos;%&#x0A;&#x0D;&#x85;&#x2028;");
   });
+
+  it("escapes multiple \\u2028 occurrences", () => {
+    expect(escapeElement("a\u2028b\u2028c")).toBe("a&#x2028;b&#x2028;c");
+  });
 });

--- a/packages-internal/xml-builder/src/escape-element.ts
+++ b/packages-internal/xml-builder/src/escape-element.ts
@@ -1,17 +1,22 @@
+const ELEMENT_ESCAPE_RE = /[&"'<>\r\n\u0085\u2028]/g;
+
+const ELEMENT_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  '"': "&quot;",
+  "'": "&apos;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "\r": "&#x0D;",
+  "\n": "&#x0A;",
+  "\u0085": "&#x85;",
+  "\u2028": "&#x2028;",
+};
+
 /**
  * @internal
  *
  * Escapes characters that can not be in an XML element.
  */
 export function escapeElement(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/\r/g, "&#x0D;")
-    .replace(/\n/g, "&#x0A;")
-    .replace(/\u0085/g, "&#x85;")
-    .replace(/\u2028/, "&#x2028;");
+  return value.replace(ELEMENT_ESCAPE_RE, (ch) => ELEMENT_ESCAPE_MAP[ch]);
 }


### PR DESCRIPTION
### Problem

`escapeElement` chains 9 sequential `.replace()` calls, each performing a full scan of the input string and allocating a new intermediate string. `escapeAttribute` does the same with 4 calls. For XML-heavy operations like S3 `DeleteObjects` (up to 1,000 keys), this means up to 9,000 full-string regex scans where 1,000 would suffice.

There is also a latent bug: the final `.replace(/\u2028/, "&#x2028;")` in `escapeElement` is missing the `/g` flag, so only the first occurrence of U+2028 (LINE SEPARATOR) is escaped.

### Changes

Both `escapeElement` and `escapeAttribute` now use a single combined regex with a lookup map, reducing the work from N sequential passes to 1 pass per call. The regex and map are module-level constants so they're compiled once.

**`escapeElement`**: 9 chained `.replace()` → single `.replace(/[&"'<>\r\n\u0085\u2028]/g, ...)`

**`escapeAttribute`**: 4 chained `.replace()` → single `.replace(/[&<>"]/g, ...)`

In addition to improving performance, this fixes the `\u2028` bug because `\u2028` is part of the combined character class which carries the `/g` flag.

### Testing

I've added a regression test for the `\u2028` bug fix with multiple occurrences in a single string.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
