### PR TITLE
fix(scripts): add escape character in changelog, message field

### DIFF
--- a/scripts/update-versions/lib/generateChangelog.mjs
+++ b/scripts/update-versions/lib/generateChangelog.mjs
@@ -101,6 +101,7 @@ async function generateChangelog(packagePath, since) {
     .split("\n")
     .map((r) => r.trim())
     .map((r) => r.replaceAll(/(^'|'$)/g, ""))
+    .map((r) => r.replace(/"message":"(.*?)"},$/, (_, msg) => `"message":"${msg.replaceAll('"', '\\"')}"},`))
     .join("\n");
 
   const changelog = JSON.parse(`[${processedRows.slice(0, -1)}]`);


### PR DESCRIPTION
### Issue
Internal JS-6720

### Description
The changelog script builds JSON by interpolating the git commit subject directly into a string template like `{"commit":"...","message":"<subject>"},`. If the subject contains double quotes, the resulting string is invalid JSON and JSON.parse throws.

The fix adds a step that escapes any `"` inside the message field to `\"` before parsing, so the JSON stays valid regardless of what's in the commit subject.



### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
