### PR TITLE
fix(xml-builder): configure maxTotalExpansions on fast-xml-parser

### DIFF
--- a/packages-internal/core/package.json
+++ b/packages-internal/core/package.json
@@ -82,7 +82,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "workspace:^3.973.6",
-    "@aws-sdk/xml-builder": "workspace:^3.972.12",
+    "@aws-sdk/xml-builder": "workspace:^3.972.13",
     "@smithy/core": "^3.23.12",
     "@smithy/node-config-provider": "^4.3.12",
     "@smithy/property-provider": "^4.2.12",

--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-sdk/xml-builder",
-  "version": "3.972.12",
+  "version": "3.972.13",
   "description": "XML utilities for the AWS SDK",
   "dependencies": {
     "@smithy/types": "^4.13.1",

--- a/packages-internal/xml-builder/src/xml-parser.spec.ts
+++ b/packages-internal/xml-builder/src/xml-parser.spec.ts
@@ -169,6 +169,44 @@ describe("xml parsing", () => {
     });
   }
 
+  it("can parse a large amount of XML including entities", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+   <IsTruncated>boolean</IsTruncated>
+   <Marker>string</Marker>
+   <NextMarker>string</NextMarker>
+   <Contents>
+      ${`<Object>
+<ChecksumAlgorithm>string</ChecksumAlgorithm>
+      <ChecksumType>string</ChecksumType>
+      <ETag>&quot;098f6bcd4621d373cade4e832627b4f6&quot;</ETag>
+      <Key>string</Key>
+      <LastModified>timestamp</LastModified>
+      <Owner>
+         <DisplayName>string</DisplayName>
+         <ID>string</ID>
+      </Owner>
+      <RestoreStatus>
+         <IsRestoreInProgress>boolean</IsRestoreInProgress>
+         <RestoreExpiryDate>timestamp</RestoreExpiryDate>
+      </RestoreStatus>
+      <Size>long</Size>
+      <StorageClass>string</StorageClass>
+</Object>`.repeat(2000)}
+   </Contents>
+   <Name>string</Name>
+   <Prefix>string</Prefix>
+   <Delimiter>string</Delimiter>
+   <MaxKeys>integer</MaxKeys>
+   <CommonPrefixes>
+      <Prefix>string</Prefix>
+   </CommonPrefixes>
+   <EncodingType>string</EncodingType>
+</ListBucketResult>`;
+
+    expect(parseXMLBrowser(xml)).toEqual(parseXML(xml));
+  });
+
   it("throws on parsing error", () => {
     const xmlSamples = [`<unclosed`, `<unmatched></matched>`];
 

--- a/packages-internal/xml-builder/src/xml-parser.ts
+++ b/packages-internal/xml-builder/src/xml-parser.ts
@@ -1,14 +1,24 @@
 import { XMLParser } from "fast-xml-parser";
 
+/**
+ * Because this is only used against trusted server responses,
+ * we should not be setting any client side limits.
+ *
+ * @internal
+ */
 const parser = new XMLParser({
   attributeNamePrefix: "",
+  processEntities: {
+    enabled: true,
+    maxTotalExpansions: Infinity,
+  },
   htmlEntities: true,
   ignoreAttributes: false,
   ignoreDeclaration: true,
   parseTagValue: false,
   trimValues: false,
   tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
-  maxNestedTags: 1024,
+  maxNestedTags: Infinity,
 });
 parser.addEntity("#xD", "\r");
 parser.addEntity("#10", "\n");

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -33,7 +33,7 @@
     "@aws-sdk/util-endpoints": "workspace:^3.996.5",
     "@aws-sdk/util-user-agent-browser": "workspace:^3.972.8",
     "@aws-sdk/util-user-agent-node": "workspace:^3.973.8",
-    "@aws-sdk/xml-builder": "workspace:^3.972.12",
+    "@aws-sdk/xml-builder": "workspace:^3.972.13",
     "@smithy/config-resolver": "^4.4.11",
     "@smithy/core": "^3.23.12",
     "@smithy/fetch-http-handler": "^5.3.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,7 +1201,7 @@ __metadata:
     "@aws-sdk/util-endpoints": "workspace:^3.996.5"
     "@aws-sdk/util-user-agent-browser": "workspace:^3.972.8"
     "@aws-sdk/util-user-agent-node": "workspace:^3.973.8"
-    "@aws-sdk/xml-builder": "workspace:^3.972.12"
+    "@aws-sdk/xml-builder": "workspace:^3.972.13"
     "@smithy/config-resolver": "npm:^4.4.11"
     "@smithy/core": "npm:^3.23.12"
     "@smithy/fetch-http-handler": "npm:^5.3.15"
@@ -23535,7 +23535,7 @@ __metadata:
   resolution: "@aws-sdk/core@workspace:packages-internal/core"
   dependencies:
     "@aws-sdk/types": "workspace:^3.973.6"
-    "@aws-sdk/xml-builder": "workspace:^3.972.12"
+    "@aws-sdk/xml-builder": "workspace:^3.972.13"
     "@smithy/core": "npm:^3.23.12"
     "@smithy/node-config-provider": "npm:^4.3.12"
     "@smithy/property-provider": "npm:^4.2.12"
@@ -25086,7 +25086,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/xml-builder@workspace:^3.972.12, @aws-sdk/xml-builder@workspace:packages-internal/xml-builder":
+"@aws-sdk/xml-builder@workspace:^3.972.13, @aws-sdk/xml-builder@workspace:packages-internal/xml-builder":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/xml-builder@workspace:packages-internal/xml-builder"
   dependencies:


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7867

### Description
Avoid `Error: Entity expansion limit exceeded`

### Testing
How was this change tested?

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
