### PR TITLE
chore: bump fast-xml-parser to 5.5.6

### DIFF
--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -4,7 +4,7 @@
   "description": "XML utilities for the AWS SDK",
   "dependencies": {
     "@smithy/types": "^4.13.1",
-    "fast-xml-parser": "5.4.1",
+    "fast-xml-parser": "5.5.6",
     "tslib": "^2.6.2"
   },
   "scripts": {

--- a/private/aws-protocoltests-restxml-schema/package.json
+++ b/private/aws-protocoltests-restxml-schema/package.json
@@ -62,7 +62,7 @@
     "@smithy/util-stream": "^4.5.19",
     "@smithy/util-utf8": "^4.2.2",
     "entities": "2.2.0",
-    "fast-xml-parser": "5.4.1",
+    "fast-xml-parser": "5.5.6",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -64,7 +64,7 @@
     "@smithy/util-utf8": "^4.2.2",
     "@smithy/uuid": "^1.1.2",
     "entities": "2.2.0",
-    "fast-xml-parser": "5.4.1",
+    "fast-xml-parser": "5.5.6",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,7 +1176,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:5.4.1"
+    fast-xml-parser: "npm:5.5.6"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -1236,7 +1236,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:5.4.1"
+    fast-xml-parser: "npm:5.5.6"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -25094,7 +25094,7 @@ __metadata:
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
-    fast-xml-parser: "npm:5.4.1"
+    fast-xml-parser: "npm:5.5.6"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -34173,22 +34173,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fast-xml-builder@npm:1.0.0"
-  checksum: 10c0/2631fda265c81e8008884d08944eeed4e284430116faa5b8b7a43a3602af367223b7bf01c933215c9ad2358b8666e45041bc038d64877156a2f88821841b3014
+"fast-xml-builder@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "fast-xml-builder@npm:1.1.4"
+  dependencies:
+    path-expression-matcher: "npm:^1.1.3"
+  checksum: 10c0/d5dfc0660f7f886b9f42747e6aa1d5e16c090c804b322652f65a5d7ffb93aa00153c3e1276cd053629f9f4c4f625131dc6886677394f7048e827e63b97b18927
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.4.1":
-  version: 5.4.1
-  resolution: "fast-xml-parser@npm:5.4.1"
+"fast-xml-parser@npm:5.5.6":
+  version: 5.5.6
+  resolution: "fast-xml-parser@npm:5.5.6"
   dependencies:
-    fast-xml-builder: "npm:^1.0.0"
+    fast-xml-builder: "npm:^1.1.4"
+    path-expression-matcher: "npm:^1.1.3"
     strnum: "npm:^2.1.2"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/8c696438a0c64135faf93ea6a93879208d649b7c9a3293d30d6eb750dc7f766fd083c0df5a82786b60809c3ead64fad155f28dbed25efea91017aaf9f64c91e5
+  checksum: 10c0/b7aed4f561f57fe4eba91c5e4a4438cb7eb09ac885b32d912eec257b84e6587dea88a7afd5738fd36c1e6a0bce778dfd8fcefea829fcc44ef019753b92e36402
   languageName: node
   linkType: hard
 
@@ -38948,6 +38951,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
   checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
+  languageName: node
+  linkType: hard
+
+"path-expression-matcher@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "path-expression-matcher@npm:1.1.3"
+  checksum: 10c0/45c01471bc62c5f38d069418aec831763e6f45bb85f9520b08de441e6cd14f84b3098ecb66255e819c2af21102abcd2b45550dc1285996717ce9292802df2bc5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7853

### Description
Bumps `fast-xml-parser` from 5.4.1 to 5.5.6

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
