### PR TITLE
chore(xml-builder): parse XML internally

### DIFF
--- a/.github/workflows/fuzz-testing.yml
+++ b/.github/workflows/fuzz-testing.yml
@@ -1,0 +1,90 @@
+name: XML Parser Fuzz Testing
+
+on:
+  pull_request:
+    paths:
+      - "packages-internal/xml-builder/src/xml-parser*"
+      - "packages-internal/xml-builder/tests/xml-parser*"
+  push:
+    branches: [main]
+    paths:
+      - "packages-internal/xml-builder/src/xml-parser*"
+      - "packages-internal/xml-builder/tests/xml-parser*"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz-property:
+    runs-on: ubuntu-latest
+    name: Property-based fuzz (fast-check)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        working-directory: packages-internal/xml-builder
+        run: yarn install
+
+      - name: Run fuzz tests
+        working-directory: packages-internal/xml-builder
+        run: npx vitest run tests/xml-parser.fuzz.spec.ts --reporter=verbose
+
+  fuzz-coverage-guided:
+    runs-on: ubuntu-latest
+    name: Coverage-guided fuzz (jazzer.js)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        working-directory: packages-internal/xml-builder
+        run: yarn install
+
+      - name: Build parser
+        working-directory: packages-internal/xml-builder
+        run: yarn build:cjs
+
+      - name: Restore fuzz corpus
+        uses: actions/cache/restore@v4
+        with:
+          key: xml-fuzz-corpus-${{ github.run_id }}
+          restore-keys: xml-fuzz-corpus-
+          path: packages-internal/xml-builder/corpus
+
+      - name: Run coverage-guided fuzzer (5 min)
+        working-directory: packages-internal/xml-builder
+        run: |
+          mkdir -p corpus
+          npx jazzer tests/xml-parser.fuzz.js corpus --sync -i xml-parser -- -max_total_time=300
+
+      - name: Save fuzz corpus
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          key: xml-fuzz-corpus-${{ github.run_id }}
+          path: packages-internal/xml-builder/corpus
+
+      - name: Upload crash artifacts
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: jazzer-crashes
+          path: |
+            packages-internal/xml-builder/crash-*
+            packages-internal/xml-builder/leak-*
+            packages-internal/xml-builder/timeout-*

--- a/clients/client-cloudfront/test/snapshots/res-err/AccessDenied.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/AccessDenied.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/BatchTooLarge.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/BatchTooLarge.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/CNAMEAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/CNAMEAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/CachePolicyAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/CachePolicyAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/CachePolicyInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/CachePolicyInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/CannotChangeImmutablePublicKeyFields.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/CannotChangeImmutablePublicKeyFields.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/CannotDeleteEntityWhileInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/CannotDeleteEntityWhileInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/CannotUpdateEntityWhileInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/CannotUpdateEntityWhileInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/CloudFrontOriginAccessIdentityAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/CloudFrontOriginAccessIdentityAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/CloudFrontOriginAccessIdentityInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/CloudFrontOriginAccessIdentityInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/ContinuousDeploymentPolicyAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/ContinuousDeploymentPolicyAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/ContinuousDeploymentPolicyInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/ContinuousDeploymentPolicyInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/DistributionAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/DistributionAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/DistributionNotDisabled.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/DistributionNotDisabled.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/EntityAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/EntityAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/EntityLimitExceeded.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/EntityLimitExceeded.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/EntityNotFound.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/EntityNotFound.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/EntitySizeLimitExceeded.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/EntitySizeLimitExceeded.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/FieldLevelEncryptionConfigAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/FieldLevelEncryptionConfigAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/FieldLevelEncryptionConfigInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/FieldLevelEncryptionConfigInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/FieldLevelEncryptionProfileAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/FieldLevelEncryptionProfileAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/FieldLevelEncryptionProfileInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/FieldLevelEncryptionProfileInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/FieldLevelEncryptionProfileSizeExceeded.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/FieldLevelEncryptionProfileSizeExceeded.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/FunctionAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/FunctionAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/FunctionInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/FunctionInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/FunctionSizeLimitExceeded.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/FunctionSizeLimitExceeded.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/IllegalDelete.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/IllegalDelete.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/IllegalOriginAccessConfiguration.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/IllegalOriginAccessConfiguration.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/IllegalUpdate.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/IllegalUpdate.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InconsistentQuantities.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InconsistentQuantities.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidArgument.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidArgument.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidAssociation.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidAssociation.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidDefaultRootObject.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidDefaultRootObject.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidDomainNameForOriginAccessControl.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidDomainNameForOriginAccessControl.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidErrorCode.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidErrorCode.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidForwardCookies.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidForwardCookies.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidFunctionAssociation.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidFunctionAssociation.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidGeoRestrictionParameter.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidGeoRestrictionParameter.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidHeadersForS3Origin.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidHeadersForS3Origin.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidIfMatchVersion.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidIfMatchVersion.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidLambdaFunctionAssociation.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidLambdaFunctionAssociation.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidLocationCode.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidLocationCode.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidMinimumProtocolVersion.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidMinimumProtocolVersion.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidOrigin.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidOrigin.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidOriginAccessControl.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidOriginAccessControl.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidOriginAccessIdentity.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidOriginAccessIdentity.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidOriginKeepaliveTimeout.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidOriginKeepaliveTimeout.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidOriginReadTimeout.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidOriginReadTimeout.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidProtocolSettings.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidProtocolSettings.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidQueryStringParameters.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidQueryStringParameters.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidRelativePath.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidRelativePath.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidRequiredProtocol.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidRequiredProtocol.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidResponseCode.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidResponseCode.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidTTLOrder.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidTTLOrder.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidTagging.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidTagging.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidViewerCertificate.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidViewerCertificate.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/InvalidWebACLId.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/InvalidWebACLId.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/KeyGroupAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/KeyGroupAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/MissingBody.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/MissingBody.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/MonitoringSubscriptionAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/MonitoringSubscriptionAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchCachePolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchCachePolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchCloudFrontOriginAccessIdentity.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchCloudFrontOriginAccessIdentity.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchContinuousDeploymentPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchContinuousDeploymentPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchDistribution.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchDistribution.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchFieldLevelEncryptionConfig.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchFieldLevelEncryptionConfig.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchFieldLevelEncryptionProfile.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchFieldLevelEncryptionProfile.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchFunctionExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchFunctionExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchInvalidation.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchInvalidation.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchMonitoringSubscription.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchMonitoringSubscription.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchOrigin.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchOrigin.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchOriginAccessControl.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchOriginAccessControl.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchOriginRequestPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchOriginRequestPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchPublicKey.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchPublicKey.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchRealtimeLogConfig.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchRealtimeLogConfig.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchResource.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchResource.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchResponseHeadersPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchResponseHeadersPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/NoSuchStreamingDistribution.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/NoSuchStreamingDistribution.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/OriginAccessControlAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/OriginAccessControlAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/OriginAccessControlInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/OriginAccessControlInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/OriginRequestPolicyAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/OriginRequestPolicyAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/OriginRequestPolicyInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/OriginRequestPolicyInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/PreconditionFailed.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/PreconditionFailed.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/PublicKeyAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/PublicKeyAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/PublicKeyInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/PublicKeyInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/QueryArgProfileEmpty.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/QueryArgProfileEmpty.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/RealtimeLogConfigAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/RealtimeLogConfigAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/RealtimeLogConfigInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/RealtimeLogConfigInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/RealtimeLogConfigOwnerMismatch.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/RealtimeLogConfigOwnerMismatch.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/ResourceInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/ResourceInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/ResourceNotDisabled.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/ResourceNotDisabled.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/ResponseHeadersPolicyAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/ResponseHeadersPolicyAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/ResponseHeadersPolicyInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/ResponseHeadersPolicyInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/StagingDistributionInUse.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/StagingDistributionInUse.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/StreamingDistributionAlreadyExists.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/StreamingDistributionAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/StreamingDistributionNotDisabled.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/StreamingDistributionNotDisabled.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TestFunctionFailed.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TestFunctionFailed.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooLongCSPInResponseHeadersPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooLongCSPInResponseHeadersPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyCacheBehaviors.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyCacheBehaviors.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyCachePolicies.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyCachePolicies.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyCertificates.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyCertificates.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyCloudFrontOriginAccessIdentities.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyCloudFrontOriginAccessIdentities.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyContinuousDeploymentPolicies.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyContinuousDeploymentPolicies.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyCookieNamesInWhiteList.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyCookieNamesInWhiteList.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyCookiesInCachePolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyCookiesInCachePolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyCookiesInOriginRequestPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyCookiesInOriginRequestPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyCustomHeadersInResponseHeadersPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyCustomHeadersInResponseHeadersPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionCNAMEs.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionCNAMEs.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributions.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributions.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToCachePolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToCachePolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToFieldLevelEncryptionConfig.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToFieldLevelEncryptionConfig.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToKeyGroup.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToKeyGroup.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToOriginAccessControl.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToOriginAccessControl.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToOriginRequestPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToOriginRequestPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToResponseHeadersPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsAssociatedToResponseHeadersPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsWithFunctionAssociations.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsWithFunctionAssociations.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsWithLambdaAssociations.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsWithLambdaAssociations.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsWithSingleFunctionARN.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyDistributionsWithSingleFunctionARN.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionConfigs.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionConfigs.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionContentTypeProfiles.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionContentTypeProfiles.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionEncryptionEntities.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionEncryptionEntities.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionFieldPatterns.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionFieldPatterns.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionProfiles.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionProfiles.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionQueryArgProfiles.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyFieldLevelEncryptionQueryArgProfiles.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyFunctionAssociations.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyFunctionAssociations.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyFunctions.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyFunctions.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyHeadersInCachePolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyHeadersInCachePolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyHeadersInForwardedValues.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyHeadersInForwardedValues.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyHeadersInOriginRequestPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyHeadersInOriginRequestPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyInvalidationsInProgress.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyInvalidationsInProgress.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyKeyGroups.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyKeyGroups.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyKeyGroupsAssociatedToDistribution.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyKeyGroupsAssociatedToDistribution.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyLambdaFunctionAssociations.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyLambdaFunctionAssociations.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyOriginAccessControls.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyOriginAccessControls.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyOriginCustomHeaders.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyOriginCustomHeaders.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyOriginGroupsPerDistribution.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyOriginGroupsPerDistribution.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyOriginRequestPolicies.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyOriginRequestPolicies.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyOrigins.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyOrigins.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyPublicKeys.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyPublicKeys.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyPublicKeysInKeyGroup.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyPublicKeysInKeyGroup.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyQueryStringParameters.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyQueryStringParameters.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyQueryStringsInCachePolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyQueryStringsInCachePolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyQueryStringsInOriginRequestPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyQueryStringsInOriginRequestPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyRealtimeLogConfigs.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyRealtimeLogConfigs.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyRemoveHeadersInResponseHeadersPolicy.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyRemoveHeadersInResponseHeadersPolicy.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyResponseHeadersPolicies.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyResponseHeadersPolicies.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyStreamingDistributionCNAMEs.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyStreamingDistributionCNAMEs.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyStreamingDistributions.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyStreamingDistributions.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TooManyTrustedSigners.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TooManyTrustedSigners.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TrustedKeyGroupDoesNotExist.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TrustedKeyGroupDoesNotExist.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/TrustedSignerDoesNotExist.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/TrustedSignerDoesNotExist.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-cloudfront/test/snapshots/res-err/UnsupportedOperation.txt
+++ b/clients/client-cloudfront/test/snapshots/res-err/UnsupportedOperation.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ec2/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-ec2/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/AccountNotManagementOrDelegatedAdministratorException.txt
+++ b/clients/client-iam/test/snapshots/res-err/AccountNotManagementOrDelegatedAdministratorException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/CallerIsNotManagementAccountException.txt
+++ b/clients/client-iam/test/snapshots/res-err/CallerIsNotManagementAccountException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/ConcurrentModificationException.txt
+++ b/clients/client-iam/test/snapshots/res-err/ConcurrentModificationException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/CredentialReportExpiredException.txt
+++ b/clients/client-iam/test/snapshots/res-err/CredentialReportExpiredException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/CredentialReportNotPresentException.txt
+++ b/clients/client-iam/test/snapshots/res-err/CredentialReportNotPresentException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/CredentialReportNotReadyException.txt
+++ b/clients/client-iam/test/snapshots/res-err/CredentialReportNotReadyException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/DeleteConflictException.txt
+++ b/clients/client-iam/test/snapshots/res-err/DeleteConflictException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/DuplicateCertificateException.txt
+++ b/clients/client-iam/test/snapshots/res-err/DuplicateCertificateException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/DuplicateSSHPublicKeyException.txt
+++ b/clients/client-iam/test/snapshots/res-err/DuplicateSSHPublicKeyException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/EntityAlreadyExistsException.txt
+++ b/clients/client-iam/test/snapshots/res-err/EntityAlreadyExistsException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/EntityTemporarilyUnmodifiableException.txt
+++ b/clients/client-iam/test/snapshots/res-err/EntityTemporarilyUnmodifiableException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/FeatureDisabledException.txt
+++ b/clients/client-iam/test/snapshots/res-err/FeatureDisabledException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/FeatureEnabledException.txt
+++ b/clients/client-iam/test/snapshots/res-err/FeatureEnabledException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/InvalidAuthenticationCodeException.txt
+++ b/clients/client-iam/test/snapshots/res-err/InvalidAuthenticationCodeException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/InvalidCertificateException.txt
+++ b/clients/client-iam/test/snapshots/res-err/InvalidCertificateException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/InvalidInputException.txt
+++ b/clients/client-iam/test/snapshots/res-err/InvalidInputException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/InvalidPublicKeyException.txt
+++ b/clients/client-iam/test/snapshots/res-err/InvalidPublicKeyException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/InvalidUserTypeException.txt
+++ b/clients/client-iam/test/snapshots/res-err/InvalidUserTypeException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/KeyPairMismatchException.txt
+++ b/clients/client-iam/test/snapshots/res-err/KeyPairMismatchException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-iam/test/snapshots/res-err/LimitExceededException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/MalformedCertificateException.txt
+++ b/clients/client-iam/test/snapshots/res-err/MalformedCertificateException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/MalformedPolicyDocumentException.txt
+++ b/clients/client-iam/test/snapshots/res-err/MalformedPolicyDocumentException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/NoSuchEntityException.txt
+++ b/clients/client-iam/test/snapshots/res-err/NoSuchEntityException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/OpenIdIdpCommunicationErrorException.txt
+++ b/clients/client-iam/test/snapshots/res-err/OpenIdIdpCommunicationErrorException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/OrganizationNotFoundException.txt
+++ b/clients/client-iam/test/snapshots/res-err/OrganizationNotFoundException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/OrganizationNotInAllFeaturesModeException.txt
+++ b/clients/client-iam/test/snapshots/res-err/OrganizationNotInAllFeaturesModeException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/PasswordPolicyViolationException.txt
+++ b/clients/client-iam/test/snapshots/res-err/PasswordPolicyViolationException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/PolicyEvaluationException.txt
+++ b/clients/client-iam/test/snapshots/res-err/PolicyEvaluationException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/PolicyNotAttachableException.txt
+++ b/clients/client-iam/test/snapshots/res-err/PolicyNotAttachableException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/ReportGenerationLimitExceededException.txt
+++ b/clients/client-iam/test/snapshots/res-err/ReportGenerationLimitExceededException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/ServiceAccessNotEnabledException.txt
+++ b/clients/client-iam/test/snapshots/res-err/ServiceAccessNotEnabledException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/ServiceFailureException.txt
+++ b/clients/client-iam/test/snapshots/res-err/ServiceFailureException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/ServiceNotSupportedException.txt
+++ b/clients/client-iam/test/snapshots/res-err/ServiceNotSupportedException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-iam/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/UnmodifiableEntityException.txt
+++ b/clients/client-iam/test/snapshots/res-err/UnmodifiableEntityException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-iam/test/snapshots/res-err/UnrecognizedPublicKeyEncodingException.txt
+++ b/clients/client-iam/test/snapshots/res-err/UnrecognizedPublicKeyEncodingException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/AuthorizationAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/AuthorizationAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/AuthorizationNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/AuthorizationNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/AuthorizationQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/AuthorizationQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/BackupPolicyNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/BackupPolicyNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/BlueGreenDeploymentAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/BlueGreenDeploymentAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/BlueGreenDeploymentNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/BlueGreenDeploymentNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/CertificateNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CertificateNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/CreateCustomDBEngineVersionFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CreateCustomDBEngineVersionFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/CustomAvailabilityZoneNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CustomAvailabilityZoneNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/CustomDBEngineVersionQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterAutomatedBackupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterAutomatedBackupNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterAutomatedBackupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterAutomatedBackupQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterBacktrackNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterBacktrackNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterEndpointAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterEndpointAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterEndpointNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterEndpointNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterEndpointQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterEndpointQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterParameterGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterParameterGroupNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterRoleAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterRoleAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterRoleNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterRoleNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterRoleQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterRoleQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterSnapshotAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterSnapshotAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBClusterSnapshotNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBClusterSnapshotNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceAutomatedBackupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceAutomatedBackupNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceAutomatedBackupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceAutomatedBackupQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceNotReadyFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceNotReadyFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceRoleAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceRoleAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceRoleNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceRoleNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBInstanceRoleQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBInstanceRoleQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBLogFileNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBLogFileNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBParameterGroupAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBParameterGroupAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBParameterGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBParameterGroupNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBParameterGroupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBParameterGroupQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBProxyAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBProxyEndpointAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyEndpointAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBProxyEndpointNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyEndpointNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBProxyEndpointQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyEndpointQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBProxyNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBProxyQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBProxyTargetAlreadyRegisteredFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyTargetAlreadyRegisteredFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBProxyTargetGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyTargetGroupNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBProxyTargetNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBProxyTargetNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSecurityGroupAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSecurityGroupAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSecurityGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSecurityGroupNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSecurityGroupNotSupportedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSecurityGroupNotSupportedFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSecurityGroupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSecurityGroupQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBShardGroupAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBShardGroupAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBShardGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBShardGroupNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSnapshotAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSnapshotAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSnapshotNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSnapshotNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSnapshotTenantDatabaseNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSnapshotTenantDatabaseNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetGroupAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetGroupAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetGroupDoesNotCoverEnoughAZs.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetGroupDoesNotCoverEnoughAZs.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetGroupNotAllowedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetGroupNotAllowedFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetGroupNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetGroupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetGroupQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBSubnetQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBSubnetQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DBUpgradeDependencyFailureFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DBUpgradeDependencyFailureFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/DomainNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/DomainNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/Ec2ImagePropertiesNotSupportedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/Ec2ImagePropertiesNotSupportedFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/EventSubscriptionQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/EventSubscriptionQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/ExportTaskAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ExportTaskAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/ExportTaskNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ExportTaskNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/GlobalClusterAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/GlobalClusterAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/GlobalClusterNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/GlobalClusterNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/GlobalClusterQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/GlobalClusterQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/IamRoleMissingPermissionsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IamRoleMissingPermissionsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/IamRoleNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IamRoleNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InstanceQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InstanceQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InsufficientAvailableIPsInSubnetFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InsufficientAvailableIPsInSubnetFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InsufficientDBClusterCapacityFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InsufficientDBClusterCapacityFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InsufficientDBInstanceCapacityFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InsufficientDBInstanceCapacityFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InsufficientStorageClusterCapacityFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InsufficientStorageClusterCapacityFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/IntegrationAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IntegrationAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/IntegrationConflictOperationFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IntegrationConflictOperationFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/IntegrationNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IntegrationNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/IntegrationQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/IntegrationQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidBlueGreenDeploymentStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidBlueGreenDeploymentStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidCustomDBEngineVersionStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidCustomDBEngineVersionStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBClusterAutomatedBackupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBClusterAutomatedBackupStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBClusterCapacityFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBClusterCapacityFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBClusterEndpointStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBClusterEndpointStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBClusterSnapshotStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBClusterSnapshotStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBClusterStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBClusterStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBInstanceAutomatedBackupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBInstanceAutomatedBackupStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBInstanceStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBInstanceStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBParameterGroupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBParameterGroupStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBProxyEndpointStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBProxyEndpointStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBProxyStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBProxyStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBSecurityGroupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBSecurityGroupStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBShardGroupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBShardGroupStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBSnapshotStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBSnapshotStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetGroupFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetGroupFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetGroupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetGroupStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidDBSubnetStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidEventSubscriptionStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidEventSubscriptionStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidExportOnlyFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidExportOnlyFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidExportSourceStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidExportSourceStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidExportTaskStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidExportTaskStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidGlobalClusterStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidGlobalClusterStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidIntegrationStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidIntegrationStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidOptionGroupStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidOptionGroupStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidResourceStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidResourceStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidRestoreFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidRestoreFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidS3BucketFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidS3BucketFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidSubnet.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidSubnet.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/InvalidVPCNetworkStateFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/InvalidVPCNetworkStateFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/KMSKeyNotAccessibleFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/KMSKeyNotAccessibleFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/MaxDBShardGroupLimitReached.txt
+++ b/clients/client-rds/test/snapshots/res-err/MaxDBShardGroupLimitReached.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/NetworkTypeNotSupported.txt
+++ b/clients/client-rds/test/snapshots/res-err/NetworkTypeNotSupported.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/OptionGroupAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/OptionGroupAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/OptionGroupNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/OptionGroupNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/OptionGroupQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/OptionGroupQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/PointInTimeRestoreNotEnabledFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/PointInTimeRestoreNotEnabledFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/ProvisionedIopsNotAvailableInAZFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ProvisionedIopsNotAvailableInAZFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ReservedDBInstanceQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/ReservedDBInstancesOfferingNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ReservedDBInstancesOfferingNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/ResourceNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/ResourceNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SNSInvalidTopicFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SNSInvalidTopicFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SNSNoAuthorizationFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SNSNoAuthorizationFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SNSTopicArnNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SNSTopicArnNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SharedSnapshotQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SharedSnapshotQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SnapshotQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SnapshotQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SourceClusterNotSupportedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SourceClusterNotSupportedFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SourceDatabaseNotSupportedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SourceDatabaseNotSupportedFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SourceNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SourceNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/StorageQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/StorageQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/StorageTypeNotAvailableFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/StorageTypeNotAvailableFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/StorageTypeNotSupportedFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/StorageTypeNotSupportedFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SubnetAlreadyInUse.txt
+++ b/clients/client-rds/test/snapshots/res-err/SubnetAlreadyInUse.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SubscriptionAlreadyExistFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SubscriptionAlreadyExistFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SubscriptionCategoryNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SubscriptionCategoryNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/SubscriptionNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/SubscriptionNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/TenantDatabaseAlreadyExistsFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/TenantDatabaseAlreadyExistsFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/TenantDatabaseNotFoundFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/TenantDatabaseNotFoundFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/TenantDatabaseQuotaExceededFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/TenantDatabaseQuotaExceededFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-rds/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/UnsupportedDBEngineVersionFault.txt
+++ b/clients/client-rds/test/snapshots/res-err/UnsupportedDBEngineVersionFault.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-rds/test/snapshots/res-err/VpcEncryptionControlViolationException.txt
+++ b/clients/client-rds/test/snapshots/res-err/VpcEncryptionControlViolationException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/CidrBlockInUseException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/CidrBlockInUseException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/CidrCollectionAlreadyExistsException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/CidrCollectionAlreadyExistsException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/CidrCollectionInUseException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/CidrCollectionInUseException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/CidrCollectionVersionMismatchException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/CidrCollectionVersionMismatchException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/ConcurrentModification.txt
+++ b/clients/client-route-53/test/snapshots/res-err/ConcurrentModification.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/ConflictingDomainExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/ConflictingDomainExists.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/ConflictingTypes.txt
+++ b/clients/client-route-53/test/snapshots/res-err/ConflictingTypes.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/DNSSECNotFound.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DNSSECNotFound.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/DelegationSetAlreadyCreated.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DelegationSetAlreadyCreated.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/DelegationSetAlreadyReusable.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DelegationSetAlreadyReusable.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/DelegationSetInUse.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DelegationSetInUse.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/DelegationSetNotAvailable.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DelegationSetNotAvailable.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/DelegationSetNotReusable.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DelegationSetNotReusable.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/HealthCheckAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HealthCheckAlreadyExists.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/HealthCheckInUse.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HealthCheckInUse.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/HealthCheckVersionMismatch.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HealthCheckVersionMismatch.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/HostedZoneAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HostedZoneAlreadyExists.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/HostedZoneNotEmpty.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HostedZoneNotEmpty.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/HostedZoneNotFound.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HostedZoneNotFound.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/HostedZoneNotPrivate.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HostedZoneNotPrivate.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/HostedZonePartiallyDelegated.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HostedZonePartiallyDelegated.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/IncompatibleVersion.txt
+++ b/clients/client-route-53/test/snapshots/res-err/IncompatibleVersion.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InsufficientCloudWatchLogsResourcePolicy.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InsufficientCloudWatchLogsResourcePolicy.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidArgument.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidArgument.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidChangeBatch.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidChangeBatch.txt
@@ -132,7 +132,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidDomainName.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidDomainName.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidInput.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidInput.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidKMSArn.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidKMSArn.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidKeySigningKeyName.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidKeySigningKeyName.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidKeySigningKeyStatus.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidKeySigningKeyStatus.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidPaginationToken.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidPaginationToken.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidSigningStatus.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidSigningStatus.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidTrafficPolicyDocument.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidTrafficPolicyDocument.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/InvalidVPCId.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidVPCId.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/KeySigningKeyAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/KeySigningKeyAlreadyExists.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/KeySigningKeyInParentDSRecord.txt
+++ b/clients/client-route-53/test/snapshots/res-err/KeySigningKeyInParentDSRecord.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/KeySigningKeyInUse.txt
+++ b/clients/client-route-53/test/snapshots/res-err/KeySigningKeyInUse.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/KeySigningKeyWithActiveStatusNotFound.txt
+++ b/clients/client-route-53/test/snapshots/res-err/KeySigningKeyWithActiveStatusNotFound.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/LastVPCAssociation.txt
+++ b/clients/client-route-53/test/snapshots/res-err/LastVPCAssociation.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/LimitsExceeded.txt
+++ b/clients/client-route-53/test/snapshots/res-err/LimitsExceeded.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchChange.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchChange.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchCidrCollectionException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchCidrCollectionException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchCidrLocationException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchCidrLocationException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchCloudWatchLogsLogGroup.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchCloudWatchLogsLogGroup.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchDelegationSet.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchDelegationSet.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchGeoLocation.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchGeoLocation.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchHealthCheck.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchHealthCheck.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchHostedZone.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchHostedZone.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchKeySigningKey.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchKeySigningKey.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchQueryLoggingConfig.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchQueryLoggingConfig.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchTrafficPolicy.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchTrafficPolicy.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchTrafficPolicyInstance.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchTrafficPolicyInstance.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/NotAuthorizedException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NotAuthorizedException.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/PriorRequestNotComplete.txt
+++ b/clients/client-route-53/test/snapshots/res-err/PriorRequestNotComplete.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/PublicZoneVPCAssociation.txt
+++ b/clients/client-route-53/test/snapshots/res-err/PublicZoneVPCAssociation.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/QueryLoggingConfigAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/QueryLoggingConfigAlreadyExists.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/ThrottlingException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/ThrottlingException.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/TooManyHealthChecks.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyHealthChecks.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/TooManyHostedZones.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyHostedZones.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/TooManyKeySigningKeys.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyKeySigningKeys.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicies.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicies.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicyInstances.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicyInstances.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicyVersionsForCurrentPolicy.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicyVersionsForCurrentPolicy.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/TooManyVPCAssociationAuthorizations.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyVPCAssociationAuthorizations.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/TrafficPolicyAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TrafficPolicyAlreadyExists.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/TrafficPolicyInUse.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TrafficPolicyInUse.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/TrafficPolicyInstanceAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TrafficPolicyInstanceAlreadyExists.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/VPCAssociationAuthorizationNotFound.txt
+++ b/clients/client-route-53/test/snapshots/res-err/VPCAssociationAuthorizationNotFound.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-route-53/test/snapshots/res-err/VPCAssociationNotFound.txt
+++ b/clients/client-route-53/test/snapshots/res-err/VPCAssociationNotFound.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/BadRequestException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/BadRequestException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/BucketAlreadyExists.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/BucketAlreadyExists.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/BucketAlreadyOwnedByYou.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/BucketAlreadyOwnedByYou.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/IdempotencyException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/IdempotencyException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/InternalServiceException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/InternalServiceException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/InvalidNextTokenException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/InvalidNextTokenException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/InvalidRequestException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/InvalidRequestException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/JobStatusException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/JobStatusException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/NoSuchPublicAccessBlockConfiguration.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/NoSuchPublicAccessBlockConfiguration.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/NotFoundException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/NotFoundException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/TooManyRequestsException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/TooManyRequestsException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/TooManyTagsException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/TooManyTagsException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3-control/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/AccessDenied.txt
+++ b/clients/client-s3/test/snapshots/res-err/AccessDenied.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/AnnotationLimitExceeded.txt
+++ b/clients/client-s3/test/snapshots/res-err/AnnotationLimitExceeded.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/AnnotationNameTooLong.txt
+++ b/clients/client-s3/test/snapshots/res-err/AnnotationNameTooLong.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/BucketAlreadyExists.txt
+++ b/clients/client-s3/test/snapshots/res-err/BucketAlreadyExists.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/BucketAlreadyOwnedByYou.txt
+++ b/clients/client-s3/test/snapshots/res-err/BucketAlreadyOwnedByYou.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/EncryptionTypeMismatch.txt
+++ b/clients/client-s3/test/snapshots/res-err/EncryptionTypeMismatch.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/IdempotencyParameterMismatch.txt
+++ b/clients/client-s3/test/snapshots/res-err/IdempotencyParameterMismatch.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/InvalidAnnotationName.txt
+++ b/clients/client-s3/test/snapshots/res-err/InvalidAnnotationName.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/InvalidObjectState.txt
+++ b/clients/client-s3/test/snapshots/res-err/InvalidObjectState.txt
@@ -108,7 +108,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/InvalidPrefix.txt
+++ b/clients/client-s3/test/snapshots/res-err/InvalidPrefix.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/InvalidRequest.txt
+++ b/clients/client-s3/test/snapshots/res-err/InvalidRequest.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/InvalidWriteOffset.txt
+++ b/clients/client-s3/test/snapshots/res-err/InvalidWriteOffset.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/NoSuchAnnotation.txt
+++ b/clients/client-s3/test/snapshots/res-err/NoSuchAnnotation.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/NoSuchBucket.txt
+++ b/clients/client-s3/test/snapshots/res-err/NoSuchBucket.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/NoSuchKey.txt
+++ b/clients/client-s3/test/snapshots/res-err/NoSuchKey.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/NoSuchUpload.txt
+++ b/clients/client-s3/test/snapshots/res-err/NoSuchUpload.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/NotFound.txt
+++ b/clients/client-s3/test/snapshots/res-err/NotFound.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/ObjectAlreadyInActiveTierError.txt
+++ b/clients/client-s3/test/snapshots/res-err/ObjectAlreadyInActiveTierError.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/ObjectNotInActiveTierError.txt
+++ b/clients/client-s3/test/snapshots/res-err/ObjectNotInActiveTierError.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/TooManyParts.txt
+++ b/clients/client-s3/test/snapshots/res-err/TooManyParts.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-s3/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-s3/test/snapshots/res-err/UnsupportedMediaType.txt
+++ b/clients/client-s3/test/snapshots/res-err/UnsupportedMediaType.txt
@@ -98,7 +98,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/AccountSendingPausedException.txt
+++ b/clients/client-ses/test/snapshots/res-err/AccountSendingPausedException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/AlreadyExistsException.txt
+++ b/clients/client-ses/test/snapshots/res-err/AlreadyExistsException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/CannotDeleteException.txt
+++ b/clients/client-ses/test/snapshots/res-err/CannotDeleteException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/ConfigurationSetAlreadyExistsException.txt
+++ b/clients/client-ses/test/snapshots/res-err/ConfigurationSetAlreadyExistsException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/ConfigurationSetDoesNotExistException.txt
+++ b/clients/client-ses/test/snapshots/res-err/ConfigurationSetDoesNotExistException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/ConfigurationSetSendingPausedException.txt
+++ b/clients/client-ses/test/snapshots/res-err/ConfigurationSetSendingPausedException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/CustomVerificationEmailInvalidContentException.txt
+++ b/clients/client-ses/test/snapshots/res-err/CustomVerificationEmailInvalidContentException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/CustomVerificationEmailTemplateAlreadyExistsException.txt
+++ b/clients/client-ses/test/snapshots/res-err/CustomVerificationEmailTemplateAlreadyExistsException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/CustomVerificationEmailTemplateDoesNotExistException.txt
+++ b/clients/client-ses/test/snapshots/res-err/CustomVerificationEmailTemplateDoesNotExistException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/EventDestinationAlreadyExistsException.txt
+++ b/clients/client-ses/test/snapshots/res-err/EventDestinationAlreadyExistsException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/EventDestinationDoesNotExistException.txt
+++ b/clients/client-ses/test/snapshots/res-err/EventDestinationDoesNotExistException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/FromEmailAddressNotVerifiedException.txt
+++ b/clients/client-ses/test/snapshots/res-err/FromEmailAddressNotVerifiedException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidCloudWatchDestinationException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidCloudWatchDestinationException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidConfigurationSetException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidConfigurationSetException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidDeliveryOptionsException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidDeliveryOptionsException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidFirehoseDestinationException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidFirehoseDestinationException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidLambdaFunctionException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidLambdaFunctionException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidPolicyException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidPolicyException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidRenderingParameterException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidRenderingParameterException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidS3ConfigurationException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidS3ConfigurationException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidSNSDestinationException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidSNSDestinationException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidSnsTopicException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidSnsTopicException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidTemplateException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidTemplateException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/InvalidTrackingOptionsException.txt
+++ b/clients/client-ses/test/snapshots/res-err/InvalidTrackingOptionsException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-ses/test/snapshots/res-err/LimitExceededException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/MailFromDomainNotVerifiedException.txt
+++ b/clients/client-ses/test/snapshots/res-err/MailFromDomainNotVerifiedException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/MessageRejected.txt
+++ b/clients/client-ses/test/snapshots/res-err/MessageRejected.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/MissingRenderingAttributeException.txt
+++ b/clients/client-ses/test/snapshots/res-err/MissingRenderingAttributeException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/ProductionAccessNotGrantedException.txt
+++ b/clients/client-ses/test/snapshots/res-err/ProductionAccessNotGrantedException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/RuleDoesNotExistException.txt
+++ b/clients/client-ses/test/snapshots/res-err/RuleDoesNotExistException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/RuleSetDoesNotExistException.txt
+++ b/clients/client-ses/test/snapshots/res-err/RuleSetDoesNotExistException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/TemplateDoesNotExistException.txt
+++ b/clients/client-ses/test/snapshots/res-err/TemplateDoesNotExistException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/TrackingOptionsAlreadyExistsException.txt
+++ b/clients/client-ses/test/snapshots/res-err/TrackingOptionsAlreadyExistsException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/TrackingOptionsDoesNotExistException.txt
+++ b/clients/client-ses/test/snapshots/res-err/TrackingOptionsDoesNotExistException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-ses/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-ses/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/ExpiredTokenException.txt
+++ b/clients/client-sts/test/snapshots/res-err/ExpiredTokenException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/ExpiredTradeInTokenException.txt
+++ b/clients/client-sts/test/snapshots/res-err/ExpiredTradeInTokenException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/IDPCommunicationErrorException.txt
+++ b/clients/client-sts/test/snapshots/res-err/IDPCommunicationErrorException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/IDPRejectedClaimException.txt
+++ b/clients/client-sts/test/snapshots/res-err/IDPRejectedClaimException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/InvalidAuthorizationMessageException.txt
+++ b/clients/client-sts/test/snapshots/res-err/InvalidAuthorizationMessageException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/InvalidIdentityTokenException.txt
+++ b/clients/client-sts/test/snapshots/res-err/InvalidIdentityTokenException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/JWTPayloadSizeExceededException.txt
+++ b/clients/client-sts/test/snapshots/res-err/JWTPayloadSizeExceededException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/MalformedPolicyDocumentException.txt
+++ b/clients/client-sts/test/snapshots/res-err/MalformedPolicyDocumentException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/OutboundWebIdentityFederationDisabledException.txt
+++ b/clients/client-sts/test/snapshots/res-err/OutboundWebIdentityFederationDisabledException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/PackedPolicyTooLargeException.txt
+++ b/clients/client-sts/test/snapshots/res-err/PackedPolicyTooLargeException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/RegionDisabledException.txt
+++ b/clients/client-sts/test/snapshots/res-err/RegionDisabledException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/SessionDurationEscalationException.txt
+++ b/clients/client-sts/test/snapshots/res-err/SessionDurationEscalationException.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/clients/client-sts/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-sts/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "eslint-plugin-sort-export-all": "1.2.2",
     "eslint-plugin-tsdoc": "0.2.17",
     "esprint": "3.6.0",
+    "fast-xml-parser": "^5.7.1",
     "fastify": "^4.11.0",
     "figlet": "^1.5.0",
     "fs-extra": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "eslint-plugin-sort-export-all": "1.2.2",
     "eslint-plugin-tsdoc": "0.2.17",
     "esprint": "3.6.0",
+    "fast-xml-parser": "5.7.3",
     "fastify": "^4.11.0",
     "figlet": "^1.5.0",
     "fs-extra": "^9.0.0",

--- a/packages-internal/core/src/submodules/protocols/xml/XmlShapeDeserializer.ts
+++ b/packages-internal/core/src/submodules/protocols/xml/XmlShapeDeserializer.ts
@@ -1,12 +1,12 @@
 import { parseXML } from "@aws-sdk/xml-builder";
 import { FromStringShapeDeserializer } from "@smithy/core/protocols";
 import { NormalizedSchema } from "@smithy/core/schema";
-import { getValueFromTextNode } from "@smithy/smithy-client";
 import type { Schema, SerdeFunctions, ShapeDeserializer } from "@smithy/types";
 import { toUtf8 } from "@smithy/util-utf8";
 
 import { SerdeContextConfig } from "../ConfigurableSerdeContext";
 import { UnionSerde } from "../UnionSerde";
+import { getValueFromTextNode } from "./getValueFromTextNode";
 import type { XmlSettings } from "./XmlCodec";
 
 /**

--- a/packages-internal/core/src/submodules/protocols/xml/getValueFromTextNode.ts
+++ b/packages-internal/core/src/submodules/protocols/xml/getValueFromTextNode.ts
@@ -1,0 +1,16 @@
+const textNodeName = "#text";
+
+/**
+ * todo(smithy-client): remove call to hasOwnProperty
+ * @internal
+ */
+export function getValueFromTextNode(obj: any) {
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key) && obj[key][textNodeName] !== undefined) {
+      obj[key] = obj[key][textNodeName];
+    } else if (typeof obj[key] === "object" && obj[key] !== null) {
+      obj[key] = getValueFromTextNode(obj[key]);
+    }
+  }
+  return obj;
+}

--- a/packages-internal/core/src/submodules/protocols/xml/parseXmlBody.ts
+++ b/packages-internal/core/src/submodules/protocols/xml/parseXmlBody.ts
@@ -1,8 +1,8 @@
 import { parseXML } from "@aws-sdk/xml-builder";
-import { getValueFromTextNode } from "@smithy/smithy-client";
 import type { HttpResponse, SerdeContext } from "@smithy/types";
 
 import { collectBodyString } from "../common";
+import { getValueFromTextNode } from "./getValueFromTextNode";
 
 /**
  * @internal

--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -4,7 +4,6 @@
   "description": "XML utilities for the AWS SDK",
   "dependencies": {
     "@smithy/types": "^4.14.3",
-    "fast-xml-parser": "5.7.3",
     "tslib": "^2.6.2"
   },
   "scripts": {
@@ -15,6 +14,7 @@
     "build:types": "premove dist-types && tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "premove dist-cjs dist-es dist-types",
+    "profile": "node --inspect-brk ./scripts/benchmark",
     "test": "yarn g:vitest run",
     "test:watch": "yarn g:vitest watch"
   },

--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -16,7 +16,8 @@
     "clean": "premove dist-cjs dist-es dist-types",
     "profile": "node --inspect-brk ./scripts/benchmark",
     "test": "yarn g:vitest run",
-    "test:watch": "yarn g:vitest watch"
+    "test:watch": "yarn g:vitest watch",
+    "test:fuzz": "jazzer tests/xml-parser.fuzz.js corpus --sync -i xml-parser -- -max_total_time=300"
   },
   "sideEffects": false,
   "author": {
@@ -54,10 +55,12 @@
     "directory": "packages-internal/xml-builder"
   },
   "devDependencies": {
+    "@jazzer.js/core": "^4.0.0",
     "@nodable/entities": "2.1.0",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
+    "fast-check": "^4.8.0",
     "premove": "4.0.0",
     "typescript": "~5.8.3"
   }

--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -4,10 +4,10 @@
   "description": "XML utilities for the AWS SDK",
   "dependencies": {
     "@smithy/types": "^4.14.1",
-    "fast-xml-parser": "5.7.1",
     "tslib": "^2.6.2"
   },
   "scripts": {
+    "profile": "node --inspect-brk ./scripts/benchmark",
     "build": "concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",
     "build:cjs": "node ../../scripts/compilation/inline xml-builder",
     "build:es": "tsc -p tsconfig.es.json",

--- a/packages-internal/xml-builder/scripts/profile.js
+++ b/packages-internal/xml-builder/scripts/profile.js
@@ -1,0 +1,37 @@
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+   <IsTruncated>boolean</IsTruncated>
+   <Marker>string</Marker>
+   <NextMarker>string</NextMarker>
+   <Contents>
+      ${`<Object>
+<ChecksumAlgorithm>string</ChecksumAlgorithm>
+      <ChecksumType>string</ChecksumType>
+      <ETag>&quot;098f6bcd4621d373cade4e832627b4f6&quot;</ETag>
+      <Key>string</Key>
+      <LastModified>timestamp</LastModified>
+      <Owner>
+         <DisplayName>string</DisplayName>
+         <ID>string</ID>
+      </Owner>
+      <RestoreStatus>
+         <IsRestoreInProgress>boolean</IsRestoreInProgress>
+         <RestoreExpiryDate>timestamp</RestoreExpiryDate>
+      </RestoreStatus>
+      <Size>long</Size>
+      <StorageClass>string</StorageClass>
+</Object>`.repeat(2000)}
+   </Contents>
+   <Name>string</Name>
+   <Prefix>string</Prefix>
+   <Delimiter>string</Delimiter>
+   <MaxKeys>integer</MaxKeys>
+   <CommonPrefixes>
+      <Prefix>string</Prefix>
+   </CommonPrefixes>
+   <EncodingType>string</EncodingType>
+</ListBucketResult>`;
+
+const { parseXML } = require("../");
+
+parseXML(xml);

--- a/packages-internal/xml-builder/src/xml-parser.browser.ts
+++ b/packages-internal/xml-builder/src/xml-parser.browser.ts
@@ -51,7 +51,7 @@ export function parseXML(xmlString: string): any {
             return childResult;
           }
 
-          if (obj[childName]) {
+          if (childName in obj) {
             if (Array.isArray(obj[childName])) {
               obj[childName].push(childResult);
             } else {

--- a/packages-internal/xml-builder/src/xml-parser.spec.ts
+++ b/packages-internal/xml-builder/src/xml-parser.spec.ts
@@ -1,11 +1,37 @@
+import { XMLParser } from "fast-xml-parser";
 import { describe, expect, test as it } from "vitest";
 
 import { parseXML } from "./xml-parser";
 import { parseXML as parseXMLBrowser } from "./xml-parser.browser";
 
+const parser = new XMLParser({
+  attributeNamePrefix: "",
+  processEntities: {
+    enabled: true,
+    maxTotalExpansions: Infinity,
+  },
+  htmlEntities: true,
+  ignoreAttributes: false,
+  ignoreDeclaration: true,
+  parseTagValue: false,
+  trimValues: false,
+  tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+  maxNestedTags: Infinity,
+});
+
+/**
+ * Reference implementation that was used in the AWS SDK from 2020-2026.
+ * We need to match its behavior for AWS service responses in XML format.
+ * @internal
+ */
+function fxp(xmlString: string): any {
+  return parser.parse(xmlString, true);
+}
+
 describe("xml parsing", () => {
   for (const { name, parse } of [
-    { name: "fast-xml-parser", parse: parseXML },
+    { name: "fast-xml-parser", parse: fxp },
+    { name: "@aws-sdk::AwsXmlParser", parse: parseXML },
     { name: "DOMParser", parse: parseXMLBrowser },
   ]) {
     describe(name, () => {
@@ -99,6 +125,27 @@ describe("xml parsing", () => {
         });
       });
 
+      it("should understand collections of empty objects", () => {
+        const xml = `<XmlEmptyMapsResponse xmlns="https://example.com/">
+          <XmlEmptyMapsResult>
+              <myMap />
+              <myMap></myMap>
+              <myMap />
+              <myMap></myMap>
+              <myMap />
+          </XmlEmptyMapsResult>
+      </XmlEmptyMapsResponse>`;
+        const object = parse(xml);
+        expect(object).toMatchObject({
+          XmlEmptyMapsResponse: {
+            xmlns: "https://example.com/",
+            XmlEmptyMapsResult: {
+              myMap: ["", "", "", "", ""],
+            },
+          },
+        });
+      });
+
       it("should parse xml (custom)", () => {
         const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <struct>
@@ -160,16 +207,66 @@ describe("xml parsing", () => {
     `<x><y>z</y></x>`,
     `<x><y>  </y></x>`,
     `<x><y>  </y><y>  </y></x>`,
+    `<ListGeoLocationsResponse xmlns="https://placeholder.amazonaws.com">
+    <GeoLocationDetailsList>
+        <GeoLocationDetails/>
+        <GeoLocationDetails/>
+        <GeoLocationDetails/>
+    </GeoLocationDetailsList>
+    <IsTruncated>
+        false
+    </IsTruncated>
+    <MaxItems>
+        0
+    </MaxItems>
+    <NextContinentCode>
+        __NextContinentCode__
+    </NextContinentCode>
+    <NextCountryCode>
+        __NextCountryCode__
+    </NextCountryCode>
+    <NextSubdivisionCode>
+        __NextSubdivisionCode__
+    </NextSubdivisionCode>
+</ListGeoLocationsResponse>`,
   ];
   let i = 0;
 
   for (const xml of xmlSamples) {
     it(`should behave identically to fast-xml-parser as far as the SDK is concerned, case ${++i}`, () => {
-      expect(parseXMLBrowser(xml)).toEqual(parseXML(xml));
+      expect(parseXML(xml)).toEqual(fxp(xml));
+      expect(parseXMLBrowser(xml)).toEqual(fxp(xml));
     });
   }
 
-  it("can parse a large amount of XML including entities", () => {
+  it("should throw on incomplete xml (1 missing closing tag)", async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListAllMyBucketsResult>
+   <Buckets>
+      <Bucket>
+         <CreationDate>timestamp</CreationDate>
+         <Name>string</Name>
+      </Bucket>
+   </Buckets>
+   <Owner>
+      <DisplayName>string</DisplayName>
+      <ID>string</ID>
+   </Owner>
+`;
+    expect(() => parseXML(xml)).toThrowError();
+  });
+
+  it("should throw on incomplete xml (truncated mid-tag)", async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListAllMyBucketsResult>
+   <Buckets>
+      <Bucket>
+         <CreationDate>timestamp</Creatio
+`;
+    expect(() => parseXML(xml)).toThrowError();
+  });
+
+  it("can parse a large amount of XML including entities", { timeout: 10_000 }, () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult>
    <IsTruncated>boolean</IsTruncated>
@@ -204,7 +301,40 @@ describe("xml parsing", () => {
    <EncodingType>string</EncodingType>
 </ListBucketResult>`;
 
-    expect(parseXMLBrowser(xml)).toEqual(parseXML(xml));
+    expect(parseXML(xml)).toEqual(fxp(xml));
+    expect(parseXMLBrowser(xml)).toEqual(fxp(xml));
+  });
+
+  it("can parse special characters", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<special>
+  <a>&#xD;&#10;xyz</a>
+  <b>&#xD;xyz</b>
+  <c>&#10;xyz</c>
+  <d>&amp;</d>
+  <e>&lt;</e>
+  <f>&gt;</f>
+  <g>&quot;</g>
+  <h>&apos;</h>
+  <i>!@#$%^&amp;*()</i>
+  <g>αβγδεζηθικλμνξοπρστυφχψω</g>
+  <c>АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ</c>
+  <h>🐪 גמל לא רואה את הדבשת שלו</h>
+  <a>🤷 اللي ما يعرف الصقر 🦅 يشويه 🍗</a>
+  <u>🦔Їжак з'їв яблуко🍎☀️</u>
+  <u>🐺Вовків боятися😨 — в ліс🌲 не ходити</u>
+  <hd>🏃💨 नौ दो ग्यारह होना</hd>
+  <te>🌊🏊 నీళ్ళలో దిగితే గానీ ఈత రాదు</te>
+  <tl>🐘🍌 யானைக்கும் அடி சறுக்கும்</tl>
+  <bg>💃🤷 নাচতে না জানলে উঠোন বাঁকা</bg>
+  <gr>🐒🫚 વાંદરાને શું ખબર અદરકનો સ્વાદ</gr>
+  <c>我靠</c>
+  <j>ぎゃふん</j>
+  <k>하늘의 별 따기✨</k>
+</special>`;
+
+    expect(parseXML(xml)).toEqual(fxp(xml));
+    expect(parseXMLBrowser(xml)).toEqual(fxp(xml));
   });
 
   it("should resolve numeric character references for CR and LF", () => {
@@ -223,6 +353,119 @@ describe("xml parsing", () => {
     for (const xml of xmlSamples) {
       expect(() => parseXMLBrowser(xml)).toThrowError();
       expect(() => parseXML(xml)).toThrowError();
+      expect(() => fxp(xml)).toThrowError();
     }
+  });
+
+  describe("XML with mal intent", () => {
+    it("ignores entity expansion attacks", () => {
+      const xml = `<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY lol "lol">
+  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+]>
+<root><data>&lol3;</data></root>`;
+
+      const result = parseXML(xml);
+      expect(result).toEqual({
+        root: {
+          data: "",
+        },
+      });
+    });
+
+    it("ignores quadratic blowup entity attacks", () => {
+      const repeatedEntity = "A".repeat(50000);
+      const xml = `<?xml version="1.0"?>
+<!DOCTYPE foo [
+  <!ENTITY big "${repeatedEntity}">
+]>
+<root>${"&big;".repeat(100)}</root>`;
+
+      const result = parseXML(xml);
+      expect(result).toEqual({
+        root: "",
+      });
+    });
+
+    it("does not process external entity (XXE) declarations", () => {
+      const xml = `<?xml version="1.0"?>
+<!DOCTYPE foo [
+  <!ENTITY xxe SYSTEM "file:///etc/passwd">
+]>
+<root><data>&xxe;</data></root>`;
+
+      const result = parseXML(xml);
+      expect(result).toEqual({
+        root: {
+          data: "",
+        },
+      });
+    });
+
+    it("does not process parameter entity (XXE) declarations", () => {
+      const xml = `<?xml version="1.0"?>
+<!dOcTyPe foo [
+  <!ENTITY % xxe SYSTEM "http://loooooooooooooocalhost/payload.dtd">
+  %xxe;
+]>
+<root><data>safe</data></root>`;
+
+      const result = parseXML(xml);
+      expect(result).toEqual({
+        root: {
+          data: "safe",
+        },
+      });
+    });
+
+    it("ignores regex DoS attempts in entity-like patterns", () => {
+      const malicious = "&" + "a".repeat(31) + ";";
+      const xml = `<root><data>${malicious.repeat(10000)}</data></root>`;
+
+      const start = Date.now();
+      const result = parseXML(xml);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(5000);
+      expect(result).toEqual({
+        root: {
+          data: "",
+        },
+      });
+    });
+
+    it("handles deeply nested entity-like references without hanging", () => {
+      const payload = Array.from({ length: 10000 }, (_, i) => `&#x${i.toString(16)};`).join("");
+      const xml = `<root><data>${payload}</data></root>`;
+
+      const start = Date.now();
+      const result = parseXML(xml);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(5000);
+      expect(result).toEqual({
+        root: {
+          data: expect.any(String),
+        },
+      });
+      expect(result.root.data).toMatch(/⛫⛬⛭⛮⛯⛰⛱/);
+    });
+
+    it("handles malformed entity patterns without catastrophic backtracking", () => {
+      const xml = `<root><data>${"&amp".repeat(10000)}</data></root>`;
+
+      const start = Date.now();
+      const result = parseXML(xml);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(5000);
+      expect(result).toEqual({
+        root: {
+          data: "&amp".repeat(10000),
+        },
+      });
+    });
   });
 });

--- a/packages-internal/xml-builder/src/xml-parser.spec.ts
+++ b/packages-internal/xml-builder/src/xml-parser.spec.ts
@@ -1,11 +1,37 @@
+import { XMLParser } from "fast-xml-parser";
 import { describe, expect, test as it } from "vitest";
 
 import { parseXML } from "./xml-parser";
 import { parseXML as parseXMLBrowser } from "./xml-parser.browser";
 
+const parser = new XMLParser({
+  attributeNamePrefix: "",
+  processEntities: {
+    enabled: true,
+    maxTotalExpansions: Infinity,
+  },
+  htmlEntities: true,
+  ignoreAttributes: false,
+  ignoreDeclaration: true,
+  parseTagValue: false,
+  trimValues: false,
+  tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+  maxNestedTags: Infinity,
+});
+
+/**
+ * Reference implementation that was used in the AWS SDK from 2020-2026.
+ * We need to match its behavior for AWS service responses in XML format.
+ * @internal
+ */
+function fxp(xmlString: string): any {
+  return parser.parse(xmlString, true);
+}
+
 describe("xml parsing", () => {
   for (const { name, parse } of [
-    { name: "fast-xml-parser", parse: parseXML },
+    { name: "fast-xml-parser", parse: fxp },
+    { name: "@aws-sdk::AwsXmlParser", parse: parseXML },
     { name: "DOMParser", parse: parseXMLBrowser },
   ]) {
     describe(name, () => {
@@ -99,6 +125,27 @@ describe("xml parsing", () => {
         });
       });
 
+      it("should understand collections of empty objects", () => {
+        const xml = `<XmlEmptyMapsResponse xmlns="https://example.com/">
+          <XmlEmptyMapsResult>
+              <myMap />
+              <myMap></myMap>
+              <myMap />
+              <myMap></myMap>
+              <myMap />
+          </XmlEmptyMapsResult>
+      </XmlEmptyMapsResponse>`;
+        const object = parse(xml);
+        expect(object).toMatchObject({
+          XmlEmptyMapsResponse: {
+            xmlns: "https://example.com/",
+            XmlEmptyMapsResult: {
+              myMap: ["", "", "", "", ""],
+            },
+          },
+        });
+      });
+
       it("should parse xml (custom)", () => {
         const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <struct>
@@ -160,16 +207,66 @@ describe("xml parsing", () => {
     `<x><y>z</y></x>`,
     `<x><y>  </y></x>`,
     `<x><y>  </y><y>  </y></x>`,
+    `<ListGeoLocationsResponse xmlns="https://placeholder.amazonaws.com">
+    <GeoLocationDetailsList>
+        <GeoLocationDetails/>
+        <GeoLocationDetails/>
+        <GeoLocationDetails/>
+    </GeoLocationDetailsList>
+    <IsTruncated>
+        false
+    </IsTruncated>
+    <MaxItems>
+        0
+    </MaxItems>
+    <NextContinentCode>
+        __NextContinentCode__
+    </NextContinentCode>
+    <NextCountryCode>
+        __NextCountryCode__
+    </NextCountryCode>
+    <NextSubdivisionCode>
+        __NextSubdivisionCode__
+    </NextSubdivisionCode>
+</ListGeoLocationsResponse>`,
   ];
   let i = 0;
 
   for (const xml of xmlSamples) {
     it(`should behave identically to fast-xml-parser as far as the SDK is concerned, case ${++i}`, () => {
-      expect(parseXMLBrowser(xml)).toEqual(parseXML(xml));
+      expect(parseXML(xml)).toEqual(fxp(xml));
+      expect(parseXMLBrowser(xml)).toEqual(fxp(xml));
     });
   }
 
-  it("can parse a large amount of XML including entities", () => {
+  it("should throw on incomplete xml (1 missing closing tag)", async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListAllMyBucketsResult>
+   <Buckets>
+      <Bucket>
+         <CreationDate>timestamp</CreationDate>
+         <Name>string</Name>
+      </Bucket>
+   </Buckets>
+   <Owner>
+      <DisplayName>string</DisplayName>
+      <ID>string</ID>
+   </Owner>
+`;
+    expect(() => parseXML(xml)).toThrowError();
+  });
+
+  it("should throw on incomplete xml (truncated mid-tag)", async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListAllMyBucketsResult>
+   <Buckets>
+      <Bucket>
+         <CreationDate>timestamp</Creatio
+`;
+    expect(() => parseXML(xml)).toThrowError();
+  });
+
+  it("can parse a large amount of XML including entities", { timeout: 10_000 }, () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult>
    <IsTruncated>boolean</IsTruncated>
@@ -204,7 +301,40 @@ describe("xml parsing", () => {
    <EncodingType>string</EncodingType>
 </ListBucketResult>`;
 
-    expect(parseXMLBrowser(xml)).toEqual(parseXML(xml));
+    expect(parseXML(xml)).toEqual(fxp(xml));
+    expect(parseXMLBrowser(xml)).toEqual(fxp(xml));
+  });
+
+  it("can parse special characters", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<special>
+  <a>&#xD;&#10;xyz</a>
+  <b>&#xD;xyz</b>
+  <c>&#10;xyz</c>
+  <d>&amp;</d>
+  <e>&lt;</e>
+  <f>&gt;</f>
+  <g>&quot;</g>
+  <h>&apos;</h>
+  <i>!@#$%^&amp;*()</i>
+  <g>αβγδεζηθικλμνξοπρστυφχψω</g>
+  <c>АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ</c>
+  <h>🐪 גמל לא רואה את הדבשת שלו</h>
+  <a>🤷 اللي ما يعرف الصقر 🦅 يشويه 🍗</a>
+  <u>🦔Їжак з'їв яблуко🍎☀️</u>
+  <u>🐺Вовків боятися😨 — в ліс🌲 не ходити</u>
+  <hd>🏃💨 नौ दो ग्यारह होना</hd>
+  <te>🌊🏊 నీళ్ళలో దిగితే గానీ ఈత రాదు</te>
+  <tl>🐘🍌 யானைக்கும் அடி சறுக்கும்</tl>
+  <bg>💃🤷 নাচতে না জানলে উঠোন বাঁকা</bg>
+  <gr>🐒🫚 વાંદરાને શું ખબર અદરકનો સ્વાદ</gr>
+  <c>我靠</c>
+  <j>ぎゃふん</j>
+  <k>하늘의 별 따기✨</k>
+</special>`;
+
+    expect(parseXML(xml)).toEqual(fxp(xml));
+    expect(parseXMLBrowser(xml)).toEqual(fxp(xml));
   });
 
   it("should resolve numeric character references for CR and LF", () => {
@@ -245,6 +375,119 @@ describe("xml parsing", () => {
     for (const xml of xmlSamples) {
       expect(() => parseXMLBrowser(xml)).toThrowError();
       expect(() => parseXML(xml)).toThrowError();
+      expect(() => fxp(xml)).toThrowError();
     }
+  });
+
+  describe("XML with mal intent", () => {
+    it("ignores entity expansion attacks", () => {
+      const xml = `<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY lol "lol">
+  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+]>
+<root><data>&lol3;</data></root>`;
+
+      const result = parseXML(xml);
+      expect(result).toEqual({
+        root: {
+          data: "",
+        },
+      });
+    });
+
+    it("ignores quadratic blowup entity attacks", () => {
+      const repeatedEntity = "A".repeat(50000);
+      const xml = `<?xml version="1.0"?>
+<!DOCTYPE foo [
+  <!ENTITY big "${repeatedEntity}">
+]>
+<root>${"&big;".repeat(100)}</root>`;
+
+      const result = parseXML(xml);
+      expect(result).toEqual({
+        root: "",
+      });
+    });
+
+    it("does not process external entity (XXE) declarations", () => {
+      const xml = `<?xml version="1.0"?>
+<!DOCTYPE foo [
+  <!ENTITY xxe SYSTEM "file:///etc/passwd">
+]>
+<root><data>&xxe;</data></root>`;
+
+      const result = parseXML(xml);
+      expect(result).toEqual({
+        root: {
+          data: "",
+        },
+      });
+    });
+
+    it("does not process parameter entity (XXE) declarations", () => {
+      const xml = `<?xml version="1.0"?>
+<!dOcTyPe foo [
+  <!ENTITY % xxe SYSTEM "http://loooooooooooooocalhost/payload.dtd">
+  %xxe;
+]>
+<root><data>safe</data></root>`;
+
+      const result = parseXML(xml);
+      expect(result).toEqual({
+        root: {
+          data: "safe",
+        },
+      });
+    });
+
+    it("ignores regex DoS attempts in entity-like patterns", () => {
+      const malicious = "&" + "a".repeat(31) + ";";
+      const xml = `<root><data>${malicious.repeat(10000)}</data></root>`;
+
+      const start = Date.now();
+      const result = parseXML(xml);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(5000);
+      expect(result).toEqual({
+        root: {
+          data: "",
+        },
+      });
+    });
+
+    it("handles deeply nested entity-like references without hanging", () => {
+      const payload = Array.from({ length: 10000 }, (_, i) => `&#x${i.toString(16)};`).join("");
+      const xml = `<root><data>${payload}</data></root>`;
+
+      const start = Date.now();
+      const result = parseXML(xml);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(5000);
+      expect(result).toEqual({
+        root: {
+          data: expect.any(String),
+        },
+      });
+      expect(result.root.data).toMatch(/⛫⛬⛭⛮⛯⛰⛱/);
+    });
+
+    it("handles malformed entity patterns without catastrophic backtracking", () => {
+      const xml = `<root><data>${"&amp".repeat(10000)}</data></root>`;
+
+      const start = Date.now();
+      const result = parseXML(xml);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(5000);
+      expect(result).toEqual({
+        root: {
+          data: "&amp".repeat(10000),
+        },
+      });
+    });
   });
 });

--- a/packages-internal/xml-builder/src/xml-parser.ts
+++ b/packages-internal/xml-builder/src/xml-parser.ts
@@ -1,29 +1,300 @@
-import { XMLParser } from "fast-xml-parser";
+/* eslint-disable @typescript-eslint/no-this-alias */
 
 /**
- * Because this is only used against trusted server responses,
- * we should not be setting any client side limits.
- *
+ * AWS SDK XML to object converter.
  * @internal
  */
-const parser = new XMLParser({
-  attributeNamePrefix: "",
-  processEntities: {
-    enabled: true,
-    maxTotalExpansions: Infinity,
-  },
-  htmlEntities: true,
-  ignoreAttributes: false,
-  ignoreDeclaration: true,
-  parseTagValue: false,
-  trimValues: false,
-  tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-  maxNestedTags: Infinity,
-});
+export function parseXML(xml: string): any {
+  const state = new AwsXmlParser(xml);
+  return state.parse();
+}
 
 /**
  * @internal
  */
-export function parseXML(xmlString: string): any {
-  return parser.parse(xmlString, true);
+class AwsXmlParser {
+  private i = 0;
+  private readonly z: number;
+
+  public constructor(private readonly x: string) {
+    this.z = x.length;
+  }
+
+  public parse(): any {
+    const p = this;
+    const { z } = p;
+
+    while (p.i < z) {
+      p.trim();
+      if (p.i >= z) {
+        break;
+      }
+      if (p.isNext("<?")) {
+        p.readTo("?>");
+        p.trim();
+      } else if (p.isNext("<!--")) {
+        p.readTo("-->");
+        p.trim();
+      } else if (p.isNext("<!DOCTYPE", false)) {
+        p.skipDoctype();
+        p.trim();
+      } else if (p.x[p.i] === "<") {
+        const root = p.parseTag();
+        return { [root.tag]: root.value };
+      } else {
+        throw new Error("@aws-sdk XML parse error: unexpected content.");
+      }
+    }
+
+    throw new Error("@aws-sdk XML parse error: no root element.");
+  }
+
+  /**
+   * @returns whether the cursor is at the given string.
+   */
+  private isNext(s: string, caseSensitive = true): boolean {
+    const p = this;
+    if (caseSensitive) {
+      return p.x.startsWith(s, p.i);
+    }
+    // this is slow, use sparingly.
+    return p.x.toLowerCase().startsWith(s.toLowerCase(), p.i);
+  }
+
+  /**
+   * Reads up to the stop string and returns the intermediate.
+   */
+  private readTo(stop: string): string {
+    const p = this;
+    const _i = p.x.indexOf(stop, p.i);
+    if (_i === -1) {
+      throw new Error(`@aws-sdk XML parse error: expected "${stop}" not found.`);
+    }
+    const result = p.x.slice(p.i, _i);
+    p.i = _i + stop.length;
+    return result;
+  }
+
+  /**
+   * Scan forward over whitespace.
+   */
+  private trim(): void {
+    const p = this;
+    while (p.i < p.z && " \t\r\n".includes(p.x[p.i])) {
+      ++p.i;
+    }
+  }
+
+  /**
+   * @returns contents of an XML attribute.
+   */
+  private readAttrValue(): string {
+    const p = this;
+    const quote = p.x[p.i];
+    ++p.i; // "
+
+    let value = "";
+
+    while (p.i < p.z && p.x[p.i] !== quote) {
+      value += p.x[p.i++];
+    }
+
+    ++p.i; // "
+    return p.decodeEntities(value);
+  }
+
+  /**
+   * The main course.
+   */
+  private parseTag(): { tag: string; value: any } {
+    const p = this;
+    ++p.i; // <
+
+    let tag = "";
+
+    // read tag name.
+    while (p.i < p.z && !" \t\r\n>/".includes(p.x[p.i])) {
+      tag += p.x[p.i++];
+    }
+
+    let hasAttrs = false;
+    const attrs: Record<string, string> = Object.create(null);
+
+    // attributes.
+    while (p.i < p.z) {
+      p.trim();
+      if (">/".includes(p.x[p.i])) {
+        break;
+      }
+      let name = "";
+      while (p.i < p.z && !"= \t\r\n>/?".includes(p.x[p.i])) {
+        name += p.x[p.i++];
+      }
+      p.trim();
+      if (p.x[p.i] !== "=") {
+        break;
+      }
+      ++p.i; // =
+      p.trim();
+      attrs[name] = p.readAttrValue();
+      hasAttrs = true;
+    }
+
+    if (p.i >= p.z) {
+      throw new Error("@aws-sdk XML parse error: unexpected end of input.");
+    }
+
+    if (p.x[p.i] === "/") {
+      // self-closed after attributes.
+      ++p.i; // /
+
+      if (p.i >= p.z || p.x[p.i] !== ">") {
+        throw new Error("@aws-sdk XML parse error: expected > at the end of self-closing tag.");
+      }
+
+      ++p.i; // >
+      Object.setPrototypeOf(attrs, Object.prototype);
+      return { tag, value: hasAttrs ? attrs : "" };
+    }
+
+    if (p.x[p.i] !== ">") {
+      throw new Error("@aws-sdk XML parse error: expected > at the end of opening tag.");
+    }
+    ++p.i; // >
+
+    const textParts: string[] = [];
+    const childTags: { tag: string; value: any }[] = [];
+    let hasElementChild = false;
+
+    // read children.
+    while (p.i < p.z) {
+      if (p.isNext("</")) {
+        break;
+      }
+
+      if (p.x[p.i] === "<") {
+        // read element.
+
+        if (p.isNext("<!--")) {
+          p.readTo("-->");
+        } else if (p.isNext("<![CDATA[")) {
+          p.i += 9; // <![CDATA[
+          textParts.push(p.readTo("]]>"));
+        } else if (p.isNext("<?")) {
+          p.readTo("?>");
+        } else {
+          hasElementChild = true;
+          childTags.push(p.parseTag());
+        }
+      } else {
+        // read text.
+
+        let text = "";
+        while (p.i < p.z && p.x[p.i] !== "<") {
+          text += p.x[p.i++];
+        }
+        textParts.push(p.decodeEntities(text));
+      }
+    }
+
+    // close.
+    if (!p.isNext("</")) {
+      throw new Error(`@aws-sdk XML parse error: missing closing tag </${tag}>.`);
+    }
+    p.i += 2; // </
+
+    const closeTag = p.readTo(">").trim();
+    if (closeTag !== tag) {
+      throw new Error(`@aws-sdk XML parse error: mismatched tags <${tag}> and </${closeTag}>.`);
+    }
+
+    if (!hasAttrs && textParts.length === 0 && !hasElementChild) {
+      // empty element.
+      return { tag, value: "" };
+    }
+
+    if (!hasAttrs && !hasElementChild) {
+      // text element.
+      const text = textParts.length === 1 ? textParts[0] : textParts.join("");
+      if (text.trim() === "" && text.includes("\n")) {
+        return { tag, value: "" };
+      }
+      return { tag, value: text };
+    }
+
+    const obj: any = Object.create(null);
+
+    for (const text of textParts) {
+      if (text.trim() === "" && text.includes("\n")) {
+        continue;
+      }
+      // #text is the text node name expected in XMLShapeDeserializer.
+      obj["#text"] = "#text" in obj ? obj["#text"] + text : text;
+    }
+
+    for (const child of childTags) {
+      if (child.tag in obj) {
+        if (Array.isArray(obj[child.tag])) {
+          obj[child.tag].push(child.value);
+        } else {
+          // convert from object into array upon seeing 2 items.
+          // single item lists are not wrapped in an Array, because
+          // that is handled by the schema-based ShapeDeserializer.
+          obj[child.tag] = [obj[child.tag], child.value];
+        }
+      } else {
+        obj[child.tag] = child.value;
+      }
+    }
+
+    // Add attributes after children (fxp puts attrs after children)
+    for (const [k, v] of Object.entries(attrs)) {
+      obj[k] = v;
+    }
+
+    Object.setPrototypeOf(obj, Object.prototype);
+    return { tag, value: obj };
+  }
+
+  private static readonly ENTITIES: Record<string, string> = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+  };
+
+  /**
+   * Skip a !DOCTYPE block, including internal subsets in [ ].
+   */
+  private skipDoctype(): void {
+    const p = this;
+    p.i += 9; // <!DOCTYPE
+    let depth = 0;
+    while (p.i < p.z) {
+      const c = p.x[p.i];
+      if (c === "[") {
+        ++depth;
+      } else if (c === "]") {
+        --depth;
+      } else if (c === ">" && depth === 0) {
+        ++p.i;
+        return;
+      }
+      ++p.i;
+    }
+    throw new Error("@aws-sdk XML parse error: unclosed DOCTYPE.");
+  }
+
+  private decodeEntities(s: string): string {
+    return s.replace(/&(?:#x([0-9a-fA-F]{1,6})|#(\d{1,7})|([a-zA-Z][a-zA-Z0-9]{0,30}));/g, (_, hex, dec, named) => {
+      if (hex) {
+        return String.fromCharCode(parseInt(hex, 16));
+      }
+      if (dec) {
+        return String.fromCharCode(parseInt(dec, 10));
+      }
+      return AwsXmlParser.ENTITIES[named] ?? "";
+    });
+  }
 }

--- a/packages-internal/xml-builder/src/xml-parser.ts
+++ b/packages-internal/xml-builder/src/xml-parser.ts
@@ -17,7 +17,9 @@ class AwsXmlParser {
   private readonly z: number;
 
   public constructor(private readonly x: string) {
-    this.z = x.length;
+    // XML spec §2.11: normalize \r\n → \n, lone \r → \n.
+    this.x = x.replace(/\r\n?/g, "\n");
+    this.z = this.x.length;
   }
 
   public parse(): any {

--- a/packages-internal/xml-builder/src/xml-parser.ts
+++ b/packages-internal/xml-builder/src/xml-parser.ts
@@ -1,70 +1,300 @@
-import { XMLParser } from "fast-xml-parser";
-
-import { type EntityDecoder, COMMON_HTML, CURRENCY, EntityDecoderImpl, XML } from "./xml-external/nodable_entities";
+/* eslint-disable @typescript-eslint/no-this-alias */
 
 /**
- * Custom entity decoder that preserves C0 control characters (e.g. U+0015)
- * which XML 1.0 strict mode would strip. AWS services may return these
- * characters in responses despite XML 1.0 declaration.
- *
+ * AWS SDK XML to object converter.
  * @internal
  */
-const entityDecoder: EntityDecoder = new EntityDecoderImpl({
-  namedEntities: { ...XML, ...COMMON_HTML, ...CURRENCY },
-  numericAllowed: true,
-  limit: {
-    maxTotalExpansions: Infinity,
-  },
-  ncr: {
-    xmlVersion: 1.1,
-  },
-});
-
-/**
- * Because this is only used against trusted server responses,
- * we should not be setting any client side limits.
- *
- * @internal
- */
-const parser = new XMLParser({
-  attributeNamePrefix: "",
-  processEntities: {
-    enabled: true,
-    maxTotalExpansions: Infinity,
-  },
-  htmlEntities: true,
-  entityDecoder: {
-    setExternalEntities: (entities: Record<string, string>): void => {
-      entityDecoder.setExternalEntities(entities);
-    },
-    addInputEntities: (entities: Record<string, string>): void => {
-      entityDecoder.addInputEntities(entities);
-    },
-    reset: (): void => {
-      entityDecoder.reset();
-    },
-    decode: (text: string): string => {
-      return entityDecoder.decode(text);
-    },
-    /**
-     * The previous XML parser allowed C0 control chars despite
-     * any presence of the xml 1.0 declaration `<?xml version="1.0" encoding="UTF-8"?>`.
-     * We will avoid having the xml version set by the incoming payload
-     * as a workaround.
-     */
-    setXmlVersion: (version: string) => void {},
-  },
-  ignoreAttributes: false,
-  ignoreDeclaration: true,
-  parseTagValue: false,
-  trimValues: false,
-  tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-  maxNestedTags: Infinity,
-});
+export function parseXML(xml: string): any {
+  const state = new AwsXmlParser(xml);
+  return state.parse();
+}
 
 /**
  * @internal
  */
-export function parseXML(xmlString: string): any {
-  return parser.parse(xmlString, true);
+class AwsXmlParser {
+  private i = 0;
+  private readonly z: number;
+
+  public constructor(private readonly x: string) {
+    this.z = x.length;
+  }
+
+  public parse(): any {
+    const p = this;
+    const { z } = p;
+
+    while (p.i < z) {
+      p.trim();
+      if (p.i >= z) {
+        break;
+      }
+      if (p.isNext("<?")) {
+        p.readTo("?>");
+        p.trim();
+      } else if (p.isNext("<!--")) {
+        p.readTo("-->");
+        p.trim();
+      } else if (p.isNext("<!DOCTYPE", false)) {
+        p.skipDoctype();
+        p.trim();
+      } else if (p.x[p.i] === "<") {
+        const root = p.parseTag();
+        return { [root.tag]: root.value };
+      } else {
+        throw new Error("@aws-sdk XML parse error: unexpected content.");
+      }
+    }
+
+    throw new Error("@aws-sdk XML parse error: no root element.");
+  }
+
+  /**
+   * @returns whether the cursor is at the given string.
+   */
+  private isNext(s: string, caseSensitive = true): boolean {
+    const p = this;
+    if (caseSensitive) {
+      return p.x.startsWith(s, p.i);
+    }
+    // this is slow, use sparingly.
+    return p.x.toLowerCase().startsWith(s.toLowerCase(), p.i);
+  }
+
+  /**
+   * Reads up to the stop string and returns the intermediate.
+   */
+  private readTo(stop: string): string {
+    const p = this;
+    const _i = p.x.indexOf(stop, p.i);
+    if (_i === -1) {
+      throw new Error(`@aws-sdk XML parse error: expected "${stop}" not found.`);
+    }
+    const result = p.x.slice(p.i, _i);
+    p.i = _i + stop.length;
+    return result;
+  }
+
+  /**
+   * Scan forward over whitespace.
+   */
+  private trim(): void {
+    const p = this;
+    while (p.i < p.z && " \t\r\n".includes(p.x[p.i])) {
+      ++p.i;
+    }
+  }
+
+  /**
+   * @returns contents of an XML attribute.
+   */
+  private readAttrValue(): string {
+    const p = this;
+    const quote = p.x[p.i];
+    ++p.i; // "
+
+    let value = "";
+
+    while (p.i < p.z && p.x[p.i] !== quote) {
+      value += p.x[p.i++];
+    }
+
+    ++p.i; // "
+    return p.decodeEntities(value);
+  }
+
+  /**
+   * The main course.
+   */
+  private parseTag(): { tag: string; value: any } {
+    const p = this;
+    ++p.i; // <
+
+    let tag = "";
+
+    // read tag name.
+    while (p.i < p.z && !" \t\r\n>/".includes(p.x[p.i])) {
+      tag += p.x[p.i++];
+    }
+
+    let hasAttrs = false;
+    const attrs: Record<string, string> = Object.create(null);
+
+    // attributes.
+    while (p.i < p.z) {
+      p.trim();
+      if (">/".includes(p.x[p.i])) {
+        break;
+      }
+      let name = "";
+      while (p.i < p.z && !"= \t\r\n>/?".includes(p.x[p.i])) {
+        name += p.x[p.i++];
+      }
+      p.trim();
+      if (p.x[p.i] !== "=") {
+        break;
+      }
+      ++p.i; // =
+      p.trim();
+      attrs[name] = p.readAttrValue();
+      hasAttrs = true;
+    }
+
+    if (p.i >= p.z) {
+      throw new Error("@aws-sdk XML parse error: unexpected end of input.");
+    }
+
+    if (p.x[p.i] === "/") {
+      // self-closed after attributes.
+      ++p.i; // /
+
+      if (p.i >= p.z || p.x[p.i] !== ">") {
+        throw new Error("@aws-sdk XML parse error: expected > at the end of self-closing tag.");
+      }
+
+      ++p.i; // >
+      Object.setPrototypeOf(attrs, Object.prototype);
+      return { tag, value: hasAttrs ? attrs : "" };
+    }
+
+    if (p.x[p.i] !== ">") {
+      throw new Error("@aws-sdk XML parse error: expected > at the end of opening tag.");
+    }
+    ++p.i; // >
+
+    const textParts: string[] = [];
+    const childTags: { tag: string; value: any }[] = [];
+    let hasElementChild = false;
+
+    // read children.
+    while (p.i < p.z) {
+      if (p.isNext("</")) {
+        break;
+      }
+
+      if (p.x[p.i] === "<") {
+        // read element.
+
+        if (p.isNext("<!--")) {
+          p.readTo("-->");
+        } else if (p.isNext("<![CDATA[")) {
+          p.i += 9; // <![CDATA[
+          textParts.push(p.readTo("]]>"));
+        } else if (p.isNext("<?")) {
+          p.readTo("?>");
+        } else {
+          hasElementChild = true;
+          childTags.push(p.parseTag());
+        }
+      } else {
+        // read text.
+
+        let text = "";
+        while (p.i < p.z && p.x[p.i] !== "<") {
+          text += p.x[p.i++];
+        }
+        textParts.push(p.decodeEntities(text));
+      }
+    }
+
+    // close.
+    if (!p.isNext("</")) {
+      throw new Error(`@aws-sdk XML parse error: missing closing tag </${tag}>.`);
+    }
+    p.i += 2; // </
+
+    const closeTag = p.readTo(">").trim();
+    if (closeTag !== tag) {
+      throw new Error(`@aws-sdk XML parse error: mismatched tags <${tag}> and </${closeTag}>.`);
+    }
+
+    if (!hasAttrs && textParts.length === 0 && !hasElementChild) {
+      // empty element.
+      return { tag, value: "" };
+    }
+
+    if (!hasAttrs && !hasElementChild) {
+      // text element.
+      const text = textParts.length === 1 ? textParts[0] : textParts.join("");
+      if (text.trim() === "" && text.includes("\n")) {
+        return { tag, value: "" };
+      }
+      return { tag, value: text };
+    }
+
+    const obj: any = Object.create(null);
+
+    for (const text of textParts) {
+      if (text.trim() === "" && text.includes("\n")) {
+        continue;
+      }
+      // #text is the text node name expected in XMLShapeDeserializer.
+      obj["#text"] = "#text" in obj ? obj["#text"] + text : text;
+    }
+
+    for (const child of childTags) {
+      if (child.tag in obj) {
+        if (Array.isArray(obj[child.tag])) {
+          obj[child.tag].push(child.value);
+        } else {
+          // convert from object into array upon seeing 2 items.
+          // single item lists are not wrapped in an Array, because
+          // that is handled by the schema-based ShapeDeserializer.
+          obj[child.tag] = [obj[child.tag], child.value];
+        }
+      } else {
+        obj[child.tag] = child.value;
+      }
+    }
+
+    // Add attributes after children (fxp puts attrs after children)
+    for (const [k, v] of Object.entries(attrs)) {
+      obj[k] = v;
+    }
+
+    Object.setPrototypeOf(obj, Object.prototype);
+    return { tag, value: obj };
+  }
+
+  private static readonly ENTITIES: Record<string, string> = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+  };
+
+  /**
+   * Skip a !DOCTYPE block, including internal subsets in [ ].
+   */
+  private skipDoctype(): void {
+    const p = this;
+    p.i += 9; // <!DOCTYPE
+    let depth = 0;
+    while (p.i < p.z) {
+      const c = p.x[p.i];
+      if (c === "[") {
+        ++depth;
+      } else if (c === "]") {
+        --depth;
+      } else if (c === ">" && depth === 0) {
+        ++p.i;
+        return;
+      }
+      ++p.i;
+    }
+    throw new Error("@aws-sdk XML parse error: unclosed DOCTYPE.");
+  }
+
+  private decodeEntities(s: string): string {
+    return s.replace(/&(?:#x([0-9a-fA-F]{1,6})|#(\d{1,7})|([a-zA-Z][a-zA-Z0-9]{0,30}));/g, (_, hex, dec, named) => {
+      if (hex) {
+        return String.fromCharCode(parseInt(hex, 16));
+      }
+      if (dec) {
+        return String.fromCharCode(parseInt(dec, 10));
+      }
+      return AwsXmlParser.ENTITIES[named] ?? "";
+    });
+  }
 }

--- a/packages-internal/xml-builder/tests/xml-parser.fuzz.js
+++ b/packages-internal/xml-builder/tests/xml-parser.fuzz.js
@@ -1,0 +1,55 @@
+// @ts-check
+/**
+ * Coverage-guided fuzz target for the XML parser using Jazzer.js (libFuzzer).
+ *
+ * Run: npx jazzer packages-internal/xml-builder/tests/xml-parser.fuzz.js corpus --sync -i xml-parser
+ */
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+
+/** @type {import('../src/xml-parser')['parseXML']} */
+let parseXML;
+try {
+  parseXML = require("../dist-cjs/xml-parser").parseXML;
+} catch {
+  parseXML = require("./xml-parser").parseXML;
+}
+
+/**
+ * @param {Buffer} data
+ */
+module.exports.fuzz = function (data) {
+  const provider = new FuzzedDataProvider(data);
+
+  // Mode 0: raw buffer as XML string
+  // Mode 1: structured — build semi-valid XML from fuzz data
+  const mode = provider.consumeIntegralInRange(0, 1);
+
+  if (mode === 0) {
+    const input = provider.consumeRemainingAsString();
+    try {
+      parseXML(input);
+    } catch (e) {
+      if (!(e instanceof Error) || !e.message.includes("@aws-sdk XML parse error")) {
+        throw e; // unexpected error type = real bug
+      }
+    }
+  } else {
+    // Build structured XML to get deeper into parser logic
+    const tag = provider.consumeString(10, "utf-8").replace(/[^a-zA-Z]/g, "") || "a";
+    const attrs = provider.consumeBoolean()
+      ? ` ${provider.consumeString(5, "utf-8").replace(/[^a-zA-Z]/g, "") || "x"}="${provider
+          .consumeString(10, "utf-8")
+          .replace(/"/g, "&quot;")}"`
+      : "";
+    const content = provider.consumeRemainingAsString();
+    const xml = `<${tag}${attrs}>${content}</${tag}>`;
+
+    try {
+      parseXML(xml);
+    } catch (e) {
+      if (!(e instanceof Error) || !e.message.includes("@aws-sdk XML parse error")) {
+        throw e;
+      }
+    }
+  }
+};

--- a/packages-internal/xml-builder/tests/xml-parser.fuzz.spec.ts
+++ b/packages-internal/xml-builder/tests/xml-parser.fuzz.spec.ts
@@ -1,0 +1,201 @@
+import fc from "fast-check";
+import { XMLParser } from "fast-xml-parser";
+import { describe, expect, it } from "vitest";
+
+import { parseXML } from "../src/xml-parser";
+
+/**
+ * Reference implementation used from 2020–2026 in the AWS SDK.
+ */
+const fxpParser = new XMLParser({
+  attributeNamePrefix: "",
+  processEntities: {
+    enabled: true,
+    maxTotalExpansions: Infinity,
+  },
+  htmlEntities: true,
+  ignoreAttributes: false,
+  ignoreDeclaration: true,
+  parseTagValue: false,
+  trimValues: false,
+  tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+  maxNestedTags: Infinity,
+});
+
+function fxp(xml: string): any {
+  return fxpParser.parse(xml, true);
+}
+
+// --- Arbitraries for generating XML structures ---
+
+/** Safe XML tag name (letter followed by alphanumeric/dash/underscore). */
+const tagName = fc
+  .tuple(
+    fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz".split("")),
+    fc.string({
+      unit: fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz0123456789".split("")),
+      minLength: 0,
+      maxLength: 8,
+    })
+  )
+  .map(([first, rest]) => first + rest);
+
+/** Text content safe for XML (no < or & unescaped). */
+const textContent = fc.string({
+  unit: fc.oneof(
+    fc.constantFrom(
+      ..."abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^*()_+-=[]{}|;:',./?\t\n\r".split("")
+    ),
+    fc.constant("&amp;"),
+    fc.constant("&lt;"),
+    fc.constant("&gt;"),
+    fc.constant("&quot;"),
+    fc.constant("&apos;")
+  ),
+  minLength: 0,
+  maxLength: 50,
+});
+
+/** Generate a well-formed XML element (recursive). */
+const xmlElement: fc.Arbitrary<string> = fc.letrec((tie) => ({
+  element: fc.oneof(
+    { depthSize: "small" },
+    // Text element
+    fc.tuple(tagName, textContent).map(([tag, text]) => `<${tag}>${text}</${tag}>`),
+    // Self-closing
+    tagName.map((tag) => `<${tag}/>`),
+    // Empty element
+    tagName.map((tag) => `<${tag}></${tag}>`),
+    // Element with attribute
+    fc
+      .tuple(tagName, tagName, textContent, textContent)
+      .map(([tag, attr, attrVal, text]) => `<${tag} ${attr}="${attrVal.replace(/"/g, "&quot;")}">${text}</${tag}>`),
+    // Nested elements
+    fc
+      .tuple(tagName, fc.array(tie("element") as fc.Arbitrary<string>, { minLength: 1, maxLength: 4 }))
+      .map(([tag, children]) => `<${tag}>${children.join("")}</${tag}>`)
+  ),
+})).element;
+
+/** Generate a complete well-formed XML document. */
+const xmlDocument = fc
+  .tuple(
+    fc.boolean(), // include xml declaration?
+    xmlElement
+  )
+  .map(([decl, root]) => (decl ? `<?xml version="1.0" encoding="UTF-8"?>${root}` : root));
+
+describe("xml-parser fuzz testing", () => {
+  it("should never crash on arbitrary strings", { timeout: 60_000 }, () => {
+    fc.assert(
+      fc.property(fc.string({ unit: "grapheme-composite", minLength: 0, maxLength: 500 }), (input) => {
+        try {
+          parseXML(input);
+        } catch (e: any) {
+          // Errors are acceptable — crashes/hangs are not.
+          expect(e).toBeInstanceOf(Error);
+          expect(e.message).toContain("@aws-sdk XML parse error");
+        }
+      }),
+      { numRuns: 10_000 }
+    );
+  });
+
+  it("should match fast-xml-parser on well-formed XML", { timeout: 60_000 }, () => {
+    fc.assert(
+      fc.property(xmlDocument, (xml) => {
+        const custom = parseXML(xml);
+        const reference = fxp(xml);
+        expect(custom).toEqual(reference);
+      }),
+      { numRuns: 10_000 }
+    );
+  });
+
+  it("should not hang on pathological inputs (deeply nested)", { timeout: 30_000 }, () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 50, max: 500 }), (depth) => {
+        const open = Array.from({ length: depth }, (_, i) => `<t${i}>`).join("");
+        const close = Array.from({ length: depth }, (_, i) => `</t${depth - 1 - i}>`).join("");
+        const xml = open + "x" + close;
+        const result = parseXML(xml);
+        expect(result).toBeDefined();
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it("should not hang on repeated entity-like patterns", { timeout: 30_000 }, () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(
+          fc.integer({ min: 100, max: 5000 }),
+          fc.string({ unit: fc.constantFrom(..."abcdefg&;#x0123456789".split("")), minLength: 1, maxLength: 20 })
+        ),
+        ([count, pattern]) => {
+          const xml = `<r>${pattern.repeat(count)}</r>`;
+          try {
+            parseXML(xml);
+          } catch (e: any) {
+            expect(e).toBeInstanceOf(Error);
+          }
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  it("should handle random byte sequences as text content without crashing", { timeout: 30_000 }, () => {
+    fc.assert(
+      fc.property(fc.tuple(tagName, fc.uint8Array({ minLength: 0, maxLength: 200 })), ([tag, bytes]) => {
+        const text = Array.from(bytes)
+          .map((b) => `&#x${b.toString(16)};`)
+          .join("");
+        const xml = `<${tag}>${text}</${tag}>`;
+        const result = parseXML(xml);
+        expect(result).toBeDefined();
+        expect(result[tag]).toBeDefined();
+      }),
+      { numRuns: 2_000 }
+    );
+  });
+
+  it("should handle duplicate sibling tags consistently with reference", { timeout: 30_000 }, () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(tagName, tagName, fc.array(textContent, { minLength: 1, maxLength: 10 })),
+        ([root, child, values]) => {
+          const children = values.map((v) => `<${child}>${v}</${child}>`).join("");
+          const xml = `<${root}>${children}</${root}>`;
+          expect(parseXML(xml)).toEqual(fxp(xml));
+        }
+      ),
+      { numRuns: 5_000 }
+    );
+  });
+
+  it("should reject malformed XML with a clean error", { timeout: 30_000 }, () => {
+    const malformedXml = fc.oneof(
+      // Unclosed tag
+      tagName.map((t) => `<${t}>`),
+      // Mismatched tags
+      fc
+        .tuple(tagName, tagName)
+        .filter(([a, b]) => a !== b)
+        .map(([a, b]) => `<${a}></${b}>`),
+      // Missing closing >
+      tagName.map((t) => `<${t}`),
+      // Double opening
+      tagName.map((t) => `<<${t}>x</${t}>`),
+      // Just text
+      textContent.filter((t) => t.length > 0 && !t.includes("<"))
+    );
+
+    fc.assert(
+      fc.property(malformedXml, (xml) => {
+        expect(() => parseXML(xml)).toThrowError();
+      }),
+      { numRuns: 5_000 }
+    );
+  });
+});

--- a/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/ComplexError.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/private/aws-protocoltests-ec2-schema/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/private/aws-protocoltests-query-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-query-schema/test/snapshots/res-err/ComplexError.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/private/aws-protocoltests-query-schema/test/snapshots/res-err/CustomCodeError.txt
+++ b/private/aws-protocoltests-query-schema/test/snapshots/res-err/CustomCodeError.txt
@@ -76,7 +76,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/private/aws-protocoltests-query-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-query-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/private/aws-protocoltests-query-schema/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/private/aws-protocoltests-query-schema/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -74,7 +74,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/ComplexError.txt
@@ -133,7 +133,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -112,7 +112,7 @@ An unmodeled error occurred in a front end layer.
 
 
 --- [error name & message] ---
-Error: char 'A' is not expected.:1:1
+Error: @aws-sdk XML parse error: unexpected content.
   Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
 
 --- [error object] ---

--- a/yarn.lock
+++ b/yarn.lock
@@ -25487,7 +25487,6 @@ __metadata:
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
-    fast-xml-parser: "npm:5.7.1"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -31736,6 +31735,7 @@ __metadata:
     eslint-plugin-sort-export-all: "npm:1.2.2"
     eslint-plugin-tsdoc: "npm:0.2.17"
     esprint: "npm:3.6.0"
+    fast-xml-parser: "npm:^5.7.1"
     fastify: "npm:^4.11.0"
     figlet: "npm:^1.5.0"
     fs-extra: "npm:^9.0.0"
@@ -34581,7 +34581,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.7.1":
+"fast-xml-parser@npm:5.7.1, fast-xml-parser@npm:^5.7.1":
   version: 5.7.1
   resolution: "fast-xml-parser@npm:5.7.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12165,7 +12165,6 @@ __metadata:
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
-    fast-xml-parser: "npm:5.7.3"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -12799,7 +12798,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.10.0, @emnapi/core@npm:^1.4.3":
+"@emnapi/core@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/core@npm:1.10.0"
   dependencies:
@@ -12809,12 +12808,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:1.10.0, @emnapi/runtime@npm:^1.4.3":
+"@emnapi/core@npm:^1.4.3":
+  version: 1.7.0
+  resolution: "@emnapi/core@npm:1.7.0"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.1.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/ea57802079fda31f87506bba63f1299f0fa60546c1a1a424d2d5926f98f1ffc4a94ae3c885155f4a60114c19d314addb45d94dc0e427ac1594cbfca7cd910a31
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/runtime@npm:1.10.0"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:^1.4.3":
+  version: 1.7.0
+  resolution: "@emnapi/runtime@npm:1.7.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/b99334582effe146e9fb5cd9e7f866c6c7047a8576f642456d56984b574b40b2ba14e4aede26217fcefa1372ddd1e098a19912f17033a9ae469928b0dc65a682
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@emnapi/wasi-threads@npm:1.1.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/e6d54bf2b1e64cdd83d2916411e44e579b6ae35d5def0dea61a3c452d9921373044dff32a8b8473ae60c80692bdc39323e98b96a3f3d87ba6886b24dd0ef7ca1
   languageName: node
   linkType: hard
 
@@ -12841,6 +12868,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/aix-ppc64@npm:0.25.12"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/aix-ppc64@npm:0.27.2"
@@ -12858,6 +12892,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/android-arm64@npm:0.25.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm64@npm:0.25.12"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -12883,6 +12924,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm@npm:0.25.12"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/android-arm@npm:0.27.2"
@@ -12900,6 +12948,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/android-x64@npm:0.25.0"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-x64@npm:0.25.12"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -12925,6 +12980,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-arm64@npm:0.25.12"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/darwin-arm64@npm:0.27.2"
@@ -12942,6 +13004,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/darwin-x64@npm:0.25.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-x64@npm:0.25.12"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -12967,6 +13036,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-arm64@npm:0.25.12"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/freebsd-arm64@npm:0.27.2"
@@ -12984,6 +13060,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/freebsd-x64@npm:0.25.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-x64@npm:0.25.12"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -13009,6 +13092,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm64@npm:0.25.12"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/linux-arm64@npm:0.27.2"
@@ -13026,6 +13116,13 @@ __metadata:
 "@esbuild/linux-arm@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/linux-arm@npm:0.25.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm@npm:0.25.12"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -13051,6 +13148,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ia32@npm:0.25.12"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/linux-ia32@npm:0.27.2"
@@ -13068,6 +13172,13 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/linux-loong64@npm:0.25.0"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-loong64@npm:0.25.12"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -13093,6 +13204,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-mips64el@npm:0.25.12"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/linux-mips64el@npm:0.27.2"
@@ -13110,6 +13228,13 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/linux-ppc64@npm:0.25.0"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ppc64@npm:0.25.12"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -13135,6 +13260,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-riscv64@npm:0.25.12"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/linux-riscv64@npm:0.27.2"
@@ -13152,6 +13284,13 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/linux-s390x@npm:0.25.0"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-s390x@npm:0.25.12"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -13177,6 +13316,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-x64@npm:0.25.12"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/linux-x64@npm:0.27.2"
@@ -13187,6 +13333,13 @@ __metadata:
 "@esbuild/netbsd-arm64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/netbsd-arm64@npm:0.25.0"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -13212,6 +13365,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-x64@npm:0.25.12"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/netbsd-x64@npm:0.27.2"
@@ -13229,6 +13389,13 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/openbsd-arm64@npm:0.25.0"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -13254,10 +13421,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-x64@npm:0.25.12"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-x64@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/openbsd-x64@npm:0.27.2"
   conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+  conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -13278,6 +13459,13 @@ __metadata:
 "@esbuild/sunos-x64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/sunos-x64@npm:0.25.0"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/sunos-x64@npm:0.25.12"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -13303,6 +13491,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-arm64@npm:0.25.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/win32-arm64@npm:0.27.2"
@@ -13320,6 +13515,13 @@ __metadata:
 "@esbuild/win32-ia32@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/win32-ia32@npm:0.25.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-ia32@npm:0.25.12"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -13345,6 +13547,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-x64@npm:0.25.12"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.27.2":
   version: 0.27.2
   resolution: "@esbuild/win32-x64@npm:0.27.2"
@@ -13352,7 +13561,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.5.0":
+"@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.5.0":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
   dependencies:
@@ -13360,6 +13569,17 @@ __metadata:
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
   checksum: 10c0/dc4ab5e3e364ef27e33666b11f4b86e1a6c1d7cbf16f0c6ff87b1619b3562335e9201a3d6ce806221887ff780ec9d828962a290bb910759fd40a674686503f02
+  languageName: node
+  linkType: hard
+
+"@eslint-community/eslint-utils@npm:^4.2.0":
+  version: 4.9.0
+  resolution: "@eslint-community/eslint-utils@npm:4.9.0"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.4.3"
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: 10c0/8881e22d519326e7dba85ea915ac7a143367c805e6ba1374c987aa2fbdd09195cc51183d2da72c0e2ff388f84363e1b220fd0d19bef10c272c63455162176817
   languageName: node
   linkType: hard
 
@@ -15043,14 +15263,14 @@ __metadata:
   linkType: hard
 
 "@napi-rs/wasm-runtime@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+  version: 1.1.5
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.5"
   dependencies:
-    "@tybys/wasm-util": "npm:^0.10.1"
+    "@tybys/wasm-util": "npm:^0.10.2"
   peerDependencies:
     "@emnapi/core": ^1.7.1
     "@emnapi/runtime": ^1.7.1
-  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
+  checksum: 10c0/727f2b6ae0e68bbe5d39aeb68aa6f183314e9f03dc50bb55a962849535b2db53ecc3fbf1554d8656a54488a608df5a2634670595cf5874dc4af2ee59f817c65d
   languageName: node
   linkType: hard
 
@@ -15507,10 +15727,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-project/types@npm:=0.132.0":
-  version: 0.132.0
-  resolution: "@oxc-project/types@npm:0.132.0"
-  checksum: 10c0/d0ca5e98be0b873d69e4f0f743eb35026833603dac11db9d55f2b5438251b381b886dc556fe3175a17b673f8e2073c49bde88d7e6e702aa09298c22b8b5504e1
+"@oxc-project/types@npm:=0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-project/types@npm:0.133.0"
+  checksum: 10c0/70c57ba58644f7ec217b670c301801f4d06995f4ccdba6b2bd106ea3e5ee49d616573e6ef8d55530b87571a960696543687f3850e87ad173d3f88965c30cdd63
   languageName: node
   linkType: hard
 
@@ -15546,93 +15766,93 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.2"
+"@rolldown/binding-android-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.3"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-arm64@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.2"
+"@rolldown/binding-darwin-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.2"
+"@rolldown/binding-darwin-x64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-freebsd-x64@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.2"
+"@rolldown/binding-freebsd-x64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.2"
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.2"
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.2"
+"@rolldown/binding-linux-arm64-musl@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-ppc64-gnu@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.2"
+"@rolldown/binding-linux-ppc64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.3"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-s390x-gnu@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.2"
+"@rolldown/binding-linux-s390x-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.3"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-gnu@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.2"
+"@rolldown/binding-linux-x64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.2"
+"@rolldown/binding-linux-x64-musl@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-openharmony-arm64@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.2"
+"@rolldown/binding-openharmony-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.3"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-wasm32-wasi@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.2"
+"@rolldown/binding-wasm32-wasi@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.3"
   dependencies:
     "@emnapi/core": "npm:1.10.0"
     "@emnapi/runtime": "npm:1.10.0"
@@ -15641,16 +15861,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.2"
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.2"
+"@rolldown/binding-win32-x64-msvc@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -15983,57 +16203,57 @@ __metadata:
   linkType: hard
 
 "@smithy/abort-controller@npm:^4.2.16":
-  version: 4.2.16
-  resolution: "@smithy/abort-controller@npm:4.2.16"
+  version: 4.3.0
+  resolution: "@smithy/abort-controller@npm:4.3.0"
   dependencies:
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/cb6ffe63cf950a0e8f015d5b8aa0542d8b56a66fb7f85473134e060a15fbe423ad9f9d8d525e65420c33c92ea28a2e789911e5b1ccce5e2a7925a252c9e85ef3
+  checksum: 10c0/6934b22231e78b3309358fa47833b8eb2e13b9959fed8dbdd8144295683212ebbe7e8ae14bf9b59a444cc0e68c7bb6f86ae8090c2bf28a323940f2954d35113d
   languageName: node
   linkType: hard
 
-"@smithy/core@npm:^3.24.6":
-  version: 3.24.6
-  resolution: "@smithy/core@npm:3.24.6"
+"@smithy/core@npm:^3.24.6, @smithy/core@npm:^3.24.7, @smithy/core@npm:^3.25.0":
+  version: 3.25.0
+  resolution: "@smithy/core@npm:3.25.0"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/4d3db2296a99a4bcb17007b8276a243930f63c3169b9b86b973a2d1422e8dee7e95e3b98eea115e2759b989b23db1ff89ca505bddbacb7391ca3fe4e222b84ff
+  checksum: 10c0/eb63370cab43828b56d0268e7eb34d63558abfeb365dcdaa840f65af757f4ae433584bfc8951bc804fc0e8600a262d2f74855ad556dd5c22f8129bfd3ad0ebda
   languageName: node
   linkType: hard
 
 "@smithy/credential-provider-imds@npm:^4.3.7":
-  version: 4.3.7
-  resolution: "@smithy/credential-provider-imds@npm:4.3.7"
+  version: 4.4.0
+  resolution: "@smithy/credential-provider-imds@npm:4.4.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/9a2f44c8bdc7f7770163fa26bc83f8adbb9e02c6ffa98751af3cbfc8107652d0a8e2a7bffc9761de20b776957eff33a865ec24523644b131003286bd2def9a4e
+  checksum: 10c0/9a6792235b079c6c5767805686be06225f24a619cf1416766783b3cd433fea57cd275cfbbf50127523b12c0580a9e1879430daac3a5ed6c43f9e0b76256b62c6
   languageName: node
   linkType: hard
 
 "@smithy/experimental-identity-and-auth@npm:^0.6.6":
-  version: 0.6.6
-  resolution: "@smithy/experimental-identity-and-auth@npm:0.6.6"
+  version: 0.6.7
+  resolution: "@smithy/experimental-identity-and-auth@npm:0.6.7"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/signature-v4": "npm:^5.4.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.24.7"
+    "@smithy/signature-v4": "npm:^5.4.7"
+    "@smithy/types": "npm:^4.14.4"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/821f683c9a54716b19bc88e9f337346083dd47213cb90877ce3e40d1f9859c8b2f7ed552bcfcc960d0a4771329fac0fb914ca13d6dc0c10864f2511f582c01cd
+  checksum: 10c0/dd2eb509ef737a69e24e14fd9469b5c41c916ddf48ab16b6bec9b62b357bea63ce8166e53799ac211092c22cc1c62e85369e678e2f5c2bc309da12bd487e3167
   languageName: node
   linkType: hard
 
 "@smithy/fetch-http-handler@npm:^5.4.6":
-  version: 5.4.6
-  resolution: "@smithy/fetch-http-handler@npm:5.4.6"
+  version: 5.5.0
+  resolution: "@smithy/fetch-http-handler@npm:5.5.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/06fd6f9a819766d1071ad0eca774ecd936b0b130057076a5e42f1bcc9c751deeddfa279adc4bcddd71ac7699744a2ed06a0405a239a379d98670855d18a6586b
+  checksum: 10c0/9f27743137005a05de22f10b7e3e9319f6a553bb51c8278df9b273f0d771ded1f12ab3894dae32bd58f1d112761f4ed97bdeeabcac162b0caea7d8d842cf961b
   languageName: node
   linkType: hard
 
@@ -16047,113 +16267,113 @@ __metadata:
   linkType: hard
 
 "@smithy/middleware-apply-body-checksum@npm:^4.4.6":
-  version: 4.4.6
-  resolution: "@smithy/middleware-apply-body-checksum@npm:4.4.6"
+  version: 4.5.0
+  resolution: "@smithy/middleware-apply-body-checksum@npm:4.5.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/7739e7f65d267ed938ac66dfb5f7b2cd0e78361b8005e0846ae56eee1acb2c8369b82faccffcd627f1f9c7b888c7ff3af000e36477d305b72d169ae1db6c2a65
+  checksum: 10c0/05bfe63ed2f543a062307ba878715f8314388cceeab010db89346fe8e230bd2487de63444cb9246f4c380f198f0caed314df68b2ac975f205d5a7308d1a352cc
   languageName: node
   linkType: hard
 
 "@smithy/middleware-compression@npm:^4.4.6":
-  version: 4.4.6
-  resolution: "@smithy/middleware-compression@npm:4.4.6"
+  version: 4.5.0
+  resolution: "@smithy/middleware-compression@npm:4.5.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/types": "npm:^4.15.0"
     fflate: "npm:0.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/470c0ad647f7b331a3a1ea54362c4e0aeaf9bd8cf05b990e6c7ea4b3e19e85f08e6fb03bbe4d7f015c166c26def350f85a3f3a66f3f162a720968906228da51d
+  checksum: 10c0/bd1fdbbfcb044b14baaa43e701b7a6eb1bd26f7f9b181f07c7a62a322435dec125aa7262daa152b43d734cba0e18048523052063c9b331693125561ef7cf863a
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^4.7.6":
-  version: 4.7.6
-  resolution: "@smithy/node-http-handler@npm:4.7.6"
+"@smithy/node-http-handler@npm:^4.7.6, @smithy/node-http-handler@npm:^4.8.0":
+  version: 4.8.0
+  resolution: "@smithy/node-http-handler@npm:4.8.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e926567ffda09c55c992f83449e185208a0fe87b0037254f8621dc13c495c2a8e6a24e0fe19211bb23f9c12d85e034e611dc2d1547494f8ef648844bddf62c56
+  checksum: 10c0/f97d4997a867c2706ef24ca43aeff2214fbedf6a4a754a6e96ecd2bfe7c2a93d226110328de274d2c4c7db72f284660094c2a85d9c3db15dea166793e5b03550
   languageName: node
   linkType: hard
 
 "@smithy/protocol-http@npm:^5.4.6":
-  version: 5.4.6
-  resolution: "@smithy/protocol-http@npm:5.4.6"
+  version: 5.5.0
+  resolution: "@smithy/protocol-http@npm:5.5.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
+    "@smithy/core": "npm:^3.25.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/076c537b66c51b21c2e3a65f0025f36bcd682fe2b2516b729ef11fb9670640089ac86a16b497745bca2c4fc75c36941a873197b1fee0fb8b6684c099eeb3ff41
+  checksum: 10c0/d00738a50ac42ccd4148e2dad29f9bedd55b84e10545791c53c3e36e15f4434f6c8fae25019d4a035f4e5de3b2c00a9b71af4f30b9fd809be6d90eefb551bfbe
   languageName: node
   linkType: hard
 
 "@smithy/shared-ini-file-loader@npm:^4.5.6":
-  version: 4.5.6
-  resolution: "@smithy/shared-ini-file-loader@npm:4.5.6"
+  version: 4.6.0
+  resolution: "@smithy/shared-ini-file-loader@npm:4.6.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
+    "@smithy/core": "npm:^3.25.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/bb078cee57c5cb69322e01605bdac058a211579b914dfd8a985efc34ed1ec3d770107d0fc9eacd321a0e3fff88d8d6a2a47d43ddc1c1e874c8e7a81324b40883
+  checksum: 10c0/6b6794581d9c021138011d59d504a06eaf9d041524f25332afb94819de86015e35b4ceb8715a993715c3d29dab44a8f8185d4dba145b4499a7a44d91c2c87763
   languageName: node
   linkType: hard
 
-"@smithy/signature-v4@npm:^5.4.6":
-  version: 5.4.6
-  resolution: "@smithy/signature-v4@npm:5.4.6"
+"@smithy/signature-v4@npm:^5.4.6, @smithy/signature-v4@npm:^5.4.7, @smithy/signature-v4@npm:^5.5.0":
+  version: 5.5.0
+  resolution: "@smithy/signature-v4@npm:5.5.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/7d7db13f4ddb09cca0a902dd760d83ff9770c085657e577153e4a93c0cd0314a36cbafaaae58c7be1aa1162e81ecab8b1395b0b0e488b20c22eb0dd9714b2b25
+  checksum: 10c0/2f68bb5493af688bd33bd595b65c0bc6bde7f644ff43c8b6c497e07efc5b2f8480fe60d84e0a5c1ab94a7c15ee970b3b67d347a0a66790afc6da45b1aa0d1e1a
   languageName: node
   linkType: hard
 
 "@smithy/signature-v4a@npm:^3.2.7":
-  version: 3.2.7
-  resolution: "@smithy/signature-v4a@npm:3.2.7"
+  version: 3.3.0
+  resolution: "@smithy/signature-v4a@npm:3.3.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/signature-v4": "npm:^5.4.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/signature-v4": "npm:^5.5.0"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8780e8f9717d0819295a32de835820b860f45d07dd7912184c2ad18cb6fb7c910aef7d3db66c6b36ecb204cd61a7f544a68a0d63fcec9c81f1a5711af98f56c6
+  checksum: 10c0/8f559e65c79cf102ddfc0d64fc53e592b59877448b9a4aae0931c8cc597046c9fd98cc00a3ff2b1b44227491a0fbd5f76b498eee200d703a7bb00ac079113b2f
   languageName: node
   linkType: hard
 
 "@smithy/smithy-client@npm:^4.13.6":
-  version: 4.13.6
-  resolution: "@smithy/smithy-client@npm:4.13.6"
+  version: 4.14.0
+  resolution: "@smithy/smithy-client@npm:4.14.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/fad0225ea40aedcd39a1232a2f63bf5f563b39ab678437273392fce3c092a06ba121c7e3224094a1c10999aa6894e93076e121da24349b7f584d6dbb38a1de4c
+  checksum: 10c0/ba60db00c1c1b66bc8e4793b531d0b1a5cc814bd1798b10baaf4bba67225278b92c63f9f27bf387e2cfeb221171c955df078c27cfbc07c062f2fcecf9bd86643
   languageName: node
   linkType: hard
 
 "@smithy/snapshot-testing@npm:^2.1.7":
-  version: 2.1.7
-  resolution: "@smithy/snapshot-testing@npm:2.1.7"
+  version: 2.2.0
+  resolution: "@smithy/snapshot-testing@npm:2.2.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/node-http-handler": "npm:^4.7.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/node-http-handler": "npm:^4.8.0"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/ed839086b67fcd753c729303325a28f2361a83bc5c9809af373dd34f2483414bad380b9590e26cffd17ecee2abfe2996e99eb5bda02092fe724a9664d0021fa7
+  checksum: 10c0/39af2bb760c29876566247168f4192ceb1a469d65fe2f37a2b682f59ea6efe741d676eaf417da98923d27838d0a9ff3263a4bf39f9924b0a1036ec4b3ded85c2
   languageName: node
   linkType: hard
 
 "@smithy/typecheck@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "@smithy/typecheck@npm:1.1.6"
+  version: 1.2.0
+  resolution: "@smithy/typecheck@npm:1.2.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/1ac559cb4967380d949ce82a0e66635c6abbb8f7484d295b93ba9f67424b37d849762a674cb089d2c692638a5e2047fce072413cb7035da7b3f19c4ac061fe04
+  checksum: 10c0/b952fc41c31fec0093d73623f330578773a10084d293ddd2bd20e38a816734fe90549713947f14cbf94f786cd3f12fd1ccfbf32047d136f9d5f4f24aef5e0298
   languageName: node
   linkType: hard
 
@@ -16166,26 +16386,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^4.14.3":
-  version: 4.14.3
-  resolution: "@smithy/types@npm:4.14.3"
+"@smithy/types@npm:^4.14.3, @smithy/types@npm:^4.14.4, @smithy/types@npm:^4.15.0":
+  version: 4.15.0
+  resolution: "@smithy/types@npm:4.15.0"
   dependencies:
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c80244d5ca88992e5609e372eaf2441497d36063688af44e9f0e81ab0ee8d5a4cbdb644822243e4cdfad2dd6484c6274e618dc2a9e91b3b9befe7c7b55e09ddc
+  checksum: 10c0/18b7f64544c7450dbc5602817d6f1a6bc337fcb19bc56d6df977bfcf7a25e233640df1f7f1791cc50a291dfedf30b99f5942ea517e0611b37f4c4a79327637cf
   languageName: node
   linkType: hard
 
 "@smithy/undici-http-handler@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "@smithy/undici-http-handler@npm:2.0.2"
+  version: 2.1.2
+  resolution: "@smithy/undici-http-handler@npm:2.1.2"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
-    "@smithy/types": "npm:^4.14.3"
+    "@smithy/core": "npm:^3.25.0"
+    "@smithy/types": "npm:^4.15.0"
     tslib: "npm:^2.6.2"
     undici: "npm:^7.0.0"
   peerDependencies:
     undici: ">=7.0.0"
-  checksum: 10c0/740792abcfb888c421c84b6f577c937fa092da75c958acd505d9375d32e8d27fa4df2a0ea315ff329b272c6155c4d6000f58d13b307716970fa4524bc897e56c
+  checksum: 10c0/04d60802e2936d299c498f57e4db85384f3428f5328fe7f6a08e3ebfc8fc0b16c8af3833daab9d0a7b1b2df25eb8983bcd82d909360e467bc58044c8bdaa5688
   languageName: node
   linkType: hard
 
@@ -16200,12 +16420,12 @@ __metadata:
   linkType: hard
 
 "@smithy/util-stream@npm:^4.6.6":
-  version: 4.6.6
-  resolution: "@smithy/util-stream@npm:4.6.6"
+  version: 4.7.0
+  resolution: "@smithy/util-stream@npm:4.7.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
+    "@smithy/core": "npm:^3.25.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/9322c81be57e7ec1c50f60efa2028a7b2e21536a2aef7c232905eb82f0aec8581491900438286df0fce0fbea446abd7bcaf3a662ae4815d171493b3451aa41bc
+  checksum: 10c0/68e34e186908bd37adfeba81e38140e14d35e41b78ca682a875726c3cad5dd81c9bf84915ab099ed659ce14ae4b1646f295d7802f5925f4f7a0ec149331b40f1
   languageName: node
   linkType: hard
 
@@ -16220,16 +16440,16 @@ __metadata:
   linkType: hard
 
 "@smithy/util-utf8@npm:^4.3.6":
-  version: 4.3.6
-  resolution: "@smithy/util-utf8@npm:4.3.6"
+  version: 4.4.0
+  resolution: "@smithy/util-utf8@npm:4.4.0"
   dependencies:
-    "@smithy/core": "npm:^3.24.6"
+    "@smithy/core": "npm:^3.25.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/0b4e9201a54658058241ec8d075661f4d105be836aea11b331cdf76ea34cb89b535d08a37405ee32726754b28e3054d1da4e87c538124f83ce10044f9a12f827
+  checksum: 10c0/ca18d4a632d696f5ef5564f64a34e4cd4a9aa82175e2963867fa93696396d759ef1215251d58f22eb84292ff757e8f24fe153fff9ecddba1005370b7c7240b91
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.1.0":
+"@standard-schema/spec@npm:^1.0.0, @standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
   checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
@@ -16327,7 +16547,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tybys/wasm-util@npm:^0.10.0, @tybys/wasm-util@npm:^0.10.1":
+"@tybys/wasm-util@npm:^0.10.0":
+  version: 0.10.1
+  resolution: "@tybys/wasm-util@npm:0.10.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/b255094f293794c6d2289300c5fbcafbb5532a3aed3a5ffd2f8dc1828e639b88d75f6a376dd8f94347a44813fd7a7149d8463477a9a49525c8b2dcaa38c2d1e8
+  languageName: node
+  linkType: hard
+
+"@tybys/wasm-util@npm:^0.10.2":
   version: 0.10.2
   resolution: "@tybys/wasm-util@npm:0.10.2"
   dependencies:
@@ -16536,12 +16765,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=20.0.0":
-  version: 25.3.3
-  resolution: "@types/node@npm:25.3.3"
+"@types/node@npm:*":
+  version: 24.10.1
+  resolution: "@types/node@npm:24.10.1"
   dependencies:
-    undici-types: "npm:~7.18.0"
-  checksum: 10c0/63e1d3816a9f4a706ab5d588d18cb98aa824b97748ff585537d327528e9438f58f69f45c7762e7cd3a1ab32c1619f551aabe8075d13172f9273cf10f6d83ab91
+    undici-types: "npm:~7.16.0"
+  checksum: 10c0/d6bca7a78f550fbb376f236f92b405d676003a8a09a1b411f55920ef34286ee3ee51f566203920e835478784df52662b5b2af89159d9d319352e9ea21801c002
   languageName: node
   linkType: hard
 
@@ -16549,6 +16778,15 @@ __metadata:
   version: 20.5.1
   resolution: "@types/node@npm:20.5.1"
   checksum: 10c0/b5aeaeb489842081190f8c2c09e923ff7b1b4ee3ecfceba12ba1030ce7750909a1b3c0f5372bd60cbe955e48a9889f416522e8a96697ad7209317752f395e3e5
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=20.0.0":
+  version: 25.3.3
+  resolution: "@types/node@npm:25.3.3"
+  dependencies:
+    undici-types: "npm:~7.18.0"
+  checksum: 10c0/63e1d3816a9f4a706ab5d588d18cb98aa824b97748ff585537d327528e9438f58f69f45c7762e7cd3a1ab32c1619f551aabe8075d13172f9273cf10f6d83ab91
   languageName: node
   linkType: hard
 
@@ -17109,25 +17347,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/expect@npm:4.1.7"
+"@vitest/expect@npm:4.0.17":
+  version: 4.0.17
+  resolution: "@vitest/expect@npm:4.0.17"
   dependencies:
-    "@standard-schema/spec": "npm:^1.1.0"
+    "@standard-schema/spec": "npm:^1.0.0"
     "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:4.1.7"
-    "@vitest/utils": "npm:4.1.7"
-    chai: "npm:^6.2.2"
-    tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/1a72387c6d3cac1e12cd4df382e666d96560b38001ea0133f1e0a22825f71ccf1640ccce13244296b0054c15cf04442f3adbd67dfc57fe542bd35a46cd805487
+    "@vitest/spy": "npm:4.0.17"
+    "@vitest/utils": "npm:4.0.17"
+    chai: "npm:^6.2.1"
+    tinyrainbow: "npm:^3.0.3"
+  checksum: 10c0/cdaa6827aa3a9473d51fd0944bcd698a94507929fa3c98b00bbdb74342319ec04279f01108d7d2dd7cbcd0d8062f65a3f21bb3615c0d5223e61adcc036c8b370
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/mocker@npm:4.1.7"
+"@vitest/expect@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/expect@npm:4.1.9"
   dependencies:
-    "@vitest/spy": "npm:4.1.7"
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.9"
+    "@vitest/utils": "npm:4.1.9"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/243bacaed2cba5e0ea4ec7465662fcec465a358a0e06381e337fac49426aa67a73b104fbb9d65d8bccadfba8f70e27f57ffb897aacfa140f579a556367357875
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.0.17":
+  version: 4.0.17
+  resolution: "@vitest/mocker@npm:4.0.17"
+  dependencies:
+    "@vitest/spy": "npm:4.0.17"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0-0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/54e657fa5b79764926b15aac993528bfe7083f6731209253617b1f27d328aa3297fcbf96b67e84d1a5632553231f795585f2396f563837cf117a574c87f5cef7
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/mocker@npm:4.1.9"
+  dependencies:
+    "@vitest/spy": "npm:4.1.9"
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.21"
   peerDependencies:
@@ -17138,56 +17409,103 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: 10c0/e03dbbba435543e3cfa5e034ba8ade371de5e398255f75366ebc370ff8dd78d45f7d7cc9daa76eb1d399b31e659e47d3cbb710566e64ceeeba3f99b418e4b955
+  checksum: 10c0/707353b7435bbfd441cc754e4ee7bc5921b70d07b051c6e414b6bbe4ca369154702b0ddeb603389469fe87ca1983e002eb2d55044582661f54a1945dd27e5c82
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/pretty-format@npm:4.1.7"
+"@vitest/pretty-format@npm:4.0.17":
+  version: 4.0.17
+  resolution: "@vitest/pretty-format@npm:4.0.17"
+  dependencies:
+    tinyrainbow: "npm:^3.0.3"
+  checksum: 10c0/10a2dd7e2daf7ee006107d380bbd28b66b09a7014d31087daab0dea7dee0d12868cfcf6b3372729268502fd9065162345b68b9b9c5d225f5c6c2fd2c664a2a86
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/pretty-format@npm:4.1.9"
   dependencies:
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/49ef801171708e3a92214e8720efbedbd6e0e6baf17971aaf4feb7422e5c9eba82262c24a9e6dd4d41a31fae77bd31d5b37cf140d13e0ac4ce29a7457bdc692f
+  checksum: 10c0/5b96295f25ab885616230ad1355fc82f490bebb39cc707688d7c8969c08270d7e076ed8a10af4e762ed57145193c6061a1f549f136f0ded344f8db0c2b3fb3de
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/runner@npm:4.1.7"
+"@vitest/runner@npm:4.0.17":
+  version: 4.0.17
+  resolution: "@vitest/runner@npm:4.0.17"
   dependencies:
-    "@vitest/utils": "npm:4.1.7"
+    "@vitest/utils": "npm:4.0.17"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/63474c6fc088d75b5d7fe735195504f923c694b83a22eb9caa53d6486c923974304c2e3ef4d5bcd808d88082174f38434be320fc4fe649a8cf33f0459a0576e3
+  checksum: 10c0/f4ccc236d1ed5ba2186d5f36ff0306d4ac7b711a40d7316ad6fd71c0f7229482b19969a8737e87670f3d4efb08f2138ff5b47a744fd7ae8db6c03cf991293a04
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/snapshot@npm:4.1.7"
+"@vitest/runner@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/runner@npm:4.1.9"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.7"
-    "@vitest/utils": "npm:4.1.7"
+    "@vitest/utils": "npm:4.1.9"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/d206b4891a64b1f55c346f832b0a7b489108094d8ae34438d3b53e78be7b45b139fa95ffa027c98c357bd532268ee573168de1943235b7eed32a9236ed5978bb
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.0.17":
+  version: 4.0.17
+  resolution: "@vitest/snapshot@npm:4.0.17"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.0.17"
     magic-string: "npm:^0.30.21"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/6fa49c4242a4acc0557ee6a20552db41f4f4c9d2d4c05993181c3f5f19e66579e08f63d34f792b79400547ab791ef500a9955b77390c381e45c3bb8e33717793
+  checksum: 10c0/31a047a097b13eff6c0f5393ea3e7203771ae9a22afe6465cd9023fd2ed516ddccd84523d48504a032c9d04a86a12e3f1235e08bb2ffc7d7a125e372c41ef53d
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/spy@npm:4.1.7"
-  checksum: 10c0/be2a95d5c5c438b57c9b33cef1289fb02659214754b5e946cb4b8183e2b5089e49e3fda6ca05981f3ea9872b207595db109e25072668c0a671203f69fddbbe99
-  languageName: node
-  linkType: hard
-
-"@vitest/utils@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/utils@npm:4.1.7"
+"@vitest/snapshot@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/snapshot@npm:4.1.9"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.7"
+    "@vitest/pretty-format": "npm:4.1.9"
+    "@vitest/utils": "npm:4.1.9"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/c3099df12ad1f9c1e180441856c9eb82f1990f87ff16aafedd6fa19978eaff20bc59220b692a99fcc822daef86eab256ba3dadb49544b7bd625b57c49cd9d995
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.0.17":
+  version: 4.0.17
+  resolution: "@vitest/spy@npm:4.0.17"
+  checksum: 10c0/c290731ba3392f11eaba8fc7fa08063a3a4d14af6baeec210b260ccd5a46613196fb4a8ff3ac8bf91a9606aef90eee9b6364bda130ce71abff368e35dfe2b265
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/spy@npm:4.1.9"
+  checksum: 10c0/e51f328f55b76e8ba66e5e18f183484a8dc0a092685b101112d3e9fb8e989ddca162c98ddf00254476502c25bc05c4ec1e277fd6ad8bfc702464c08f6b5dd115
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.0.17":
+  version: 4.0.17
+  resolution: "@vitest/utils@npm:4.0.17"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.0.17"
+    tinyrainbow: "npm:^3.0.3"
+  checksum: 10c0/1e2e4d7d7709ec022f603a1e12015523a2290f326c0bbe0c6bd5481ec396d4efc6bf8c738d601915d88e74267e9841df1e05157edced10f5048865204aeb86ff
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/utils@npm:4.1.9"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.9"
     convert-source-map: "npm:^2.0.0"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/aa0079d8923506300527dc23ff68cf090ffcb2c6a9549e598ae22ba0eb8a6bb4448b10724b38bc6b077f9957333302a857d791ad2f7abd807bb6263c9a218833
+  checksum: 10c0/d55506c077fd72c091eb66f02926f0abf72801c87a085f565698289562f47befa114ae2c680ab8736dfe46abab0cfd6b8031f2ac519bafeb37578aa6e5ad03c5
   languageName: node
   linkType: hard
 
@@ -17888,8 +18206,8 @@ __metadata:
   linkType: hard
 
 "aws-crt@npm:^1.31.0":
-  version: 1.31.0
-  resolution: "aws-crt@npm:1.31.0"
+  version: 1.32.2
+  resolution: "aws-crt@npm:1.32.2"
   dependencies:
     "@aws-sdk/util-utf8-browser": "npm:^3.259.0"
     "@httptoolkit/websocket-stream": "npm:^6.0.1"
@@ -17898,7 +18216,7 @@ __metadata:
     crypto-js: "npm:^4.2.0"
     mqtt: "npm:^4.3.8"
     process: "npm:^0.11.10"
-  checksum: 10c0/0a56d8034f94968ffd3531d813307b4532b89d484d5434e767d0a9a8fcb3f1fa01dd31618c7870f539803a57ae1a23d5f89ff7278ce5b771284af357952e870a
+  checksum: 10c0/8ae9837cfe5dfa896f26766dd9425a6dd9c8bdba897efc672f862d779db44349698952156349f2b6afff1386f15bbcfc17e535e47641f1ffa4e5cc8a6fde4f36
   languageName: node
   linkType: hard
 
@@ -17933,6 +18251,7 @@ __metadata:
     eslint-plugin-sort-export-all: "npm:1.2.2"
     eslint-plugin-tsdoc: "npm:0.2.17"
     esprint: "npm:3.6.0"
+    fast-xml-parser: "npm:5.7.3"
     fastify: "npm:^4.11.0"
     figlet: "npm:^1.5.0"
     fs-extra: "npm:^9.0.0"
@@ -17977,14 +18296,13 @@ __metadata:
   linkType: hard
 
 "axios@npm:^1.0.0, axios@npm:^1.12.2":
-  version: 1.17.0
-  resolution: "axios@npm:1.17.0"
+  version: 1.13.2
+  resolution: "axios@npm:1.13.2"
   dependencies:
-    follow-redirects: "npm:^1.16.0"
-    form-data: "npm:^4.0.5"
-    https-proxy-agent: "npm:^5.0.1"
-    proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/c4fa19ff3a3a63bde48beec03ad816b133b9a6385cccffffe172577ab18c6a70e299280d57f12c80c867fe25df41f92cb91d3a8258708a6d2be3e9e085f92650
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/e8a42e37e5568ae9c7a28c348db0e8cf3e43d06fcbef73f0048669edfe4f71219664da7b6cc991b0c0f01c28a48f037c515263cb79be1f1ae8ff034cd813867b
   languageName: node
   linkType: hard
 
@@ -18505,7 +18823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai@npm:^6.2.2":
+"chai@npm:^6.2.1, chai@npm:^6.2.2":
   version: 6.2.2
   resolution: "chai@npm:6.2.2"
   checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
@@ -19641,7 +19959,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.0.0, enhanced-resolve@npm:^5.17.1, enhanced-resolve@npm:^5.17.2":
+"enhanced-resolve@npm:^5.0.0, enhanced-resolve@npm:^5.17.2":
+  version: 5.18.3
+  resolution: "enhanced-resolve@npm:5.18.3"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    tapable: "npm:^2.2.0"
+  checksum: 10c0/d413c23c2d494e4c1c9c9ac7d60b812083dc6d446699ed495e69c920988af0a3c66bf3f8d0e7a45cb1686c2d4c1df9f4e7352d973f5b56fe63d8d711dd0ccc54
+  languageName: node
+  linkType: hard
+
+"enhanced-resolve@npm:^5.17.1":
   version: 5.19.0
   resolution: "enhanced-resolve@npm:5.19.0"
   dependencies:
@@ -19753,7 +20081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.2.1":
+"es-module-lexer@npm:^1.2.1, es-module-lexer@npm:^1.7.0":
   version: 1.7.0
   resolution: "es-module-lexer@npm:1.7.0"
   checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
@@ -19768,11 +20096,11 @@ __metadata:
   linkType: hard
 
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "es-object-atoms@npm:1.1.2"
+  version: 1.1.1
+  resolution: "es-object-atoms@npm:1.1.1"
   dependencies:
     es-errors: "npm:^1.3.0"
-  checksum: 10c0/1772861f094f739d6f41b579cfb9a18579daffeb434552a370a5fbef50a32d22227e27b63fdbb757b7ddd429d1b42fe52ccae7966d9302a2ec221b6f1b41bbc4
+  checksum: 10c0/65364812ca4daf48eb76e2a3b7a89b3f6a2e62a1c420766ce9f692665a29d94fe41fe88b65f24106f449859549711e4b40d9fb8002d862dfd7eb1c512d10be0c
   languageName: node
   linkType: hard
 
@@ -19887,6 +20215,95 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/5767b72da46da3cfec51661647ec850ddbf8a8d0662771139f10ef0692a8831396a0004b2be7966cecdb08264fb16bdc16290dcecd92396fac5f12d722fa013d
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.25.0":
+  version: 0.25.12
+  resolution: "esbuild@npm:0.25.12"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.25.12"
+    "@esbuild/android-arm": "npm:0.25.12"
+    "@esbuild/android-arm64": "npm:0.25.12"
+    "@esbuild/android-x64": "npm:0.25.12"
+    "@esbuild/darwin-arm64": "npm:0.25.12"
+    "@esbuild/darwin-x64": "npm:0.25.12"
+    "@esbuild/freebsd-arm64": "npm:0.25.12"
+    "@esbuild/freebsd-x64": "npm:0.25.12"
+    "@esbuild/linux-arm": "npm:0.25.12"
+    "@esbuild/linux-arm64": "npm:0.25.12"
+    "@esbuild/linux-ia32": "npm:0.25.12"
+    "@esbuild/linux-loong64": "npm:0.25.12"
+    "@esbuild/linux-mips64el": "npm:0.25.12"
+    "@esbuild/linux-ppc64": "npm:0.25.12"
+    "@esbuild/linux-riscv64": "npm:0.25.12"
+    "@esbuild/linux-s390x": "npm:0.25.12"
+    "@esbuild/linux-x64": "npm:0.25.12"
+    "@esbuild/netbsd-arm64": "npm:0.25.12"
+    "@esbuild/netbsd-x64": "npm:0.25.12"
+    "@esbuild/openbsd-arm64": "npm:0.25.12"
+    "@esbuild/openbsd-x64": "npm:0.25.12"
+    "@esbuild/openharmony-arm64": "npm:0.25.12"
+    "@esbuild/sunos-x64": "npm:0.25.12"
+    "@esbuild/win32-arm64": "npm:0.25.12"
+    "@esbuild/win32-ia32": "npm:0.25.12"
+    "@esbuild/win32-x64": "npm:0.25.12"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/c205357531423220a9de8e1e6c6514242bc9b1666e762cd67ccdf8fdfdc3f1d0bd76f8d9383958b97ad4c953efdb7b6e8c1f9ca5951cd2b7c5235e8755b34a6b
   languageName: node
   linkType: hard
 
@@ -20450,7 +20867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect-type@npm:^1.3.0":
+"expect-type@npm:^1.2.2, expect-type@npm:^1.3.0":
   version: 1.3.0
   resolution: "expect-type@npm:1.3.0"
   checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
@@ -20913,13 +21330,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.16.0":
-  version: 1.16.0
-  resolution: "follow-redirects@npm:1.16.0"
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.11
+  resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
+  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
   languageName: node
   linkType: hard
 
@@ -20940,7 +21357,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0":
+"form-data@npm:^4.0.0, form-data@npm:^4.0.4":
   version: 4.0.4
   resolution: "form-data@npm:4.0.4"
   dependencies:
@@ -20950,19 +21367,6 @@ __metadata:
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/373525a9a034b9d57073e55eab79e501a714ffac02e7a9b01be1c820780652b16e4101819785e1e18f8d98f0aee866cc654d660a435c378e16a72f2e7cac9695
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
   languageName: node
   linkType: hard
 
@@ -21212,7 +21616,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.7.5, get-tsconfig@npm:^4.8.1":
+"get-tsconfig@npm:^4.7.5":
+  version: 4.13.0
+  resolution: "get-tsconfig@npm:4.13.0"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/2c49ef8d3907047a107f229fd610386fe3b7fe9e42dfd6b42e7406499493cdda8c62e83e57e8d7a98125610774b9f604d3a0ff308d7f9de5c7ac6d1b07cb6036
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.8.1":
   version: 4.13.6
   resolution: "get-tsconfig@npm:4.13.6"
   dependencies:
@@ -21373,7 +21786,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.3.10, glob@npm:^10.3.7":
+"glob@npm:^10.3.10":
+  version: 10.4.5
+  resolution: "glob@npm:10.4.5"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^3.1.2"
+    minimatch: "npm:^9.0.4"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^1.11.1"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.3.7":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
   dependencies:
@@ -21628,11 +22057,11 @@ __metadata:
   linkType: hard
 
 "hasown@npm:^2.0.2":
-  version: 2.0.4
-  resolution: "hasown@npm:2.0.4"
+  version: 2.0.2
+  resolution: "hasown@npm:2.0.2"
   dependencies:
     function-bind: "npm:^1.1.2"
-  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
+  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
   languageName: node
   linkType: hard
 
@@ -21746,7 +22175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:5.0.1, https-proxy-agent@npm:^5.0.0, https-proxy-agent@npm:^5.0.1":
+"https-proxy-agent@npm:5.0.1, https-proxy-agent@npm:^5.0.0":
   version: 5.0.1
   resolution: "https-proxy-agent@npm:5.0.1"
   dependencies:
@@ -24700,6 +25129,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.11":
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.12":
   version: 3.3.12
   resolution: "nanoid@npm:3.3.12"
@@ -25675,7 +26113,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "picomatch@npm:4.0.3"
+  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
@@ -25836,7 +26281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.15, postcss@npm:^8.5.6":
+"postcss@npm:^8.5.15":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
   dependencies:
@@ -25844,6 +26289,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.6":
+  version: 8.5.6
+  resolution: "postcss@npm:8.5.6"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
   languageName: node
   linkType: hard
 
@@ -26042,10 +26498,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "proxy-from-env@npm:2.1.0"
-  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
   languageName: node
   linkType: hard
 
@@ -26059,12 +26515,12 @@ __metadata:
   linkType: hard
 
 "pump@npm:^3.0.0":
-  version: 3.0.4
-  resolution: "pump@npm:3.0.4"
+  version: 3.0.3
+  resolution: "pump@npm:3.0.3"
   dependencies:
     end-of-stream: "npm:^1.1.0"
     once: "npm:^1.3.1"
-  checksum: 10c0/2780e66b5471c19e3e3e1063b84f3f6a3a08367f24c5ed552f98cd5901e6ada27c7ad6495d4244f553fd03b01884a4561933064f053f47c8994d84fd352768ea
+  checksum: 10c0/ada5cdf1d813065bbc99aa2c393b8f6beee73b5de2890a8754c9f488d7323ffd2ca5f5a0943b48934e3fcbd97637d0337369c3c631aeb9614915db629f1c75c9
   languageName: node
   linkType: hard
 
@@ -26592,26 +27048,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.2":
-  version: 1.0.2
-  resolution: "rolldown@npm:1.0.2"
+"rolldown@npm:1.0.3":
+  version: 1.0.3
+  resolution: "rolldown@npm:1.0.3"
   dependencies:
-    "@oxc-project/types": "npm:=0.132.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.2"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.2"
-    "@rolldown/binding-darwin-x64": "npm:1.0.2"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.2"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.2"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.2"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.2"
-    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.2"
-    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.2"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.2"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.2"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.2"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.2"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.2"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.2"
+    "@oxc-project/types": "npm:=0.133.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.3"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.3"
+    "@rolldown/binding-darwin-x64": "npm:1.0.3"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.3"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.3"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.3"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.3"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.3"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.3"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.3"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.3"
     "@rolldown/pluginutils": "npm:^1.0.0"
   dependenciesMeta:
     "@rolldown/binding-android-arm64":
@@ -26646,7 +27102,7 @@ __metadata:
       optional: true
   bin:
     rolldown: ./bin/cli.mjs
-  checksum: 10c0/628327a6e3122c0b62880f1c87d54095394e5138a6af2e6e7b2f67ef4c4b11f1421db68c9a5bb4e1be161465a863ab4f68f15076ce895cd4bb3d0ba18a3b20b1
+  checksum: 10c0/5f9dd47b7abf203b16bc600db68542f245e974c800e59ff50b76157d1dada1403657690435b036fabca88e93d13a67c31abe5cfaa6f61ce33717f61720204cdf
   languageName: node
   linkType: hard
 
@@ -26912,7 +27368,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.2":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.2":
+  version: 7.7.3
+  resolution: "semver@npm:7.7.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/4afe5c986567db82f44c8c6faef8fe9df2a9b1d98098fc1721f57c696c4c21cebd572f297fc21002f81889492345b8470473bc6f4aff5fb032a6ea59ea2bc45e
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.6.3":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -27396,6 +27861,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"std-env@npm:^3.10.0":
+  version: 3.10.0
+  resolution: "std-env@npm:3.10.0"
+  checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
+  languageName: node
+  linkType: hard
+
 "std-env@npm:^4.0.0-rc.1":
   version: 4.1.0
   resolution: "std-env@npm:4.1.0"
@@ -27613,7 +28085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.1.1, tapable@npm:^2.3.0":
+"tapable@npm:^2.1.1, tapable@npm:^2.2.0, tapable@npm:^2.3.0":
   version: 2.3.0
   resolution: "tapable@npm:2.3.0"
   checksum: 10c0/cb9d67cc2c6a74dedc812ef3085d9d681edd2c1fa18e4aef57a3c0605fdbe44e6b8ea00bd9ef21bc74dd45314e39d31227aa031ebf2f5e38164df514136f2681
@@ -27796,13 +28268,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.16":
-  version: 0.2.16
-  resolution: "tinyglobby@npm:0.2.16"
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15":
+  version: 0.2.15
+  resolution: "tinyglobby@npm:0.2.15"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.3"
+  checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.17":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
   dependencies:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.4"
-  checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
+  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "tinyrainbow@npm:3.0.3"
+  checksum: 10c0/1e799d35cd23cabe02e22550985a3051dc88814a979be02dc632a159c393a998628eacfc558e4c746b3006606d54b00bcdea0c39301133956d10a27aa27e988c
   languageName: node
   linkType: hard
 
@@ -28242,6 +28731,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~7.16.0":
+  version: 7.16.0
+  resolution: "undici-types@npm:7.16.0"
+  checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~7.18.0":
   version: 7.18.2
   resolution: "undici-types@npm:7.18.2"
@@ -28250,9 +28746,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.0.0":
-  version: 7.27.2
-  resolution: "undici@npm:7.27.2"
-  checksum: 10c0/714632147c80eb8eda8a52df51b481d346df5e035ccc1d87eb3bbcb8f92ec25d7cbbe81abdeae5db4e37a93e490c8d2fa2359ecdca4b2c5c6c513dcd2626ad47
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 
@@ -28618,64 +29114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.0.14
-  resolution: "vite@npm:8.0.14"
-  dependencies:
-    fsevents: "npm:~2.3.3"
-    lightningcss: "npm:^1.32.0"
-    picomatch: "npm:^4.0.4"
-    postcss: "npm:^8.5.15"
-    rolldown: "npm:1.0.2"
-    tinyglobby: "npm:^0.2.16"
-  peerDependencies:
-    "@types/node": ^20.19.0 || >=22.12.0
-    "@vitejs/devtools": ^0.1.18
-    esbuild: ^0.27.0 || ^0.28.0
-    jiti: ">=1.21.0"
-    less: ^4.0.0
-    sass: ^1.70.0
-    sass-embedded: ^1.70.0
-    stylus: ">=0.54.8"
-    sugarss: ^5.0.0
-    terser: ^5.16.0
-    tsx: ^4.8.1
-    yaml: ^2.4.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    "@vitejs/devtools":
-      optional: true
-    esbuild:
-      optional: true
-    jiti:
-      optional: true
-    less:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-    tsx:
-      optional: true
-    yaml:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/1ff99b4daadc64aed5f9e40387ecf39fd3bca45c1a5c4fa4aa82197de901930f0507af8d75c54715e2744c99575913947efb625653a78ef6df3997c5613970bd
-  languageName: node
-  linkType: hard
-
-"vite@npm:^7.1.11":
+"vite@npm:^6.0.0 || ^7.0.0":
   version: 7.3.1
   resolution: "vite@npm:7.3.1"
   dependencies:
@@ -28730,6 +29169,118 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.0.16
+  resolution: "vite@npm:8.0.16"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.32.0"
+    picomatch: "npm:^4.0.4"
+    postcss: "npm:^8.5.15"
+    rolldown: "npm:1.0.3"
+    tinyglobby: "npm:^0.2.17"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.1.18
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/d75be3fbe2f63e6a8145325970338afaf0dd4d96ba9175c13f9a286fd5f95afc489401b693e4fa6c0899a4dd0e137be91cdf9401a40a635563911ad5036e3467
+  languageName: node
+  linkType: hard
+
+"vite@npm:^7.1.11":
+  version: 7.2.2
+  resolution: "vite@npm:7.2.2"
+  dependencies:
+    esbuild: "npm:^0.25.0"
+    fdir: "npm:^6.5.0"
+    fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.3"
+    postcss: "npm:^8.5.6"
+    rollup: "npm:^4.43.0"
+    tinyglobby: "npm:^0.2.15"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    lightningcss: ^1.21.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/9c76ee441f8dbec645ddaecc28d1f9cf35670ffa91cff69af7b1d5081545331603f0b1289d437b2fa8dc43cdc77b4d96b5bd9c9aed66310f490cb1a06f9c814c
+  languageName: node
+  linkType: hard
+
 "vitest-websocket-mock@npm:0.2.3":
   version: 0.2.3
   resolution: "vitest-websocket-mock@npm:0.2.3"
@@ -28742,17 +29293,76 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^4.0.17, vitest@npm:^4.1.7":
-  version: 4.1.7
-  resolution: "vitest@npm:4.1.7"
+"vitest@npm:^4.0.17":
+  version: 4.0.17
+  resolution: "vitest@npm:4.0.17"
   dependencies:
-    "@vitest/expect": "npm:4.1.7"
-    "@vitest/mocker": "npm:4.1.7"
-    "@vitest/pretty-format": "npm:4.1.7"
-    "@vitest/runner": "npm:4.1.7"
-    "@vitest/snapshot": "npm:4.1.7"
-    "@vitest/spy": "npm:4.1.7"
-    "@vitest/utils": "npm:4.1.7"
+    "@vitest/expect": "npm:4.0.17"
+    "@vitest/mocker": "npm:4.0.17"
+    "@vitest/pretty-format": "npm:4.0.17"
+    "@vitest/runner": "npm:4.0.17"
+    "@vitest/snapshot": "npm:4.0.17"
+    "@vitest/spy": "npm:4.0.17"
+    "@vitest/utils": "npm:4.0.17"
+    es-module-lexer: "npm:^1.7.0"
+    expect-type: "npm:^1.2.2"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^3.10.0"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.0.3"
+    vite: "npm:^6.0.0 || ^7.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.0.17
+    "@vitest/browser-preview": 4.0.17
+    "@vitest/browser-webdriverio": 4.0.17
+    "@vitest/ui": 4.0.17
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/e1648bbfe2d01e23ceb6856863344035d2a1c139f39e8b15859e6ea8dc510ac3ba425df7c45486492d85ca516472aa892540dfd11ab6ad0613be98fd56d40716
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^4.1.7":
+  version: 4.1.9
+  resolution: "vitest@npm:4.1.9"
+  dependencies:
+    "@vitest/expect": "npm:4.1.9"
+    "@vitest/mocker": "npm:4.1.9"
+    "@vitest/pretty-format": "npm:4.1.9"
+    "@vitest/runner": "npm:4.1.9"
+    "@vitest/snapshot": "npm:4.1.9"
+    "@vitest/spy": "npm:4.1.9"
+    "@vitest/utils": "npm:4.1.9"
     es-module-lexer: "npm:^2.0.0"
     expect-type: "npm:^1.3.0"
     magic-string: "npm:^0.30.21"
@@ -28770,12 +29380,12 @@ __metadata:
     "@edge-runtime/vm": "*"
     "@opentelemetry/api": ^1.9.0
     "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.1.7
-    "@vitest/browser-preview": 4.1.7
-    "@vitest/browser-webdriverio": 4.1.7
-    "@vitest/coverage-istanbul": 4.1.7
-    "@vitest/coverage-v8": 4.1.7
-    "@vitest/ui": 4.1.7
+    "@vitest/browser-playwright": 4.1.9
+    "@vitest/browser-preview": 4.1.9
+    "@vitest/browser-webdriverio": 4.1.9
+    "@vitest/coverage-istanbul": 4.1.9
+    "@vitest/coverage-v8": 4.1.9
+    "@vitest/ui": 4.1.9
     happy-dom: "*"
     jsdom: "*"
     vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -28805,8 +29415,8 @@ __metadata:
     vite:
       optional: false
   bin:
-    vitest: vitest.mjs
-  checksum: 10c0/5328eab211161bdb854159154b02d7b2beab0cf1e26a1c13f6a64b0f1402029d41f19987cf60684051c09a6925030285195ecbe57271c2033e1d4f7a666590d0
+    vitest: ./vitest.mjs
+  checksum: 10c0/1ac80ef4991be82822a52aea48415f1bc64ddf8fd88ee24c172ec368f1d480fefacbde622c3c951982f7961a1d07313e18deaafc774d29e42ad6f6ffa63334a7
   languageName: node
   linkType: hard
 
@@ -29165,9 +29775,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:*, ws@npm:^8.18.3":
-  version: 8.21.0
-  resolution: "ws@npm:8.21.0"
+"ws@npm:*":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -29176,13 +29786,13 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
+  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
   languageName: node
   linkType: hard
 
 "ws@npm:^7.4.5, ws@npm:^7.5.5":
-  version: 7.5.11
-  resolution: "ws@npm:7.5.11"
+  version: 7.5.10
+  resolution: "ws@npm:7.5.10"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -29191,7 +29801,22 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/7972670b676fb1ccba73b0899ca3c2e04e8c2075629c2614cced7f556536f96a672bbf4619fc5a06c8b8720bb839a47ca88c69c95dc14c9c61a99fbecba1c866
+  checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.19.0
+  resolution: "ws@npm:8.19.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/4741d9b9bc3f9c791880882414f96e36b8b254e34d4b503279d6400d9a4b87a033834856dbdd94ee4b637944df17ea8afc4bce0ff4a1560d2166be8855da5b04
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12160,11 +12160,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk/xml-builder@workspace:packages-internal/xml-builder"
   dependencies:
+    "@jazzer.js/core": "npm:^4.0.0"
     "@nodable/entities": "npm:2.1.0"
     "@smithy/types": "npm:^4.14.3"
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
+    fast-check: "npm:^4.8.0"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -12201,10 +12203,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10c0/169fc2080169a40c1760155eaaaf739bcb882df0bec76a83adbda5493645bc17270a3434b8848c494b1933e96fe1d147370001e3cda09a39f43ae30f08ef2069
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.27.2":
   version: 7.28.5
   resolution: "@babel/compat-data@npm:7.28.5"
   checksum: 10c0/702a25de73087b0eba325c1d10979eed7c9b6662677386ba7b5aa6eace0fc0676f78343bae080a0176ae26f58bd5535d73b9d0fbb547fef377692e8b249353a7
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/compat-data@npm:7.29.7"
+  checksum: 10c0/47913f05e08a45a1c9df38c02b4b49e391005085b489432647a1abe112e5d9c75e3be8ea5972b7f6da4ec5d1339922ceb9ea02b8a25d4ed1cb8636e5261f344e
   languageName: node
   linkType: hard
 
@@ -12228,6 +12248,42 @@ __metadata:
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
   checksum: 10c0/535f82238027621da6bdffbdbe896ebad3558b311d6f8abc680637a9859b96edbf929ab010757055381570b29cf66c4a295b5618318d27a4273c0e2033925e72
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.25.2":
+  version: 7.29.7
+  resolution: "@babel/core@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-compilation-targets": "npm:^7.29.7"
+    "@babel/helper-module-transforms": "npm:^7.29.7"
+    "@babel/helpers": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/remapping": "npm:^2.3.5"
+    convert-source-map: "npm:^2.0.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.2.3"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/112fb09c24de7a1de64d1de2c31fe65c4e6af4cb2fb6e6d99ea5373e6fc51e75b88581c0efae4c4c68f119a02a988c7106e95011a41530a2fb8ed793c7eaa07b
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.25.6, @babel/generator@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/generator@npm:7.29.7"
+  dependencies:
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10c0/9bf72b01b5bd0ea5b1288a0e37dbd360bff2f2b1ce73342c0d40fb3db2ec3dc004ada5ffa925c5e12939a416eed59e600d562b8ecd938ce0d27dfd0eb6c6c2b7
   languageName: node
   linkType: hard
 
@@ -12257,10 +12313,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-compilation-targets@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-compilation-targets@npm:7.29.7"
+  dependencies:
+    "@babel/compat-data": "npm:^7.29.7"
+    "@babel/helper-validator-option": "npm:^7.29.7"
+    browserslist: "npm:^4.24.0"
+    lru-cache: "npm:^5.1.1"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/4c15fd4c69a0a7047799a28a88460c19cede0a0ee8af994ea169114986f4af48b92c7393a4a3fee0456c11a656eece3448a6ed06354453d6c27cccf17195453b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-globals@npm:^7.28.0":
   version: 7.28.0
   resolution: "@babel/helper-globals@npm:7.28.0"
   checksum: 10c0/5a0cd0c0e8c764b5f27f2095e4243e8af6fa145daea2b41b53c0c1414fe6ff139e3640f4e2207ae2b3d2153a1abd346f901c26c290ee7cb3881dd922d4ee9232
+  languageName: node
+  linkType: hard
+
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: 10c0/f38417c40b1129a1b2b519ca961b9040c8827d1444fd74068702286b91b77089431dc76b6b9d5c1496e5da2a4f3ad329c6946e688ba3fa0d1d0b3d2b4f34f36a
   languageName: node
   linkType: hard
 
@@ -12274,6 +12350,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/6adf60d97356027413342a092f818d9678c4f5caff716a33e3284b5ae14e47a9e88059d421dde4ee4894691260039a12602c0e7becadc175602194b40dfa345d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.28.3":
   version: 7.28.3
   resolution: "@babel/helper-module-transforms@npm:7.28.3"
@@ -12284,6 +12370,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 10c0/549be62515a6d50cd4cfefcab1b005c47f89bd9135a22d602ee6a5e3a01f27571868ada10b75b033569f24dc4a2bb8d04bfa05ee75c16da7ade2d0db1437fcdb
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-transforms@npm:7.29.7"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10c0/ee5a2172c24a42be696836f4b0d947489c9729d8adf5821885cf77d1ad5333e3c447368e9a71f67df1099570490553dccf9f888ef0a92a48aa63cb086bd8c7e1
   languageName: node
   linkType: hard
 
@@ -12301,6 +12400,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 10c0/194bc0f1716e396d5ffde56ad6119745fb9557662c98611590e5e454906783a4ccb21ce93056b8eb69a4909044834e45d96e50ac695bbe9e3221648fe033c06c
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.27.1, @babel/helper-validator-identifier@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-validator-identifier@npm:7.28.5"
@@ -12308,10 +12414,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10c0/4795354e7ae0dcafa72de1cd04ec51252dc1498517170beaf019e03effc5b7bf13c6b21a3949a77e07b8125be7f106ed1131350d8ebd4566ae874094a726d62b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-validator-option@npm:7.27.1"
   checksum: 10c0/6fec5f006eba40001a20f26b1ef5dbbda377b7b68c8ad518c05baa9af3f396e780bdfded24c4eef95d14bb7b8fd56192a6ed38d5d439b97d10efc5f1a191d148
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-option@npm:7.29.7"
+  checksum: 10c0/d2a06c6d0ac40ba4a2f219fc2cab249c7a94bacdb2686273b7f9598571c908809b48468ff588915a346e6cc7296f60b581023d1d498b747fed06f779d335c2cc
   languageName: node
   linkType: hard
 
@@ -12325,6 +12445,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helpers@npm:7.29.7"
+  dependencies:
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/218e8d10953647c9f44775f5a022b227a182674853b5ea8631889deb7e1a3e4bc870388aaecf59bb8bd92a87f9a96220ed3f70a35bffec6bcf9169ecb67891ac
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/parser@npm:7.28.5"
@@ -12333,6 +12463,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/5bbe48bf2c79594ac02b490a41ffde7ef5aa22a9a88ad6bcc78432a6ba8a9d638d531d868bd1f104633f1f6bba9905746e15185b8276a3756c42b765d131b1ef
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/parser@npm:7.29.7"
+  dependencies:
+    "@babel/types": "npm:^7.29.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/65133038f80b54a714d6027cb77cee3f9a6b5c4c6842ce674301e13947cbcbfa8055e63acaf1b84c085d34226a14425b2c2b97b829e0e226d2e8f1299942a51d
   languageName: node
   linkType: hard
 
@@ -12541,6 +12682,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/8bb7f900dcab0e9e1c5ffbc33ca10e0d26b7b2e2ca804becb73ee771b9c4ed6e2908a4ae4a14c08560febb45d2b6b9a173955e42ad404d05f8b04840a14d9c58
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.3, @babel/traverse@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/traverse@npm:7.28.5"
@@ -12556,6 +12708,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/traverse@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-globals": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    debug: "npm:^4.3.1"
+  checksum: 10c0/e256a1fbdb956555b76f3c285b1e453f6bedec8b3afb61751d99d933efd11c7d79caf5ddf2493570058a9f7deaa1b48324380d7c1aa1443fd9508becbf56331a
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.4, @babel/types@npm:^7.28.5, @babel/types@npm:^7.3.3":
   version: 7.28.5
   resolution: "@babel/types@npm:7.28.5"
@@ -12563,6 +12730,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: 10c0/a5a483d2100befbf125793640dec26b90b95fd233a94c19573325898a5ce1e52cdfa96e495c7dcc31b5eca5b66ce3e6d4a0f5a4a62daec271455959f208ab08a
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/types@npm:7.29.7"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10c0/b6623994c69717fa27294f5fa46d59140338e2d86c6c1c13085c84ef7d53086ee357fbf4fe9abe3dd3da75734dc77c4c0df2f90fb29e667558bb3b3fb705e88f
   languageName: node
   linkType: hard
 
@@ -13793,6 +13970,69 @@ __metadata:
   version: 0.1.3
   resolution: "@istanbuljs/schema@npm:0.1.3"
   checksum: 10c0/61c5286771676c9ca3eb2bd8a7310a9c063fb6e0e9712225c8471c582d157392c88f5353581c8c9adbe0dff98892317d2fdfc56c3499aa42e0194405206a963a
+  languageName: node
+  linkType: hard
+
+"@jazzer.js/bug-detectors@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@jazzer.js/bug-detectors@npm:4.0.0"
+  dependencies:
+    "@jazzer.js/core": "npm:4.0.0"
+    "@jazzer.js/hooking": "npm:4.0.0"
+  checksum: 10c0/d040dd7ac8c0763a76162b896a9d331340aaecddcc09d55774ce3d30c136876218d2537f05f09236f8f49c59d102a3c82a737aa58d73e8f22eed1ccb5346a7f5
+  languageName: node
+  linkType: hard
+
+"@jazzer.js/core@npm:4.0.0, @jazzer.js/core@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@jazzer.js/core@npm:4.0.0"
+  dependencies:
+    "@jazzer.js/bug-detectors": "npm:4.0.0"
+    "@jazzer.js/fuzzer": "npm:4.0.0"
+    "@jazzer.js/hooking": "npm:4.0.0"
+    "@jazzer.js/instrumentor": "npm:4.0.0"
+    istanbul-lib-coverage: "npm:^3.2.2"
+    istanbul-lib-report: "npm:^3.0.1"
+    istanbul-reports: "npm:^3.1.7"
+    tmp: "npm:^0.2.5"
+    yargs: "npm:<18.0.0"
+  bin:
+    jazzer: dist/cli.js
+  checksum: 10c0/2923d8eb2b6a5ef7ecd99a118f13e0990805cd83b35d07482592145bf93b3ec0e81e7adff1299b2fa750310e2ca5862a45ab3ae80ff7c910e56e6cfd36bd6157
+  languageName: node
+  linkType: hard
+
+"@jazzer.js/fuzzer@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@jazzer.js/fuzzer@npm:4.0.0"
+  dependencies:
+    bindings: "npm:^1.5.0"
+    cmake-js: "npm:^8.0.0"
+    node-addon-api: "npm:^8.7.0"
+  checksum: 10c0/3e8ff8c309da294f96f4e57df7a6ab9aead3a2d126ab079db46e5c4218e1f3a8b03bf1692bf5582c3deaedcf35030172e7868fec347a3eabff88be8f7cb5cd27
+  languageName: node
+  linkType: hard
+
+"@jazzer.js/hooking@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@jazzer.js/hooking@npm:4.0.0"
+  checksum: 10c0/bf7bc1bf025500bbfe6d25f17df75c5b3bdc7089a498614d39e967b9eaf2b527fa1bff8775f39700f2f3ce3af230d8edd3111728b47cb5932b5b20e27bf5c091
+  languageName: node
+  linkType: hard
+
+"@jazzer.js/instrumentor@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@jazzer.js/instrumentor@npm:4.0.0"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@babel/generator": "npm:^7.25.6"
+    "@jazzer.js/fuzzer": "npm:4.0.0"
+    "@jazzer.js/hooking": "npm:4.0.0"
+    istanbul-lib-hook: "npm:^3.0.0"
+    istanbul-lib-instrument: "npm:^6.0.3"
+    proper-lockfile: "npm:^4.1.2"
+    source-map-support: "npm:^0.5.21"
+  checksum: 10c0/f1bd49cb27227a12d1967eaddc4f992c149c366b2b1b002cf6be15d26451dff5fc0484c98af5183ced9ac77c76729440988e878a7e851b1e4004f183ef4bb27b
   languageName: node
   linkType: hard
 
@@ -18034,6 +18274,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"append-transform@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "append-transform@npm:2.0.0"
+  dependencies:
+    default-require-extensions: "npm:^3.0.0"
+  checksum: 10c0/f1505e4f4597f4eb7b3df8da898e431fc25d6cdc6c78d01c700a4fab38d835e7cbac693eade8df7b0a0944dc52a35f92b1771e440af59f1b1f8a1dadaba7d17b
+  languageName: node
+  linkType: hard
+
 "aproba@npm:^1.0.3 || ^2.0.0, aproba@npm:^2.0.0":
   version: 2.1.0
   resolution: "aproba@npm:2.1.0"
@@ -18493,6 +18742,15 @@ __metadata:
     rimraf: "npm:^3.0.0"
     write-file-atomic: "npm:^4.0.0"
   checksum: 10c0/a7f3ea8663213d14134695b42f66994e11f00f0519617537d80cee3b78b7cbb5a627c0d3aafd9d8c748eee9b1af03dbdddedfbf18be738b50a4c11bdd739a160
+  languageName: node
+  linkType: hard
+
+"bindings@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "bindings@npm:1.5.0"
+  dependencies:
+    file-uri-to-path: "npm:1.0.0"
+  checksum: 10c0/3dab2491b4bb24124252a91e656803eac24292473e56554e35bbfe3cc1875332cfa77600c3bac7564049dc95075bf6fcc63a4609920ff2d64d0fe405fcf0d4ba
   languageName: node
   linkType: hard
 
@@ -19005,6 +19263,25 @@ __metadata:
   version: 1.0.4
   resolution: "clone@npm:1.0.4"
   checksum: 10c0/2176952b3649293473999a95d7bebfc9dc96410f6cbd3d2595cf12fd401f63a4bf41a7adbfd3ab2ff09ed60cb9870c58c6acdd18b87767366fabfc163700f13b
+  languageName: node
+  linkType: hard
+
+"cmake-js@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "cmake-js@npm:8.0.0"
+  dependencies:
+    debug: "npm:^4.4.3"
+    fs-extra: "npm:^11.3.3"
+    node-api-headers: "npm:^1.8.0"
+    rc: "npm:1.2.8"
+    semver: "npm:^7.7.3"
+    tar: "npm:^7.5.6"
+    url-join: "npm:^4.0.1"
+    which: "npm:^6.0.0"
+    yargs: "npm:^17.7.2"
+  bin:
+    cmake-js: bin/cmake-js
+  checksum: 10c0/ec56a2436a66619a4e0731e2738da36716f28b89ae20a72bd37708a7e54d36746b2cf6d33954e4b776dbf541fb71d18ba20439df3006fc52a071bf2ced62dd3c
   languageName: node
   linkType: hard
 
@@ -19575,7 +19852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.2.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.2.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -19651,6 +19928,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-extend@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "deep-extend@npm:0.6.0"
+  checksum: 10c0/1c6b0abcdb901e13a44c7d699116d3d4279fdb261983122a3783e7273844d5f2537dc2e1c454a23fcf645917f93fbf8d07101c1d03c015a87faa662755212566
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -19662,6 +19946,15 @@ __metadata:
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
+  languageName: node
+  linkType: hard
+
+"default-require-extensions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "default-require-extensions@npm:3.0.1"
+  dependencies:
+    strip-bom: "npm:^4.0.0"
+  checksum: 10c0/5ca376cb527d9474336ad76dd302d06367a7163379dda26558258de26f85861e696d0b7bb19ee3c6b8456bb7c95cdc0e4e4d45c2aa487e61b2d3b60d80c10648
   languageName: node
   linkType: hard
 
@@ -20982,6 +21275,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-check@npm:^4.8.0":
+  version: 4.8.0
+  resolution: "fast-check@npm:4.8.0"
+  dependencies:
+    pure-rand: "npm:^8.0.0"
+  checksum: 10c0/f72556a29db4ff386a8b6e50d420b06c7e5eaafff7db5560a99136c57d8d4777998155eb02d1bbeff396f575cc0b1442c8a1c4ddb798c4a919b542de1a1904ff
+  languageName: node
+  linkType: hard
+
 "fast-content-type-parse@npm:^1.1.0":
   version: 1.1.0
   resolution: "fast-content-type-parse@npm:1.1.0"
@@ -21230,6 +21532,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-uri-to-path@npm:1.0.0":
+  version: 1.0.0
+  resolution: "file-uri-to-path@npm:1.0.0"
+  checksum: 10c0/3b545e3a341d322d368e880e1c204ef55f1d45cdea65f7efc6c6ce9e0c4d22d802d5629320eb779d006fe59624ac17b0e848d83cc5af7cd101f206cb704f5519
+  languageName: node
+  linkType: hard
+
 "fill-range@npm:^7.1.1":
   version: 7.1.1
   resolution: "fill-range@npm:7.1.1"
@@ -21410,6 +21719,17 @@ __metadata:
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
   checksum: 10c0/f5d629e1bb646d5dedb4d8b24c5aad3deb8cc1d5438979d6f237146cd10e113b49a949ae1b54212c2fbc98e2d0995f38009a9a1d0520f0287943335e65fe919b
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^11.3.3":
+  version: 11.3.5
+  resolution: "fs-extra@npm:11.3.5"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/33e80bad6b5d17308faa197e5ede99ecba4b6f6cb4aa4645d52745476c75afc57665bdf39ec75b2ebb38b97b7110f634a8dcc0a546e248eb4de059275cf5ac90
   languageName: node
   linkType: hard
 
@@ -22356,7 +22676,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ini@npm:^1.3.2, ini@npm:^1.3.4":
+"ini@npm:^1.3.2, ini@npm:^1.3.4, ini@npm:~1.3.0":
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: 10c0/ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
@@ -22722,10 +23042,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0, istanbul-lib-coverage@npm:^3.2.2":
   version: 3.2.2
   resolution: "istanbul-lib-coverage@npm:3.2.2"
   checksum: 10c0/6c7ff2106769e5f592ded1fb418f9f73b4411fd5a084387a5410538332b6567cd1763ff6b6cadca9b9eb2c443cce2f7ea7d7f1b8d315f9ce58539793b1e0922b
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-hook@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "istanbul-lib-hook@npm:3.0.0"
+  dependencies:
+    append-transform: "npm:^2.0.0"
+  checksum: 10c0/0029bdbc4ae82c2a5a0b48a2f4ba074de72601a5d27505493c9be83d4c7952039ad787d2f6d1321710b75a05059c4335a0eb7c8857ca82e7e6d19f8d88d03b46
   languageName: node
   linkType: hard
 
@@ -22742,7 +23071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-instrument@npm:^6.0.0, istanbul-lib-instrument@npm:^6.0.2":
+"istanbul-lib-instrument@npm:^6.0.0, istanbul-lib-instrument@npm:^6.0.2, istanbul-lib-instrument@npm:^6.0.3":
   version: 6.0.3
   resolution: "istanbul-lib-instrument@npm:6.0.3"
   dependencies:
@@ -22755,7 +23084,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-report@npm:^3.0.0":
+"istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
   version: 3.0.1
   resolution: "istanbul-lib-report@npm:3.0.1"
   dependencies:
@@ -22788,7 +23117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-reports@npm:^3.1.3":
+"istanbul-reports@npm:^3.1.3, istanbul-reports@npm:^3.1.7":
   version: 3.2.0
   resolution: "istanbul-reports@npm:3.2.0"
   dependencies:
@@ -25216,6 +25545,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:^8.7.0":
+  version: 8.8.0
+  resolution: "node-addon-api@npm:8.8.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/4fc508efce85b448eac0e6ca5e3df7f287db42ca6b7c83490c1b9e805f56f558f0d4411112b3b1cb27a573a5a1007eefd0ca91e7aa2afa5b9b513a146b1ae8f9
+  languageName: node
+  linkType: hard
+
+"node-api-headers@npm:^1.8.0":
+  version: 1.9.0
+  resolution: "node-api-headers@npm:1.9.0"
+  checksum: 10c0/7702eb5218c25ff7cc96b4e342815b3bfe940cbd81f233015799e37dad4f34d34db68aa10945a5243b0c8d074f70fb88d90a553a088a52434c2343e532d50dc2
+  languageName: node
+  linkType: hard
+
 "node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
@@ -26467,6 +26812,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proper-lockfile@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "proper-lockfile@npm:4.1.2"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    retry: "npm:^0.12.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10c0/2f265dbad15897a43110a02dae55105c04d356ec4ed560723dcb9f0d34bc4fb2f13f79bb930e7561be10278e2314db5aca2527d5d3dcbbdee5e6b331d1571f6d
+  languageName: node
+  linkType: hard
+
 "property-expr@npm:^2.0.4":
   version: 2.0.6
   resolution: "property-expr@npm:2.0.6"
@@ -26556,6 +26912,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pure-rand@npm:^8.0.0":
+  version: 8.4.0
+  resolution: "pure-rand@npm:8.4.0"
+  checksum: 10c0/6414bbc1c6f45fb774173431c7205e79783b77cfae0e2145e741b6999363554dbd2f4210d2a5bc08683e0b2f6823198c9308766b1d0911e1dccd7beb8842f860
+  languageName: node
+  linkType: hard
+
 "q@npm:^1.5.1":
   version: 1.5.1
   resolution: "q@npm:1.5.1"
@@ -26637,6 +27000,20 @@ __metadata:
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
   checksum: 10c0/b201c4b66049369a60e766318caff5cb3cc5a900efd89bdac431463822d976ad0670912c931fdbdcf5543207daf6f6833bca57aa116e1661d2ea91e12ca692c4
+  languageName: node
+  linkType: hard
+
+"rc@npm:1.2.8":
+  version: 1.2.8
+  resolution: "rc@npm:1.2.8"
+  dependencies:
+    deep-extend: "npm:^0.6.0"
+    ini: "npm:~1.3.0"
+    minimist: "npm:^1.2.0"
+    strip-json-comments: "npm:~2.0.1"
+  bin:
+    rc: ./cli.js
+  checksum: 10c0/24a07653150f0d9ac7168e52943cc3cb4b7a22c0e43c7dff3219977c2fdca5a2760a304a029c20811a0e79d351f57d46c9bde216193a0f73978496afc2b85b15
   languageName: node
   linkType: hard
 
@@ -27386,6 +27763,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.7.3":
+  version: 7.8.4
+  resolution: "semver@npm:7.8.4"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/81b7c296fd7927b80f67fa516b75fa1017caac8167795320de28e76ccbc6f7f01763c30ecd10d6a0d8fd089708ab0548a5aebb94b0870e99c2a2b4600a46389b
+  languageName: node
+  linkType: hard
+
 "send@npm:0.18.0":
   version: 0.18.0
   resolution: "send@npm:0.18.0"
@@ -27700,7 +28086,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:~0.5.20":
+"source-map-support@npm:^0.5.21, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -28031,6 +28417,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-json-comments@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "strip-json-comments@npm:2.0.1"
+  checksum: 10c0/b509231cbdee45064ff4f9fd73609e2bcc4e84a4d508e9dd0f31f70356473fde18abfb5838c17d56fb236f5a06b102ef115438de0600b749e818a35fbbc48c43
+  languageName: node
+  linkType: hard
+
 "strnum@npm:^2.2.3":
   version: 2.2.3
   resolution: "strnum@npm:2.2.3"
@@ -28129,6 +28522,19 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10c0/a7d8b801139b52f93a7e34830db0de54c5aa45487c7cb551f6f3d44a112c67f1cb8ffdae856b05fd4f17b1749911f1c26f1e3a23bbe0279e17fd96077f13f467
+  languageName: node
+  linkType: hard
+
+"tar@npm:^7.5.6":
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
+  dependencies:
+    "@isaacs/fs-minipass": "npm:^4.0.0"
+    chownr: "npm:^3.0.0"
+    minipass: "npm:^7.1.2"
+    minizlib: "npm:^3.1.0"
+    yallist: "npm:^5.0.0"
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 
@@ -28299,6 +28705,13 @@ __metadata:
   version: 3.1.0
   resolution: "tinyrainbow@npm:3.1.0"
   checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.2.5":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10c0/59eb55584f2f07210d3231b6a1f6b5c2b9794d8a7b509c8ee867ed2acad6d2245ee2448b7937b676ffbff3155a70077edde8a69f9d7cf0f90c86a62e8910c357
   languageName: node
   linkType: hard
 
@@ -28920,6 +29333,13 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"url-join@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "url-join@npm:4.0.1"
+  checksum: 10c0/ac65e2c7c562d7b49b68edddcf55385d3e922bc1dd5d90419ea40b53b6de1607d1e45ceb71efb9d60da02c681d13c6cb3a1aa8b13fc0c989dfc219df97ee992d
   languageName: node
   linkType: hard
 
@@ -29905,6 +30325,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs@npm:<18.0.0, yargs@npm:^17.0.0, yargs@npm:^17.3.1, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
+  dependencies:
+    cliui: "npm:^8.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.3"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10c0/ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
+  languageName: node
+  linkType: hard
+
 "yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
@@ -29917,21 +30352,6 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^20.2.2"
   checksum: 10c0/b1dbfefa679848442454b60053a6c95d62f2d2e21dd28def92b647587f415969173c6e99a0f3bab4f1b67ee8283bf735ebe3544013f09491186ba9e8a9a2b651
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^17.0.0, yargs@npm:^17.3.1, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
-  version: 17.7.2
-  resolution: "yargs@npm:17.7.2"
-  dependencies:
-    cliui: "npm:^8.0.1"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.3"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^21.1.1"
-  checksum: 10c0/ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7366

### Description
Switch from fast-xml-parser to internal implementation.

Benchmarks: https://github.com/trivikr/benchmark-xml-parser/pull/6

The main diff is that the XML parsing error will be communicated with a differently worded message.

### Testing
snapshot tests, CI, new fuzz tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
