### PR TITLE
docs(client-cognito-identity-provider): fix "ornull" typo in field docs

### DIFF
--- a/clients/client-cognito-identity-provider/src/models/models_0.ts
+++ b/clients/client-cognito-identity-provider/src/models/models_0.ts
@@ -2147,7 +2147,7 @@ export interface GroupType {
    * <p>A non-negative integer value that specifies the precedence of this group relative to
    *             the other groups that a user can belong to in the user pool. Zero is the highest
    *             precedence value. Groups with lower <code>Precedence</code> values take precedence over
-   *             groups with higher ornull <code>Precedence</code> values. If a user belongs to two or
+   *             groups with higher or null <code>Precedence</code> values. If a user belongs to two or
    *             more groups, it is the group with the lowest precedence value whose role ARN is given in
    *             the user's tokens for the <code>cognito:roles</code> and
    *                 <code>cognito:preferred_role</code> claims.</p>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Fixes a minor typo in the `client-cognito-identity-provider` package documentation where "ornull" was written as a single word instead of "or null".

**Testing**

No testing required — this is a documentation-only change with no impact on runtime behavior.

**Checklist**

- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work??
  - [x] No streams here.