### PR TITLE
chore(endpoint-cache): reduce redundant LRU cache lookups in EndpointCache.get()

### DIFF
--- a/packages-internal/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages-internal/endpoint-cache/src/EndpointCache.spec.ts
@@ -54,44 +54,27 @@ describe(EndpointCache.name, () => {
 
   describe("get", () => {
     beforeEach(() => {
-      has.mockReturnValue(true);
       const endpointsWithExpiry = getEndpointsWithExpiry(mockEndpoints);
-      peek.mockReturnValue(endpointsWithExpiry);
       get.mockReturnValue(endpointsWithExpiry);
       vi.spyOn(Date, "now").mockImplementation(() => now);
     });
 
-    const verifyHasAndGetCalls = () => {
-      expect(has).toHaveBeenCalledTimes(1);
-      expect(has).toHaveBeenCalledWith(key);
+    const verifyGetCalls = () => {
       expect(get).toHaveBeenCalledTimes(1);
       expect(get).toHaveBeenCalledWith(key);
     };
 
     it("returns undefined if cache doesn't have key", () => {
-      has.mockReturnValueOnce(false);
-      expect(endpointCache.get(key)).toBeUndefined();
-      expect(has).toHaveBeenCalledTimes(1);
-      expect(has).toHaveBeenCalledWith(key);
-      expect(peek).not.toHaveBeenCalled();
-      expect(get).not.toHaveBeenCalled();
-    });
-
-    it("returns undefined if cache has empty array", () => {
-      has.mockReturnValueOnce(true);
-      peek.mockReturnValueOnce([]);
-      expect(endpointCache.get(key)).toBeUndefined();
-      expect(has).toHaveBeenCalledTimes(1);
-      expect(has).toHaveBeenCalledWith(key);
-      expect(peek).toHaveBeenCalledTimes(1);
-      expect(peek).toHaveBeenCalledWith(key);
-      expect(get).not.toHaveBeenCalled();
-    });
-
-    it("returns undefined if cache returns undefined for key", () => {
       get.mockReturnValueOnce(undefined);
       expect(endpointCache.get(key)).toBeUndefined();
-      verifyHasAndGetCalls();
+      verifyGetCalls();
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined if cache has empty array (soft-deleted)", () => {
+      get.mockReturnValueOnce([]);
+      expect(endpointCache.get(key)).toBeUndefined();
+      verifyGetCalls();
       expect(set).not.toHaveBeenCalled();
     });
 
@@ -99,7 +82,7 @@ describe(EndpointCache.name, () => {
       const maxCachePeriod = getMaxCachePeriodInMins(mockEndpoints);
       vi.spyOn(Date, "now").mockImplementation(() => now + (maxCachePeriod + 1) * 60 * 1000);
       expect(endpointCache.get(key)).toBeUndefined();
-      verifyHasAndGetCalls();
+      verifyGetCalls();
       expect(set).toHaveBeenCalledTimes(1);
       expect(set).toHaveBeenCalledWith(key, []);
     });
@@ -107,14 +90,14 @@ describe(EndpointCache.name, () => {
     describe("getEndpoint", () => {
       it("returns one of the un-expired endpoints", () => {
         expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.getEndpoint(key));
-        verifyHasAndGetCalls();
+        verifyGetCalls();
         expect(set).not.toHaveBeenCalled();
       });
 
       it("returns un-expired endpoint", () => {
         vi.spyOn(Date, "now").mockImplementation(() => now + 90 * 1000);
         expect(endpointCache.getEndpoint(key)).toEqual(mockEndpoints[1].Address);
-        verifyHasAndGetCalls();
+        verifyGetCalls();
         expect(set).not.toHaveBeenCalled();
       });
 
@@ -122,7 +105,7 @@ describe(EndpointCache.name, () => {
         it(`returns un-expired endpoint at index ${index}`, () => {
           vi.spyOn(Math, "floor").mockImplementation(() => index);
           expect(mockEndpoints.map((endpoint) => endpoint.Address)).toContain(endpointCache.getEndpoint(key));
-          verifyHasAndGetCalls();
+          verifyGetCalls();
           expect(set).not.toHaveBeenCalled();
         });
       });

--- a/packages-internal/endpoint-cache/src/EndpointCache.ts
+++ b/packages-internal/endpoint-cache/src/EndpointCache.ts
@@ -41,12 +41,8 @@ export class EndpointCache {
    * @returns
    */
   get(key: string) {
-    if (!this.has(key)) {
-      return;
-    }
-
     const value = this.cache.get(key);
-    if (!value) {
+    if (!value || value.length === 0) {
       return;
     }
 


### PR DESCRIPTION
## Problem

`EndpointCache.get()` performs 3 underlying LRU cache accesses for a single lookup:

1. `this.has(key)` → calls `this.cache.has(key)` (hash lookup)
2. Inside `has()` → calls `this.cache.peek(key)` (hash lookup + array read, no LRU promotion)
3. Back in `get()` → calls `this.cache.get(key)` (hash lookup + array read + splay/LRU promotion)

The `has()` check exists to handle soft-deleted entries (mnemonist's LRUCache lacks a `delete` method, so deletion is emulated by setting the value to `[]`). But `get()` can handle this directly.

## Solution

Replace the `has()` guard + separate `get()` with a single `this.cache.get(key)` call, followed by a `!value || value.length === 0` check that covers both the missing-key and soft-deleted cases.

Before:
```ts
get(key: string) {
  if (!this.has(key)) {   // cache.has() + cache.peek()
    return;
  }
  const value = this.cache.get(key);  // 3rd lookup
  if (!value) {
    return;
  }
  // ... filter expired endpoints
}
```

After:
```ts
get(key: string) {
  const value = this.cache.get(key);  // single lookup
  if (!value || value.length === 0) {
    return;
  }
  // ... filter expired endpoints
}
```

## Behavioral notes

- `has()` is unchanged and still available for external callers.
- LRU recency change: the old code used `peek()` (via `has()`) to detect soft-deleted entries without promoting them in the LRU. The new code calls `cache.get()` unconditionally, which does promote tombstones (empty arrays from `delete()`). This means looked-up tombstones will be kept alive slightly longer and could displace real entries in a full cache. In practice this is negligible — tombstones are overwritten by future `set()` calls, and the cache capacity would need to be very tight for displacement to matter.
- Tests were updated to reflect that `get()` no longer delegates to `has()`/`peek()`.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
