### PR TITLE
chore(lib-storage): change default AbortController in Upload to the global implementation

### DIFF
--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -30,7 +30,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@smithy/abort-controller": "^4.2.12",
     "@smithy/middleware-endpoint": "^4.4.27",
     "@smithy/protocol-http": "^5.3.12",
     "@smithy/smithy-client": "^4.12.7",

--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -917,7 +917,7 @@ describe(Upload.name, () => {
         client: new S3({}),
       });
 
-      expect((upload as any).abortController).toBeInstanceOf(AbortControllerPolyfill);
+      expect((upload as any).abortController).toBeInstanceOf(AbortController);
     });
 
     it("should calculate expectedPartsCount correctly when totalBytes is known", () => {

--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -8,7 +8,7 @@ import {
   S3Client,
   UploadPartCommand,
 } from "@aws-sdk/client-s3";
-import { AbortController } from "@smithy/abort-controller";
+import { AbortController as AbortControllerPolyfill } from "@smithy/abort-controller";
 import { EventEmitter, Readable } from "node:stream";
 import { afterAll, afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
 
@@ -783,6 +783,24 @@ describe(Upload.name, () => {
     }
   });
 
+  it("should respect external abort signal from polyfill", async () => {
+    const abortController = new AbortControllerPolyfill();
+
+    try {
+      const upload = new Upload({
+        params,
+        client: new S3({}),
+        abortController,
+      });
+
+      abortController.abort();
+
+      await upload.done();
+    } catch (error) {
+      expect(error).toBeDefined();
+    }
+  });
+
   it("should reject calling .done() more than once on an instance", async () => {
     const upload = new Upload({
       params,
@@ -883,7 +901,7 @@ describe(Upload.name, () => {
     });
 
     it("should use custom abortController when provided", () => {
-      const customAbortController = new AbortController();
+      const customAbortController = new AbortControllerPolyfill();
       const upload = new Upload({
         params,
         abortController: customAbortController,
@@ -899,7 +917,7 @@ describe(Upload.name, () => {
         client: new S3({}),
       });
 
-      expect((upload as any).abortController).toBeInstanceOf(AbortController);
+      expect((upload as any).abortController).toBeInstanceOf(AbortControllerPolyfill);
     });
 
     it("should calculate expectedPartsCount correctly when totalBytes is known", () => {

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -18,12 +18,15 @@ import {
   PutObjectTaggingCommand,
   UploadPartCommand,
 } from "@aws-sdk/client-s3";
-import { AbortController } from "@smithy/abort-controller";
 import type { EndpointParameterInstructionsSupplier } from "@smithy/middleware-endpoint";
 import { getEndpointFromInstructions, toEndpointV1 } from "@smithy/middleware-endpoint";
 import type { HttpRequest } from "@smithy/protocol-http";
 import { extendedEncodeURIComponent } from "@smithy/smithy-client";
-import type { AbortController as IAbortController, AbortSignal as IAbortSignal, Endpoint } from "@smithy/types";
+import type {
+  AbortController as AbortControllerPolyfill,
+  AbortSignal as AbortSignalPolyfill,
+  Endpoint,
+} from "@smithy/types";
 // eslint-disable-next-line n/prefer-node-protocol
 import { EventEmitter } from "events";
 
@@ -66,7 +69,7 @@ export class Upload extends EventEmitter {
   private bytesUploadedSoFar: number;
 
   // used in the upload.
-  private abortController: IAbortController;
+  private abortController: AbortController | AbortControllerPolyfill;
   private concurrentUploaders: Promise<void>[] = [];
   private createMultiPartPromise?: Promise<CreateMultipartUploadCommandOutput>;
   private abortMultipartUploadCommand: AbortMultipartUploadCommand | null = null;
@@ -448,7 +451,7 @@ to input.params.ContentLength in bytes.
     }
   }
 
-  private async __abortTimeout(abortSignal: IAbortSignal): Promise<never> {
+  private async __abortTimeout(abortSignal: AbortSignal | AbortSignalPolyfill): Promise<never> {
     return new Promise((resolve, reject) => {
       abortSignal.onabort = () => {
         const abortError = new Error("Upload aborted.");

--- a/lib/lib-storage/src/types.ts
+++ b/lib/lib-storage/src/types.ts
@@ -6,7 +6,7 @@ import type {
   Tag,
   UploadPartCommandInput,
 } from "@aws-sdk/client-s3";
-import type { AbortController } from "@smithy/types";
+import type { AbortController as AbortControllerPolyfill } from "@smithy/types";
 
 export interface Progress {
   loaded?: number;
@@ -52,7 +52,7 @@ export interface Configuration {
   /**
    * Optional abort controller for controlling this upload's abort signal externally.
    */
-  abortController?: AbortController;
+  abortController?: AbortController | AbortControllerPolyfill;
 }
 
 export interface Options extends Partial<Configuration> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24025,7 +24025,6 @@ __metadata:
   resolution: "@aws-sdk/lib-storage@workspace:lib/lib-storage"
   dependencies:
     "@aws-sdk/client-s3": "workspace:3.1017.0"
-    "@smithy/abort-controller": "npm:^4.2.12"
     "@smithy/middleware-endpoint": "npm:^4.4.27"
     "@smithy/protocol-http": "npm:^5.3.12"
     "@smithy/smithy-client": "npm:^4.12.7"


### PR DESCRIPTION
### Issue

N/A

### Description

`@aws-sdk/lib-storage` already targets Node.js >= 20.0.0, where Node.js introduced the native `AbortController` back in 15.4.0, which means we do not need to polyfill anymore and should prefer the native version.

In fact, even `@smithy/abort-controller` says itself is deprecated and you should prefer the native version.

To be backward compatible, I still import `AbortController` and `AbortSignal` types from `@smithy/types` package instead, so TypeScript won't scream at existing polyfilled external abort signal usage.

Do notice that `@smithy/abort-controller` is not completely removed, but moved to devDeps, because we still need to test against it to ensure backward compatibility.

I can start applying the same change to other `@smithy/abort-controller` usage in this repo once this PR is merged.

### Testing

To be backward compatible, I have updated `Upload.spec.ts` to test against both native and polyfilled `AbortSignal`.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
