### PR TITLE
chore: disable TypeScript detection when env var is 'true'

### DIFF
--- a/packages-internal/util-user-agent-node/package.json
+++ b/packages-internal/util-user-agent-node/package.json
@@ -28,6 +28,7 @@
     "@aws-sdk/types": "workspace:^3.973.5",
     "@smithy/node-config-provider": "^4.3.11",
     "@smithy/types": "^4.13.0",
+    "@smithy/util-config-provider": "^4.2.2",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages-internal/util-user-agent-node/src/getTypeScriptUserAgentPair.spec.ts
+++ b/packages-internal/util-user-agent-node/src/getTypeScriptUserAgentPair.spec.ts
@@ -1,9 +1,11 @@
+import { booleanSelector } from "@smithy/util-config-provider";
 import { readFile } from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getSanitizedTypeScriptVersion } from "./getSanitizedTypeScriptVersion";
 import { getTypeScriptPackageJsonPaths } from "./getTypeScriptPackageJsonPaths";
 
+vi.mock("@smithy/util-config-provider");
 vi.mock("node:fs/promises");
 vi.mock("./getSanitizedTypeScriptVersion");
 vi.mock("./getTypeScriptPackageJsonPaths");
@@ -141,19 +143,34 @@ describe("getTypeScriptUserAgentPair", () => {
     });
   });
 
-  describe("returns undefined without reading files", () => {
-    afterEach(() => {
-      delete process.env.AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED;
+  describe("when booleanSelector is used to read env var", () => {
+    it("returns undefined without reading files when booleanSelector returns true", async () => {
+      vi.mocked(booleanSelector).mockReturnValue(true);
+      const { getTypeScriptUserAgentPair } = await import("./getTypeScriptUserAgentPair");
+      await expect(getTypeScriptUserAgentPair()).resolves.toBeUndefined();
       expect(readFile).not.toHaveBeenCalled();
     });
 
-    it.each(["true", "false", "1", "0"])(
-      "when AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED is set to '%s'",
-      async (value) => {
-        process.env.AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED = value;
-        const { getTypeScriptUserAgentPair } = await import("./getTypeScriptUserAgentPair");
-        await expect(getTypeScriptUserAgentPair()).resolves.toBeUndefined();
-      }
-    );
+    it("proceeds with TypeScript detection when booleanSelector returns undefined", async () => {
+      vi.mocked(booleanSelector).mockReturnValue(undefined);
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: mockTscVersion }));
+
+      const { getTypeScriptUserAgentPair } = await import("./getTypeScriptUserAgentPair");
+      await expect(getTypeScriptUserAgentPair()).resolves.toEqual(["md/tsc", mockSanitizedVersion]);
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: mockTscVersion }));
+      expect(readFile).toHaveBeenCalledOnce();
+    });
+
+    it("proceeds with TypeScript detection when booleanSelector throws error", async () => {
+      vi.mocked(booleanSelector).mockImplementation(() => {
+        throw new Error("Invalid value");
+      });
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: mockTscVersion }));
+
+      const { getTypeScriptUserAgentPair } = await import("./getTypeScriptUserAgentPair");
+      await expect(getTypeScriptUserAgentPair()).resolves.toEqual(["md/tsc", mockSanitizedVersion]);
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: mockTscVersion }));
+      expect(readFile).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/packages-internal/util-user-agent-node/src/getTypeScriptUserAgentPair.ts
+++ b/packages-internal/util-user-agent-node/src/getTypeScriptUserAgentPair.ts
@@ -1,4 +1,5 @@
 import type { UserAgentPair } from "@smithy/types";
+import { booleanSelector, SelectorType } from "@smithy/util-config-provider";
 import { readFile } from "node:fs/promises";
 
 import { getSanitizedTypeScriptVersion } from "./getSanitizedTypeScriptVersion";
@@ -19,7 +20,12 @@ export const getTypeScriptUserAgentPair = async (): Promise<UserAgentPair | unde
   }
 
   // Disable TypeScript detection if environment variable is set.
-  if (process.env.AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED) {
+  let isTypeScriptDetectionDisabled = false;
+  try {
+    isTypeScriptDetectionDisabled =
+      booleanSelector(process.env, "AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED", SelectorType.ENV) || false;
+  } catch {}
+  if (isTypeScriptDetectionDisabled) {
     tscVersion = null;
     return undefined;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -24884,6 +24884,7 @@ __metadata:
     "@aws-sdk/types": "workspace:^3.973.5"
     "@smithy/node-config-provider": "npm:^4.3.11"
     "@smithy/types": "npm:^4.13.0"
+    "@smithy/util-config-provider": "npm:^4.2.2"
     "@tsconfig/recommended": "npm:1.0.1"
     "@types/node": "npm:^20.14.8"
     concurrently: "npm:7.0.0"


### PR DESCRIPTION
### Issue
Internal JS-6695

### Description
Adds an option to disable TypeScript detection with an environment variable

### Testing
CI

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
  - [x] Integ test done in https://github.com/trivikr/test-aws-sdk-js-typescript-detection/pull/19
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
