### PR TITLE
chore(middleware-sdk-s3): custom request validation for s3 client

### DIFF
--- a/clients/client-s3/src/runtimeConfig.shared.ts
+++ b/clients/client-s3/src/runtimeConfig.shared.ts
@@ -1,6 +1,6 @@
 // smithy-typescript generated code
 import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core";
-import { AwsRestXmlProtocol } from "@aws-sdk/core/protocols";
+import { S3RestXmlProtocol } from "@aws-sdk/middleware-sdk-s3";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
@@ -42,7 +42,7 @@ export const getRuntimeConfig = (config: S3ClientConfig) => {
       },
     ],
     logger: config?.logger ?? new NoOpLogger(),
-    protocol: config?.protocol ?? AwsRestXmlProtocol,
+    protocol: config?.protocol ?? S3RestXmlProtocol,
     protocolSettings: config?.protocolSettings ?? {
       defaultNamespace: "com.amazonaws.s3",
       errorTypeRegistries,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -336,6 +336,12 @@ public final class AddS3Config implements TypeScriptIntegration {
                     "useArnRegion",
                     writer -> {
                         writer.write("undefined");
+                    },
+                    "protocol",
+                    writer -> {
+                        writer.addImport("S3RestXmlProtocol", null, AwsDependency.S3_MIDDLEWARE);
+                        writer.write("""
+                                     S3RestXmlProtocol""");
                     }
                 );
             case NODE:

--- a/packages-internal/middleware-sdk-s3/src/index.ts
+++ b/packages-internal/middleware-sdk-s3/src/index.ts
@@ -6,3 +6,4 @@ export * from "./s3-express/index";
 export * from "./s3Configuration";
 export * from "./throw-200-exceptions";
 export * from "./validate-bucket-name";
+export { S3RestXmlProtocol } from "./protocol/S3RestXmlProtocol";

--- a/packages-internal/middleware-sdk-s3/src/middleware-sdk-s3.integ.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/middleware-sdk-s3.integ.spec.ts
@@ -7,6 +7,10 @@ describe("middleware-sdk-s3", () => {
     it("validates bucket names", async () => {
       const client = new S3({
         region: "us-west-2",
+        credentials: {
+          accessKeyId: "INTEG",
+          secretAccessKey: "INTEG",
+        },
       });
 
       requireRequestsFrom(client).toMatch({
@@ -32,6 +36,10 @@ describe("middleware-sdk-s3", () => {
     it("warns on input streams of unknown length", async () => {
       const client = new S3({
         region: "us-west-2",
+        credentials: {
+          accessKeyId: "INTEG",
+          secretAccessKey: "INTEG",
+        },
         logger: Object.assign({
           trace: vi.fn(),
           debug: vi.fn(),
@@ -61,6 +69,10 @@ describe("middleware-sdk-s3", () => {
     it("allows using a bucket input value as the endpoint", async () => {
       const client = new S3({
         region: "us-west-2",
+        credentials: {
+          accessKeyId: "INTEG",
+          secretAccessKey: "INTEG",
+        },
         bucketEndpoint: true,
       });
 
@@ -80,6 +92,37 @@ describe("middleware-sdk-s3", () => {
         Key: "my-key",
         Body: "abcd",
       });
+
+      expect.hasAssertions();
+    });
+
+    it("considers missing Bucket an http label error", async () => {
+      const client = new S3({
+        region: "us-west-2",
+        credentials: {
+          accessKeyId: "INTEG",
+          secretAccessKey: "INTEG",
+        },
+      });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          bucket: "assertion-not-reached",
+        },
+      });
+
+      await client
+        .headBucket(
+          {} as unknown as {
+            Bucket: "present";
+          }
+        )
+        .then(() => {
+          throw new Error("this should not be reached");
+        })
+        .catch((err) => {
+          expect(err).toEqual(new Error("No value provided for input HTTP label: Bucket."));
+        });
 
       expect.hasAssertions();
     });

--- a/packages-internal/middleware-sdk-s3/src/protocol/S3RestXmlProtocol.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/protocol/S3RestXmlProtocol.spec.ts
@@ -1,0 +1,109 @@
+import { errorTypeRegistries, GetObject$ } from "@aws-sdk/client-s3";
+import type { StaticStructureSchema } from "@smithy/types";
+import { describe, expect, test as it } from "vitest";
+
+import { S3RestXmlProtocol } from "./S3RestXmlProtocol";
+
+describe("S3RestXmlProtocol", () => {
+  const protocol = new S3RestXmlProtocol({
+    defaultNamespace: "com.amazonaws.s3",
+    errorTypeRegistries,
+    xmlNamespace: "http://s3.amazonaws.com/doc/2006-03-01/",
+  });
+
+  const [, namespace, name, traits, input, output] = GetObject$;
+
+  const input_BucketNotRequired = [
+    3,
+    "com.amazonaws.s3",
+    "Input",
+    {},
+    ["Key", "Bucket"],
+    [0, [0, { httpLabel: 1 }]],
+    1,
+  ] satisfies StaticStructureSchema;
+  const input_BucketNotHttpLabel = [
+    3,
+    "com.amazonaws.s3",
+    "Input",
+    {},
+    ["Key", "Bucket"],
+    [0, 0],
+    2,
+  ] satisfies StaticStructureSchema;
+
+  it("should throw an error if Bucket is missing from input top level, it is required, and it is an http label", async () => {
+    await expect(
+      async () =>
+        await protocol.serializeRequest(
+          {
+            namespace,
+            name,
+            traits,
+            input,
+            output,
+          },
+          {
+            Key: "test-key",
+          },
+          {
+            async endpoint() {
+              return {
+                hostname: "localhost",
+                path: "/",
+                protocol: "https:",
+              };
+            },
+          } as any
+        )
+    ).rejects.toThrowError("No value provided for input HTTP label: Bucket.");
+  });
+
+  it("should not throw if the Bucket member is not required", async () => {
+    await protocol.serializeRequest(
+      {
+        namespace,
+        name,
+        traits,
+        input: input_BucketNotRequired,
+        output,
+      },
+      {
+        Key: "test-key",
+      },
+      {
+        async endpoint() {
+          return {
+            hostname: "localhost",
+            path: "/",
+            protocol: "https:",
+          };
+        },
+      } as any
+    );
+  });
+
+  it("should not throw if the Bucket member is not an HTTP Label", async () => {
+    await protocol.serializeRequest(
+      {
+        namespace,
+        name,
+        traits,
+        input: input_BucketNotHttpLabel,
+        output,
+      },
+      {
+        Key: "test-key",
+      },
+      {
+        async endpoint() {
+          return {
+            hostname: "localhost",
+            path: "/",
+            protocol: "https:",
+          };
+        },
+      } as any
+    );
+  });
+});

--- a/packages-internal/middleware-sdk-s3/src/protocol/S3RestXmlProtocol.ts
+++ b/packages-internal/middleware-sdk-s3/src/protocol/S3RestXmlProtocol.ts
@@ -1,0 +1,56 @@
+import { AwsRestXmlProtocol } from "@aws-sdk/core/protocols";
+import { NormalizedSchema } from "@smithy/core/schema";
+import type {
+  EndpointBearer,
+  HandlerExecutionContext,
+  HttpRequest,
+  OperationSchema,
+  SerdeFunctions,
+  StaticStructureSchema,
+} from "@smithy/types";
+
+/**
+ * Customization for S3 backwards compatibility.
+ *
+ * In the S3 model, Bucket is considered an HTTP label, and we normally perform http label client
+ * side validation. However, the standard validation is that the http label appears in
+ * the request path. Bucket is unique in that it is an endpoint context param. It appears
+ * where the endpoint resolver decides, rather than in the URL path (although sometimes it does appear there).
+ *
+ * For consistency with older code generated clients, we throw the HTTP label validation
+ * error when the Bucket input is missing, if-and-only-if it is an httpLabel and is a required top level member.
+ *
+ * This does not apply to S3 Control.
+ *
+ * @internal
+ */
+export class S3RestXmlProtocol extends AwsRestXmlProtocol {
+  public async serializeRequest<Input extends object>(
+    operationSchema: OperationSchema,
+    input: Input,
+    context: HandlerExecutionContext & SerdeFunctions & EndpointBearer
+  ): Promise<HttpRequest> {
+    const request = await super.serializeRequest(operationSchema, input, context);
+    const ns = NormalizedSchema.of(operationSchema.input);
+    const staticStructureSchema = ns.getSchema() as StaticStructureSchema;
+
+    let bucketMemberIndex = 0;
+    const requiredMemberCount = staticStructureSchema[6] ?? 0;
+
+    if (input && typeof input === "object") {
+      for (const [memberName, memberNs] of ns.structIterator()) {
+        if (++bucketMemberIndex > requiredMemberCount) {
+          break;
+        }
+        if (memberName === "Bucket") {
+          if (!(input as any).Bucket && memberNs.getMergedTraits().httpLabel) {
+            throw new Error(`No value provided for input HTTP label: Bucket.`);
+          }
+          break;
+        }
+      }
+    }
+
+    return request;
+  }
+}

--- a/scripts/validation/api.json
+++ b/scripts/validation/api.json
@@ -303,7 +303,8 @@
     "throw200ExceptionsMiddleware": "function, since <=3.930.0",
     "throw200ExceptionsMiddlewareOptions": "object, since <=3.930.0",
     "validateBucketNameMiddleware": "function, since <=3.930.0",
-    "validateBucketNameMiddlewareOptions": "object, since <=3.930.0"
+    "validateBucketNameMiddlewareOptions": "object, since <=3.930.0",
+    "S3RestXmlProtocol": "function, since 3.972.24"
   },
   "@aws-sdk/middleware-sdk-s3-control": {
     "NODE_USE_ARN_REGION_CONFIG_OPTIONS": "object, since <=3.930.0",


### PR DESCRIPTION
### Issue
P400702805

### Description
customize S3 input validation due to the unique edge case of Bucket being a context param and http label.

### Testing
CI, new unit tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
