### PR TITLE
fix(core/protocols): use composite error registry for error handling, revert default error message to "UnknownError"

### DIFF
--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/AccessDeniedException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/AccessDeniedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-AccessDeniedException: Unknown
+AccessDeniedException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ AccessDeniedException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "AccessDeniedException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#AccessDeniedException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ConflictException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ConflictException: Unknown
+ConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ConflictException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/DataAlreadyAcceptedException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/DataAlreadyAcceptedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-DataAlreadyAcceptedException: Unknown
+DataAlreadyAcceptedException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ DataAlreadyAcceptedException: Unknown
   },
   name: "DataAlreadyAcceptedException",
   expectedSequenceToken: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#DataAlreadyAcceptedException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/InternalServerException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/InternalServerException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InternalServerException: Unknown
+InternalServerException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalServerException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalServerException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#InternalServerException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/InternalStreamingException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/InternalStreamingException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InternalStreamingException: Unknown
+InternalStreamingException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalStreamingException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalStreamingException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#InternalStreamingException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidOperationException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidOperationException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidOperationException: Unknown
+InvalidOperationException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidOperationException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidOperationException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#InvalidOperationException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidParameterException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidParameterException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidParameterException: Unknown
+InvalidParameterException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidParameterException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidParameterException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#InvalidParameterException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidSequenceTokenException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/InvalidSequenceTokenException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidSequenceTokenException: Unknown
+InvalidSequenceTokenException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ InvalidSequenceTokenException: Unknown
   },
   name: "InvalidSequenceTokenException",
   expectedSequenceToken: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#InvalidSequenceTokenException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ LimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "LimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#LimitExceededException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/MalformedQueryException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/MalformedQueryException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-MalformedQueryException: Unknown
+MalformedQueryException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ MalformedQueryException: Unknown
   },
   name: "MalformedQueryException",
   queryCompileError: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#MalformedQueryException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/OperationAbortedException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/OperationAbortedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-OperationAbortedException: Unknown
+OperationAbortedException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ OperationAbortedException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "OperationAbortedException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#OperationAbortedException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ResourceAlreadyExistsException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ResourceAlreadyExistsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceAlreadyExistsException: Unknown
+ResourceAlreadyExistsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceAlreadyExistsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceAlreadyExistsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ResourceAlreadyExistsException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ResourceNotFoundException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ServiceQuotaExceededException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ServiceQuotaExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ServiceQuotaExceededException: Unknown
+ServiceQuotaExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ServiceQuotaExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ServiceQuotaExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ServiceQuotaExceededException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ServiceUnavailableException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ServiceUnavailableException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ServiceUnavailableException: Unknown
+ServiceUnavailableException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ServiceUnavailableException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ServiceUnavailableException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ServiceUnavailableException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/SessionStreamingException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/SessionStreamingException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-SessionStreamingException: Unknown
+SessionStreamingException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ SessionStreamingException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "SessionStreamingException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#SessionStreamingException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/SessionTimeoutException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/SessionTimeoutException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-SessionTimeoutException: Unknown
+SessionTimeoutException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ SessionTimeoutException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "SessionTimeoutException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#SessionTimeoutException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ThrottlingException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ThrottlingException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ThrottlingException: Unknown
+ThrottlingException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ThrottlingException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ThrottlingException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ThrottlingException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/TooManyTagsException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/TooManyTagsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-TooManyTagsException: Unknown
+TooManyTagsException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ TooManyTagsException: Unknown
   },
   name: "TooManyTagsException",
   resourceName: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#TooManyTagsException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/UnrecognizedClientException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/UnrecognizedClientException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-UnrecognizedClientException: Unknown
+UnrecognizedClientException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ UnrecognizedClientException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "UnrecognizedClientException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#UnrecognizedClientException"
 }
 

--- a/clients/client-cloudwatch-logs/test/snapshots/res-err/ValidationException.txt
+++ b/clients/client-cloudwatch-logs/test/snapshots/res-err/ValidationException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ValidationException: Unknown
+ValidationException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ValidationException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ValidationException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatchlogs#ValidationException"
 }
 

--- a/clients/client-cloudwatch/test/snapshots/res-err/ConflictException.txt
+++ b/clients/client-cloudwatch/test/snapshots/res-err/ConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ConflictException: Unknown
+ConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cloudwatch#ConflictException",
   Error: {
     Type: (undefined),

--- a/clients/client-cognito-identity/test/snapshots/res-err/ConcurrentModificationException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/ConcurrentModificationException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ConcurrentModificationException: Unknown
+ConcurrentModificationException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ConcurrentModificationException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ConcurrentModificationException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#ConcurrentModificationException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/DeveloperUserAlreadyRegisteredException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/DeveloperUserAlreadyRegisteredException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-DeveloperUserAlreadyRegisteredException: Unknown
+DeveloperUserAlreadyRegisteredException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ DeveloperUserAlreadyRegisteredException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "DeveloperUserAlreadyRegisteredException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#DeveloperUserAlreadyRegisteredException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/ExternalServiceException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/ExternalServiceException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ExternalServiceException: Unknown
+ExternalServiceException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ExternalServiceException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ExternalServiceException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#ExternalServiceException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/InternalErrorException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/InternalErrorException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InternalErrorException: Unknown
+InternalErrorException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalErrorException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalErrorException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#InternalErrorException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/InvalidIdentityPoolConfigurationException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/InvalidIdentityPoolConfigurationException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidIdentityPoolConfigurationException: Unknown
+InvalidIdentityPoolConfigurationException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidIdentityPoolConfigurationException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidIdentityPoolConfigurationException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#InvalidIdentityPoolConfigurationException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/InvalidParameterException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/InvalidParameterException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidParameterException: Unknown
+InvalidParameterException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidParameterException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidParameterException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#InvalidParameterException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ LimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "LimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#LimitExceededException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/NotAuthorizedException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/NotAuthorizedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-NotAuthorizedException: Unknown
+NotAuthorizedException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ NotAuthorizedException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "NotAuthorizedException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#NotAuthorizedException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/ResourceConflictException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/ResourceConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceConflictException: Unknown
+ResourceConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#ResourceConflictException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#ResourceNotFoundException"
 }
 

--- a/clients/client-cognito-identity/test/snapshots/res-err/TooManyRequestsException.txt
+++ b/clients/client-cognito-identity/test/snapshots/res-err/TooManyRequestsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-TooManyRequestsException: Unknown
+TooManyRequestsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TooManyRequestsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TooManyRequestsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.cognitoidentity#TooManyRequestsException"
 }
 

--- a/clients/client-dynamodb-streams/test/snapshots/res-err/ExpiredIteratorException.txt
+++ b/clients/client-dynamodb-streams/test/snapshots/res-err/ExpiredIteratorException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ExpiredIteratorException: Unknown
+ExpiredIteratorException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ExpiredIteratorException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ExpiredIteratorException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodbstreams#ExpiredIteratorException"
 }
 

--- a/clients/client-dynamodb-streams/test/snapshots/res-err/InternalServerError.txt
+++ b/clients/client-dynamodb-streams/test/snapshots/res-err/InternalServerError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InternalServerError: Unknown
+InternalServerError: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalServerError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalServerError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodbstreams#InternalServerError"
 }
 

--- a/clients/client-dynamodb-streams/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-dynamodb-streams/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ LimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "LimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodbstreams#LimitExceededException"
 }
 

--- a/clients/client-dynamodb-streams/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/clients/client-dynamodb-streams/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodbstreams#ResourceNotFoundException"
 }
 

--- a/clients/client-dynamodb-streams/test/snapshots/res-err/TrimmedDataAccessException.txt
+++ b/clients/client-dynamodb-streams/test/snapshots/res-err/TrimmedDataAccessException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TrimmedDataAccessException: Unknown
+TrimmedDataAccessException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TrimmedDataAccessException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TrimmedDataAccessException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodbstreams#TrimmedDataAccessException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/BackupInUseException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/BackupInUseException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-BackupInUseException: Unknown
+BackupInUseException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ BackupInUseException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "BackupInUseException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#BackupInUseException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/BackupNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/BackupNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-BackupNotFoundException: Unknown
+BackupNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ BackupNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "BackupNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#BackupNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ConditionalCheckFailedException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ConditionalCheckFailedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ConditionalCheckFailedException: Unknown
+ConditionalCheckFailedException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ ConditionalCheckFailedException: Unknown
   },
   name: "ConditionalCheckFailedException",
   Item: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ConditionalCheckFailedException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ContinuousBackupsUnavailableException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ContinuousBackupsUnavailableException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ContinuousBackupsUnavailableException: Unknown
+ContinuousBackupsUnavailableException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ContinuousBackupsUnavailableException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ContinuousBackupsUnavailableException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ContinuousBackupsUnavailableException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/DuplicateItemException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/DuplicateItemException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-DuplicateItemException: Unknown
+DuplicateItemException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ DuplicateItemException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "DuplicateItemException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#DuplicateItemException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ExportConflictException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ExportConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ExportConflictException: Unknown
+ExportConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ExportConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ExportConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ExportConflictException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ExportNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ExportNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ExportNotFoundException: Unknown
+ExportNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ExportNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ExportNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ExportNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/GlobalTableAlreadyExistsException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/GlobalTableAlreadyExistsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-GlobalTableAlreadyExistsException: Unknown
+GlobalTableAlreadyExistsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ GlobalTableAlreadyExistsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "GlobalTableAlreadyExistsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#GlobalTableAlreadyExistsException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/GlobalTableNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/GlobalTableNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-GlobalTableNotFoundException: Unknown
+GlobalTableNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ GlobalTableNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "GlobalTableNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#GlobalTableNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/IdempotentParameterMismatchException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/IdempotentParameterMismatchException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-IdempotentParameterMismatchException: Unknown
+IdempotentParameterMismatchException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ IdempotentParameterMismatchException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "IdempotentParameterMismatchException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#IdempotentParameterMismatchException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ImportConflictException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ImportConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ImportConflictException: Unknown
+ImportConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ImportConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ImportConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ImportConflictException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ImportNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ImportNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ImportNotFoundException: Unknown
+ImportNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ImportNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ImportNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ImportNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/IndexNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/IndexNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-IndexNotFoundException: Unknown
+IndexNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ IndexNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "IndexNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#IndexNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/InternalServerError.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/InternalServerError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InternalServerError: Unknown
+InternalServerError: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalServerError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalServerError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#InternalServerError"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/InvalidEndpointException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/InvalidEndpointException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidEndpointException: Unknown
+InvalidEndpointException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidEndpointException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidEndpointException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#InvalidEndpointException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/InvalidExportTimeException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/InvalidExportTimeException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidExportTimeException: Unknown
+InvalidExportTimeException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidExportTimeException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidExportTimeException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#InvalidExportTimeException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/InvalidRestoreTimeException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/InvalidRestoreTimeException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidRestoreTimeException: Unknown
+InvalidRestoreTimeException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidRestoreTimeException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidRestoreTimeException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#InvalidRestoreTimeException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ItemCollectionSizeLimitExceededException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ItemCollectionSizeLimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ItemCollectionSizeLimitExceededException: Unknown
+ItemCollectionSizeLimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ItemCollectionSizeLimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ItemCollectionSizeLimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ItemCollectionSizeLimitExceededException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ LimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "LimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#LimitExceededException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/PointInTimeRecoveryUnavailableException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/PointInTimeRecoveryUnavailableException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-PointInTimeRecoveryUnavailableException: Unknown
+PointInTimeRecoveryUnavailableException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ PointInTimeRecoveryUnavailableException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "PointInTimeRecoveryUnavailableException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#PointInTimeRecoveryUnavailableException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/PolicyNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/PolicyNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-PolicyNotFoundException: Unknown
+PolicyNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ PolicyNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "PolicyNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#PolicyNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ProvisionedThroughputExceededException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ProvisionedThroughputExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ProvisionedThroughputExceededException: Unknown
+ProvisionedThroughputExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ ProvisionedThroughputExceededException: Unknown
   },
   name: "ProvisionedThroughputExceededException",
   ThrottlingReasons: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ProvisionedThroughputExceededException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ReplicaAlreadyExistsException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ReplicaAlreadyExistsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ReplicaAlreadyExistsException: Unknown
+ReplicaAlreadyExistsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ReplicaAlreadyExistsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ReplicaAlreadyExistsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ReplicaAlreadyExistsException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ReplicaNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ReplicaNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ReplicaNotFoundException: Unknown
+ReplicaNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ReplicaNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ReplicaNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ReplicaNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ReplicatedWriteConflictException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ReplicatedWriteConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ReplicatedWriteConflictException: Unknown
+ReplicatedWriteConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ReplicatedWriteConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ReplicatedWriteConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ReplicatedWriteConflictException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/RequestLimitExceeded.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/RequestLimitExceeded.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-RequestLimitExceeded: Unknown
+RequestLimitExceeded: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ RequestLimitExceeded: Unknown
   },
   name: "RequestLimitExceeded",
   ThrottlingReasons: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#RequestLimitExceeded"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ResourceInUseException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ResourceInUseException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ResourceInUseException: Unknown
+ResourceInUseException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceInUseException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceInUseException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ResourceInUseException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ResourceNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TableAlreadyExistsException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TableAlreadyExistsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TableAlreadyExistsException: Unknown
+TableAlreadyExistsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TableAlreadyExistsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TableAlreadyExistsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TableAlreadyExistsException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TableInUseException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TableInUseException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TableInUseException: Unknown
+TableInUseException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TableInUseException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TableInUseException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TableInUseException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TableNotFoundException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TableNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TableNotFoundException: Unknown
+TableNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TableNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TableNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TableNotFoundException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/ThrottlingException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/ThrottlingException.txt
@@ -11,7 +11,7 @@ x-amzn-query-error: undefined;Sender
 
 
 --- [error name & message] ---
-ThrottlingException: Unknown
+ThrottlingException: UnknownError
 
 --- [error object] ---
 {
@@ -27,7 +27,7 @@ ThrottlingException: Unknown
   },
   name: "ThrottlingException",
   throttlingReasons: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#ThrottlingException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TransactionCanceledException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TransactionCanceledException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TransactionCanceledException: Unknown
+TransactionCanceledException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ TransactionCanceledException: Unknown
   },
   name: "TransactionCanceledException",
   CancellationReasons: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TransactionCanceledException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TransactionConflictException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TransactionConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TransactionConflictException: Unknown
+TransactionConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TransactionConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TransactionConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TransactionConflictException"
 }
 

--- a/clients/client-dynamodb/test/snapshots/res-err/TransactionInProgressException.txt
+++ b/clients/client-dynamodb/test/snapshots/res-err/TransactionInProgressException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-TransactionInProgressException: Unknown
+TransactionInProgressException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ TransactionInProgressException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "TransactionInProgressException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.dynamodb#TransactionInProgressException"
 }
 

--- a/clients/client-sagemaker/test/snapshots/res-err/ConflictException.txt
+++ b/clients/client-sagemaker/test/snapshots/res-err/ConflictException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ConflictException: Unknown
+ConflictException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ConflictException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ConflictException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sagemaker#ConflictException"
 }
 

--- a/clients/client-sagemaker/test/snapshots/res-err/ResourceInUse.txt
+++ b/clients/client-sagemaker/test/snapshots/res-err/ResourceInUse.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceInUse: Unknown
+ResourceInUse: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceInUse: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceInUse",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sagemaker#ResourceInUse"
 }
 

--- a/clients/client-sagemaker/test/snapshots/res-err/ResourceLimitExceeded.txt
+++ b/clients/client-sagemaker/test/snapshots/res-err/ResourceLimitExceeded.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceLimitExceeded: Unknown
+ResourceLimitExceeded: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceLimitExceeded: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceLimitExceeded",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sagemaker#ResourceLimitExceeded"
 }
 

--- a/clients/client-sagemaker/test/snapshots/res-err/ResourceNotFound.txt
+++ b/clients/client-sagemaker/test/snapshots/res-err/ResourceNotFound.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceNotFound: Unknown
+ResourceNotFound: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFound: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFound",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sagemaker#ResourceNotFound"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/DecryptionFailure.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/DecryptionFailure.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-DecryptionFailure: Unknown
+DecryptionFailure: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ DecryptionFailure: Unknown
     totalRetryDelay: (number) 0
   },
   name: "DecryptionFailure",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#DecryptionFailure"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/EncryptionFailure.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/EncryptionFailure.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-EncryptionFailure: Unknown
+EncryptionFailure: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ EncryptionFailure: Unknown
     totalRetryDelay: (number) 0
   },
   name: "EncryptionFailure",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#EncryptionFailure"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/InternalServiceError.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/InternalServiceError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InternalServiceError: Unknown
+InternalServiceError: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InternalServiceError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InternalServiceError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#InternalServiceError"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/InvalidNextTokenException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/InvalidNextTokenException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidNextTokenException: Unknown
+InvalidNextTokenException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidNextTokenException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidNextTokenException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#InvalidNextTokenException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/InvalidParameterException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/InvalidParameterException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidParameterException: Unknown
+InvalidParameterException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidParameterException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidParameterException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#InvalidParameterException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/InvalidRequestException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/InvalidRequestException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidRequestException: Unknown
+InvalidRequestException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidRequestException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidRequestException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#InvalidRequestException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/LimitExceededException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ LimitExceededException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "LimitExceededException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#LimitExceededException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/MalformedPolicyDocumentException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/MalformedPolicyDocumentException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-MalformedPolicyDocumentException: Unknown
+MalformedPolicyDocumentException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ MalformedPolicyDocumentException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "MalformedPolicyDocumentException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#MalformedPolicyDocumentException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/PreconditionNotMetException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/PreconditionNotMetException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-PreconditionNotMetException: Unknown
+PreconditionNotMetException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ PreconditionNotMetException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "PreconditionNotMetException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#PreconditionNotMetException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/PublicPolicyException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/PublicPolicyException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-PublicPolicyException: Unknown
+PublicPolicyException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ PublicPolicyException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "PublicPolicyException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#PublicPolicyException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/ResourceExistsException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/ResourceExistsException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceExistsException: Unknown
+ResourceExistsException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceExistsException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceExistsException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#ResourceExistsException"
 }
 

--- a/clients/client-secrets-manager/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/clients/client-secrets-manager/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ResourceNotFoundException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ResourceNotFoundException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.secretsmanager#ResourceNotFoundException"
 }
 

--- a/clients/client-sqs/test/snapshots/res-err/InvalidAttributeName.txt
+++ b/clients/client-sqs/test/snapshots/res-err/InvalidAttributeName.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidAttributeName: Unknown
+InvalidAttributeName: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidAttributeName: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidAttributeName",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sqs#InvalidAttributeName",
   Error: {
     Type: (undefined),

--- a/clients/client-sqs/test/snapshots/res-err/InvalidAttributeValue.txt
+++ b/clients/client-sqs/test/snapshots/res-err/InvalidAttributeValue.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidAttributeValue: Unknown
+InvalidAttributeValue: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidAttributeValue: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidAttributeValue",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sqs#InvalidAttributeValue",
   Error: {
     Type: (undefined),

--- a/clients/client-sqs/test/snapshots/res-err/InvalidIdFormat.txt
+++ b/clients/client-sqs/test/snapshots/res-err/InvalidIdFormat.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidIdFormat: Unknown
+InvalidIdFormat: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidIdFormat: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidIdFormat",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sqs#InvalidIdFormat",
   Error: {
     Type: (undefined),
@@ -46,7 +46,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidIdFormat: Unknown
+InvalidIdFormat: UnknownError
 
 --- [error object] ---
 {
@@ -61,7 +61,7 @@ InvalidIdFormat: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidIdFormat",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sqs#InvalidIdFormat",
   Error: {
     Type: (undefined),

--- a/clients/client-sqs/test/snapshots/res-err/InvalidMessageContents.txt
+++ b/clients/client-sqs/test/snapshots/res-err/InvalidMessageContents.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidMessageContents: Unknown
+InvalidMessageContents: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidMessageContents: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidMessageContents",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.sqs#InvalidMessageContents",
   Error: {
     Type: (undefined),

--- a/packages-internal/core/src/submodules/protocols/ProtocolLib.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/ProtocolLib.spec.ts
@@ -1,6 +1,7 @@
+import { TypeRegistry } from "@smithy/core/schema";
 import { ServiceException } from "@smithy/smithy-client";
-import { type HttpResponse as IHttpResponse } from "@smithy/types";
-import { describe, expect, test as it } from "vitest";
+import type { HttpResponse as IHttpResponse, StaticErrorSchema } from "@smithy/types";
+import { afterEach, describe, expect, test as it } from "vitest";
 
 import { ProtocolLib } from "./ProtocolLib";
 
@@ -175,6 +176,206 @@ describe("ProtocolLib", () => {
 
       expect(output.Error).toBeUndefined();
       expect(output.message).toBe("Access denied");
+    });
+  });
+
+  describe("error composition", () => {
+    afterEach(() => {
+      TypeRegistry.for("com.example").clear();
+      TypeRegistry.for("com.other").clear();
+      TypeRegistry.for("smithy.ts.sdk.synthetic.com.example").clear();
+    });
+
+    describe("compose", () => {
+      it("copies the static registry for the default namespace into the composite", () => {
+        const lib = new ProtocolLib();
+        const composite = TypeRegistry.for("composite.a");
+        const staticReg = TypeRegistry.for("com.example");
+        const schema: StaticErrorSchema = [-3, "com.example", "SomeError", { error: "client" }, ["Message"], [0]];
+        staticReg.register("com.example#SomeError", schema);
+
+        lib.compose(composite, "SomeError", "com.example");
+
+        expect(composite.getSchema("com.example#SomeError")).toBe(schema);
+        composite.clear();
+      });
+
+      it("copies the synthetic registry for the default namespace into the composite", () => {
+        const lib = new ProtocolLib();
+        const composite = TypeRegistry.for("composite.b");
+        const syntheticReg = TypeRegistry.for("smithy.ts.sdk.synthetic.com.example");
+        const baseSchema: StaticErrorSchema = [
+          -3,
+          "smithy.ts.sdk.synthetic.com.example",
+          "ServiceException",
+          { error: "client" },
+          [],
+          [],
+        ];
+        syntheticReg.register("smithy.ts.sdk.synthetic.com.example#ServiceException", baseSchema);
+
+        lib.compose(composite, "SomeError", "com.example");
+
+        expect(composite.getSchema("smithy.ts.sdk.synthetic.com.example#ServiceException")).toBe(baseSchema);
+        composite.clear();
+      });
+
+      it("uses namespace from errorIdentifier when it contains #", () => {
+        const lib = new ProtocolLib();
+        const composite = TypeRegistry.for("composite.c");
+        const otherReg = TypeRegistry.for("com.other");
+        const schema: StaticErrorSchema = [-3, "com.other", "OtherError", { error: "client" }, [], []];
+        otherReg.register("com.other#OtherError", schema);
+
+        lib.compose(composite, "com.other#OtherError", "com.example");
+
+        expect(composite.getSchema("com.other#OtherError")).toBe(schema);
+        composite.clear();
+      });
+    });
+
+    describe("getErrorSchemaOrThrowBaseException", () => {
+      const metadata = { httpStatusCode: 400, requestId: "req-1" };
+      const response = { statusCode: 400, headers: {}, body: undefined } as IHttpResponse;
+
+      it("throws if compose was not called (errorRegistry not initialized)", async () => {
+        const lib = new ProtocolLib();
+        await expect(
+          lib.getErrorSchemaOrThrowBaseException("SomeError", "com.example", response, {}, metadata)
+        ).rejects.toThrow("error handler not initialized");
+      });
+
+      it("returns the error schema when found in the registry", async () => {
+        const lib = new ProtocolLib();
+        const composite = TypeRegistry.for("composite.d");
+        const schema: StaticErrorSchema = [-3, "com.example", "SomeError", { error: "client" }, ["Message"], [0]];
+        composite.register("com.example#SomeError", schema);
+        lib.compose(composite, "com.example#SomeError", "com.example");
+
+        const result = await lib.getErrorSchemaOrThrowBaseException(
+          "com.example#SomeError",
+          "com.example",
+          response,
+          {},
+          metadata
+        );
+        expect(result.errorSchema).toBe(schema);
+        expect(result.errorMetadata.$fault).toBe("client");
+        composite.clear();
+      });
+
+      it("uses only the error name part of fully qualified error identifiers", async () => {
+        const lib = new ProtocolLib();
+        const composite = TypeRegistry.for("composite.f");
+        const schema: StaticErrorSchema = [-3, "com.example", "SomeError", { error: "client" }, [], []];
+        composite.register("com.example#SomeError", schema);
+        lib.compose(composite, "com.example#SomeError", "com.example");
+
+        const getErrorSchema = (registry: TypeRegistry, errorName: string) => {
+          expect(errorName).toBe("SomeError");
+          return registry.getSchema("com.example#SomeError") as StaticErrorSchema;
+        };
+
+        const result = await lib.getErrorSchemaOrThrowBaseException(
+          "com.example#SomeError",
+          "com.example",
+          response,
+          {},
+          metadata,
+          getErrorSchema
+        );
+        expect(result.errorSchema).toBe(schema);
+        composite.clear();
+      });
+
+      it("throws a generic Error with errorName and message when no base exception and no schema found", async () => {
+        const lib = new ProtocolLib();
+        const composite = TypeRegistry.for("composite.g");
+        lib.compose(composite, "UnknownError", "com.example");
+
+        const error: any = await lib
+          .getErrorSchemaOrThrowBaseException("UnknownError", "com.example", response, { message: "oops" }, metadata)
+          .catch((e) => e);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.name).toBe("UnknownError");
+        expect(error.message).toBe("oops");
+        expect(error.$fault).toBe("client");
+        expect(error.$metadata).toEqual(metadata);
+        composite.clear();
+      });
+
+      it("falls back to 'UnknownError' message when dataObject has no message fields", async () => {
+        const lib = new ProtocolLib();
+        const composite = TypeRegistry.for("composite.h");
+        lib.compose(composite, "SomeError", "com.example");
+
+        const error: any = await lib
+          .getErrorSchemaOrThrowBaseException("SomeError", "com.example", response, {}, metadata)
+          .catch((e) => e);
+
+        expect(error.message).toBe("UnknownError");
+        expect(error.name).toBe("SomeError");
+        composite.clear();
+      });
+
+      it("throws base exception when base exception schema exists but error schema not found", async () => {
+        const lib = new ProtocolLib();
+        const composite = TypeRegistry.for("composite.i");
+
+        class ServiceException extends Error {
+          constructor(opts: any) {
+            super(opts.name);
+            this.name = opts.name ?? "ServiceException";
+          }
+        }
+
+        const baseSchema: StaticErrorSchema = [
+          -3,
+          "smithy.ts.sdk.synthetic.com.example",
+          "ServiceException",
+          { error: "client" },
+          [],
+          [],
+        ];
+        composite.registerError(baseSchema, ServiceException);
+        lib.compose(composite, "MissingError", "com.example");
+
+        const error: any = await lib
+          .getErrorSchemaOrThrowBaseException(
+            "MissingError",
+            "com.example",
+            response,
+            { message: "base exception message" },
+            metadata
+          )
+          .catch((e) => e);
+
+        expect(error).toBeInstanceOf(ServiceException);
+        expect(error.$fault).toBe("client");
+        // ErrorCtor receives { name: errorName }, so message is set by the constructor
+        expect(error.name).toBe("MissingError");
+        composite.clear();
+      });
+
+      it("uses dataObject.Message when dataObject.message is absent", async () => {
+        const lib = new ProtocolLib();
+        const composite = TypeRegistry.for("composite.j");
+        lib.compose(composite, "SomeError", "com.example");
+
+        const error: any = await lib
+          .getErrorSchemaOrThrowBaseException(
+            "SomeError",
+            "com.example",
+            response,
+            { Message: "capital M message" },
+            metadata
+          )
+          .catch((e) => e);
+
+        expect(error.message).toBe("capital M message");
+        composite.clear();
+      });
     });
   });
 });

--- a/packages-internal/core/src/submodules/protocols/ProtocolLib.ts
+++ b/packages-internal/core/src/submodules/protocols/ProtocolLib.ts
@@ -17,6 +17,8 @@ type ErrorMetadataBearer = MetadataBearer & {
  * @internal
  */
 export class ProtocolLib {
+  private errorRegistry?: TypeRegistry;
+
   public constructor(private queryCompat = false) {}
 
   /**
@@ -70,10 +72,9 @@ export class ProtocolLib {
     metadata: ResponseMetadata,
     getErrorSchema?: (registry: TypeRegistry, errorName: string) => StaticErrorSchema
   ): Promise<{ errorSchema: StaticErrorSchema; errorMetadata: ErrorMetadataBearer }> {
-    let namespace = defaultNamespace;
     let errorName = errorIdentifier;
     if (errorIdentifier.includes("#")) {
-      [namespace, errorName] = errorIdentifier.split("#");
+      [, errorName] = errorIdentifier.split("#");
     }
 
     const errorMetadata: ErrorMetadataBearer = {
@@ -81,16 +82,20 @@ export class ProtocolLib {
       $fault: response.statusCode < 500 ? ("client" as const) : ("server" as const),
     };
 
-    const registry = TypeRegistry.for(namespace);
+    if (!this.errorRegistry) {
+      throw new Error("@aws-sdk/core/protocols - error handler not initialized.");
+    }
 
     try {
       const errorSchema =
-        getErrorSchema?.(registry, errorName) ?? (registry.getSchema(errorIdentifier) as StaticErrorSchema);
+        getErrorSchema?.(this.errorRegistry, errorName) ??
+        (this.errorRegistry.getSchema(errorIdentifier) as StaticErrorSchema);
       return { errorSchema, errorMetadata };
     } catch (e) {
       dataObject.message = dataObject.message ?? dataObject.Message ?? "UnknownError";
-      const synthetic = TypeRegistry.for("smithy.ts.sdk.synthetic." + namespace);
+      const synthetic = this.errorRegistry;
       const baseExceptionSchema = synthetic.getBaseException();
+
       if (baseExceptionSchema) {
         const ErrorCtor = synthetic.getErrorCtor(baseExceptionSchema) ?? Error;
         throw this.decorateServiceException(
@@ -98,8 +103,43 @@ export class ProtocolLib {
           dataObject
         );
       }
-      throw this.decorateServiceException(Object.assign(new Error(errorName), errorMetadata), dataObject);
+
+      const d = dataObject;
+      const message = d?.message ?? d?.Message ?? d?.Error?.Message ?? d?.Error?.message;
+      throw this.decorateServiceException(
+        Object.assign(
+          new Error(message),
+          {
+            name: errorName,
+          },
+          errorMetadata
+        ),
+        dataObject
+      );
     }
+  }
+
+  /**
+   * This method exists because in older clients, no `errorTypeRegistries` array is provided to the Protocol
+   * implementation. This means that the TypeRegistry queried by the error's namespace or the service's defaultNamespace
+   * must be composed into the possibly-empty local compositeErrorRegistry.
+   *
+   *
+   * @param composite - TypeRegistry instance local to instances of HttpProtocol. In newer clients, this instance directly
+   * receives the error registries exported by the client.
+   * @param errorIdentifier - parsed from the response, used to look up the error schema within the registry.
+   * @param defaultNamespace - property of the Protocol implementation pointing to a specific service.
+   */
+  public compose(composite: TypeRegistry, errorIdentifier: string, defaultNamespace: string): void {
+    let namespace = defaultNamespace;
+    if (errorIdentifier.includes("#")) {
+      [namespace] = errorIdentifier.split("#");
+    }
+    const staticRegistry = TypeRegistry.for(namespace);
+    const defaultSyntheticRegistry = TypeRegistry.for("smithy.ts.sdk.synthetic." + defaultNamespace);
+    composite.copyFrom(staticRegistry);
+    composite.copyFrom(defaultSyntheticRegistry);
+    this.errorRegistry = composite;
   }
 
   /**

--- a/packages-internal/core/src/submodules/protocols/cbor/AwsSmithyRpcV2CborProtocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/cbor/AwsSmithyRpcV2CborProtocol.spec.ts
@@ -1,7 +1,7 @@
 import { cbor } from "@smithy/core/cbor";
-import { error as registerError } from "@smithy/core/schema";
+import { error as registerError, TypeRegistry } from "@smithy/core/schema";
 import { HttpResponse } from "@smithy/protocol-http";
-import type { NumericSchema, StringSchema } from "@smithy/types";
+import type { NumericSchema, StaticErrorSchema, StringSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
 import { context } from "../test-schema.spec";
@@ -110,5 +110,43 @@ describe(AwsSmithyRpcV2CborProtocol.name, () => {
         httpStatusCode: 400,
       },
     });
+  });
+
+  it("has a shapeId of smithy.protocols#rpcv2Cbor", () => {
+    const protocol = new AwsSmithyRpcV2CborProtocol({
+      defaultNamespace: "ns",
+      awsQueryCompatible: true,
+    });
+    expect(protocol.getShapeId()).toEqual("smithy.protocols#rpcv2Cbor");
+  });
+
+  it("uses compositeErrorRegistries from instantiation", () => {
+    const GenericServiceException$: StaticErrorSchema = [
+      -3,
+      "com.amazonaws.sdk.example",
+      "GenericServiceException",
+      0,
+      [],
+      [],
+    ];
+    class GenericServiceException extends Error {}
+
+    const registry = TypeRegistry.for("com.amazonaws.sdk.example");
+    registry.registerError(GenericServiceException$, GenericServiceException);
+
+    const protocol = new (class extends AwsSmithyRpcV2CborProtocol {
+      public getCompositeErrorRegistry() {
+        return this.compositeErrorRegistry;
+      }
+    })({
+      defaultNamespace: "ns",
+      awsQueryCompatible: true,
+      errorTypeRegistries: [registry],
+    });
+
+    expect(protocol.getCompositeErrorRegistry()).not.toBe(registry);
+    expect(protocol.getCompositeErrorRegistry().getSchema("com.amazonaws.sdk.example#GenericServiceException")).toBe(
+      GenericServiceException$
+    );
   });
 });

--- a/packages-internal/core/src/submodules/protocols/cbor/AwsSmithyRpcV2CborProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/cbor/AwsSmithyRpcV2CborProtocol.ts
@@ -1,5 +1,6 @@
 import { loadSmithyRpcV2CborErrorCode, SmithyRpcV2CborProtocol } from "@smithy/core/cbor";
-import { NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
+import type { TypeRegistry } from "@smithy/core/schema";
+import { NormalizedSchema } from "@smithy/core/schema";
 import type {
   EndpointBearer,
   HandlerExecutionContext,
@@ -23,12 +24,14 @@ export class AwsSmithyRpcV2CborProtocol extends SmithyRpcV2CborProtocol {
 
   public constructor({
     defaultNamespace,
+    errorTypeRegistries,
     awsQueryCompatible,
   }: {
     defaultNamespace: string;
+    errorTypeRegistries?: TypeRegistry[];
     awsQueryCompatible?: boolean;
   }) {
-    super({ defaultNamespace });
+    super({ defaultNamespace, errorTypeRegistries });
     this.awsQueryCompatible = !!awsQueryCompatible;
     this.mixin = new ProtocolLib(this.awsQueryCompatible);
   }
@@ -68,6 +71,7 @@ export class AwsSmithyRpcV2CborProtocol extends SmithyRpcV2CborProtocol {
       }
       return loadSmithyRpcV2CborErrorCode(response, dataObject) ?? "Unknown";
     })();
+    this.mixin.compose(this.compositeErrorRegistry, errorName, this.options.defaultNamespace);
 
     const { errorSchema, errorMetadata } = await this.mixin.getErrorSchemaOrThrowBaseException(
       errorName,
@@ -79,8 +83,8 @@ export class AwsSmithyRpcV2CborProtocol extends SmithyRpcV2CborProtocol {
     );
 
     const ns = NormalizedSchema.of(errorSchema);
-    const message = dataObject.message ?? dataObject.Message ?? "Unknown";
-    const ErrorCtor = TypeRegistry.for(errorSchema[1]).getErrorCtor(errorSchema) ?? Error;
+    const message = dataObject.message ?? dataObject.Message ?? "UnknownError";
+    const ErrorCtor = this.compositeErrorRegistry.getErrorCtor(errorSchema) ?? Error;
     const exception = new ErrorCtor(message);
 
     const output = {} as any;

--- a/packages-internal/core/src/submodules/protocols/json/AwsJson1_0Protocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsJson1_0Protocol.spec.ts
@@ -1,9 +1,11 @@
+import { TypeRegistry } from "@smithy/core/schema";
 import type {
   BlobSchema,
   BooleanSchema,
   DocumentSchema,
   NumericSchema,
   OperationSchema,
+  StaticErrorSchema,
   StaticStructureSchema,
   StringSchema,
   TimestampDefaultSchema,
@@ -48,6 +50,36 @@ describe(AwsJson1_0Protocol.name, () => {
       serviceTarget: "JsonRpc10",
     });
     expect(protocol.getShapeId()).toEqual("aws.protocols#awsJson1_0");
+  });
+
+  it("uses compositeErrorRegistries from instantiation", () => {
+    const GenericServiceException$: StaticErrorSchema = [
+      -3,
+      "com.amazonaws.sdk.example",
+      "GenericServiceException",
+      0,
+      [],
+      [],
+    ];
+    class GenericServiceException extends Error {}
+
+    const registry = TypeRegistry.for("com.amazonaws.sdk.example");
+    registry.registerError(GenericServiceException$, GenericServiceException);
+
+    const protocol = new (class extends AwsJson1_0Protocol {
+      public getCompositeErrorRegistry() {
+        return this.compositeErrorRegistry;
+      }
+    })({
+      defaultNamespace: "",
+      serviceTarget: "JsonRpc10",
+      errorTypeRegistries: [registry],
+    });
+
+    expect(protocol.getCompositeErrorRegistry()).not.toBe(registry);
+    expect(protocol.getCompositeErrorRegistry().getSchema("com.amazonaws.sdk.example#GenericServiceException")).toBe(
+      GenericServiceException$
+    );
   });
 
   describe("codec", () => {

--- a/packages-internal/core/src/submodules/protocols/json/AwsJson1_0Protocol.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsJson1_0Protocol.ts
@@ -1,3 +1,5 @@
+import type { TypeRegistry } from "@smithy/core/schema";
+
 import { AwsJsonRpcProtocol } from "./AwsJsonRpcProtocol";
 import type { JsonCodec } from "./JsonCodec";
 
@@ -8,17 +10,20 @@ import type { JsonCodec } from "./JsonCodec";
 export class AwsJson1_0Protocol extends AwsJsonRpcProtocol {
   public constructor({
     defaultNamespace,
+    errorTypeRegistries,
     serviceTarget,
     awsQueryCompatible,
     jsonCodec,
   }: {
     defaultNamespace: string;
+    errorTypeRegistries?: TypeRegistry[];
     serviceTarget: string;
     awsQueryCompatible?: boolean;
     jsonCodec?: JsonCodec;
   }) {
     super({
       defaultNamespace,
+      errorTypeRegistries,
       serviceTarget,
       awsQueryCompatible,
       jsonCodec,

--- a/packages-internal/core/src/submodules/protocols/json/AwsJson1_1Protocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsJson1_1Protocol.spec.ts
@@ -1,4 +1,6 @@
+import { TypeRegistry } from "@smithy/core/schema";
 import { HttpResponse } from "@smithy/protocol-http";
+import type { StaticErrorSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
 import { context, createNestingWidget, deleteObjects, nestingWidget } from "../test-schema.spec";
@@ -7,7 +9,7 @@ import { AwsJson1_1Protocol } from "./AwsJson1_1Protocol";
 /**
  * These tests are cursory since most coverage is provided by protocol tests.
  */
-describe(AwsJson1_1Protocol, () => {
+describe(AwsJson1_1Protocol.name, () => {
   const [, namespace, name, traits, input, output] = deleteObjects;
   const deleteObjectsOperation = {
     namespace,
@@ -23,6 +25,36 @@ describe(AwsJson1_1Protocol, () => {
       serviceTarget: "JsonRpc11",
     });
     expect(protocol.getShapeId()).toEqual("aws.protocols#awsJson1_1");
+  });
+
+  it("uses compositeErrorRegistries from instantiation", () => {
+    const GenericServiceException$: StaticErrorSchema = [
+      -3,
+      "com.amazonaws.sdk.example",
+      "GenericServiceException",
+      0,
+      [],
+      [],
+    ];
+    class GenericServiceException extends Error {}
+
+    const registry = TypeRegistry.for("com.amazonaws.sdk.example");
+    registry.registerError(GenericServiceException$, GenericServiceException);
+
+    const protocol = new (class extends AwsJson1_1Protocol {
+      public getCompositeErrorRegistry() {
+        return this.compositeErrorRegistry;
+      }
+    })({
+      defaultNamespace: "",
+      serviceTarget: "JsonRpc11",
+      errorTypeRegistries: [registry],
+    });
+
+    expect(protocol.getCompositeErrorRegistry()).not.toBe(registry);
+    expect(protocol.getCompositeErrorRegistry().getSchema("com.amazonaws.sdk.example#GenericServiceException")).toBe(
+      GenericServiceException$
+    );
   });
 
   it("serializes a request", async () => {

--- a/packages-internal/core/src/submodules/protocols/json/AwsJson1_1Protocol.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsJson1_1Protocol.ts
@@ -1,3 +1,5 @@
+import type { TypeRegistry } from "@smithy/core/schema";
+
 import { AwsJsonRpcProtocol } from "./AwsJsonRpcProtocol";
 import type { JsonCodec } from "./JsonCodec";
 
@@ -8,17 +10,20 @@ import type { JsonCodec } from "./JsonCodec";
 export class AwsJson1_1Protocol extends AwsJsonRpcProtocol {
   public constructor({
     defaultNamespace,
+    errorTypeRegistries,
     serviceTarget,
     awsQueryCompatible,
     jsonCodec,
   }: {
     defaultNamespace: string;
+    errorTypeRegistries?: TypeRegistry[];
     serviceTarget: string;
     awsQueryCompatible?: boolean;
     jsonCodec?: JsonCodec;
   }) {
     super({
       defaultNamespace,
+      errorTypeRegistries,
       serviceTarget,
       awsQueryCompatible,
       jsonCodec,

--- a/packages-internal/core/src/submodules/protocols/json/AwsJsonRpcProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsJsonRpcProtocol.ts
@@ -1,5 +1,6 @@
 import { RpcProtocol } from "@smithy/core/protocols";
-import { deref, NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
+import type { TypeRegistry } from "@smithy/core/schema";
+import { deref, NormalizedSchema } from "@smithy/core/schema";
 import type {
   EndpointBearer,
   HandlerExecutionContext,
@@ -30,17 +31,20 @@ export abstract class AwsJsonRpcProtocol extends RpcProtocol {
 
   protected constructor({
     defaultNamespace,
+    errorTypeRegistries,
     serviceTarget,
     awsQueryCompatible,
     jsonCodec,
   }: {
     defaultNamespace: string;
+    errorTypeRegistries?: TypeRegistry[];
     serviceTarget: string;
     awsQueryCompatible?: boolean;
     jsonCodec?: JsonCodec;
   }) {
     super({
       defaultNamespace,
+      errorTypeRegistries,
     });
     this.serviceTarget = serviceTarget;
     this.codec =
@@ -99,11 +103,12 @@ export abstract class AwsJsonRpcProtocol extends RpcProtocol {
     dataObject: any,
     metadata: ResponseMetadata
   ): Promise<never> {
-    // loadRestJsonErrorCode is still used in JSON RPC.
     if (this.awsQueryCompatible) {
       this.mixin.setQueryCompatError(dataObject, response);
     }
+    // loadRestJsonErrorCode is still used in JSON RPC.
     const errorIdentifier = loadRestJsonErrorCode(response, dataObject) ?? "Unknown";
+    this.mixin.compose(this.compositeErrorRegistry, errorIdentifier, this.options.defaultNamespace);
 
     const { errorSchema, errorMetadata } = await this.mixin.getErrorSchemaOrThrowBaseException(
       errorIdentifier,
@@ -115,8 +120,8 @@ export abstract class AwsJsonRpcProtocol extends RpcProtocol {
     );
 
     const ns = NormalizedSchema.of(errorSchema);
-    const message = dataObject.message ?? dataObject.Message ?? "Unknown";
-    const ErrorCtor = TypeRegistry.for(errorSchema[1]).getErrorCtor(errorSchema) ?? Error;
+    const message = dataObject.message ?? dataObject.Message ?? "UnknownError";
+    const ErrorCtor = this.compositeErrorRegistry.getErrorCtor(errorSchema) ?? Error;
     const exception = new ErrorCtor(message);
 
     const output = {} as any;

--- a/packages-internal/core/src/submodules/protocols/json/AwsRestJsonProtocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsRestJsonProtocol.spec.ts
@@ -1,9 +1,11 @@
+import { TypeRegistry } from "@smithy/core/schema";
 import { HttpResponse } from "@smithy/protocol-http";
 import type {
   BlobSchema,
   BooleanSchema,
   MapSchemaModifier,
   NumericSchema,
+  StaticErrorSchema,
   StaticOperationSchema,
   StaticSimpleSchema,
   StaticStructureSchema,
@@ -168,6 +170,35 @@ describe(AwsRestJsonProtocol.name, () => {
 
     it("should have a shapeId of aws.protocols#restJson1", () => {
       expect(protocol.getShapeId()).toEqual("aws.protocols#restJson1");
+    });
+
+    it("uses compositeErrorRegistries from instantiation", () => {
+      const GenericServiceException$: StaticErrorSchema = [
+        -3,
+        "com.amazonaws.sdk.example",
+        "GenericServiceException",
+        0,
+        [],
+        [],
+      ];
+      class GenericServiceException extends Error {}
+
+      const registry = TypeRegistry.for("com.amazonaws.sdk.example");
+      registry.registerError(GenericServiceException$, GenericServiceException);
+
+      const protocol = new (class extends AwsRestJsonProtocol {
+        public getCompositeErrorRegistry() {
+          return this.compositeErrorRegistry;
+        }
+      })({
+        defaultNamespace: "ns",
+        errorTypeRegistries: [registry],
+      });
+
+      expect(protocol.getCompositeErrorRegistry()).not.toBe(registry);
+      expect(protocol.getCompositeErrorRegistry().getSchema("com.amazonaws.sdk.example#GenericServiceException")).toBe(
+        GenericServiceException$
+      );
     });
 
     it("obeys jsonName and HTTP bindings during serialization", async () => {

--- a/packages-internal/core/src/submodules/protocols/json/AwsRestJsonProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsRestJsonProtocol.ts
@@ -3,7 +3,8 @@ import {
   HttpInterceptingShapeDeserializer,
   HttpInterceptingShapeSerializer,
 } from "@smithy/core/protocols";
-import { NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
+import type { TypeRegistry } from "@smithy/core/schema";
+import { NormalizedSchema } from "@smithy/core/schema";
 import type {
   EndpointBearer,
   HandlerExecutionContext,
@@ -32,9 +33,16 @@ export class AwsRestJsonProtocol extends HttpBindingProtocol {
   private readonly codec: JsonCodec;
   private readonly mixin = new ProtocolLib();
 
-  public constructor({ defaultNamespace }: { defaultNamespace: string }) {
+  public constructor({
+    defaultNamespace,
+    errorTypeRegistries,
+  }: {
+    defaultNamespace: string;
+    errorTypeRegistries?: TypeRegistry[];
+  }) {
     super({
       defaultNamespace,
+      errorTypeRegistries,
     });
     const settings: JsonSettings = {
       timestampFormat: {
@@ -119,6 +127,7 @@ export class AwsRestJsonProtocol extends HttpBindingProtocol {
     metadata: ResponseMetadata
   ): Promise<never> {
     const errorIdentifier = loadRestJsonErrorCode(response, dataObject) ?? "Unknown";
+    this.mixin.compose(this.compositeErrorRegistry, errorIdentifier, this.options.defaultNamespace);
 
     const { errorSchema, errorMetadata } = await this.mixin.getErrorSchemaOrThrowBaseException(
       errorIdentifier,
@@ -129,8 +138,8 @@ export class AwsRestJsonProtocol extends HttpBindingProtocol {
     );
 
     const ns = NormalizedSchema.of(errorSchema);
-    const message = dataObject.message ?? dataObject.Message ?? "Unknown";
-    const ErrorCtor = TypeRegistry.for(errorSchema[1]).getErrorCtor(errorSchema) ?? Error;
+    const message = dataObject.message ?? dataObject.Message ?? "UnknownError";
+    const ErrorCtor = this.compositeErrorRegistry.getErrorCtor(errorSchema) ?? Error;
     const exception = new ErrorCtor(message);
 
     await this.deserializeHttpMessage(errorSchema, context, response, dataObject);

--- a/packages-internal/core/src/submodules/protocols/query/AwsEc2QueryProtocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/query/AwsEc2QueryProtocol.spec.ts
@@ -1,3 +1,5 @@
+import { TypeRegistry } from "@smithy/core/schema";
+import type { StaticErrorSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
 import { AwsEc2QueryProtocol } from "./AwsEc2QueryProtocol";
@@ -11,5 +13,36 @@ describe("AwsEc2QueryProtocol", () => {
     });
 
     expect(protocol.getShapeId()).toEqual("aws.protocols#ec2Query");
+  });
+
+  it("uses compositeErrorRegistries from instantiation", () => {
+    const GenericServiceException$: StaticErrorSchema = [
+      -3,
+      "com.amazonaws.sdk.example",
+      "GenericServiceException",
+      0,
+      [],
+      [],
+    ];
+    class GenericServiceException extends Error {}
+
+    const registry = TypeRegistry.for("com.amazonaws.sdk.example");
+    registry.registerError(GenericServiceException$, GenericServiceException);
+
+    const protocol = new (class extends AwsEc2QueryProtocol {
+      public getCompositeErrorRegistry() {
+        return this.compositeErrorRegistry;
+      }
+    })({
+      defaultNamespace: "",
+      version: "",
+      xmlNamespace: "",
+      errorTypeRegistries: [registry],
+    });
+
+    expect(protocol.getCompositeErrorRegistry()).not.toBe(registry);
+    expect(protocol.getCompositeErrorRegistry().getSchema("com.amazonaws.sdk.example#GenericServiceException")).toBe(
+      GenericServiceException$
+    );
   });
 });

--- a/packages-internal/core/src/submodules/protocols/query/AwsEc2QueryProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/query/AwsEc2QueryProtocol.ts
@@ -1,3 +1,5 @@
+import type { TypeRegistry } from "@smithy/core/schema";
+
 import { AwsQueryProtocol } from "./AwsQueryProtocol";
 import type { QuerySerializerSettings } from "./QuerySerializerSettings";
 
@@ -10,6 +12,7 @@ export class AwsEc2QueryProtocol extends AwsQueryProtocol {
       defaultNamespace: string;
       xmlNamespace: string;
       version: string;
+      errorTypeRegistries?: TypeRegistry[];
     }
   ) {
     super(options);

--- a/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.spec.ts
@@ -28,6 +28,37 @@ describe(AwsQueryProtocol.name, () => {
     );
   });
 
+  it("uses compositeErrorRegistries from instantiation", () => {
+    const GenericServiceException$: StaticErrorSchema = [
+      -3,
+      "com.amazonaws.sdk.example",
+      "GenericServiceException",
+      0,
+      [],
+      [],
+    ];
+    class GenericServiceException extends Error {}
+
+    const registry = TypeRegistry.for("com.amazonaws.sdk.example");
+    registry.registerError(GenericServiceException$, GenericServiceException);
+
+    const protocol = new (class extends AwsQueryProtocol {
+      public getCompositeErrorRegistry() {
+        return this.compositeErrorRegistry;
+      }
+    })({
+      version: "",
+      defaultNamespace: "",
+      xmlNamespace: "",
+      errorTypeRegistries: [registry],
+    });
+
+    expect(protocol.getCompositeErrorRegistry()).not.toBe(registry);
+    expect(protocol.getCompositeErrorRegistry().getSchema("com.amazonaws.sdk.example#GenericServiceException")).toBe(
+      GenericServiceException$
+    );
+  });
+
   it("decorates service exceptions with unmodeled fields", async () => {
     const httpResponse = new HttpResponse({
       statusCode: 400,

--- a/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/query/AwsQueryProtocol.ts
@@ -1,5 +1,6 @@
 import { collectBody, RpcProtocol } from "@smithy/core/protocols";
-import { deref, ErrorSchema, NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
+import type { TypeRegistry } from "@smithy/core/schema";
+import { deref, ErrorSchema, NormalizedSchema } from "@smithy/core/schema";
 import type {
   Codec,
   DocumentSchema,
@@ -32,10 +33,12 @@ export class AwsQueryProtocol extends RpcProtocol {
       defaultNamespace: string;
       xmlNamespace: string;
       version: string;
+      errorTypeRegistries?: TypeRegistry[];
     }
   ) {
     super({
       defaultNamespace: options.defaultNamespace,
+      errorTypeRegistries: options.errorTypeRegistries,
     });
     const settings = {
       timestampFormat: {
@@ -146,6 +149,8 @@ export class AwsQueryProtocol extends RpcProtocol {
     metadata: ResponseMetadata
   ): Promise<never> {
     const errorIdentifier = this.loadQueryErrorCode(response, dataObject) ?? "Unknown";
+    this.mixin.compose(this.compositeErrorRegistry, errorIdentifier, this.options.defaultNamespace);
+
     const errorData = this.loadQueryError(dataObject) ?? {};
     const message = this.loadQueryErrorMessage(dataObject);
     errorData.message = message;
@@ -165,7 +170,7 @@ export class AwsQueryProtocol extends RpcProtocol {
     );
 
     const ns = NormalizedSchema.of(errorSchema);
-    const ErrorCtor = TypeRegistry.for(errorSchema[1]).getErrorCtor(errorSchema) ?? Error;
+    const ErrorCtor = this.compositeErrorRegistry.getErrorCtor(errorSchema) ?? Error;
     const exception = new ErrorCtor(message);
 
     const output = {

--- a/packages-internal/core/src/submodules/protocols/xml/AwsRestXmlProtocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/xml/AwsRestXmlProtocol.spec.ts
@@ -22,6 +22,36 @@ describe(AwsRestXmlProtocol.name, () => {
     expect(protocol.getShapeId()).toEqual("aws.protocols#restXml");
   });
 
+  it("uses compositeErrorRegistries from instantiation", () => {
+    const GenericServiceException$: StaticErrorSchema = [
+      -3,
+      "com.amazonaws.sdk.example",
+      "GenericServiceException",
+      0,
+      [],
+      [],
+    ];
+    class GenericServiceException extends Error {}
+
+    const registry = TypeRegistry.for("com.amazonaws.sdk.example");
+    registry.registerError(GenericServiceException$, GenericServiceException);
+
+    const protocol = new (class extends AwsRestXmlProtocol {
+      public getCompositeErrorRegistry() {
+        return this.compositeErrorRegistry;
+      }
+    })({
+      xmlNamespace: "http://s3.amazonaws.com/doc/2006-03-01/",
+      defaultNamespace: "com.amazonaws.s3",
+      errorTypeRegistries: [registry],
+    });
+
+    expect(protocol.getCompositeErrorRegistry()).not.toBe(registry);
+    expect(protocol.getCompositeErrorRegistry().getSchema("com.amazonaws.sdk.example#GenericServiceException")).toBe(
+      GenericServiceException$
+    );
+  });
+
   describe("serialization", () => {
     const testCases = [
       {

--- a/packages-internal/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
@@ -3,7 +3,8 @@ import {
   HttpInterceptingShapeDeserializer,
   HttpInterceptingShapeSerializer,
 } from "@smithy/core/protocols";
-import { NormalizedSchema, TypeRegistry } from "@smithy/core/schema";
+import type { TypeRegistry } from "@smithy/core/schema";
+import { NormalizedSchema } from "@smithy/core/schema";
 import type {
   EndpointBearer,
   HandlerExecutionContext,
@@ -32,7 +33,11 @@ export class AwsRestXmlProtocol extends HttpBindingProtocol {
   protected deserializer: ShapeDeserializer<string | Uint8Array>;
   private readonly mixin = new ProtocolLib();
 
-  public constructor(options: { defaultNamespace: string; xmlNamespace: string }) {
+  public constructor(options: {
+    defaultNamespace: string;
+    xmlNamespace: string;
+    errorTypeRegistries?: TypeRegistry[];
+  }) {
     super(options);
     const settings: XmlSettings = {
       timestampFormat: {
@@ -46,6 +51,7 @@ export class AwsRestXmlProtocol extends HttpBindingProtocol {
     this.codec = new XmlCodec(settings);
     this.serializer = new HttpInterceptingShapeSerializer(this.codec.createSerializer(), settings);
     this.deserializer = new HttpInterceptingShapeDeserializer(this.codec.createDeserializer(), settings);
+    this.compositeErrorRegistry;
   }
 
   public getPayloadCodec(): XmlCodec {
@@ -108,6 +114,7 @@ export class AwsRestXmlProtocol extends HttpBindingProtocol {
     metadata: ResponseMetadata
   ): Promise<never> {
     const errorIdentifier = loadRestXmlErrorCode(response, dataObject) ?? "Unknown";
+    this.mixin.compose(this.compositeErrorRegistry, errorIdentifier, this.options.defaultNamespace);
 
     // see https://smithy.io/2.0/aws/protocols/aws-restxml-protocol.html#error-response-serialization
     if (dataObject.Error && typeof dataObject.Error === "object") {
@@ -132,8 +139,12 @@ export class AwsRestXmlProtocol extends HttpBindingProtocol {
 
     const ns = NormalizedSchema.of(errorSchema);
     const message =
-      dataObject.Error?.message ?? dataObject.Error?.Message ?? dataObject.message ?? dataObject.Message ?? "Unknown";
-    const ErrorCtor = TypeRegistry.for(errorSchema[1]).getErrorCtor(errorSchema) ?? Error;
+      dataObject.Error?.message ??
+      dataObject.Error?.Message ??
+      dataObject.message ??
+      dataObject.Message ??
+      "UnknownError";
+    const ErrorCtor = this.compositeErrorRegistry.getErrorCtor(errorSchema) ?? Error;
     const exception = new ErrorCtor(message);
 
     await this.deserializeHttpMessage(errorSchema, context, response, dataObject);

--- a/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/ComplexError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -27,7 +27,7 @@ ComplexError: Unknown
   name: "ComplexError",
   TopLevel: (undefined),
   Nested: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json10#ComplexError"
 }
 
@@ -47,7 +47,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -66,7 +66,7 @@ ComplexError: Unknown
   Nested: {
     Foo: "__Foo__"
   },
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json10#ComplexError"
 }
 

--- a/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/FooError.txt
+++ b/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/FooError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-FooError: Unknown
+FooError: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ FooError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "FooError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json10#FooError"
 }
 
@@ -41,7 +41,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-FooError: Unknown
+FooError: UnknownError
 
 --- [error object] ---
 {
@@ -56,7 +56,7 @@ FooError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "FooError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json10#FooError"
 }
 

--- a/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-json-10-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.0
 
 
 --- [error name & message] ---
-InvalidGreeting: Unknown
+InvalidGreeting: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidGreeting: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidGreeting",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json10#InvalidGreeting"
 }
 

--- a/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/InternalServerException.txt
+++ b/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/InternalServerException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InternalServerException: Unknown
+InternalServerException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ InternalServerException: Unknown
   },
   name: "InternalServerException",
   code: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.machinelearning#InternalServerException"
 }
 

--- a/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/InvalidInputException.txt
+++ b/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/InvalidInputException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidInputException: Unknown
+InvalidInputException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ InvalidInputException: Unknown
   },
   name: "InvalidInputException",
   code: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.machinelearning#InvalidInputException"
 }
 

--- a/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/LimitExceededException.txt
+++ b/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/LimitExceededException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-LimitExceededException: Unknown
+LimitExceededException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ LimitExceededException: Unknown
   },
   name: "LimitExceededException",
   code: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.machinelearning#LimitExceededException"
 }
 

--- a/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/PredictorNotMountedException.txt
+++ b/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/PredictorNotMountedException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-PredictorNotMountedException: Unknown
+PredictorNotMountedException: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ PredictorNotMountedException: Unknown
     totalRetryDelay: (number) 0
   },
   name: "PredictorNotMountedException",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.machinelearning#PredictorNotMountedException"
 }
 

--- a/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/ResourceNotFoundException.txt
+++ b/private/aws-protocoltests-json-schema-machinelearning/test/snapshots/res-err/ResourceNotFoundException.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ResourceNotFoundException: Unknown
+ResourceNotFoundException: UnknownError
 
 --- [error object] ---
 {
@@ -26,7 +26,7 @@ ResourceNotFoundException: Unknown
   },
   name: "ResourceNotFoundException",
   code: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "com.amazonaws.machinelearning#ResourceNotFoundException"
 }
 

--- a/private/aws-protocoltests-json-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-json-schema/test/snapshots/res-err/ComplexError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -27,7 +27,7 @@ ComplexError: Unknown
   name: "ComplexError",
   TopLevel: (undefined),
   Nested: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#ComplexError"
 }
 
@@ -47,7 +47,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -66,7 +66,7 @@ ComplexError: Unknown
   Nested: {
     Foo: "__Foo__"
   },
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#ComplexError"
 }
 

--- a/private/aws-protocoltests-json-schema/test/snapshots/res-err/ErrorWithMembers.txt
+++ b/private/aws-protocoltests-json-schema/test/snapshots/res-err/ErrorWithMembers.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ErrorWithMembers: Unknown
+ErrorWithMembers: UnknownError
 
 --- [error object] ---
 {
@@ -31,7 +31,7 @@ ErrorWithMembers: Unknown
   ListField: (undefined),
   MapField: (undefined),
   StringField: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#ErrorWithMembers"
 }
 

--- a/private/aws-protocoltests-json-schema/test/snapshots/res-err/ErrorWithoutMembers.txt
+++ b/private/aws-protocoltests-json-schema/test/snapshots/res-err/ErrorWithoutMembers.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ErrorWithoutMembers: Unknown
+ErrorWithoutMembers: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ ErrorWithoutMembers: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ErrorWithoutMembers",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#ErrorWithoutMembers"
 }
 
@@ -41,7 +41,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-ErrorWithoutMembers: Unknown
+ErrorWithoutMembers: UnknownError
 
 --- [error object] ---
 {
@@ -56,7 +56,7 @@ ErrorWithoutMembers: Unknown
     totalRetryDelay: (number) 0
   },
   name: "ErrorWithoutMembers",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#ErrorWithoutMembers"
 }
 

--- a/private/aws-protocoltests-json-schema/test/snapshots/res-err/FooError.txt
+++ b/private/aws-protocoltests-json-schema/test/snapshots/res-err/FooError.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-FooError: Unknown
+FooError: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ FooError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "FooError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#FooError"
 }
 
@@ -41,7 +41,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-FooError: Unknown
+FooError: UnknownError
 
 --- [error object] ---
 {
@@ -56,7 +56,7 @@ FooError: Unknown
     totalRetryDelay: (number) 0
   },
   name: "FooError",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#FooError"
 }
 

--- a/private/aws-protocoltests-json-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-json-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -10,7 +10,7 @@ content-type: application/x-amz-json-1.1
 
 
 --- [error name & message] ---
-InvalidGreeting: Unknown
+InvalidGreeting: UnknownError
 
 --- [error object] ---
 {
@@ -25,7 +25,7 @@ InvalidGreeting: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidGreeting",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "aws.protocoltests.json#InvalidGreeting"
 }
 

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/test/snapshots/res-err/ComplexError.txt
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/test/snapshots/res-err/ComplexError.txt
@@ -16,7 +16,7 @@ content-type: application/cbor
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -33,7 +33,7 @@ ComplexError: Unknown
   name: "ComplexError",
   TopLevel: (undefined),
   Nested: (undefined),
-  message: "Unknown",
+  message: "UnknownError",
   __type: "smithy.protocoltests.rpcv2Cbor#ComplexError"
 }
 
@@ -60,7 +60,7 @@ content-type: application/cbor
 
 
 --- [error name & message] ---
-ComplexError: Unknown
+ComplexError: UnknownError
 
 --- [error object] ---
 {
@@ -79,7 +79,7 @@ ComplexError: Unknown
   Nested: {
     Foo: "__Foo__"
   },
-  message: "Unknown",
+  message: "UnknownError",
   __type: "smithy.protocoltests.rpcv2Cbor#ComplexError"
 }
 

--- a/private/aws-protocoltests-smithy-rpcv2-cbor-schema/test/snapshots/res-err/InvalidGreeting.txt
+++ b/private/aws-protocoltests-smithy-rpcv2-cbor-schema/test/snapshots/res-err/InvalidGreeting.txt
@@ -16,7 +16,7 @@ content-type: application/cbor
 
 
 --- [error name & message] ---
-InvalidGreeting: Unknown
+InvalidGreeting: UnknownError
 
 --- [error object] ---
 {
@@ -31,7 +31,7 @@ InvalidGreeting: Unknown
     totalRetryDelay: (number) 0
   },
   name: "InvalidGreeting",
-  message: "Unknown",
+  message: "UnknownError",
   __type: "smithy.protocoltests.rpcv2Cbor#InvalidGreeting"
 }
 


### PR DESCRIPTION
### Issue
Prior PR about this, incomplete fix: https://github.com/smithy-lang/smithy-typescript/pull/1867

reported bug: https://github.com/aws/aws-sdk-js-v3/issues/7507
reported bug: https://github.com/aws/aws-sdk-js-v3/issues/7859
reported bug: https://github.com/aws/aws-cdk-cli/issues/954
reported bug: https://github.com/smithy-lang/smithy-typescript/issues/1930

### Description
When `@smithy/core` is duplicated within an application's `node_modules`, the error creation mechanism in the AWS SDK JS may produce a generic error instead of the expected service synthetic/generic error (e.g. `S3ServiceException`) or service-modeled error (e.g. `BucketAlreadyExists`).

There was a previous PR that attempted to fix this, but it was incomplete. 

### Testing
new unit tests

updated snapshots

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
