### PR TITLE
fix(core/protocols): restore error fallback to UnknownError for protocols

### DIFF
--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/AccessDeniedException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/AccessDeniedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-AccessDeniedException: Unknown
+AccessDeniedException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ AccessDeniedException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "AccessDeniedException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#AccessDeniedException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ConflictException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ConflictException: Unknown
+ConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ConflictException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/DataAlreadyAcceptedException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/DataAlreadyAcceptedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-DataAlreadyAcceptedException: Unknown
+DataAlreadyAcceptedException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ DataAlreadyAcceptedException: Unknown
   },
   name: "DataAlreadyAcceptedException",
   expectedSequenceToken: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#DataAlreadyAcceptedException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/InternalServerException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/InternalServerException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InternalServerException: Unknown
+InternalServerException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalServerException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalServerException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#InternalServerException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/InternalStreamingException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/InternalStreamingException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InternalStreamingException: Unknown
+InternalStreamingException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalStreamingException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalStreamingException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#InternalStreamingException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidOperationException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidOperationException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidOperationException: Unknown
+InvalidOperationException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidOperationException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidOperationException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#InvalidOperationException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidParameterException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidParameterException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidParameterException: Unknown
+InvalidParameterException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidParameterException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidParameterException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#InvalidParameterException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidSequenceTokenException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidSequenceTokenException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidSequenceTokenException: Unknown
+InvalidSequenceTokenException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ InvalidSequenceTokenException: Unknown
   },
   name: "InvalidSequenceTokenException",
   expectedSequenceToken: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#InvalidSequenceTokenException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ LimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "LimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#LimitExceededException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/MalformedQueryException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/MalformedQueryException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-MalformedQueryException: Unknown
+MalformedQueryException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ MalformedQueryException: Unknown
   },
   name: "MalformedQueryException",
   queryCompileError: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#MalformedQueryException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/OperationAbortedException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/OperationAbortedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-OperationAbortedException: Unknown
+OperationAbortedException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ OperationAbortedException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "OperationAbortedException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#OperationAbortedException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ResourceAlreadyExistsException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ResourceAlreadyExistsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceAlreadyExistsException: Unknown
+ResourceAlreadyExistsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceAlreadyExistsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceAlreadyExistsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ResourceAlreadyExistsException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ResourceNotFoundException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ServiceQuotaExceededException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ServiceQuotaExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ServiceQuotaExceededException: Unknown
+ServiceQuotaExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ServiceQuotaExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ServiceQuotaExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ServiceQuotaExceededException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ServiceUnavailableException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ServiceUnavailableException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ServiceUnavailableException: Unknown
+ServiceUnavailableException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ServiceUnavailableException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ServiceUnavailableException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ServiceUnavailableException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/SessionStreamingException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/SessionStreamingException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-SessionStreamingException: Unknown
+SessionStreamingException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ SessionStreamingException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "SessionStreamingException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#SessionStreamingException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/SessionTimeoutException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/SessionTimeoutException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-SessionTimeoutException: Unknown
+SessionTimeoutException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ SessionTimeoutException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "SessionTimeoutException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#SessionTimeoutException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ThrottlingException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ThrottlingException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ThrottlingException: Unknown
+ThrottlingException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ThrottlingException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ThrottlingException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ThrottlingException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/TooManyTagsException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/TooManyTagsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-TooManyTagsException: Unknown
+TooManyTagsException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ TooManyTagsException: Unknown
   },
   name: "TooManyTagsException",
   resourceName: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#TooManyTagsException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/UnrecognizedClientException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/UnrecognizedClientException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-UnrecognizedClientException: Unknown
+UnrecognizedClientException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ UnrecognizedClientException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "UnrecognizedClientException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#UnrecognizedClientException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ValidationException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ValidationException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ValidationException: Unknown
+ValidationException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ValidationException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ValidationException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ValidationException"
 }
 

--- a/clients/client-cloudwatch/test/snapshots/res-err/ConflictException.txt
+++ b/clients/client-cloudwatch/test/snapshots/res-err/ConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ConflictException: Unknown
+ConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatch#ConflictException",
   Error: {
     Type: (undefined),

--- a/clients/client-cognito-identity/test/snapshots/res-err/ConcurrentModificationException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/ConcurrentModificationException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ConcurrentModificationException: Unknown
+ConcurrentModificationException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ConcurrentModificationException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ConcurrentModificationException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#ConcurrentModificationException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/DeveloperUserAlreadyRegisteredException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/DeveloperUserAlreadyRegisteredException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-DeveloperUserAlreadyRegisteredException: Unknown
+DeveloperUserAlreadyRegisteredException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ DeveloperUserAlreadyRegisteredException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "DeveloperUserAlreadyRegisteredException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#DeveloperUserAlreadyRegisteredException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/ExternalServiceException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/ExternalServiceException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ExternalServiceException: Unknown
+ExternalServiceException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ExternalServiceException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ExternalServiceException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#ExternalServiceException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/InternalErrorException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/InternalErrorException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InternalErrorException: Unknown
+InternalErrorException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalErrorException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalErrorException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#InternalErrorException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/InvalidIdentityPoolConfigurationException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/InvalidIdentityPoolConfigurationException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidIdentityPoolConfigurationException: Unknown
+InvalidIdentityPoolConfigurationException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidIdentityPoolConfigurationException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidIdentityPoolConfigurationException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#InvalidIdentityPoolConfigurationException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/InvalidParameterException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/InvalidParameterException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidParameterException: Unknown
+InvalidParameterException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidParameterException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidParameterException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#InvalidParameterException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ LimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "LimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#LimitExceededException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/NotAuthorizedException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/NotAuthorizedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-NotAuthorizedException: Unknown
+NotAuthorizedException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ NotAuthorizedException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotAuthorizedException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#NotAuthorizedException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/ResourceConflictException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/ResourceConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceConflictException: Unknown
+ResourceConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#ResourceConflictException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#ResourceNotFoundException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/TooManyRequestsException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/TooManyRequestsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-TooManyRequestsException: Unknown
+TooManyRequestsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TooManyRequestsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TooManyRequestsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#TooManyRequestsException"
 }
 

--- a/clients/client-dynamodb-streams/test/snapshots/res-err/ExpiredIteratorException.txt
+++ b/clients/client-dynamodb-streams/test/snapshots/res-err/ExpiredIteratorException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ExpiredIteratorException: Unknown
+ExpiredIteratorException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ExpiredIteratorException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ExpiredIteratorException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodbstreams#ExpiredIteratorException"
 }
 

--- a/clients/client-dynamodb-streams/test/snapshots/res-err/InternalServerError.txt
+++ b/clients/client-dynamodb-streams/test/snapshots/res-err/InternalServerError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InternalServerError: Unknown
+InternalServerError: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalServerError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalServerError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodbstreams#InternalServerError"
 }
 

--- a/clients/client-dynamodb-streams/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-dynamodb-streams/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ LimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "LimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodbstreams#LimitExceededException"
 }
 

--- a/clients/client-dynamodb-streams/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/clients/client-dynamodb-streams/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodbstreams#ResourceNotFoundException"
 }
 

--- a/clients/client-dynamodb-streams/test/snapshots/res-err/TrimmedDataAccessException.txt
+++ b/clients/client-dynamodb-streams/test/snapshots/res-err/TrimmedDataAccessException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TrimmedDataAccessException: Unknown
+TrimmedDataAccessException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TrimmedDataAccessException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TrimmedDataAccessException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodbstreams#TrimmedDataAccessException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/BackupInUseException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/BackupInUseException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-BackupInUseException: Unknown
+BackupInUseException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ BackupInUseException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "BackupInUseException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#BackupInUseException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/BackupNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/BackupNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-BackupNotFoundException: Unknown
+BackupNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ BackupNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "BackupNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#BackupNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ConditionalCheckFailedException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ConditionalCheckFailedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ConditionalCheckFailedException: Unknown
+ConditionalCheckFailedException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ ConditionalCheckFailedException: Unknown
   },
   name: "ConditionalCheckFailedException",
   Item: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ConditionalCheckFailedException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ContinuousBackupsUnavailableException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ContinuousBackupsUnavailableException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ContinuousBackupsUnavailableException: Unknown
+ContinuousBackupsUnavailableException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ContinuousBackupsUnavailableException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ContinuousBackupsUnavailableException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ContinuousBackupsUnavailableException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/DuplicateItemException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/DuplicateItemException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-DuplicateItemException: Unknown
+DuplicateItemException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ DuplicateItemException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "DuplicateItemException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#DuplicateItemException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ExportConflictException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ExportConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ExportConflictException: Unknown
+ExportConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ExportConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ExportConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ExportConflictException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ExportNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ExportNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ExportNotFoundException: Unknown
+ExportNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ExportNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ExportNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ExportNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/GlobalTableAlreadyExistsException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/GlobalTableAlreadyExistsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-GlobalTableAlreadyExistsException: Unknown
+GlobalTableAlreadyExistsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ GlobalTableAlreadyExistsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "GlobalTableAlreadyExistsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#GlobalTableAlreadyExistsException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/GlobalTableNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/GlobalTableNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-GlobalTableNotFoundException: Unknown
+GlobalTableNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ GlobalTableNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "GlobalTableNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#GlobalTableNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/IdempotentParameterMismatchException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/IdempotentParameterMismatchException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-IdempotentParameterMismatchException: Unknown
+IdempotentParameterMismatchException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ IdempotentParameterMismatchException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "IdempotentParameterMismatchException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#IdempotentParameterMismatchException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ImportConflictException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ImportConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ImportConflictException: Unknown
+ImportConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ImportConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ImportConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ImportConflictException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ImportNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ImportNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ImportNotFoundException: Unknown
+ImportNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ImportNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ImportNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ImportNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/IndexNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/IndexNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-IndexNotFoundException: Unknown
+IndexNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ IndexNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "IndexNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#IndexNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/InternalServerError.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/InternalServerError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InternalServerError: Unknown
+InternalServerError: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalServerError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalServerError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#InternalServerError"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/InvalidEndpointException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/InvalidEndpointException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidEndpointException: Unknown
+InvalidEndpointException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidEndpointException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidEndpointException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#InvalidEndpointException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/InvalidExportTimeException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/InvalidExportTimeException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidExportTimeException: Unknown
+InvalidExportTimeException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidExportTimeException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidExportTimeException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#InvalidExportTimeException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/InvalidRestoreTimeException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/InvalidRestoreTimeException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidRestoreTimeException: Unknown
+InvalidRestoreTimeException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidRestoreTimeException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidRestoreTimeException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#InvalidRestoreTimeException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ItemCollectionSizeLimitExceededException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ItemCollectionSizeLimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ItemCollectionSizeLimitExceededException: Unknown
+ItemCollectionSizeLimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ItemCollectionSizeLimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ItemCollectionSizeLimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ItemCollectionSizeLimitExceededException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ LimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "LimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#LimitExceededException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/PointInTimeRecoveryUnavailableException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/PointInTimeRecoveryUnavailableException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-PointInTimeRecoveryUnavailableException: Unknown
+PointInTimeRecoveryUnavailableException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ PointInTimeRecoveryUnavailableException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "PointInTimeRecoveryUnavailableException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#PointInTimeRecoveryUnavailableException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/PolicyNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/PolicyNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-PolicyNotFoundException: Unknown
+PolicyNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ PolicyNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "PolicyNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#PolicyNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ProvisionedThroughputExceededException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ProvisionedThroughputExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ProvisionedThroughputExceededException: Unknown
+ProvisionedThroughputExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ ProvisionedThroughputExceededException: Unknown
   },
   name: "ProvisionedThroughputExceededException",
   ThrottlingReasons: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ProvisionedThroughputExceededException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ReplicaAlreadyExistsException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ReplicaAlreadyExistsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ReplicaAlreadyExistsException: Unknown
+ReplicaAlreadyExistsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ReplicaAlreadyExistsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ReplicaAlreadyExistsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ReplicaAlreadyExistsException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ReplicaNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ReplicaNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ReplicaNotFoundException: Unknown
+ReplicaNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ReplicaNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ReplicaNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ReplicaNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ReplicatedWriteConflictException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ReplicatedWriteConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ReplicatedWriteConflictException: Unknown
+ReplicatedWriteConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ReplicatedWriteConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ReplicatedWriteConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ReplicatedWriteConflictException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/RequestLimitExceeded.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/RequestLimitExceeded.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-RequestLimitExceeded: Unknown
+RequestLimitExceeded: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ RequestLimitExceeded: Unknown
   },
   name: "RequestLimitExceeded",
   ThrottlingReasons: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#RequestLimitExceeded"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ResourceInUseException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ResourceInUseException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ResourceInUseException: Unknown
+ResourceInUseException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceInUseException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceInUseException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ResourceInUseException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ResourceNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TableAlreadyExistsException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TableAlreadyExistsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TableAlreadyExistsException: Unknown
+TableAlreadyExistsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TableAlreadyExistsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TableAlreadyExistsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TableAlreadyExistsException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TableInUseException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TableInUseException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TableInUseException: Unknown
+TableInUseException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TableInUseException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TableInUseException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TableInUseException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TableNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TableNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TableNotFoundException: Unknown
+TableNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TableNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TableNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TableNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ThrottlingException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ThrottlingException.txt
@@ -11,7 +11,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-ThrottlingException: Unknown
+ThrottlingException: UnknownError
 
 --- [error object] ---
 {
@@ -27,7 +27,7 @@ ThrottlingException: Unknown
   },
   name: "ThrottlingException",
   throttlingReasons: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ThrottlingException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TransactionCanceledException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TransactionCanceledException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TransactionCanceledException: Unknown
+TransactionCanceledException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ TransactionCanceledException: Unknown
   },
   name: "TransactionCanceledException",
   CancellationReasons: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TransactionCanceledException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TransactionConflictException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TransactionConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TransactionConflictException: Unknown
+TransactionConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TransactionConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TransactionConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TransactionConflictException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TransactionInProgressException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TransactionInProgressException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TransactionInProgressException: Unknown
+TransactionInProgressException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TransactionInProgressException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TransactionInProgressException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TransactionInProgressException"
 }
 

--- a/clients/client-ec2/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-ec2/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/AccountNotManagementOrDelegatedAdministratorException.txt
+++ b/clients/client-iam/test/snapshots/res-err/AccountNotManagementOrDelegatedAdministratorException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/CallerIsNotManagementAccountException.txt
+++ b/clients/client-iam/test/snapshots/res-err/CallerIsNotManagementAccountException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/ConcurrentModificationException.txt
+++ b/clients/client-iam/test/snapshots/res-err/ConcurrentModificationException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/CredentialReportExpiredException.txt
+++ b/clients/client-iam/test/snapshots/res-err/CredentialReportExpiredException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/CredentialReportNotPresentException.txt
+++ b/clients/client-iam/test/snapshots/res-err/CredentialReportNotPresentException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/CredentialReportNotReadyException.txt
+++ b/clients/client-iam/test/snapshots/res-err/CredentialReportNotReadyException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/DeleteConflictException.txt
+++ b/clients/client-iam/test/snapshots/res-err/DeleteConflictException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/DuplicateCertificateException.txt
+++ b/clients/client-iam/test/snapshots/res-err/DuplicateCertificateException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/DuplicateSSHPublicKeyException.txt
+++ b/clients/client-iam/test/snapshots/res-err/DuplicateSSHPublicKeyException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/EntityAlreadyExistsException.txt
+++ b/clients/client-iam/test/snapshots/res-err/EntityAlreadyExistsException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/EntityTemporarilyUnmodifiableException.txt
+++ b/clients/client-iam/test/snapshots/res-err/EntityTemporarilyUnmodifiableException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/FeatureDisabledException.txt
+++ b/clients/client-iam/test/snapshots/res-err/FeatureDisabledException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/FeatureEnabledException.txt
+++ b/clients/client-iam/test/snapshots/res-err/FeatureEnabledException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/InvalidAuthenticationCodeException.txt
+++ b/clients/client-iam/test/snapshots/res-err/InvalidAuthenticationCodeException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/InvalidCertificateException.txt
+++ b/clients/client-iam/test/snapshots/res-err/InvalidCertificateException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/InvalidInputException.txt
+++ b/clients/client-iam/test/snapshots/res-err/InvalidInputException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/InvalidPublicKeyException.txt
+++ b/clients/client-iam/test/snapshots/res-err/InvalidPublicKeyException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/InvalidUserTypeException.txt
+++ b/clients/client-iam/test/snapshots/res-err/InvalidUserTypeException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/KeyPairMismatchException.txt
+++ b/clients/client-iam/test/snapshots/res-err/KeyPairMismatchException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-iam/test/snapshots/res-err/LimitExceededException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/MalformedCertificateException.txt
+++ b/clients/client-iam/test/snapshots/res-err/MalformedCertificateException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/MalformedPolicyDocumentException.txt
+++ b/clients/client-iam/test/snapshots/res-err/MalformedPolicyDocumentException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/NoSuchEntityException.txt
+++ b/clients/client-iam/test/snapshots/res-err/NoSuchEntityException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/OpenIdIdpCommunicationErrorException.txt
+++ b/clients/client-iam/test/snapshots/res-err/OpenIdIdpCommunicationErrorException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/OrganizationNotFoundException.txt
+++ b/clients/client-iam/test/snapshots/res-err/OrganizationNotFoundException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/OrganizationNotInAllFeaturesModeException.txt
+++ b/clients/client-iam/test/snapshots/res-err/OrganizationNotInAllFeaturesModeException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/PasswordPolicyViolationException.txt
+++ b/clients/client-iam/test/snapshots/res-err/PasswordPolicyViolationException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/PolicyEvaluationException.txt
+++ b/clients/client-iam/test/snapshots/res-err/PolicyEvaluationException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/PolicyNotAttachableException.txt
+++ b/clients/client-iam/test/snapshots/res-err/PolicyNotAttachableException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/ReportGenerationLimitExceededException.txt
+++ b/clients/client-iam/test/snapshots/res-err/ReportGenerationLimitExceededException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/ServiceAccessNotEnabledException.txt
+++ b/clients/client-iam/test/snapshots/res-err/ServiceAccessNotEnabledException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/ServiceFailureException.txt
+++ b/clients/client-iam/test/snapshots/res-err/ServiceFailureException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/ServiceNotSupportedException.txt
+++ b/clients/client-iam/test/snapshots/res-err/ServiceNotSupportedException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-iam/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/UnmodifiableEntityException.txt
+++ b/clients/client-iam/test/snapshots/res-err/UnmodifiableEntityException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-iam/test/snapshots/res-err/UnrecognizedPublicKeyEncodingException.txt
+++ b/clients/client-iam/test/snapshots/res-err/UnrecognizedPublicKeyEncodingException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/AuthorizationAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/AuthorizationAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/AuthorizationNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/AuthorizationNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/AuthorizationQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/AuthorizationQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/BackupPolicyNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/BackupPolicyNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/BlueGreenDeploymentAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/BlueGreenDeploymentAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/BlueGreenDeploymentNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/BlueGreenDeploymentNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/CertificateNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CertificateNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/CreateCustomDBEngineVersionFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CreateCustomDBEngineVersionFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/CustomAvailabilityZoneNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CustomAvailabilityZoneNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterAutomatedBackupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterAutomatedBackupNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterAutomatedBackupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterAutomatedBackupQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterBacktrackNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterBacktrackNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterEndpointAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterEndpointAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterEndpointNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterEndpointNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterEndpointQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterEndpointQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterParameterGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterParameterGroupNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterRoleAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterRoleAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterRoleNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterRoleNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterRoleQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterRoleQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterSnapshotAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterSnapshotAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBClusterSnapshotNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterSnapshotNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceAutomatedBackupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceAutomatedBackupNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceAutomatedBackupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceAutomatedBackupQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceNotReadyFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceNotReadyFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceRoleAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceRoleAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceRoleNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceRoleNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceRoleQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceRoleQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBLogFileNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBLogFileNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBParameterGroupAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBParameterGroupAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBParameterGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBParameterGroupNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBParameterGroupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBParameterGroupQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBProxyAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBProxyEndpointAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyEndpointAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBProxyEndpointNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyEndpointNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBProxyEndpointQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyEndpointQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBProxyNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBProxyQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBProxyTargetAlreadyRegisteredFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyTargetAlreadyRegisteredFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBProxyTargetGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyTargetGroupNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBProxyTargetNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyTargetNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSecurityGroupAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSecurityGroupAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSecurityGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSecurityGroupNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSecurityGroupNotSupportedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSecurityGroupNotSupportedFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSecurityGroupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSecurityGroupQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBShardGroupAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBShardGroupAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBShardGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBShardGroupNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSnapshotAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSnapshotAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSnapshotNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSnapshotNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSnapshotTenantDatabaseNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSnapshotTenantDatabaseNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetGroupAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetGroupAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetGroupDoesNotCoverEnoughAZs.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetGroupDoesNotCoverEnoughAZs.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetGroupNotAllowedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetGroupNotAllowedFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetGroupNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetGroupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetGroupQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DBUpgradeDependencyFailureFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBUpgradeDependencyFailureFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/DomainNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DomainNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/Ec2ImagePropertiesNotSupportedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/Ec2ImagePropertiesNotSupportedFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/EventSubscriptionQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/EventSubscriptionQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/ExportTaskAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ExportTaskAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/ExportTaskNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ExportTaskNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/GlobalClusterAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/GlobalClusterAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/GlobalClusterNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/GlobalClusterNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/GlobalClusterQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/GlobalClusterQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/IamRoleMissingPermissionsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IamRoleMissingPermissionsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/IamRoleNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IamRoleNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InstanceQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InstanceQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InsufficientAvailableIPsInSubnetFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InsufficientAvailableIPsInSubnetFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InsufficientDBClusterCapacityFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InsufficientDBClusterCapacityFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InsufficientDBInstanceCapacityFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InsufficientDBInstanceCapacityFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InsufficientStorageClusterCapacityFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InsufficientStorageClusterCapacityFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/IntegrationAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IntegrationAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/IntegrationConflictOperationFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IntegrationConflictOperationFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/IntegrationNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IntegrationNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/IntegrationQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IntegrationQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidBlueGreenDeploymentStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidBlueGreenDeploymentStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidCustomDBEngineVersionStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidCustomDBEngineVersionStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBClusterAutomatedBackupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBClusterAutomatedBackupStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBClusterCapacityFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBClusterCapacityFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBClusterEndpointStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBClusterEndpointStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBClusterSnapshotStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBClusterSnapshotStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBClusterStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBClusterStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBInstanceAutomatedBackupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBInstanceAutomatedBackupStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBInstanceStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBInstanceStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBParameterGroupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBParameterGroupStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBProxyEndpointStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBProxyEndpointStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBProxyStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBProxyStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBSecurityGroupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBSecurityGroupStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBShardGroupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBShardGroupStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBSnapshotStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBSnapshotStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetGroupFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetGroupFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetGroupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetGroupStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidEventSubscriptionStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidEventSubscriptionStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidExportOnlyFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidExportOnlyFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidExportSourceStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidExportSourceStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidExportTaskStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidExportTaskStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidGlobalClusterStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidGlobalClusterStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidIntegrationStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidIntegrationStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidOptionGroupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidOptionGroupStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidResourceStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidResourceStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidRestoreFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidRestoreFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidS3BucketFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidS3BucketFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidSubnet.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidSubnet.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/InvalidVPCNetworkStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidVPCNetworkStateFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/KMSKeyNotAccessibleFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/KMSKeyNotAccessibleFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/MaxDBShardGroupLimitReached.txt
+++ b/clients/client-rds/test/snapshots/res-err/MaxDBShardGroupLimitReached.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/NetworkTypeNotSupported.txt
+++ b/clients/client-rds/test/snapshots/res-err/NetworkTypeNotSupported.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/OptionGroupAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/OptionGroupAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/OptionGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/OptionGroupNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/OptionGroupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/OptionGroupQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/PointInTimeRestoreNotEnabledFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/PointInTimeRestoreNotEnabledFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/ProvisionedIopsNotAvailableInAZFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ProvisionedIopsNotAvailableInAZFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/ReservedDBInstancesOfferingNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ReservedDBInstancesOfferingNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/ResourceNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ResourceNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SNSInvalidTopicFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SNSInvalidTopicFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SNSNoAuthorizationFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SNSNoAuthorizationFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SNSTopicArnNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SNSTopicArnNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SharedSnapshotQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SharedSnapshotQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SnapshotQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SnapshotQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SourceClusterNotSupportedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SourceClusterNotSupportedFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SourceDatabaseNotSupportedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SourceDatabaseNotSupportedFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SourceNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SourceNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/StorageQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/StorageQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/StorageTypeNotAvailableFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/StorageTypeNotAvailableFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/StorageTypeNotSupportedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/StorageTypeNotSupportedFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SubnetAlreadyInUse.txt
+++ b/clients/client-rds/test/snapshots/res-err/SubnetAlreadyInUse.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SubscriptionAlreadyExistFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SubscriptionAlreadyExistFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SubscriptionCategoryNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SubscriptionCategoryNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/SubscriptionNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SubscriptionNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/TenantDatabaseAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/TenantDatabaseAlreadyExistsFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/TenantDatabaseNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/TenantDatabaseNotFoundFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-NotFound: Unknown
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ NotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/TenantDatabaseQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/TenantDatabaseQuotaExceededFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-rds/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/UnsupportedDBEngineVersionFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/UnsupportedDBEngineVersionFault.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-rds/test/snapshots/res-err/VpcEncryptionControlViolationException.txt
+++ b/clients/client-rds/test/snapshots/res-err/VpcEncryptionControlViolationException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-s3/test/snapshots/res-err/AccessDenied.txt
+++ b/clients/client-s3/test/snapshots/res-err/AccessDenied.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </AccessDenied>
 
 
 --- [error name & message] ---
-AccessDenied: unmodeled message.
+AccessDenied: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ AccessDenied: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "AccessDenied",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "AccessDenied",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </AccessDenied>
 
 
 --- [error name & message] ---
-AccessDenied: unmodeled message.
+AccessDenied: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ AccessDenied: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "AccessDenied",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "AccessDenied",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/BucketAlreadyExists.txt
+++ b/clients/client-s3/test/snapshots/res-err/BucketAlreadyExists.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </BucketAlreadyExists>
 
 
 --- [error name & message] ---
-BucketAlreadyExists: unmodeled message.
+BucketAlreadyExists: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ BucketAlreadyExists: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "BucketAlreadyExists",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "BucketAlreadyExists",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </BucketAlreadyExists>
 
 
 --- [error name & message] ---
-BucketAlreadyExists: unmodeled message.
+BucketAlreadyExists: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ BucketAlreadyExists: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "BucketAlreadyExists",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "BucketAlreadyExists",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/BucketAlreadyOwnedByYou.txt
+++ b/clients/client-s3/test/snapshots/res-err/BucketAlreadyOwnedByYou.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </BucketAlreadyOwnedByYou>
 
 
 --- [error name & message] ---
-BucketAlreadyOwnedByYou: unmodeled message.
+BucketAlreadyOwnedByYou: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ BucketAlreadyOwnedByYou: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "BucketAlreadyOwnedByYou",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "BucketAlreadyOwnedByYou",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </BucketAlreadyOwnedByYou>
 
 
 --- [error name & message] ---
-BucketAlreadyOwnedByYou: unmodeled message.
+BucketAlreadyOwnedByYou: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ BucketAlreadyOwnedByYou: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "BucketAlreadyOwnedByYou",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "BucketAlreadyOwnedByYou",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/EncryptionTypeMismatch.txt
+++ b/clients/client-s3/test/snapshots/res-err/EncryptionTypeMismatch.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </EncryptionTypeMismatch>
 
 
 --- [error name & message] ---
-EncryptionTypeMismatch: unmodeled message.
+EncryptionTypeMismatch: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ EncryptionTypeMismatch: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "EncryptionTypeMismatch",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "EncryptionTypeMismatch",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </EncryptionTypeMismatch>
 
 
 --- [error name & message] ---
-EncryptionTypeMismatch: unmodeled message.
+EncryptionTypeMismatch: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ EncryptionTypeMismatch: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "EncryptionTypeMismatch",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "EncryptionTypeMismatch",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/IdempotencyParameterMismatch.txt
+++ b/clients/client-s3/test/snapshots/res-err/IdempotencyParameterMismatch.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </IdempotencyParameterMismatch>
 
 
 --- [error name & message] ---
-IdempotencyParameterMismatch: unmodeled message.
+IdempotencyParameterMismatch: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ IdempotencyParameterMismatch: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "IdempotencyParameterMismatch",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "IdempotencyParameterMismatch",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </IdempotencyParameterMismatch>
 
 
 --- [error name & message] ---
-IdempotencyParameterMismatch: unmodeled message.
+IdempotencyParameterMismatch: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ IdempotencyParameterMismatch: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "IdempotencyParameterMismatch",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "IdempotencyParameterMismatch",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/InvalidObjectState.txt
+++ b/clients/client-s3/test/snapshots/res-err/InvalidObjectState.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </InvalidObjectState>
 
 
 --- [error name & message] ---
-InvalidObjectState: unmodeled message.
+InvalidObjectState: UnknownError
 
 --- [error object] ---
 {
@@ -38,7 +35,7 @@ InvalidObjectState: unmodeled message.
   name: "InvalidObjectState",
   StorageClass: (undefined),
   AccessTier: (undefined),
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "InvalidObjectState",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/InvalidRequest.txt
+++ b/clients/client-s3/test/snapshots/res-err/InvalidRequest.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </InvalidRequest>
 
 
 --- [error name & message] ---
-InvalidRequest: unmodeled message.
+InvalidRequest: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ InvalidRequest: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "InvalidRequest",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "InvalidRequest",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </InvalidRequest>
 
 
 --- [error name & message] ---
-InvalidRequest: unmodeled message.
+InvalidRequest: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ InvalidRequest: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "InvalidRequest",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "InvalidRequest",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/InvalidWriteOffset.txt
+++ b/clients/client-s3/test/snapshots/res-err/InvalidWriteOffset.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </InvalidWriteOffset>
 
 
 --- [error name & message] ---
-InvalidWriteOffset: unmodeled message.
+InvalidWriteOffset: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ InvalidWriteOffset: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "InvalidWriteOffset",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "InvalidWriteOffset",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </InvalidWriteOffset>
 
 
 --- [error name & message] ---
-InvalidWriteOffset: unmodeled message.
+InvalidWriteOffset: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ InvalidWriteOffset: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "InvalidWriteOffset",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "InvalidWriteOffset",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/NoSuchBucket.txt
+++ b/clients/client-s3/test/snapshots/res-err/NoSuchBucket.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </NoSuchBucket>
 
 
 --- [error name & message] ---
-NoSuchBucket: unmodeled message.
+NoSuchBucket: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ NoSuchBucket: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "NoSuchBucket",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "NoSuchBucket",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </NoSuchBucket>
 
 
 --- [error name & message] ---
-NoSuchBucket: unmodeled message.
+NoSuchBucket: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ NoSuchBucket: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "NoSuchBucket",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "NoSuchBucket",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/NoSuchKey.txt
+++ b/clients/client-s3/test/snapshots/res-err/NoSuchKey.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </NoSuchKey>
 
 
 --- [error name & message] ---
-NoSuchKey: unmodeled message.
+NoSuchKey: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ NoSuchKey: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "NoSuchKey",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "NoSuchKey",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </NoSuchKey>
 
 
 --- [error name & message] ---
-NoSuchKey: unmodeled message.
+NoSuchKey: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ NoSuchKey: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "NoSuchKey",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "NoSuchKey",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/NoSuchUpload.txt
+++ b/clients/client-s3/test/snapshots/res-err/NoSuchUpload.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </NoSuchUpload>
 
 
 --- [error name & message] ---
-NoSuchUpload: unmodeled message.
+NoSuchUpload: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ NoSuchUpload: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "NoSuchUpload",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "NoSuchUpload",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </NoSuchUpload>
 
 
 --- [error name & message] ---
-NoSuchUpload: unmodeled message.
+NoSuchUpload: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ NoSuchUpload: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "NoSuchUpload",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "NoSuchUpload",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/NotFound.txt
+++ b/clients/client-s3/test/snapshots/res-err/NotFound.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </NotFound>
 
 
 --- [error name & message] ---
-NotFound: unmodeled message.
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ NotFound: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "NotFound",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </NotFound>
 
 
 --- [error name & message] ---
-NotFound: unmodeled message.
+NotFound: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ NotFound: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "NotFound",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "NotFound",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/ObjectAlreadyInActiveTierError.txt
+++ b/clients/client-s3/test/snapshots/res-err/ObjectAlreadyInActiveTierError.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </ObjectAlreadyInActiveTierError>
 
 
 --- [error name & message] ---
-ObjectAlreadyInActiveTierError: unmodeled message.
+ObjectAlreadyInActiveTierError: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ ObjectAlreadyInActiveTierError: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "ObjectAlreadyInActiveTierError",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "ObjectAlreadyInActiveTierError",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </ObjectAlreadyInActiveTierError>
 
 
 --- [error name & message] ---
-ObjectAlreadyInActiveTierError: unmodeled message.
+ObjectAlreadyInActiveTierError: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ ObjectAlreadyInActiveTierError: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "ObjectAlreadyInActiveTierError",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "ObjectAlreadyInActiveTierError",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/ObjectNotInActiveTierError.txt
+++ b/clients/client-s3/test/snapshots/res-err/ObjectNotInActiveTierError.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </ObjectNotInActiveTierError>
 
 
 --- [error name & message] ---
-ObjectNotInActiveTierError: unmodeled message.
+ObjectNotInActiveTierError: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ ObjectNotInActiveTierError: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "ObjectNotInActiveTierError",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "ObjectNotInActiveTierError",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </ObjectNotInActiveTierError>
 
 
 --- [error name & message] ---
-ObjectNotInActiveTierError: unmodeled message.
+ObjectNotInActiveTierError: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ ObjectNotInActiveTierError: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "ObjectNotInActiveTierError",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "ObjectNotInActiveTierError",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/TooManyParts.txt
+++ b/clients/client-s3/test/snapshots/res-err/TooManyParts.txt
@@ -14,14 +14,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </TooManyParts>
 
 
 --- [error name & message] ---
-TooManyParts: unmodeled message.
+TooManyParts: UnknownError
 
 --- [error object] ---
 {
@@ -36,7 +33,7 @@ TooManyParts: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "TooManyParts",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "TooManyParts",
   RequestId: "00000000-0000-4000-8000-000000000000",
@@ -59,14 +56,11 @@ content-type: application/xml
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
-    <Message>
-        unmodeled message.
-    </Message>
 </TooManyParts>
 
 
 --- [error name & message] ---
-TooManyParts: unmodeled message.
+TooManyParts: UnknownError
 
 --- [error object] ---
 {
@@ -81,7 +75,7 @@ TooManyParts: unmodeled message.
     totalRetryDelay: (number) 0
   },
   name: "TooManyParts",
-  message: "unmodeled message.",
+  message: "UnknownError",
   Type: "Sender",
   Code: "TooManyParts",
   RequestId: "00000000-0000-4000-8000-000000000000",

--- a/clients/client-s3/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-s3/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -11,9 +11,6 @@ content-type: application/xml
     <Code>
         UnmodeledServiceException
     </Code>
-    <Message>
-        unmodeled message.
-    </Message>
     <RequestId>
         00000000-0000-4000-8000-000000000000
     </RequestId>
@@ -21,7 +18,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-UnmodeledServiceException: unmodeled message.
+UnmodeledServiceException: UnknownError
 
 --- [error object] ---
 {
@@ -40,7 +37,7 @@ UnmodeledServiceException: unmodeled message.
   Code: "UnmodeledServiceException",
   RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "unmodeled message."
+  message: "UnknownError"
 }
 
 ======================== w/ optional fields ========================

--- a/clients/client-sagemaker/test/snapshots/res-err/ConflictException.txt
+++ b/clients/client-sagemaker/test/snapshots/res-err/ConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ConflictException: Unknown
+ConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sagemaker#ConflictException"
 }
 

--- a/clients/client-sagemaker/test/snapshots/res-err/ResourceInUse.txt
+++ b/clients/client-sagemaker/test/snapshots/res-err/ResourceInUse.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceInUse: Unknown
+ResourceInUse: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceInUse: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceInUse",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sagemaker#ResourceInUse"
 }
 

--- a/clients/client-sagemaker/test/snapshots/res-err/ResourceLimitExceeded.txt
+++ b/clients/client-sagemaker/test/snapshots/res-err/ResourceLimitExceeded.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceLimitExceeded: Unknown
+ResourceLimitExceeded: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceLimitExceeded: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceLimitExceeded",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sagemaker#ResourceLimitExceeded"
 }
 

--- a/clients/client-sagemaker/test/snapshots/res-err/ResourceNotFound.txt
+++ b/clients/client-sagemaker/test/snapshots/res-err/ResourceNotFound.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceNotFound: Unknown
+ResourceNotFound: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFound",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sagemaker#ResourceNotFound"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/DecryptionFailure.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/DecryptionFailure.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-DecryptionFailure: Unknown
+DecryptionFailure: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ DecryptionFailure: Unknown
     totalRetryDelay: (number) 0
   },
   name: "DecryptionFailure",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#DecryptionFailure"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/EncryptionFailure.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/EncryptionFailure.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-EncryptionFailure: Unknown
+EncryptionFailure: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ EncryptionFailure: Unknown
     totalRetryDelay: (number) 0
   },
   name: "EncryptionFailure",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#EncryptionFailure"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/InternalServiceError.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/InternalServiceError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InternalServiceError: Unknown
+InternalServiceError: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalServiceError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalServiceError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#InternalServiceError"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/InvalidNextTokenException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/InvalidNextTokenException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidNextTokenException: Unknown
+InvalidNextTokenException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidNextTokenException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidNextTokenException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#InvalidNextTokenException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/InvalidParameterException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/InvalidParameterException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidParameterException: Unknown
+InvalidParameterException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidParameterException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidParameterException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#InvalidParameterException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/InvalidRequestException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/InvalidRequestException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidRequestException: Unknown
+InvalidRequestException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidRequestException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidRequestException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#InvalidRequestException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ LimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "LimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#LimitExceededException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/MalformedPolicyDocumentException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/MalformedPolicyDocumentException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-MalformedPolicyDocumentException: Unknown
+MalformedPolicyDocumentException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ MalformedPolicyDocumentException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "MalformedPolicyDocumentException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#MalformedPolicyDocumentException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/PreconditionNotMetException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/PreconditionNotMetException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-PreconditionNotMetException: Unknown
+PreconditionNotMetException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ PreconditionNotMetException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "PreconditionNotMetException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#PreconditionNotMetException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/PublicPolicyException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/PublicPolicyException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-PublicPolicyException: Unknown
+PublicPolicyException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ PublicPolicyException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "PublicPolicyException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#PublicPolicyException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/ResourceExistsException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/ResourceExistsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceExistsException: Unknown
+ResourceExistsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceExistsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceExistsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#ResourceExistsException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#ResourceNotFoundException"
 }
 

--- a/clients/client-sqs/test/snapshots/res-err/InvalidAttributeName.txt
+++ b/clients/client-sqs/test/snapshots/res-err/InvalidAttributeName.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidAttributeName: Unknown
+InvalidAttributeName: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidAttributeName: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidAttributeName",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sqs#InvalidAttributeName",
   Error: {
     Type: (undefined),

--- a/clients/client-sqs/test/snapshots/res-err/InvalidAttributeValue.txt
+++ b/clients/client-sqs/test/snapshots/res-err/InvalidAttributeValue.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidAttributeValue: Unknown
+InvalidAttributeValue: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidAttributeValue: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidAttributeValue",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sqs#InvalidAttributeValue",
   Error: {
     Type: (undefined),

--- a/clients/client-sqs/test/snapshots/res-err/InvalidIdFormat.txt
+++ b/clients/client-sqs/test/snapshots/res-err/InvalidIdFormat.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidIdFormat: Unknown
+InvalidIdFormat: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidIdFormat: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidIdFormat",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sqs#InvalidIdFormat",
   Error: {
     Type: (undefined),
@@ -46,7 +46,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidIdFormat: Unknown
+InvalidIdFormat: UnknownError
 
 --- [error object] ---
 {
@@ -61,7 +61,7 @@ InvalidIdFormat: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidIdFormat",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sqs#InvalidIdFormat",
   Error: {
     Type: (undefined),

--- a/clients/client-sqs/test/snapshots/res-err/InvalidMessageContents.txt
+++ b/clients/client-sqs/test/snapshots/res-err/InvalidMessageContents.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidMessageContents: Unknown
+InvalidMessageContents: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidMessageContents: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidMessageContents",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sqs#InvalidMessageContents",
   Error: {
     Type: (undefined),

--- a/clients/client-sts/test/snapshots/res-err/ExpiredTokenException.txt
+++ b/clients/client-sts/test/snapshots/res-err/ExpiredTokenException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/ExpiredTradeInTokenException.txt
+++ b/clients/client-sts/test/snapshots/res-err/ExpiredTradeInTokenException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/IDPCommunicationErrorException.txt
+++ b/clients/client-sts/test/snapshots/res-err/IDPCommunicationErrorException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/IDPRejectedClaimException.txt
+++ b/clients/client-sts/test/snapshots/res-err/IDPRejectedClaimException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/InvalidAuthorizationMessageException.txt
+++ b/clients/client-sts/test/snapshots/res-err/InvalidAuthorizationMessageException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/InvalidIdentityTokenException.txt
+++ b/clients/client-sts/test/snapshots/res-err/InvalidIdentityTokenException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/JWTPayloadSizeExceededException.txt
+++ b/clients/client-sts/test/snapshots/res-err/JWTPayloadSizeExceededException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/MalformedPolicyDocumentException.txt
+++ b/clients/client-sts/test/snapshots/res-err/MalformedPolicyDocumentException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/OutboundWebIdentityFederationDisabledException.txt
+++ b/clients/client-sts/test/snapshots/res-err/OutboundWebIdentityFederationDisabledException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/PackedPolicyTooLargeException.txt
+++ b/clients/client-sts/test/snapshots/res-err/PackedPolicyTooLargeException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/RegionDisabledException.txt
+++ b/clients/client-sts/test/snapshots/res-err/RegionDisabledException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/SessionDurationEscalationException.txt
+++ b/clients/client-sts/test/snapshots/res-err/SessionDurationEscalationException.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/clients/client-sts/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-sts/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/packages-internal/core/src/submodules/protocols/cbor/AwsSmithyRpcV2CborProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/cbor/AwsSmithyRpcV2CborProtocol.ts
@@ -79,7 +79,7 @@ export class AwsSmithyRpcV2CborProtocol extends SmithyRpcV2CborProtocol {
     );
 
     const ns = NormalizedSchema.of(errorSchema);
-    const message = dataObject.message ?? dataObject.Message ?? "Unknown";
+    const message = dataObject.message ?? dataObject.Message ?? "UnknownError";
     const ErrorCtor = TypeRegistry.for(errorSchema[1]).getErrorCtor(errorSchema) ?? Error;
     const exception = new ErrorCtor(message);
 

--- a/packages-internal/core/src/submodules/protocols/json/AwsJsonRpcProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsJsonRpcProtocol.ts
@@ -115,7 +115,7 @@ export abstract class AwsJsonRpcProtocol extends RpcProtocol {
     );
 
     const ns = NormalizedSchema.of(errorSchema);
-    const message = dataObject.message ?? dataObject.Message ?? "Unknown";
+    const message = dataObject.message ?? dataObject.Message ?? "UnknownError";
     const ErrorCtor = TypeRegistry.for(errorSchema[1]).getErrorCtor(errorSchema) ?? Error;
     const exception = new ErrorCtor(message);
 

--- a/packages-internal/core/src/submodules/protocols/json/AwsRestJsonProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsRestJsonProtocol.ts
@@ -129,7 +129,7 @@ export class AwsRestJsonProtocol extends HttpBindingProtocol {
     );
 
     const ns = NormalizedSchema.of(errorSchema);
-    const message = dataObject.message ?? dataObject.Message ?? "Unknown";
+    const message = dataObject.message ?? dataObject.Message ?? "UnknownError";
     const ErrorCtor = TypeRegistry.for(errorSchema[1]).getErrorCtor(errorSchema) ?? Error;
     const exception = new ErrorCtor(message);
 

--- a/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.spec.ts
@@ -169,10 +169,10 @@ it("should not crash when error response body is empty", async () => {
   expect(actual).toBeDefined();
   expect(actual).not.toBeInstanceOf(TypeError);
   expect(actual.$metadata.httpStatusCode).toBe(500);
-  expect(actual.message).toBe("Unknown");
+  expect(actual.message).toBe("UnknownError");
   expect(actual.Error).toEqual({
     Type: undefined,
     Code: undefined,
-    Message: "Unknown",
+    Message: "UnknownError",
   });
 });

--- a/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.ts
@@ -214,7 +214,7 @@ export class AwsQueryProtocol extends RpcProtocol {
 
   protected loadQueryErrorMessage(data: any): string {
     const errorData = this.loadQueryError(data);
-    return errorData?.message ?? errorData?.Message ?? data.message ?? data.Message ?? "Unknown";
+    return errorData?.message ?? errorData?.Message ?? data.message ?? data.Message ?? "UnknownError";
   }
 
   /**

--- a/packages-internal/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
@@ -132,7 +132,11 @@ export class AwsRestXmlProtocol extends HttpBindingProtocol {
 
     const ns = NormalizedSchema.of(errorSchema);
     const message =
-      dataObject.Error?.message ?? dataObject.Error?.Message ?? dataObject.message ?? dataObject.Message ?? "Unknown";
+      dataObject.Error?.message ??
+      dataObject.Error?.Message ??
+      dataObject.message ??
+      dataObject.Message ??
+      "UnknownError";
     const ErrorCtor = TypeRegistry.for(errorSchema[1]).getErrorCtor(errorSchema) ?? Error;
     const exception = new ErrorCtor(message);
 

--- a/packages-internal/snapshot-testing/src/snapshot-response-serializers/AwsRestXmlSnapshotResponseSerializer.ts
+++ b/packages-internal/snapshot-testing/src/snapshot-response-serializers/AwsRestXmlSnapshotResponseSerializer.ts
@@ -71,7 +71,7 @@ export class AwsRestXmlSnapshotResponseSerializer extends HttpBindingSnapshotRes
             Type: "Sender",
             Code: name,
             RequestId: "00000000-0000-4000-8000-000000000000",
-            Message: "unmodeled message.",
+            ...(Object.keys(output).length > 0 ? { Message: "unmodeled message." } : {}),
           },
           output
         ),
@@ -92,7 +92,7 @@ export class AwsRestXmlSnapshotResponseSerializer extends HttpBindingSnapshotRes
           Error: {
             Type: "Sender",
             Code: name,
-            Message: "unmodeled message.",
+            ...(Object.keys(output).length > 0 ? { Message: "unmodeled message." } : {}),
             ...output,
           },
           RequestId: "00000000-0000-4000-8000-000000000000",

--- a/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/ComplexError.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/ComplexError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -27,7 +27,7 @@ ComplexError: Unknown
   name: "ComplexError",
   TopLevel: (undefined),
   Nested: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json10#ComplexError"
 }
 
@@ -47,7 +47,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -66,7 +66,7 @@ ComplexError: Unknown
   Nested: {
     Foo: "__Foo__"
   },
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json10#ComplexError"
 }
 

--- a/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/FooError.txt
+++ b/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/FooError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-FooError: Unknown
+FooError: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ FooError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "FooError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json10#FooError"
 }
 
@@ -41,7 +41,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-FooError: Unknown
+FooError: UnknownError
 
 --- [error object] ---
 {
@@ -56,7 +56,7 @@ FooError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "FooError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json10#FooError"
 }
 

--- a/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidGreeting: Unknown
+InvalidGreeting: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidGreeting: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidGreeting",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json10#InvalidGreeting"
 }
 

--- a/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/InternalServerException.txt
+++ b/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/InternalServerException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InternalServerException: Unknown
+InternalServerException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ InternalServerException: Unknown
   },
   name: "InternalServerException",
   code: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.machinelearning#InternalServerException"
 }
 

--- a/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/InvalidInputException.txt
+++ b/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/InvalidInputException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidInputException: Unknown
+InvalidInputException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ InvalidInputException: Unknown
   },
   name: "InvalidInputException",
   code: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.machinelearning#InvalidInputException"
 }
 

--- a/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/LimitExceededException.txt
+++ b/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ LimitExceededException: Unknown
   },
   name: "LimitExceededException",
   code: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.machinelearning#LimitExceededException"
 }
 

--- a/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/PredictorNotMountedException.txt
+++ b/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/PredictorNotMountedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-PredictorNotMountedException: Unknown
+PredictorNotMountedException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ PredictorNotMountedException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "PredictorNotMountedException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.machinelearning#PredictorNotMountedException"
 }
 

--- a/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ ResourceNotFoundException: Unknown
   },
   name: "ResourceNotFoundException",
   code: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.machinelearning#ResourceNotFoundException"
 }
 

--- a/private/aws-protocoltests-json-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-json-schema/test/snapshots/res-err/ComplexError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -27,7 +27,7 @@ ComplexError: Unknown
   name: "ComplexError",
   TopLevel: (undefined),
   Nested: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#ComplexError"
 }
 
@@ -47,7 +47,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -66,7 +66,7 @@ ComplexError: Unknown
   Nested: {
     Foo: "__Foo__"
   },
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#ComplexError"
 }
 

--- a/private/aws-protocoltests-json-schema/test/snapshots/res-err/ErrorWithMembers.txt
+++ b/private/aws-protocoltests-json-schema/test/snapshots/res-err/ErrorWithMembers.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ErrorWithMembers: Unknown
+ErrorWithMembers: UnknownError
 
 --- [error object] ---
 {
@@ -31,7 +31,7 @@ ErrorWithMembers: Unknown
   ListField: (undefined),
   MapField: (undefined),
   StringField: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#ErrorWithMembers"
 }
 

--- a/private/aws-protocoltests-json-schema/test/snapshots/res-err/ErrorWithoutMembers.txt
+++ b/private/aws-protocoltests-json-schema/test/snapshots/res-err/ErrorWithoutMembers.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ErrorWithoutMembers: Unknown
+ErrorWithoutMembers: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ErrorWithoutMembers: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ErrorWithoutMembers",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#ErrorWithoutMembers"
 }
 
@@ -41,7 +41,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ErrorWithoutMembers: Unknown
+ErrorWithoutMembers: UnknownError
 
 --- [error object] ---
 {
@@ -56,7 +56,7 @@ ErrorWithoutMembers: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ErrorWithoutMembers",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#ErrorWithoutMembers"
 }
 

--- a/private/aws-protocoltests-json-schema/test/snapshots/res-err/FooError.txt
+++ b/private/aws-protocoltests-json-schema/test/snapshots/res-err/FooError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-FooError: Unknown
+FooError: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ FooError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "FooError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#FooError"
 }
 
@@ -41,7 +41,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-FooError: Unknown
+FooError: UnknownError
 
 --- [error object] ---
 {
@@ -56,7 +56,7 @@ FooError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "FooError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#FooError"
 }
 

--- a/private/aws-protocoltests-json-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-json-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidGreeting: Unknown
+InvalidGreeting: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidGreeting: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidGreeting",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#InvalidGreeting"
 }
 

--- a/private/aws-protocoltests-query-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-query-schema/test/snapshots/res-err/ComplexError.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/private/aws-protocoltests-query-schema/test/snapshots/res-err/CustomCodeError.txt
+++ b/private/aws-protocoltests-query-schema/test/snapshots/res-err/CustomCodeError.txt
@@ -9,7 +9,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -24,11 +24,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -43,7 +43,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -58,11 +58,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/private/aws-protocoltests-query-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-query-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/private/aws-protocoltests-query-schema/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/private/aws-protocoltests-query-schema/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -8,7 +8,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -23,11 +23,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 
@@ -41,7 +41,7 @@ content-type: application/xml
 
 
 --- [error name & message] ---
-Unknown: Unknown
+Unknown: UnknownError
 
 --- [error object] ---
 {
@@ -56,11 +56,11 @@ Unknown: Unknown
     totalRetryDelay: (number) 0
   },
   name: "Unknown",
-  message: "Unknown",
+  message: "UnknownError",
   Error: {
     Type: (undefined),
     Code: (undefined),
-    Message: "Unknown"
+    Message: "UnknownError"
   }
 }
 

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/test/snapshots/res-err/ComplexError.txt
@@ -16,7 +16,7 @@ content-type: application/cbor
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -33,7 +33,7 @@ ComplexError: Unknown
   name: "ComplexError",
   TopLevel: (undefined),
   Nested: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "smithy.protocoltests.rpcv2Cbor#ComplexError"
 }
 
@@ -60,7 +60,7 @@ content-type: application/cbor
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -79,7 +79,7 @@ ComplexError: Unknown
   Nested: {
     Foo: "__Foo__"
   },
-  message: "Unknown",
+  message: "UnknownError",
   __type: "smithy.protocoltests.rpcv2Cbor#ComplexError"
 }
 

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -16,7 +16,7 @@ content-type: application/cbor
 
 
 --- [error name & message] ---
-InvalidGreeting: Unknown
+InvalidGreeting: UnknownError
 
 --- [error object] ---
 {
@@ -31,7 +31,7 @@ InvalidGreeting: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidGreeting",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "smithy.protocoltests.rpcv2Cbor#InvalidGreeting"
 }
 


### PR DESCRIPTION
### Issue
Internal JS-6638

### Description
restore error fallback for all protocols to "UnknownError" instead of "Unknown"
related fix: https://github.com/aws/aws-sdk-js-v3/pull/7717

### Testing
- local script to get error response and `core` package tests pass
- snapshot tests (diffs attached)

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
