### PR TITLE
test(canary): use vitest 4.0.17 in canary tests

### DIFF
--- a/tests/canary/canary-runner.js
+++ b/tests/canary/canary-runner.js
@@ -49,7 +49,7 @@ const packageJson = {
     ...Object.fromEntries([...dependencies].sort().map((dep) => [dep, "latest"])),
     "@aws-sdk/config": "latest",
     "happy-dom": "20.8.3",
-    vitest: "~4.0.17",
+    vitest: "4.0.17",
   },
 };
 

--- a/tests/canary/canary-runner.js
+++ b/tests/canary/canary-runner.js
@@ -49,7 +49,7 @@ const packageJson = {
     ...Object.fromEntries([...dependencies].sort().map((dep) => [dep, "latest"])),
     "@aws-sdk/config": "latest",
     "happy-dom": "20.8.3",
-    vitest: "^4.0.17",
+    vitest: "~4.0.17",
   },
 };
 


### PR DESCRIPTION
### Issue
Internal JS-6701

### Description
Use `4.0.x` in canary tests

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
