### PR TITLE
test(snapshot-testing): fix structure of XML errors from mock service

### DIFF
--- a/clients/client-route-53/test/snapshots/res-err/CidrBlockInUseException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/CidrBlockInUseException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            CidrBlockInUseException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+CidrBlockInUseException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "CidrBlockInUseException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "CidrBlockInUseException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "CidrBlockInUseException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            CidrBlockInUseException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+CidrBlockInUseException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "CidrBlockInUseException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "CidrBlockInUseException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "CidrBlockInUseException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/CidrCollectionAlreadyExistsException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/CidrCollectionAlreadyExistsException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            CidrCollectionAlreadyExistsException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+CidrCollectionAlreadyExistsException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "CidrCollectionAlreadyExistsException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "CidrCollectionAlreadyExistsException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "CidrCollectionAlreadyExistsException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            CidrCollectionAlreadyExistsException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+CidrCollectionAlreadyExistsException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "CidrCollectionAlreadyExistsException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "CidrCollectionAlreadyExistsException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "CidrCollectionAlreadyExistsException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/CidrCollectionInUseException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/CidrCollectionInUseException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            CidrCollectionInUseException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+CidrCollectionInUseException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "CidrCollectionInUseException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "CidrCollectionInUseException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "CidrCollectionInUseException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            CidrCollectionInUseException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+CidrCollectionInUseException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "CidrCollectionInUseException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "CidrCollectionInUseException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "CidrCollectionInUseException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/CidrCollectionVersionMismatchException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/CidrCollectionVersionMismatchException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            CidrCollectionVersionMismatchException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+CidrCollectionVersionMismatchException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "CidrCollectionVersionMismatchException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "CidrCollectionVersionMismatchException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "CidrCollectionVersionMismatchException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            CidrCollectionVersionMismatchException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+CidrCollectionVersionMismatchException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "CidrCollectionVersionMismatchException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "CidrCollectionVersionMismatchException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "CidrCollectionVersionMismatchException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/ConcurrentModification.txt
+++ b/clients/client-route-53/test/snapshots/res-err/ConcurrentModification.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            ConcurrentModification
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+ConcurrentModification: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "ConcurrentModification",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "ConcurrentModification"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "ConcurrentModification"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            ConcurrentModification
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+ConcurrentModification: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "ConcurrentModification",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "ConcurrentModification",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "ConcurrentModification"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/ConflictingDomainExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/ConflictingDomainExists.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            ConflictingDomainExists
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+ConflictingDomainExists: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "ConflictingDomainExists",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "ConflictingDomainExists"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "ConflictingDomainExists"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            ConflictingDomainExists
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+ConflictingDomainExists: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "ConflictingDomainExists",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "ConflictingDomainExists",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "ConflictingDomainExists"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/ConflictingTypes.txt
+++ b/clients/client-route-53/test/snapshots/res-err/ConflictingTypes.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            ConflictingTypes
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+ConflictingTypes: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "ConflictingTypes",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "ConflictingTypes"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "ConflictingTypes"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            ConflictingTypes
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+ConflictingTypes: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "ConflictingTypes",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "ConflictingTypes",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "ConflictingTypes"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/DNSSECNotFound.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DNSSECNotFound.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DNSSECNotFound
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DNSSECNotFound: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DNSSECNotFound",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "DNSSECNotFound"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DNSSECNotFound"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DNSSECNotFound
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DNSSECNotFound: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DNSSECNotFound",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "DNSSECNotFound",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DNSSECNotFound"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/DelegationSetAlreadyCreated.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DelegationSetAlreadyCreated.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DelegationSetAlreadyCreated
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DelegationSetAlreadyCreated: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DelegationSetAlreadyCreated",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "DelegationSetAlreadyCreated"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DelegationSetAlreadyCreated"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DelegationSetAlreadyCreated
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DelegationSetAlreadyCreated: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DelegationSetAlreadyCreated",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "DelegationSetAlreadyCreated",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DelegationSetAlreadyCreated"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/DelegationSetAlreadyReusable.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DelegationSetAlreadyReusable.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DelegationSetAlreadyReusable
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DelegationSetAlreadyReusable: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DelegationSetAlreadyReusable",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "DelegationSetAlreadyReusable"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DelegationSetAlreadyReusable"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DelegationSetAlreadyReusable
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DelegationSetAlreadyReusable: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DelegationSetAlreadyReusable",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "DelegationSetAlreadyReusable",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DelegationSetAlreadyReusable"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/DelegationSetInUse.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DelegationSetInUse.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DelegationSetInUse
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DelegationSetInUse: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DelegationSetInUse",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "DelegationSetInUse"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DelegationSetInUse"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DelegationSetInUse
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DelegationSetInUse: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DelegationSetInUse",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "DelegationSetInUse",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DelegationSetInUse"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/DelegationSetNotAvailable.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DelegationSetNotAvailable.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DelegationSetNotAvailable
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DelegationSetNotAvailable: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DelegationSetNotAvailable",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "DelegationSetNotAvailable"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DelegationSetNotAvailable"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DelegationSetNotAvailable
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DelegationSetNotAvailable: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DelegationSetNotAvailable",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "DelegationSetNotAvailable",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DelegationSetNotAvailable"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/DelegationSetNotReusable.txt
+++ b/clients/client-route-53/test/snapshots/res-err/DelegationSetNotReusable.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DelegationSetNotReusable
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DelegationSetNotReusable: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DelegationSetNotReusable",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "DelegationSetNotReusable"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DelegationSetNotReusable"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            DelegationSetNotReusable
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+DelegationSetNotReusable: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "DelegationSetNotReusable",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "DelegationSetNotReusable",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "DelegationSetNotReusable"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/HealthCheckAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HealthCheckAlreadyExists.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HealthCheckAlreadyExists
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HealthCheckAlreadyExists: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HealthCheckAlreadyExists",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "HealthCheckAlreadyExists"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HealthCheckAlreadyExists"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HealthCheckAlreadyExists
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HealthCheckAlreadyExists: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HealthCheckAlreadyExists",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "HealthCheckAlreadyExists",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HealthCheckAlreadyExists"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/HealthCheckInUse.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HealthCheckInUse.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HealthCheckInUse
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HealthCheckInUse: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HealthCheckInUse",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "HealthCheckInUse"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HealthCheckInUse"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HealthCheckInUse
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HealthCheckInUse: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HealthCheckInUse",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "HealthCheckInUse",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HealthCheckInUse"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/HealthCheckVersionMismatch.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HealthCheckVersionMismatch.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HealthCheckVersionMismatch
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HealthCheckVersionMismatch: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HealthCheckVersionMismatch",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "HealthCheckVersionMismatch"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HealthCheckVersionMismatch"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HealthCheckVersionMismatch
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HealthCheckVersionMismatch: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HealthCheckVersionMismatch",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "HealthCheckVersionMismatch",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HealthCheckVersionMismatch"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/HostedZoneAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HostedZoneAlreadyExists.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HostedZoneAlreadyExists
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HostedZoneAlreadyExists: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HostedZoneAlreadyExists",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "HostedZoneAlreadyExists"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HostedZoneAlreadyExists"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HostedZoneAlreadyExists
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HostedZoneAlreadyExists: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HostedZoneAlreadyExists",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "HostedZoneAlreadyExists",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HostedZoneAlreadyExists"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/HostedZoneNotEmpty.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HostedZoneNotEmpty.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HostedZoneNotEmpty
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HostedZoneNotEmpty: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HostedZoneNotEmpty",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "HostedZoneNotEmpty"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HostedZoneNotEmpty"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HostedZoneNotEmpty
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HostedZoneNotEmpty: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HostedZoneNotEmpty",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "HostedZoneNotEmpty",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HostedZoneNotEmpty"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/HostedZoneNotFound.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HostedZoneNotFound.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HostedZoneNotFound
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HostedZoneNotFound: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HostedZoneNotFound",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "HostedZoneNotFound"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HostedZoneNotFound"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HostedZoneNotFound
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HostedZoneNotFound: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HostedZoneNotFound",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "HostedZoneNotFound",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HostedZoneNotFound"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/HostedZoneNotPrivate.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HostedZoneNotPrivate.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HostedZoneNotPrivate
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HostedZoneNotPrivate: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HostedZoneNotPrivate",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "HostedZoneNotPrivate"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HostedZoneNotPrivate"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HostedZoneNotPrivate
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HostedZoneNotPrivate: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HostedZoneNotPrivate",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "HostedZoneNotPrivate",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HostedZoneNotPrivate"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/HostedZonePartiallyDelegated.txt
+++ b/clients/client-route-53/test/snapshots/res-err/HostedZonePartiallyDelegated.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HostedZonePartiallyDelegated
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HostedZonePartiallyDelegated: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HostedZonePartiallyDelegated",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "HostedZonePartiallyDelegated"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HostedZonePartiallyDelegated"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            HostedZonePartiallyDelegated
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+HostedZonePartiallyDelegated: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "HostedZonePartiallyDelegated",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "HostedZonePartiallyDelegated",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "HostedZonePartiallyDelegated"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/IncompatibleVersion.txt
+++ b/clients/client-route-53/test/snapshots/res-err/IncompatibleVersion.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            IncompatibleVersion
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+IncompatibleVersion: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "IncompatibleVersion",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "IncompatibleVersion"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "IncompatibleVersion"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            IncompatibleVersion
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+IncompatibleVersion: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "IncompatibleVersion",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "IncompatibleVersion",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "IncompatibleVersion"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InsufficientCloudWatchLogsResourcePolicy.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InsufficientCloudWatchLogsResourcePolicy.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InsufficientCloudWatchLogsResourcePolicy
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InsufficientCloudWatchLogsResourcePolicy: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InsufficientCloudWatchLogsResourcePolicy",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InsufficientCloudWatchLogsResourcePolicy"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InsufficientCloudWatchLogsResourcePolicy"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InsufficientCloudWatchLogsResourcePolicy
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InsufficientCloudWatchLogsResourcePolicy: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InsufficientCloudWatchLogsResourcePolicy",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InsufficientCloudWatchLogsResourcePolicy",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InsufficientCloudWatchLogsResourcePolicy"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidArgument.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidArgument.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidArgument
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidArgument: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidArgument",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidArgument"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidArgument"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidArgument
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidArgument: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidArgument",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidArgument",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidArgument"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidChangeBatch.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidChangeBatch.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidChangeBatch
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidChangeBatch: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidChangeBatch",
+  messages: [],
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidChangeBatch"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidChangeBatch"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +53,37 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidChangeBatch
+        </Code>
+        <messages>
+            <Message>
+                __member__
+            </Message>
+            <Message>
+                __member__
+            </Message>
+            <Message>
+                __member__
+            </Message>
+        </messages>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidChangeBatch: __message__
 
 --- [error object] ---
 {
@@ -45,15 +91,35 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidChangeBatch",
+  messages: [
+    "__member__",
+    "__member__",
+    "__member__"
+  ],
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidChangeBatch",
+    messages: {
+      Message: [
+        "__member__",
+        "__member__",
+        "__member__"
+      ]
+    },
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidChangeBatch"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidDomainName.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidDomainName.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidDomainName
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidDomainName: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidDomainName",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidDomainName"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidDomainName"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidDomainName
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidDomainName: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidDomainName",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidDomainName",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidDomainName"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidInput.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidInput.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidInput
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidInput: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidInput",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidInput"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidInput"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidInput
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidInput: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidInput",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidInput",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidInput"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidKMSArn.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidKMSArn.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidKMSArn
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidKMSArn: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidKMSArn",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidKMSArn"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidKMSArn"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidKMSArn
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidKMSArn: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidKMSArn",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidKMSArn",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidKMSArn"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidKeySigningKeyName.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidKeySigningKeyName.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidKeySigningKeyName
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidKeySigningKeyName: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidKeySigningKeyName",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidKeySigningKeyName"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidKeySigningKeyName"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidKeySigningKeyName
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidKeySigningKeyName: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidKeySigningKeyName",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidKeySigningKeyName",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidKeySigningKeyName"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidKeySigningKeyStatus.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidKeySigningKeyStatus.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidKeySigningKeyStatus
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidKeySigningKeyStatus: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidKeySigningKeyStatus",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidKeySigningKeyStatus"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidKeySigningKeyStatus"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidKeySigningKeyStatus
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidKeySigningKeyStatus: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidKeySigningKeyStatus",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidKeySigningKeyStatus",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidKeySigningKeyStatus"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidPaginationToken.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidPaginationToken.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidPaginationToken
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidPaginationToken: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidPaginationToken",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidPaginationToken"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidPaginationToken"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidPaginationToken
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidPaginationToken: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidPaginationToken",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidPaginationToken",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidPaginationToken"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidSigningStatus.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidSigningStatus.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidSigningStatus
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidSigningStatus: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidSigningStatus",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidSigningStatus"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidSigningStatus"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidSigningStatus
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidSigningStatus: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidSigningStatus",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidSigningStatus",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidSigningStatus"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidTrafficPolicyDocument.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidTrafficPolicyDocument.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidTrafficPolicyDocument
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidTrafficPolicyDocument: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidTrafficPolicyDocument",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidTrafficPolicyDocument"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidTrafficPolicyDocument"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidTrafficPolicyDocument
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidTrafficPolicyDocument: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidTrafficPolicyDocument",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidTrafficPolicyDocument",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidTrafficPolicyDocument"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/InvalidVPCId.txt
+++ b/clients/client-route-53/test/snapshots/res-err/InvalidVPCId.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidVPCId
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidVPCId: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidVPCId",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidVPCId"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidVPCId"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidVPCId
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidVPCId: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidVPCId",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidVPCId",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidVPCId"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/KeySigningKeyAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/KeySigningKeyAlreadyExists.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            KeySigningKeyAlreadyExists
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+KeySigningKeyAlreadyExists: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "KeySigningKeyAlreadyExists",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "KeySigningKeyAlreadyExists"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "KeySigningKeyAlreadyExists"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            KeySigningKeyAlreadyExists
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+KeySigningKeyAlreadyExists: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "KeySigningKeyAlreadyExists",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "KeySigningKeyAlreadyExists",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "KeySigningKeyAlreadyExists"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/KeySigningKeyInParentDSRecord.txt
+++ b/clients/client-route-53/test/snapshots/res-err/KeySigningKeyInParentDSRecord.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            KeySigningKeyInParentDSRecord
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+KeySigningKeyInParentDSRecord: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "KeySigningKeyInParentDSRecord",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "KeySigningKeyInParentDSRecord"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "KeySigningKeyInParentDSRecord"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            KeySigningKeyInParentDSRecord
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+KeySigningKeyInParentDSRecord: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "KeySigningKeyInParentDSRecord",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "KeySigningKeyInParentDSRecord",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "KeySigningKeyInParentDSRecord"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/KeySigningKeyInUse.txt
+++ b/clients/client-route-53/test/snapshots/res-err/KeySigningKeyInUse.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            KeySigningKeyInUse
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+KeySigningKeyInUse: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "KeySigningKeyInUse",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "KeySigningKeyInUse"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "KeySigningKeyInUse"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            KeySigningKeyInUse
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+KeySigningKeyInUse: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "KeySigningKeyInUse",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "KeySigningKeyInUse",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "KeySigningKeyInUse"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/KeySigningKeyWithActiveStatusNotFound.txt
+++ b/clients/client-route-53/test/snapshots/res-err/KeySigningKeyWithActiveStatusNotFound.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            KeySigningKeyWithActiveStatusNotFound
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+KeySigningKeyWithActiveStatusNotFound: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "KeySigningKeyWithActiveStatusNotFound",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "KeySigningKeyWithActiveStatusNotFound"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "KeySigningKeyWithActiveStatusNotFound"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            KeySigningKeyWithActiveStatusNotFound
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+KeySigningKeyWithActiveStatusNotFound: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "KeySigningKeyWithActiveStatusNotFound",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "KeySigningKeyWithActiveStatusNotFound",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "KeySigningKeyWithActiveStatusNotFound"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/LastVPCAssociation.txt
+++ b/clients/client-route-53/test/snapshots/res-err/LastVPCAssociation.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            LastVPCAssociation
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+LastVPCAssociation: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "LastVPCAssociation",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "LastVPCAssociation"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "LastVPCAssociation"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            LastVPCAssociation
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+LastVPCAssociation: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "LastVPCAssociation",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "LastVPCAssociation",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "LastVPCAssociation"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/LimitsExceeded.txt
+++ b/clients/client-route-53/test/snapshots/res-err/LimitsExceeded.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            LimitsExceeded
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+LimitsExceeded: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "LimitsExceeded",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "LimitsExceeded"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "LimitsExceeded"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            LimitsExceeded
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+LimitsExceeded: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "LimitsExceeded",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "LimitsExceeded",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "LimitsExceeded"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchChange.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchChange.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchChange
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchChange: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchChange",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchChange"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchChange"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchChange
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchChange: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchChange",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchChange",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchChange"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchCidrCollectionException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchCidrCollectionException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchCidrCollectionException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchCidrCollectionException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchCidrCollectionException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchCidrCollectionException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchCidrCollectionException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchCidrCollectionException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchCidrCollectionException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchCidrCollectionException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchCidrCollectionException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchCidrCollectionException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchCidrLocationException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchCidrLocationException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchCidrLocationException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchCidrLocationException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchCidrLocationException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchCidrLocationException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchCidrLocationException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchCidrLocationException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchCidrLocationException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchCidrLocationException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchCidrLocationException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchCidrLocationException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchCloudWatchLogsLogGroup.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchCloudWatchLogsLogGroup.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchCloudWatchLogsLogGroup
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchCloudWatchLogsLogGroup: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchCloudWatchLogsLogGroup",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchCloudWatchLogsLogGroup"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchCloudWatchLogsLogGroup"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchCloudWatchLogsLogGroup
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchCloudWatchLogsLogGroup: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchCloudWatchLogsLogGroup",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchCloudWatchLogsLogGroup",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchCloudWatchLogsLogGroup"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchDelegationSet.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchDelegationSet.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchDelegationSet
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+NoSuchDelegationSet: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "NoSuchDelegationSet",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchDelegationSet"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchDelegationSet"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchDelegationSet
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+NoSuchDelegationSet: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "NoSuchDelegationSet",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchDelegationSet",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchDelegationSet"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchGeoLocation.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchGeoLocation.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchGeoLocation
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchGeoLocation: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchGeoLocation",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchGeoLocation"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchGeoLocation"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchGeoLocation
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchGeoLocation: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchGeoLocation",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchGeoLocation",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchGeoLocation"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchHealthCheck.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchHealthCheck.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchHealthCheck
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchHealthCheck: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchHealthCheck",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchHealthCheck"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchHealthCheck"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchHealthCheck
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchHealthCheck: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchHealthCheck",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchHealthCheck",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchHealthCheck"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchHostedZone.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchHostedZone.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchHostedZone
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchHostedZone: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchHostedZone",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchHostedZone"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchHostedZone"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchHostedZone
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchHostedZone: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchHostedZone",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchHostedZone",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchHostedZone"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchKeySigningKey.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchKeySigningKey.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchKeySigningKey
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchKeySigningKey: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchKeySigningKey",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchKeySigningKey"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchKeySigningKey"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchKeySigningKey
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchKeySigningKey: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchKeySigningKey",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchKeySigningKey",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchKeySigningKey"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchQueryLoggingConfig.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchQueryLoggingConfig.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchQueryLoggingConfig
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchQueryLoggingConfig: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchQueryLoggingConfig",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchQueryLoggingConfig"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchQueryLoggingConfig"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchQueryLoggingConfig
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchQueryLoggingConfig: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchQueryLoggingConfig",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchQueryLoggingConfig",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchQueryLoggingConfig"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchTrafficPolicy.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchTrafficPolicy.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchTrafficPolicy
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchTrafficPolicy: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchTrafficPolicy",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchTrafficPolicy"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchTrafficPolicy"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchTrafficPolicy
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchTrafficPolicy: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchTrafficPolicy",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchTrafficPolicy",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchTrafficPolicy"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NoSuchTrafficPolicyInstance.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NoSuchTrafficPolicyInstance.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchTrafficPolicyInstance
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchTrafficPolicyInstance: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchTrafficPolicyInstance",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchTrafficPolicyInstance"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchTrafficPolicyInstance"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchTrafficPolicyInstance
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchTrafficPolicyInstance: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchTrafficPolicyInstance",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchTrafficPolicyInstance",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchTrafficPolicyInstance"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/NotAuthorizedException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/NotAuthorizedException.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NotAuthorizedException
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+NotAuthorizedException: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 401,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "NotAuthorizedException",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "NotAuthorizedException"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NotAuthorizedException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NotAuthorizedException
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+NotAuthorizedException: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 401,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "NotAuthorizedException",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "NotAuthorizedException",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NotAuthorizedException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/PriorRequestNotComplete.txt
+++ b/clients/client-route-53/test/snapshots/res-err/PriorRequestNotComplete.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            PriorRequestNotComplete
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+PriorRequestNotComplete: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "PriorRequestNotComplete",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "PriorRequestNotComplete"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "PriorRequestNotComplete"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            PriorRequestNotComplete
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+PriorRequestNotComplete: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "PriorRequestNotComplete",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "PriorRequestNotComplete",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "PriorRequestNotComplete"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/PublicZoneVPCAssociation.txt
+++ b/clients/client-route-53/test/snapshots/res-err/PublicZoneVPCAssociation.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            PublicZoneVPCAssociation
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+PublicZoneVPCAssociation: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "PublicZoneVPCAssociation",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "PublicZoneVPCAssociation"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "PublicZoneVPCAssociation"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            PublicZoneVPCAssociation
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+PublicZoneVPCAssociation: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "PublicZoneVPCAssociation",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "PublicZoneVPCAssociation",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "PublicZoneVPCAssociation"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/QueryLoggingConfigAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/QueryLoggingConfigAlreadyExists.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            QueryLoggingConfigAlreadyExists
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+QueryLoggingConfigAlreadyExists: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "QueryLoggingConfigAlreadyExists",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "QueryLoggingConfigAlreadyExists"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "QueryLoggingConfigAlreadyExists"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            QueryLoggingConfigAlreadyExists
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+QueryLoggingConfigAlreadyExists: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "QueryLoggingConfigAlreadyExists",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "QueryLoggingConfigAlreadyExists",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "QueryLoggingConfigAlreadyExists"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/ThrottlingException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/ThrottlingException.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            ThrottlingException
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+ThrottlingException: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "ThrottlingException",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "ThrottlingException"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "ThrottlingException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            ThrottlingException
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+ThrottlingException: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "ThrottlingException",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "ThrottlingException",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "ThrottlingException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/TooManyHealthChecks.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyHealthChecks.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyHealthChecks
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyHealthChecks: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyHealthChecks",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyHealthChecks"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyHealthChecks"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyHealthChecks
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyHealthChecks: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyHealthChecks",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyHealthChecks",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyHealthChecks"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/TooManyHostedZones.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyHostedZones.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyHostedZones
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyHostedZones: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyHostedZones",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyHostedZones"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyHostedZones"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyHostedZones
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyHostedZones: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyHostedZones",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyHostedZones",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyHostedZones"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/TooManyKeySigningKeys.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyKeySigningKeys.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyKeySigningKeys
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyKeySigningKeys: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyKeySigningKeys",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyKeySigningKeys"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyKeySigningKeys"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyKeySigningKeys
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyKeySigningKeys: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyKeySigningKeys",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyKeySigningKeys",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyKeySigningKeys"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicies.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicies.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyTrafficPolicies
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyTrafficPolicies: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyTrafficPolicies",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyTrafficPolicies"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyTrafficPolicies"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyTrafficPolicies
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyTrafficPolicies: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyTrafficPolicies",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyTrafficPolicies",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyTrafficPolicies"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicyInstances.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicyInstances.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyTrafficPolicyInstances
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyTrafficPolicyInstances: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyTrafficPolicyInstances",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyTrafficPolicyInstances"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyTrafficPolicyInstances"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyTrafficPolicyInstances
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyTrafficPolicyInstances: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyTrafficPolicyInstances",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyTrafficPolicyInstances",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyTrafficPolicyInstances"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicyVersionsForCurrentPolicy.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyTrafficPolicyVersionsForCurrentPolicy.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyTrafficPolicyVersionsForCurrentPolicy
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyTrafficPolicyVersionsForCurrentPolicy: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyTrafficPolicyVersionsForCurrentPolicy",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyTrafficPolicyVersionsForCurrentPolicy"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyTrafficPolicyVersionsForCurrentPolicy"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyTrafficPolicyVersionsForCurrentPolicy
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyTrafficPolicyVersionsForCurrentPolicy: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyTrafficPolicyVersionsForCurrentPolicy",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyTrafficPolicyVersionsForCurrentPolicy",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyTrafficPolicyVersionsForCurrentPolicy"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/TooManyVPCAssociationAuthorizations.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TooManyVPCAssociationAuthorizations.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyVPCAssociationAuthorizations
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyVPCAssociationAuthorizations: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyVPCAssociationAuthorizations",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyVPCAssociationAuthorizations"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyVPCAssociationAuthorizations"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyVPCAssociationAuthorizations
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyVPCAssociationAuthorizations: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyVPCAssociationAuthorizations",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyVPCAssociationAuthorizations",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyVPCAssociationAuthorizations"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/TrafficPolicyAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TrafficPolicyAlreadyExists.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TrafficPolicyAlreadyExists
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TrafficPolicyAlreadyExists: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TrafficPolicyAlreadyExists",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "TrafficPolicyAlreadyExists"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TrafficPolicyAlreadyExists"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TrafficPolicyAlreadyExists
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TrafficPolicyAlreadyExists: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TrafficPolicyAlreadyExists",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "TrafficPolicyAlreadyExists",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TrafficPolicyAlreadyExists"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/TrafficPolicyInUse.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TrafficPolicyInUse.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TrafficPolicyInUse
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TrafficPolicyInUse: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TrafficPolicyInUse",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "TrafficPolicyInUse"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TrafficPolicyInUse"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TrafficPolicyInUse
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TrafficPolicyInUse: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TrafficPolicyInUse",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "TrafficPolicyInUse",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TrafficPolicyInUse"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/TrafficPolicyInstanceAlreadyExists.txt
+++ b/clients/client-route-53/test/snapshots/res-err/TrafficPolicyInstanceAlreadyExists.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TrafficPolicyInstanceAlreadyExists
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TrafficPolicyInstanceAlreadyExists: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TrafficPolicyInstanceAlreadyExists",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "TrafficPolicyInstanceAlreadyExists"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TrafficPolicyInstanceAlreadyExists"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TrafficPolicyInstanceAlreadyExists
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TrafficPolicyInstanceAlreadyExists: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 409,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TrafficPolicyInstanceAlreadyExists",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "TrafficPolicyInstanceAlreadyExists",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TrafficPolicyInstanceAlreadyExists"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-route-53/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            UnmodeledServiceException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+UnmodeledServiceException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "UnmodeledServiceException",
+  Error: {
+    Type: "Sender",
+    Code: "UnmodeledServiceException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "UnmodeledServiceException",
+  message: "unmodeled message."
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            UnmodeledServiceException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+UnmodeledServiceException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "UnmodeledServiceException",
+  Error: {
+    Type: "Sender",
+    Code: "UnmodeledServiceException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "UnmodeledServiceException",
+  message: "__Message__"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/VPCAssociationAuthorizationNotFound.txt
+++ b/clients/client-route-53/test/snapshots/res-err/VPCAssociationAuthorizationNotFound.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            VPCAssociationAuthorizationNotFound
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+VPCAssociationAuthorizationNotFound: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "VPCAssociationAuthorizationNotFound",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "VPCAssociationAuthorizationNotFound"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "VPCAssociationAuthorizationNotFound"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            VPCAssociationAuthorizationNotFound
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+VPCAssociationAuthorizationNotFound: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "VPCAssociationAuthorizationNotFound",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "VPCAssociationAuthorizationNotFound",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "VPCAssociationAuthorizationNotFound"
 }
 
 ======================== frontend error ========================

--- a/clients/client-route-53/test/snapshots/res-err/VPCAssociationNotFound.txt
+++ b/clients/client-route-53/test/snapshots/res-err/VPCAssociationNotFound.txt
@@ -4,11 +4,23 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            VPCAssociationNotFound
+        </Code>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+VPCAssociationNotFound: UnknownError
 
 --- [error object] ---
 {
@@ -16,15 +28,22 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "VPCAssociationNotFound",
+  message: "UnknownError",
+  Error: {
+    Type: "Sender",
+    Code: "VPCAssociationNotFound"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "VPCAssociationNotFound"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +52,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            VPCAssociationNotFound
+        </Code>
+        <message>
+            __message__
+        </message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+VPCAssociationNotFound: __message__
 
 --- [error object] ---
 {
@@ -45,15 +79,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "VPCAssociationNotFound",
+  message: "__message__",
+  Error: {
+    Type: "Sender",
+    Code: "VPCAssociationNotFound",
+    message: "__message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "VPCAssociationNotFound"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/BadRequestException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/BadRequestException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            BadRequestException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+BadRequestException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "BadRequestException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "BadRequestException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "BadRequestException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            BadRequestException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+BadRequestException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "BadRequestException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "BadRequestException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "BadRequestException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/BucketAlreadyExists.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/BucketAlreadyExists.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            BucketAlreadyExists
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+BucketAlreadyExists: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "BucketAlreadyExists",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "BucketAlreadyExists",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "BucketAlreadyExists"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            BucketAlreadyExists
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+BucketAlreadyExists: unmodeled message.
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "BucketAlreadyExists",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "BucketAlreadyExists",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "BucketAlreadyExists"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/BucketAlreadyOwnedByYou.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/BucketAlreadyOwnedByYou.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            BucketAlreadyOwnedByYou
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+BucketAlreadyOwnedByYou: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "BucketAlreadyOwnedByYou",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "BucketAlreadyOwnedByYou",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "BucketAlreadyOwnedByYou"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            BucketAlreadyOwnedByYou
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+BucketAlreadyOwnedByYou: unmodeled message.
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "BucketAlreadyOwnedByYou",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "BucketAlreadyOwnedByYou",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "BucketAlreadyOwnedByYou"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/IdempotencyException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/IdempotencyException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            IdempotencyException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+IdempotencyException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "IdempotencyException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "IdempotencyException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "IdempotencyException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            IdempotencyException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+IdempotencyException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "IdempotencyException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "IdempotencyException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "IdempotencyException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/InternalServiceException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/InternalServiceException.txt
@@ -4,27 +4,50 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InternalServiceException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InternalServiceException: unmodeled message.
 
 --- [error object] ---
 {
-  $fault: "client",
+  $fault: "server",
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InternalServiceException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "InternalServiceException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InternalServiceException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,27 +56,50 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InternalServiceException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InternalServiceException: __Message__
 
 --- [error object] ---
 {
-  $fault: "client",
+  $fault: "server",
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InternalServiceException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "InternalServiceException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InternalServiceException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/InvalidNextTokenException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/InvalidNextTokenException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidNextTokenException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidNextTokenException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidNextTokenException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidNextTokenException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidNextTokenException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidNextTokenException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidNextTokenException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidNextTokenException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidNextTokenException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidNextTokenException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/InvalidRequestException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/InvalidRequestException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidRequestException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidRequestException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidRequestException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidRequestException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidRequestException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidRequestException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidRequestException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidRequestException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidRequestException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidRequestException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/JobStatusException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/JobStatusException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            JobStatusException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+JobStatusException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "JobStatusException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "JobStatusException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "JobStatusException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            JobStatusException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+JobStatusException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "JobStatusException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "JobStatusException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "JobStatusException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/NoSuchPublicAccessBlockConfiguration.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/NoSuchPublicAccessBlockConfiguration.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchPublicAccessBlockConfiguration
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchPublicAccessBlockConfiguration: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchPublicAccessBlockConfiguration",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchPublicAccessBlockConfiguration",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchPublicAccessBlockConfiguration"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ NotFound: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NoSuchPublicAccessBlockConfiguration
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-NotFound: UnknownError
+NoSuchPublicAccessBlockConfiguration: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ NotFound: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 404,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "NotFound",
+  name: "NoSuchPublicAccessBlockConfiguration",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "NoSuchPublicAccessBlockConfiguration",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NoSuchPublicAccessBlockConfiguration"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/NotFoundException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/NotFoundException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NotFoundException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+NotFoundException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "NotFoundException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "NotFoundException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NotFoundException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            NotFoundException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+NotFoundException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "NotFoundException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "NotFoundException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "NotFoundException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/TooManyRequestsException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/TooManyRequestsException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyRequestsException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyRequestsException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyRequestsException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyRequestsException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyRequestsException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyRequestsException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyRequestsException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyRequestsException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyRequestsException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyRequestsException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/TooManyTagsException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/TooManyTagsException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyTagsException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyTagsException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyTagsException",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyTagsException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyTagsException"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            TooManyTagsException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+TooManyTagsException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "TooManyTagsException",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "TooManyTagsException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "TooManyTagsException"
 }
 
 ======================== frontend error ========================

--- a/clients/client-s3-control/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/clients/client-s3-control/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            UnmodeledServiceException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+UnmodeledServiceException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "UnmodeledServiceException",
+  Error: {
+    Type: "Sender",
+    Code: "UnmodeledServiceException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "UnmodeledServiceException",
+  message: "unmodeled message."
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            UnmodeledServiceException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+UnmodeledServiceException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "UnmodeledServiceException",
+  Error: {
+    Type: "Sender",
+    Code: "UnmodeledServiceException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "UnmodeledServiceException",
+  message: "__Message__"
 }
 
 ======================== frontend error ========================

--- a/packages-internal/snapshot-testing/src/snapshot-response-serializers/AwsRestXmlSnapshotResponseSerializer.ts
+++ b/packages-internal/snapshot-testing/src/snapshot-response-serializers/AwsRestXmlSnapshotResponseSerializer.ts
@@ -85,18 +85,17 @@ export class AwsRestXmlSnapshotResponseSerializer extends HttpBindingSnapshotRes
       ["Error", "RequestId"],
       [$unwrapped, 0],
     ] satisfies StaticErrorSchema;
+
     return [
       NormalizedSchema.of($wrapped),
       {
-        ErrorResponse: {
-          Error: {
-            Type: "Sender",
-            Code: name,
-            Message: "unmodeled message.",
-            ...output,
-          },
-          RequestId: "00000000-0000-4000-8000-000000000000",
+        Error: {
+          Type: "Sender",
+          Code: name,
+          Message: "unmodeled message.",
+          ...output,
         },
+        RequestId: "00000000-0000-4000-8000-000000000000",
       },
     ];
   }

--- a/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/ComplexError.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            ComplexError
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+ComplexError: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,26 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 403,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "ComplexError",
+  Header: (undefined),
+  TopLevel: (undefined),
+  Nested: (undefined),
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "ComplexError",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "ComplexError"
 }
 
 ======================== w/ optional fields ========================
@@ -34,11 +60,34 @@ content-type: application/xml
 X-Header: __Header__
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            ComplexError
+        </Code>
+        <TopLevel>
+            __TopLevel__
+        </TopLevel>
+        <Nested>
+            <Foo>
+                __Foo__
+            </Foo>
+        </Nested>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+ComplexError: unmodeled message.
 
 --- [error object] ---
 {
@@ -46,15 +95,32 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 403,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "ComplexError",
+  Header: (undefined),
+  TopLevel: "__TopLevel__",
+  Nested: {
+    Foo: "__Foo__"
+  },
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "ComplexError",
+    TopLevel: "__TopLevel__",
+    Nested: {
+      Foo: "__Foo__"
+    },
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "ComplexError"
 }
 
 ======================== frontend error ========================

--- a/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidGreeting
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidGreeting: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidGreeting",
+  message: "unmodeled message.",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidGreeting",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidGreeting"
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            InvalidGreeting
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+InvalidGreeting: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "InvalidGreeting",
+  message: "__Message__",
+  Error: {
+    Type: "Sender",
+    Code: "InvalidGreeting",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "InvalidGreeting"
 }
 
 ======================== frontend error ========================

--- a/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/UnmodeledServiceException.txt
+++ b/private/aws-protocoltests-restxml-schema/test/snapshots/res-err/UnmodeledServiceException.txt
@@ -4,11 +4,26 @@
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            UnmodeledServiceException
+        </Code>
+        <Message>
+            unmodeled message.
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+UnmodeledServiceException: unmodeled message.
 
 --- [error object] ---
 {
@@ -16,15 +31,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "UnmodeledServiceException",
+  Error: {
+    Type: "Sender",
+    Code: "UnmodeledServiceException",
+    Message: "unmodeled message."
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "UnmodeledServiceException",
+  message: "unmodeled message."
 }
 
 ======================== w/ optional fields ========================
@@ -33,11 +56,26 @@ Unknown: UnknownError
 content-type: application/xml
 
 [Uint8Array (xml)]
-<ErrorResponse xmlns="https://placeholder.amazonaws.com"/>
+<ErrorResponse xmlns="https://placeholder.amazonaws.com">
+    <Error>
+        <Type>
+            Sender
+        </Type>
+        <Code>
+            UnmodeledServiceException
+        </Code>
+        <Message>
+            __Message__
+        </Message>
+    </Error>
+    <RequestId>
+        00000000-0000-4000-8000-000000000000
+    </RequestId>
+</ErrorResponse>
 
 
 --- [error name & message] ---
-Unknown: UnknownError
+UnmodeledServiceException: __Message__
 
 --- [error object] ---
 {
@@ -45,15 +83,23 @@ Unknown: UnknownError
   $retryable: (undefined),
   $metadata: {
     httpStatusCode: (number) 400,
-    requestId: (undefined),
+    requestId: "00000000-0000-4000-8000-000000000000",
     extendedRequestId: (undefined),
     cfId: (undefined),
     attempts: (number) 1,
     totalRetryDelay: (number) 0
   },
-  name: "Unknown",
+  name: "UnmodeledServiceException",
+  Error: {
+    Type: "Sender",
+    Code: "UnmodeledServiceException",
+    Message: "__Message__"
+  },
+  RequestId: "00000000-0000-4000-8000-000000000000",
   xmlns: "https://placeholder.amazonaws.com",
-  message: "UnknownError"
+  Type: "Sender",
+  Code: "UnmodeledServiceException",
+  message: "__Message__"
 }
 
 ======================== frontend error ========================


### PR DESCRIPTION
### Description
fixes the structure of the mock AWS REST XML error in the snapshot serializer, so that error snapshots are generated correctly.

### Testing
CI / visual diff

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
