### PR TITLE
chore(xml-builder): update fast-xml-parser dependency to version 5.5.6

### DIFF
--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -4,7 +4,7 @@
   "description": "XML utilities for the AWS SDK",
   "dependencies": {
     "@smithy/types": "^4.13.1",
-    "fast-xml-parser": "5.4.1",
+    "fast-xml-parser": "5.5.6",
     "tslib": "^2.6.2"
   },
   "scripts": {


### PR DESCRIPTION
A patch for [CVE-2026-26278](https://github.com/advisories/GHSA-jmr7-xgp7-cmfj)

### Issue
N/A

### Description
Updating the package to fix vulnerability for fast-xml-parser v5.x through v5.5.3 (and likely v5.5.5 on npm). This is showing for multiple parent packages like `@aws-sdk/client-identitystore` or `@aws-sdk/core` in Dependabot.

### Testing
 N/A

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [ ] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [ ] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
