### PR TITLE
chore(scripts): cjs inliner - cache externality check to reduce logging

### DIFF
--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -174,6 +174,8 @@ module.exports = class Inliner {
 
     const entryPoint = path.join(root, this.subfolder, this.package, "dist-es", "index.js");
 
+    const externalityAssessments = {};
+
     const inputOptions = (externals) => ({
       input: [entryPoint],
       plugins: [nodeResolve(), json()],
@@ -188,15 +190,19 @@ module.exports = class Inliner {
         }
       },
       external: (id) => {
+        if (undefined !== externalityAssessments[id]) {
+          return externalityAssessments[id];
+        }
+
         const relative = !!id.match(/^\.?\.?\//);
         if (!relative) {
           this.verbose && console.log("EXTERN (pkg)", id);
-          return true;
+          return (externalityAssessments[id] = true);
         }
 
         if (id === entryPoint) {
           this.verbose && console.log("INTERN (entry point)", id);
-          return false;
+          return (externalityAssessments[id] = false);
         }
 
         const local =
@@ -205,19 +211,19 @@ module.exports = class Inliner {
             (id.includes(`/packages-internal/`) && !id.includes(`packages-internal/${this.package}/`)));
         if (local) {
           this.verbose && console.log("EXTERN (local)", id);
-          return true;
+          return (externalityAssessments[id] = true);
         }
 
         for (const file of externals) {
           const idWithoutExtension = id.replace(/\.[tj]s$/, "");
           if (idWithoutExtension.endsWith(path.basename(file))) {
             this.verbose && console.log("EXTERN (variant)", id);
-            return true;
+            return (externalityAssessments[id] = true);
           }
         }
 
         this.verbose && console.log("INTERN (invariant)", id);
-        return false;
+        return (externalityAssessments[id] = false);
       },
     });
 


### PR DESCRIPTION
### Issue
n/a

### Description
reduce logging in inliner verbose mode

### Testing
```
DEBUG=1 b s3 - cjs
```

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
