### PR TITLE
chore(scripts): add script to generate client tarball (attempt 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "g:jest": "cd $INIT_CWD && jest",
     "generate-clients": "node ./scripts/generate-clients",
     "generate:clients:generic": "node ./scripts/generate-clients/generic",
+    "generate:client:tarball": "node ./scripts/generate-client-tarball/index.mjs",
     "generate:defaults-mode-provider": "./scripts/generate-defaults-mode-provider/index.js",
     "lerna:version": "yarn update:versions:current && node ./scripts/update-versions/bumpReleaseCandidates.mjs && yarn update:versions:default",
     "lint:ci": "lerna exec --since origin/main --exclude-dependents --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' 'eslint --quiet src/**/*.ts'",

--- a/scripts/generate-client-tarball/index.mjs
+++ b/scripts/generate-client-tarball/index.mjs
@@ -1,0 +1,22 @@
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const clientName = process.argv[2];
+if (!clientName) {
+  throw new Error("Usage: yarn generate:client:tarball <client-name> (e.g. client-s3)");
+}
+
+const clientDir = join(import.meta.dirname, "..", "..", "clients", clientName);
+const pkgJsonPath = join(clientDir, "package.json");
+
+const curPkgJson = readFileSync(pkgJsonPath, "utf-8");
+const newPkgJson = JSON.parse(curPkgJson);
+newPkgJson.bundleDependencies = Object.keys(newPkgJson.dependencies ?? {});
+writeFileSync(pkgJsonPath, JSON.stringify(newPkgJson, null, 2) + "\n");
+
+try {
+  execSync("npm pack", { cwd: clientDir, stdio: "inherit" });
+} finally {
+  writeFileSync(pkgJsonPath, curPkgJson);
+}


### PR DESCRIPTION
### Issue
Internal JS-6672

### Description
First attempt to add script to generate client tarball.

This fails because yarn workspaces hoists the dependencies in the root, and not in workspace node_modules.
Thus, the tarball created by both `yarn pack` nor `npm pack` does not bundle dependencies.

The `bundleDependencies` is correctly populated though.
And in case of `yarn pack`, the dependency versions are updated to current versions.

### Testing

Example run when using `npm pack`
```console
$ yarn generate:client:tarball client-s3
...
npm notice Tarball Details
npm notice name: @aws-sdk/client-s3
npm notice version: 3.1008.0
npm notice filename: aws-sdk-client-s3-3.1008.0.tgz
npm notice package size: 344.4 kB
npm notice unpacked size: 2.8 MB
npm notice shasum: 187aa432077a4d0c7eaed955cf004311ad4722d1
npm notice integrity: sha512-0+jSrO00tGPbA[...]8bHwrsahuKgNQ==
npm notice total files: 292
npm notice
aws-sdk-client-s3-3.1008.0.tgz
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
