### PR TITLE
chore(lib): add dependency validation coverage for lib folder

### DIFF
--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -32,7 +32,9 @@
   "dependencies": {
     "@smithy/abort-controller": "^4.2.12",
     "@smithy/middleware-endpoint": "^4.4.27",
+    "@smithy/protocol-http": "^5.3.12",
     "@smithy/smithy-client": "^4.12.7",
+    "@smithy/types": "^4.13.1",
     "buffer": "5.6.0",
     "events": "3.3.0",
     "stream-browserify": "3.0.0",
@@ -43,7 +45,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "workspace:3.1016.0",
-    "@smithy/types": "^4.13.1",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^20.14.8",
     "concurrently": "7.0.0",

--- a/scripts/runtime-dependency-version-check/check-dependencies.js
+++ b/scripts/runtime-dependency-version-check/check-dependencies.js
@@ -10,8 +10,9 @@ const pkgJsonEnforcement = require("./package-json-enforcement");
 const root = path.join(__dirname, "..", "..");
 const packages = path.join(root, "packages");
 const packagesInternal = path.join(root, "packages-internal");
+const lib = path.join(root, "lib");
 const _private = path.join(root, "private");
-const topLevelFolders = [packages, packagesInternal, _private];
+const topLevelFolders = [packages, packagesInternal, _private, lib];
 const packageFolders = [];
 const walk = require("../utils/walk");
 const { listFolders } = require("../utils/list-folders");
@@ -56,11 +57,6 @@ const shouldIgnore = (dep) => ignored.includes(dep) || (dep.startsWith("node:") 
   const errors = [];
 
   for (const packageFolder of packageFolders) {
-    if (packageFolder === "util-dynamodb") {
-      // exempt
-      continue;
-    }
-
     const containingFolder = topLevelFolders.find((f) => fs.existsSync(path.join(f, packageFolder, "package.json")));
 
     const pkgJsonPath = path.join(containingFolder, packageFolder, "package.json");
@@ -124,6 +120,11 @@ const shouldIgnore = (dep) => ignored.includes(dep) || (dep.startsWith("node:") 
 
       for (const [dep, version] of Object.entries(pkgJson.devDependencies ?? {})) {
         if ((dep.startsWith("@smithy") || dep.startsWith("@aws-sdk")) && contents.includes(`from "${dep}";`)) {
+          if (dep in pkgJson.peerDependencies) {
+            // peers can be declared in devDeps to set correct build order.
+            continue;
+          }
+
           errors.push(`${dep} incorrectly declared in devDependencies of ${packageFolder}`);
           delete pkgJson.devDependencies[dep];
           if (!pkgJson.dependencies) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23973,6 +23973,7 @@ __metadata:
     "@aws-sdk/client-s3": "workspace:3.1016.0"
     "@smithy/abort-controller": "npm:^4.2.12"
     "@smithy/middleware-endpoint": "npm:^4.4.27"
+    "@smithy/protocol-http": "npm:^5.3.12"
     "@smithy/smithy-client": "npm:^4.12.7"
     "@smithy/types": "npm:^4.13.1"
     "@tsconfig/recommended": "npm:1.0.1"


### PR DESCRIPTION
### Issue
n/a, noticed in https://github.com/aws/aws-sdk-js-v3/pull/7880

### Description
add dependency validation for the `lib` folder.

### Testing
by running the validation

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
