### PR TITLE
docs(clients): fix protocol listings in readme files

### DIFF
--- a/clients/client-arc-region-switch/README.md
+++ b/clients/client-arc-region-switch/README.md
@@ -83,10 +83,10 @@ const client = new ARCRegionSwitchClient({
 
 This protocol uses CBOR payloads.
 ```js
-import { AwsJson1_0Protocol } from "@aws-sdk/config/protocol";
+import { AwsSmithyRpcV2CborProtocol } from "@aws-sdk/config/protocol";
 
 const client = new ARCRegionSwitchClient({
-  protocol: AwsJson1_0Protocol
+  protocol: AwsSmithyRpcV2CborProtocol
 });
 ```
 

--- a/clients/client-cloudwatch/README.md
+++ b/clients/client-cloudwatch/README.md
@@ -106,10 +106,10 @@ const client = new CloudWatchClient({
 
 This protocol uses CBOR payloads.
 ```js
-import { AwsJson1_0Protocol } from "@aws-sdk/config/protocol";
+import { AwsSmithyRpcV2CborProtocol } from "@aws-sdk/config/protocol";
 
 const client = new CloudWatchClient({
-  protocol: AwsJson1_0Protocol
+  protocol: AwsSmithyRpcV2CborProtocol
 });
 ```
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
@@ -83,10 +83,10 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
         """
         This protocol uses CBOR payloads.
         ```js
-        import { AwsJson1_0Protocol } from "@aws-sdk/config/protocol";
+        import { AwsSmithyRpcV2CborProtocol } from "@aws-sdk/config/protocol";
 
         const client = new \\${serviceId}Client({
-          protocol: AwsJson1_0Protocol
+          protocol: AwsSmithyRpcV2CborProtocol
         });
         ```
         """,
@@ -94,10 +94,10 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
         """
         This protocol uses XML for structured payloads in the REST pattern.
         ```js
-        import { AwsSmithyRpcV2CborProtocol } from "@aws-sdk/config/protocol";
+        import { AwsRestXmlProtocol } from "@aws-sdk/config/protocol";
 
         const client = new \\${serviceId}Client({
-          protocol: AwsSmithyRpcV2CborProtocol
+          protocol: AwsRestXmlProtocol
         });
         ```
         """,


### PR DESCRIPTION
### Issue
fix typos from https://github.com/aws/aws-sdk-js-v3/pull/7839


### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
