### PR TITLE
docs(packages-internal): readme updates for internal packages

### DIFF
--- a/packages-internal/body-checksum-browser/README.md
+++ b/packages-internal/body-checksum-browser/README.md
@@ -3,8 +3,15 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/body-checksum-browser/latest.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/body-checksum-browser.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-browser)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly.
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---

--- a/packages-internal/body-checksum-node/README.md
+++ b/packages-internal/body-checksum-node/README.md
@@ -3,8 +3,15 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/body-checksum-node/latest.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/body-checksum-node.svg)](https://www.npmjs.com/package/@aws-sdk/body-checksum-node)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly.
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---

--- a/packages-internal/chunked-stream-reader-node/README.md
+++ b/packages-internal/chunked-stream-reader-node/README.md
@@ -3,12 +3,19 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/chunked-stream-reader-node/latest.svg)](https://www.npmjs.com/package/@aws-sdk/chunked-stream-reader-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/chunked-stream-reader-node.svg)](https://www.npmjs.com/package/@aws-sdk/chunked-stream-reader-node)
 
+### :warning: Internal API :warning:
+
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
+
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
+
 Exports a streamReader function that accepts a readable stream, a function to call on each chunk, and a chunk size in bytes to buffer internally before calling the supplied function.
 
 This package is meant for the AWS SDK for JavaScript to enable reading a stream with consistent chunk sizes.
-
-> An internal package
-
-## Usage
-
-You probably shouldn't, at least directly.

--- a/packages-internal/core/src/submodules/account-id-endpoint/README.md
+++ b/packages-internal/core/src/submodules/account-id-endpoint/README.md
@@ -1,9 +1,16 @@
 # @aws-sdk/core/account-id-endpoint
 
-> An internal package
+### :warning: Internal API :warning:
+
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
+
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
 
 This submodule provides functionality for AccountId based endpoint routing.
-
-## Usage
-
-You probably shouldn't, at least directly.

--- a/packages-internal/credential-provider-cognito-identity/README.md
+++ b/packages-internal/credential-provider-cognito-identity/README.md
@@ -3,9 +3,18 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-cognito-identity/latest.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-cognito-identity)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-cognito-identity.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-cognito-identity)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly. Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
+
+Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
 instead.

--- a/packages-internal/credential-provider-env/README.md
+++ b/packages-internal/credential-provider-env/README.md
@@ -3,9 +3,18 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-env/latest.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-env)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-env.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-env)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly. Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
+
+Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
 instead.

--- a/packages-internal/credential-provider-ini/README.md
+++ b/packages-internal/credential-provider-ini/README.md
@@ -3,9 +3,18 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-ini/latest.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-ini)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-ini.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-ini)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly. Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
+
+Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
 instead.

--- a/packages-internal/credential-provider-login/README.md
+++ b/packages-internal/credential-provider-login/README.md
@@ -1,7 +1,16 @@
 # @aws-sdk/credential-provider-login
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly. Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers) instead.
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
+
+Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers) instead.

--- a/packages-internal/credential-provider-process/README.md
+++ b/packages-internal/credential-provider-process/README.md
@@ -3,9 +3,18 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-process/latest.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-process)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-process.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-process)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly. Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
+
+Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
 instead.

--- a/packages-internal/credential-provider-sso/README.md
+++ b/packages-internal/credential-provider-sso/README.md
@@ -3,9 +3,18 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-sso/latest.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-sso)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-sso.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-sso)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly. Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
+
+Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
 instead.

--- a/packages-internal/credential-provider-web-identity/README.md
+++ b/packages-internal/credential-provider-web-identity/README.md
@@ -3,9 +3,18 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-web-identity/latest.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-web-identity)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-web-identity.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-web-identity)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly. Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
+
+Please use [@aws-sdk/credential-providers](https://www.npmjs.com/package/@aws-sdk/credential-providers)
 instead.

--- a/packages-internal/endpoint-cache/README.md
+++ b/packages-internal/endpoint-cache/README.md
@@ -3,11 +3,18 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/endpoint-cache/latest.svg)](https://www.npmjs.com/package/@aws-sdk/endpoint-cache)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/endpoint-cache.svg)](https://www.npmjs.com/package/@aws-sdk/endpoint-cache)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly.
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
 
 ## EndpointCache
 

--- a/packages-internal/eventstream-handler-node/README.md
+++ b/packages-internal/eventstream-handler-node/README.md
@@ -3,8 +3,15 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/eventstream-handler-node/latest.svg)](https://www.npmjs.com/package/@aws-sdk/eventstream-handler-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/eventstream-handler-node.svg)](https://www.npmjs.com/package/@aws-sdk/eventstream-handler-node)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly.
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---

--- a/packages-internal/karma-credential-loader/README.md
+++ b/packages-internal/karma-credential-loader/README.md
@@ -3,8 +3,4 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/karma-credential-loader/latest.svg)](https://www.npmjs.com/package/@aws-sdk/karma-credential-loader)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/karma-credential-loader.svg)](https://www.npmjs.com/package/@aws-sdk/karma-credential-loader)
 
-> An internal package
-
-## Usage
-
-You probably shouldn't, at least directly.
+This is a private testing package that is not part of the AWS SDK runtime.

--- a/packages-internal/middleware-recursion-detection/README.md
+++ b/packages-internal/middleware-recursion-detection/README.md
@@ -3,8 +3,15 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-recursion-detection/latest.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-recursion-detection)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-recursion-detection.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-recursion-detection)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly.
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---

--- a/packages-internal/middleware-token/README.md
+++ b/packages-internal/middleware-token/README.md
@@ -3,10 +3,17 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-token/latest.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-token)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-token.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-token)
 
+### :warning: Internal API :warning:
+
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
+
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
+
 Middleware and Plugin for setting token authentication.
-
-> An internal package
-
-## Usage
-
-You probably shouldn't, at least directly.

--- a/packages-internal/middleware-websocket/README.md
+++ b/packages-internal/middleware-websocket/README.md
@@ -3,10 +3,17 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-websocket/latest.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-websocket)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-websocket.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-websocket)
 
-> An internal package
+### :warning: Internal API :warning:
+
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
+
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
 
 This package contains necessary dependency to support WebSocket connections for AWS services. These behaviors are subject to change.
-
-## Usage
-
-You probably shouldn't, at least directly.

--- a/packages-internal/region-config-resolver/README.md
+++ b/packages-internal/region-config-resolver/README.md
@@ -3,10 +3,17 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/region-config-resolver/latest.svg)](https://www.npmjs.com/package/@aws-sdk/region-config-resolver)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/region-config-resolver.svg)](https://www.npmjs.com/package/@aws-sdk/region-config-resolver)
 
-> An internal package
+### :warning: Internal API :warning:
+
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
+
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
 
 This package provides utilities for AWS region config resolvers.
-
-## Usage
-
-You probably shouldn't, at least directly.

--- a/packages-internal/sha256-tree-hash/README.md
+++ b/packages-internal/sha256-tree-hash/README.md
@@ -3,8 +3,15 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/sha256-tree-hash/latest.svg)](https://www.npmjs.com/package/@aws-sdk/sha256-tree-hash)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/sha256-tree-hash.svg)](https://www.npmjs.com/package/@aws-sdk/sha256-tree-hash)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly.
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---

--- a/packages-internal/util-dns/README.md
+++ b/packages-internal/util-dns/README.md
@@ -3,10 +3,17 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-dns/latest.svg)](https://www.npmjs.com/package/@aws-sdk/util-dns)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-dns.svg)](https://www.npmjs.com/package/@aws-sdk/util-dns)
 
-> An internal package
+### :warning: Internal API :warning:
+
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
+
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---
 
 This package provides utilities for DNS host resolvers.
-
-## Usage
-
-You probably shouldn't, at least directly.

--- a/packages-internal/util-user-agent-node/README.md
+++ b/packages-internal/util-user-agent-node/README.md
@@ -3,8 +3,15 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-user-agent-node/latest.svg)](https://www.npmjs.com/package/@aws-sdk/util-user-agent-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-user-agent-node.svg)](https://www.npmjs.com/package/@aws-sdk/util-user-agent-node)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly.
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---

--- a/packages-internal/xml-builder/README.md
+++ b/packages-internal/xml-builder/README.md
@@ -3,8 +3,15 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/xml-builder/latest.svg)](https://www.npmjs.com/package/@aws-sdk/xml-builder)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/xml-builder.svg)](https://www.npmjs.com/package/@aws-sdk/xml-builder)
 
-> An internal package
+### :warning: Internal API :warning:
 
-## Usage
+> This is an internal package.
+> That means this is used as a dependency for other, public packages, but
+> should not be taken directly as a dependency in your application's `package.json`.
 
-You probably shouldn't, at least directly.
+> If you are updating the version of this package, for example to bring in a
+> bug-fix, you should do so by updating your application lockfile with
+> e.g. `npm up @scope/package` or equivalent command in another
+> package manager, rather than taking a direct dependency.
+
+---


### PR DESCRIPTION
### Issue
similar to https://github.com/smithy-lang/smithy-typescript/pull/1933

### Description
updates internal pkg readme wording

### Testing
doc update only

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
