### PR TITLE
chore(codegen): import from core submodules instead of root

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,12 @@ module.exports = {
             patterns: [
               {
                 group: ["*src*", "*dist-*", "!*csrc*"],
+                message:
+                  "Imports must not contain the src folder in their path. Either import from the official package name, or you are already in the src folder and the relative path will not contain src.",
+              },
+              {
+                group: ["@aws-sdk/core", "!@aws-sdk/core/"],
+                message: "Import from a specific submodule like @aws-sdk/core/submodule instead.",
               },
             ],
           },

--- a/Makefile
+++ b/Makefile
@@ -118,17 +118,9 @@ unlink-smithy:
 copy-smithy:
 	node ./scripts/copy-smithy-dist-files
 
-gen-auth:
-	node ./scripts/cli-dispatcher client sso - gen;
-	node ./scripts/cli-dispatcher client sts - gen;
-	node ./scripts/cli-dispatcher client sso-oidc - gen;
-	node ./scripts/cli-dispatcher client cognito identity - gen;
-
-b-auth:
-	node ./scripts/cli-dispatcher client sso - deps;
-	node ./scripts/cli-dispatcher client sts - b;
-	node ./scripts/cli-dispatcher client sso-oidc - b;
-	node ./scripts/cli-dispatcher client cognito identity - b;
+# format Java code.
+jfmt:
+	(cd codegen && ./gradlew spotlessApply)
 
 # run turbo build for packages only.
 tpk:

--- a/clients/client-accessanalyzer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-accessanalyzer/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-accessanalyzer/src/runtimeConfig.shared.ts
+++ b/clients/client-accessanalyzer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-accessanalyzer/src/runtimeConfig.ts
+++ b/clients/client-accessanalyzer/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-account/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-account/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-account/src/runtimeConfig.shared.ts
+++ b/clients/client-account/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-account/src/runtimeConfig.ts
+++ b/clients/client-account/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-acm-pca/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-acm-pca/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-acm-pca/src/runtimeConfig.shared.ts
+++ b/clients/client-acm-pca/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-acm-pca/src/runtimeConfig.ts
+++ b/clients/client-acm-pca/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-acm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-acm/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-acm/src/runtimeConfig.shared.ts
+++ b/clients/client-acm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-acm/src/runtimeConfig.ts
+++ b/clients/client-acm/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-aiops/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-aiops/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-aiops/src/runtimeConfig.shared.ts
+++ b/clients/client-aiops/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-aiops/src/runtimeConfig.ts
+++ b/clients/client-aiops/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-amp/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amp/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-amp/src/runtimeConfig.shared.ts
+++ b/clients/client-amp/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-amp/src/runtimeConfig.ts
+++ b/clients/client-amp/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-amplify/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amplify/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-amplify/src/runtimeConfig.shared.ts
+++ b/clients/client-amplify/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-amplify/src/runtimeConfig.ts
+++ b/clients/client-amplify/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-amplifybackend/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amplifybackend/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-amplifybackend/src/runtimeConfig.shared.ts
+++ b/clients/client-amplifybackend/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-amplifybackend/src/runtimeConfig.ts
+++ b/clients/client-amplifybackend/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-amplifyuibuilder/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amplifyuibuilder/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-amplifyuibuilder/src/runtimeConfig.shared.ts
+++ b/clients/client-amplifyuibuilder/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-amplifyuibuilder/src/runtimeConfig.ts
+++ b/clients/client-amplifyuibuilder/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-api-gateway/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-api-gateway/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-api-gateway/src/runtimeConfig.shared.ts
+++ b/clients/client-api-gateway/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-api-gateway/src/runtimeConfig.ts
+++ b/clients/client-api-gateway/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-apigatewaymanagementapi/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-apigatewaymanagementapi/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-apigatewaymanagementapi/src/runtimeConfig.shared.ts
+++ b/clients/client-apigatewaymanagementapi/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-apigatewaymanagementapi/src/runtimeConfig.ts
+++ b/clients/client-apigatewaymanagementapi/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-apigatewayv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-apigatewayv2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-apigatewayv2/src/runtimeConfig.shared.ts
+++ b/clients/client-apigatewayv2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-apigatewayv2/src/runtimeConfig.ts
+++ b/clients/client-apigatewayv2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-app-mesh/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-app-mesh/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-app-mesh/src/runtimeConfig.shared.ts
+++ b/clients/client-app-mesh/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-app-mesh/src/runtimeConfig.ts
+++ b/clients/client-app-mesh/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-appconfig/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appconfig/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-appconfig/src/runtimeConfig.shared.ts
+++ b/clients/client-appconfig/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-appconfig/src/runtimeConfig.ts
+++ b/clients/client-appconfig/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-appconfigdata/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appconfigdata/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-appconfigdata/src/runtimeConfig.shared.ts
+++ b/clients/client-appconfigdata/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-appconfigdata/src/runtimeConfig.ts
+++ b/clients/client-appconfigdata/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-appfabric/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appfabric/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-appfabric/src/runtimeConfig.shared.ts
+++ b/clients/client-appfabric/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-appfabric/src/runtimeConfig.ts
+++ b/clients/client-appfabric/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-appflow/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appflow/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-appflow/src/runtimeConfig.shared.ts
+++ b/clients/client-appflow/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-appflow/src/runtimeConfig.ts
+++ b/clients/client-appflow/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-appintegrations/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appintegrations/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-appintegrations/src/runtimeConfig.shared.ts
+++ b/clients/client-appintegrations/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-appintegrations/src/runtimeConfig.ts
+++ b/clients/client-appintegrations/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-application-auto-scaling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-auto-scaling/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-application-auto-scaling/src/runtimeConfig.shared.ts
+++ b/clients/client-application-auto-scaling/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-application-auto-scaling/src/runtimeConfig.ts
+++ b/clients/client-application-auto-scaling/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-application-discovery-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-discovery-service/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-application-discovery-service/src/runtimeConfig.shared.ts
+++ b/clients/client-application-discovery-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-application-discovery-service/src/runtimeConfig.ts
+++ b/clients/client-application-discovery-service/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-application-insights/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-insights/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-application-insights/src/runtimeConfig.shared.ts
+++ b/clients/client-application-insights/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-application-insights/src/runtimeConfig.ts
+++ b/clients/client-application-insights/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-application-signals/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-signals/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-application-signals/src/runtimeConfig.shared.ts
+++ b/clients/client-application-signals/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-application-signals/src/runtimeConfig.ts
+++ b/clients/client-application-signals/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-applicationcostprofiler/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-applicationcostprofiler/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-applicationcostprofiler/src/runtimeConfig.shared.ts
+++ b/clients/client-applicationcostprofiler/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-applicationcostprofiler/src/runtimeConfig.ts
+++ b/clients/client-applicationcostprofiler/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-apprunner/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-apprunner/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-apprunner/src/runtimeConfig.shared.ts
+++ b/clients/client-apprunner/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-apprunner/src/runtimeConfig.ts
+++ b/clients/client-apprunner/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-appstream/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appstream/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-appstream/src/runtimeConfig.shared.ts
+++ b/clients/client-appstream/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-appstream/src/runtimeConfig.ts
+++ b/clients/client-appstream/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-appsync/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appsync/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-appsync/src/runtimeConfig.shared.ts
+++ b/clients/client-appsync/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-appsync/src/runtimeConfig.ts
+++ b/clients/client-appsync/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-arc-region-switch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-arc-region-switch/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-arc-region-switch/src/runtimeConfig.shared.ts
+++ b/clients/client-arc-region-switch/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-arc-region-switch/src/runtimeConfig.ts
+++ b/clients/client-arc-region-switch/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-arc-zonal-shift/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-arc-zonal-shift/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-arc-zonal-shift/src/runtimeConfig.shared.ts
+++ b/clients/client-arc-zonal-shift/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-arc-zonal-shift/src/runtimeConfig.ts
+++ b/clients/client-arc-zonal-shift/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-artifact/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-artifact/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-artifact/src/runtimeConfig.shared.ts
+++ b/clients/client-artifact/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-artifact/src/runtimeConfig.ts
+++ b/clients/client-artifact/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-athena/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-athena/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-athena/src/runtimeConfig.shared.ts
+++ b/clients/client-athena/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-athena/src/runtimeConfig.ts
+++ b/clients/client-athena/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-auditmanager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-auditmanager/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-auditmanager/src/runtimeConfig.shared.ts
+++ b/clients/client-auditmanager/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-auditmanager/src/runtimeConfig.ts
+++ b/clients/client-auditmanager/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-auto-scaling-plans/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-auto-scaling-plans/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-auto-scaling-plans/src/runtimeConfig.shared.ts
+++ b/clients/client-auto-scaling-plans/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-auto-scaling-plans/src/runtimeConfig.ts
+++ b/clients/client-auto-scaling-plans/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-auto-scaling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-auto-scaling/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-auto-scaling/src/runtimeConfig.shared.ts
+++ b/clients/client-auto-scaling/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-auto-scaling/src/runtimeConfig.ts
+++ b/clients/client-auto-scaling/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-b2bi/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-b2bi/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-b2bi/src/runtimeConfig.shared.ts
+++ b/clients/client-b2bi/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-b2bi/src/runtimeConfig.ts
+++ b/clients/client-b2bi/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-backup-gateway/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-backup-gateway/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-backup-gateway/src/runtimeConfig.shared.ts
+++ b/clients/client-backup-gateway/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-backup-gateway/src/runtimeConfig.ts
+++ b/clients/client-backup-gateway/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-backup/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-backup/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-backup/src/runtimeConfig.shared.ts
+++ b/clients/client-backup/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-backup/src/runtimeConfig.ts
+++ b/clients/client-backup/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-backupsearch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-backupsearch/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-backupsearch/src/runtimeConfig.shared.ts
+++ b/clients/client-backupsearch/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-backupsearch/src/runtimeConfig.ts
+++ b/clients/client-backupsearch/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-batch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-batch/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-batch/src/runtimeConfig.shared.ts
+++ b/clients/client-batch/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-batch/src/runtimeConfig.ts
+++ b/clients/client-batch/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bcm-dashboards/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bcm-dashboards/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-bcm-dashboards/src/runtimeConfig.shared.ts
+++ b/clients/client-bcm-dashboards/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-bcm-dashboards/src/runtimeConfig.ts
+++ b/clients/client-bcm-dashboards/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bcm-data-exports/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bcm-data-exports/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-bcm-data-exports/src/runtimeConfig.shared.ts
+++ b/clients/client-bcm-data-exports/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-bcm-data-exports/src/runtimeConfig.ts
+++ b/clients/client-bcm-data-exports/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bcm-pricing-calculator/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bcm-pricing-calculator/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-bcm-pricing-calculator/src/runtimeConfig.shared.ts
+++ b/clients/client-bcm-pricing-calculator/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-bcm-pricing-calculator/src/runtimeConfig.ts
+++ b/clients/client-bcm-pricing-calculator/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bcm-recommended-actions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bcm-recommended-actions/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-bcm-recommended-actions/src/runtimeConfig.shared.ts
+++ b/clients/client-bcm-recommended-actions/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-bcm-recommended-actions/src/runtimeConfig.ts
+++ b/clients/client-bcm-recommended-actions/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bedrock-agent-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-agent-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-bedrock-agent-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-bedrock-agent-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-bedrock-agent-runtime/src/runtimeConfig.ts
+++ b/clients/client-bedrock-agent-runtime/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bedrock-agent/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-agent/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-bedrock-agent/src/runtimeConfig.shared.ts
+++ b/clients/client-bedrock-agent/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-bedrock-agent/src/runtimeConfig.ts
+++ b/clients/client-bedrock-agent/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bedrock-agentcore-control/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-agentcore-control/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-bedrock-agentcore-control/src/runtimeConfig.shared.ts
+++ b/clients/client-bedrock-agentcore-control/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-bedrock-agentcore-control/src/runtimeConfig.ts
+++ b/clients/client-bedrock-agentcore-control/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bedrock-agentcore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-agentcore/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-bedrock-agentcore/src/runtimeConfig.shared.ts
+++ b/clients/client-bedrock-agentcore/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-bedrock-agentcore/src/runtimeConfig.ts
+++ b/clients/client-bedrock-agentcore/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bedrock-data-automation-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-data-automation-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-bedrock-data-automation-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-bedrock-data-automation-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-bedrock-data-automation-runtime/src/runtimeConfig.ts
+++ b/clients/client-bedrock-data-automation-runtime/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bedrock-data-automation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-data-automation/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-bedrock-data-automation/src/runtimeConfig.shared.ts
+++ b/clients/client-bedrock-data-automation/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-bedrock-data-automation/src/runtimeConfig.ts
+++ b/clients/client-bedrock-data-automation/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-bedrock-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import { FromSsoInit } from "@aws-sdk/token-providers";
 import { doesIdentityRequireRefresh, isIdentityExpired, memoizeIdentityProvider } from "@smithy/core";
 import {

--- a/clients/client-bedrock-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-bedrock-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { HttpBearerAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-bedrock-runtime/src/runtimeConfig.ts
+++ b/clients/client-bedrock-runtime/src/runtimeConfig.ts
@@ -2,11 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import {
-  AwsSdkSigV4Signer,
-  emitWarningIfUnsupportedVersion as awsCheckVersion,
-  NODE_AUTH_SCHEME_PREFERENCE_OPTIONS,
-} from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { AwsSdkSigV4Signer, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { fromEnvSigningName, FromSsoInit, nodeProvider } from "@aws-sdk/token-providers";

--- a/clients/client-bedrock/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import { FromSsoInit } from "@aws-sdk/token-providers";
 import { doesIdentityRequireRefresh, isIdentityExpired, memoizeIdentityProvider } from "@smithy/core";
 import {

--- a/clients/client-bedrock/src/runtimeConfig.shared.ts
+++ b/clients/client-bedrock/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { HttpBearerAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-bedrock/src/runtimeConfig.ts
+++ b/clients/client-bedrock/src/runtimeConfig.ts
@@ -2,11 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import {
-  AwsSdkSigV4Signer,
-  emitWarningIfUnsupportedVersion as awsCheckVersion,
-  NODE_AUTH_SCHEME_PREFERENCE_OPTIONS,
-} from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { AwsSdkSigV4Signer, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { fromEnvSigningName, FromSsoInit, nodeProvider } from "@aws-sdk/token-providers";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-billing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-billing/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-billing/src/runtimeConfig.shared.ts
+++ b/clients/client-billing/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-billing/src/runtimeConfig.ts
+++ b/clients/client-billing/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-billingconductor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-billingconductor/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-billingconductor/src/runtimeConfig.shared.ts
+++ b/clients/client-billingconductor/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-billingconductor/src/runtimeConfig.ts
+++ b/clients/client-billingconductor/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-braket/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-braket/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-braket/src/runtimeConfig.shared.ts
+++ b/clients/client-braket/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-braket/src/runtimeConfig.ts
+++ b/clients/client-braket/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-budgets/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-budgets/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-budgets/src/runtimeConfig.shared.ts
+++ b/clients/client-budgets/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-budgets/src/runtimeConfig.ts
+++ b/clients/client-budgets/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-chatbot/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chatbot/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-chatbot/src/runtimeConfig.shared.ts
+++ b/clients/client-chatbot/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-chatbot/src/runtimeConfig.ts
+++ b/clients/client-chatbot/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-chime-sdk-identity/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-identity/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-chime-sdk-identity/src/runtimeConfig.shared.ts
+++ b/clients/client-chime-sdk-identity/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-chime-sdk-identity/src/runtimeConfig.ts
+++ b/clients/client-chime-sdk-identity/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-chime-sdk-media-pipelines/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-chime-sdk-media-pipelines/src/runtimeConfig.shared.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-chime-sdk-media-pipelines/src/runtimeConfig.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-chime-sdk-meetings/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-meetings/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-chime-sdk-meetings/src/runtimeConfig.shared.ts
+++ b/clients/client-chime-sdk-meetings/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-chime-sdk-meetings/src/runtimeConfig.ts
+++ b/clients/client-chime-sdk-meetings/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-chime-sdk-messaging/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-messaging/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-chime-sdk-messaging/src/runtimeConfig.shared.ts
+++ b/clients/client-chime-sdk-messaging/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-chime-sdk-messaging/src/runtimeConfig.ts
+++ b/clients/client-chime-sdk-messaging/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-chime-sdk-voice/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-voice/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-chime-sdk-voice/src/runtimeConfig.shared.ts
+++ b/clients/client-chime-sdk-voice/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-chime-sdk-voice/src/runtimeConfig.ts
+++ b/clients/client-chime-sdk-voice/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-chime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-chime/src/runtimeConfig.shared.ts
+++ b/clients/client-chime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-chime/src/runtimeConfig.ts
+++ b/clients/client-chime/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cleanrooms/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cleanrooms/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cleanrooms/src/runtimeConfig.shared.ts
+++ b/clients/client-cleanrooms/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cleanrooms/src/runtimeConfig.ts
+++ b/clients/client-cleanrooms/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cleanroomsml/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cleanroomsml/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cleanroomsml/src/runtimeConfig.shared.ts
+++ b/clients/client-cleanroomsml/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cleanroomsml/src/runtimeConfig.ts
+++ b/clients/client-cleanroomsml/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloud9/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloud9/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloud9/src/runtimeConfig.shared.ts
+++ b/clients/client-cloud9/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloud9/src/runtimeConfig.ts
+++ b/clients/client-cloud9/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudcontrol/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudcontrol/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudcontrol/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudcontrol/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudcontrol/src/runtimeConfig.ts
+++ b/clients/client-cloudcontrol/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-clouddirectory/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-clouddirectory/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-clouddirectory/src/runtimeConfig.shared.ts
+++ b/clients/client-clouddirectory/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-clouddirectory/src/runtimeConfig.ts
+++ b/clients/client-clouddirectory/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudformation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudformation/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudformation/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudformation/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudformation/src/runtimeConfig.ts
+++ b/clients/client-cloudformation/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudfront-keyvaluestore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/auth/httpAuthSchemeProvider.ts
@@ -8,7 +8,7 @@ import {
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { EndpointParameterInstructions, resolveParams } from "@smithy/middleware-endpoint";
 import {

--- a/clients/client-cloudfront-keyvaluestore/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-cloudfront-keyvaluestore/src/runtimeConfig.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/runtimeConfig.ts
@@ -2,11 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import {
-  emitWarningIfUnsupportedVersion as awsCheckVersion,
-  NODE_AUTH_SCHEME_PREFERENCE_OPTIONS,
-  NODE_SIGV4A_CONFIG_OPTIONS,
-} from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS, NODE_SIGV4A_CONFIG_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudfront/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudfront/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudfront/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudfront/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestXmlProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudfront/src/runtimeConfig.ts
+++ b/clients/client-cloudfront/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudhsm-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudhsm-v2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudhsm-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudhsm-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudhsm-v2/src/runtimeConfig.ts
+++ b/clients/client-cloudhsm-v2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudhsm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudhsm/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudhsm/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudhsm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudhsm/src/runtimeConfig.ts
+++ b/clients/client-cloudhsm/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudsearch-domain/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudsearch-domain/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudsearch-domain/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudsearch-domain/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudsearch-domain/src/runtimeConfig.ts
+++ b/clients/client-cloudsearch-domain/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudsearch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudsearch/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudsearch/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudsearch/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudsearch/src/runtimeConfig.ts
+++ b/clients/client-cloudsearch/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudtrail-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudtrail-data/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudtrail-data/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudtrail-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudtrail-data/src/runtimeConfig.ts
+++ b/clients/client-cloudtrail-data/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudtrail/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudtrail/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudtrail/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudtrail/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudtrail/src/runtimeConfig.ts
+++ b/clients/client-cloudtrail/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudwatch-events/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudwatch-events/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudwatch-events/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudwatch-events/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudwatch-events/src/runtimeConfig.ts
+++ b/clients/client-cloudwatch-events/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudwatch-logs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudwatch-logs/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudwatch-logs/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudwatch-logs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudwatch-logs/src/runtimeConfig.ts
+++ b/clients/client-cloudwatch-logs/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudwatch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudwatch/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cloudwatch/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudwatch/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cloudwatch/src/runtimeConfig.ts
+++ b/clients/client-cloudwatch/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cloudwatch/test/e2e/CloudWatch.e2e.spec.ts
+++ b/clients/client-cloudwatch/test/e2e/CloudWatch.e2e.spec.ts
@@ -1,5 +1,5 @@
 import { CloudWatch } from "@aws-sdk/client-cloudwatch";
-import { AwsJson1_0Protocol, AwsQueryProtocol, AwsSmithyRpcV2CborProtocol } from "@aws-sdk/core";
+import { AwsJson1_0Protocol, AwsQueryProtocol, AwsSmithyRpcV2CborProtocol } from "@aws-sdk/core/protocols";
 import { describe, expect, test as it } from "vitest";
 
 describe(CloudWatch.name, () => {

--- a/clients/client-cloudwatch/test/e2e/query-compatibility.e2e.spec.ts
+++ b/clients/client-cloudwatch/test/e2e/query-compatibility.e2e.spec.ts
@@ -7,7 +7,7 @@ import {
   PutMetricAlarmCommand,
   ResourceNotFound,
 } from "@aws-sdk/client-cloudwatch";
-import { AwsJson1_0Protocol, AwsQueryProtocol, AwsSmithyRpcV2CborProtocol } from "@aws-sdk/core";
+import { AwsJson1_0Protocol, AwsQueryProtocol, AwsSmithyRpcV2CborProtocol } from "@aws-sdk/core/protocols";
 import { describe, expect, test as it } from "vitest";
 
 describe("CloudWatch Query Compatibility E2E", () => {

--- a/clients/client-codeartifact/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeartifact/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codeartifact/src/runtimeConfig.shared.ts
+++ b/clients/client-codeartifact/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codeartifact/src/runtimeConfig.ts
+++ b/clients/client-codeartifact/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codebuild/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codebuild/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codebuild/src/runtimeConfig.shared.ts
+++ b/clients/client-codebuild/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codebuild/src/runtimeConfig.ts
+++ b/clients/client-codebuild/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codecatalyst/src/runtimeConfig.ts
+++ b/clients/client-codecatalyst/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { FromSsoInit, nodeProvider } from "@aws-sdk/token-providers";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codecommit/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codecommit/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codecommit/src/runtimeConfig.shared.ts
+++ b/clients/client-codecommit/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codecommit/src/runtimeConfig.ts
+++ b/clients/client-codecommit/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codeconnections/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeconnections/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codeconnections/src/runtimeConfig.shared.ts
+++ b/clients/client-codeconnections/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codeconnections/src/runtimeConfig.ts
+++ b/clients/client-codeconnections/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codedeploy/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codedeploy/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codedeploy/src/runtimeConfig.shared.ts
+++ b/clients/client-codedeploy/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codedeploy/src/runtimeConfig.ts
+++ b/clients/client-codedeploy/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codeguru-reviewer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeguru-reviewer/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codeguru-reviewer/src/runtimeConfig.shared.ts
+++ b/clients/client-codeguru-reviewer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codeguru-reviewer/src/runtimeConfig.ts
+++ b/clients/client-codeguru-reviewer/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codeguru-security/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeguru-security/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codeguru-security/src/runtimeConfig.shared.ts
+++ b/clients/client-codeguru-security/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codeguru-security/src/runtimeConfig.ts
+++ b/clients/client-codeguru-security/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codeguruprofiler/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeguruprofiler/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codeguruprofiler/src/runtimeConfig.shared.ts
+++ b/clients/client-codeguruprofiler/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codeguruprofiler/src/runtimeConfig.ts
+++ b/clients/client-codeguruprofiler/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codepipeline/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codepipeline/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codepipeline/src/runtimeConfig.shared.ts
+++ b/clients/client-codepipeline/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codepipeline/src/runtimeConfig.ts
+++ b/clients/client-codepipeline/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codestar-connections/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codestar-connections/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codestar-connections/src/runtimeConfig.shared.ts
+++ b/clients/client-codestar-connections/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codestar-connections/src/runtimeConfig.ts
+++ b/clients/client-codestar-connections/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-codestar-notifications/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codestar-notifications/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-codestar-notifications/src/runtimeConfig.shared.ts
+++ b/clients/client-codestar-notifications/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-codestar-notifications/src/runtimeConfig.ts
+++ b/clients/client-codestar-notifications/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cognito-identity-provider/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cognito-identity-provider/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cognito-identity-provider/src/runtimeConfig.shared.ts
+++ b/clients/client-cognito-identity-provider/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-cognito-identity-provider/src/runtimeConfig.ts
+++ b/clients/client-cognito-identity-provider/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cognito-identity/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cognito-identity/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cognito-identity/src/runtimeConfig.shared.ts
+++ b/clients/client-cognito-identity/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-cognito-identity/src/runtimeConfig.ts
+++ b/clients/client-cognito-identity/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cognito-sync/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cognito-sync/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cognito-sync/src/runtimeConfig.shared.ts
+++ b/clients/client-cognito-sync/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cognito-sync/src/runtimeConfig.ts
+++ b/clients/client-cognito-sync/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-comprehend/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-comprehend/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-comprehend/src/runtimeConfig.shared.ts
+++ b/clients/client-comprehend/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-comprehend/src/runtimeConfig.ts
+++ b/clients/client-comprehend/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-comprehendmedical/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-comprehendmedical/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-comprehendmedical/src/runtimeConfig.shared.ts
+++ b/clients/client-comprehendmedical/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-comprehendmedical/src/runtimeConfig.ts
+++ b/clients/client-comprehendmedical/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-compute-optimizer-automation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-compute-optimizer-automation/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-compute-optimizer-automation/src/runtimeConfig.shared.ts
+++ b/clients/client-compute-optimizer-automation/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-compute-optimizer-automation/src/runtimeConfig.ts
+++ b/clients/client-compute-optimizer-automation/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-compute-optimizer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-compute-optimizer/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-compute-optimizer/src/runtimeConfig.shared.ts
+++ b/clients/client-compute-optimizer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-compute-optimizer/src/runtimeConfig.ts
+++ b/clients/client-compute-optimizer/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-config-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-config-service/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-config-service/src/runtimeConfig.shared.ts
+++ b/clients/client-config-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-config-service/src/runtimeConfig.ts
+++ b/clients/client-config-service/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-connect-contact-lens/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connect-contact-lens/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-connect-contact-lens/src/runtimeConfig.shared.ts
+++ b/clients/client-connect-contact-lens/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-connect-contact-lens/src/runtimeConfig.ts
+++ b/clients/client-connect-contact-lens/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-connect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connect/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-connect/src/runtimeConfig.shared.ts
+++ b/clients/client-connect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-connect/src/runtimeConfig.ts
+++ b/clients/client-connect/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-connectcampaigns/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectcampaigns/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-connectcampaigns/src/runtimeConfig.shared.ts
+++ b/clients/client-connectcampaigns/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-connectcampaigns/src/runtimeConfig.ts
+++ b/clients/client-connectcampaigns/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-connectcampaignsv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectcampaignsv2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-connectcampaignsv2/src/runtimeConfig.shared.ts
+++ b/clients/client-connectcampaignsv2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-connectcampaignsv2/src/runtimeConfig.ts
+++ b/clients/client-connectcampaignsv2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-connectcases/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectcases/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-connectcases/src/runtimeConfig.shared.ts
+++ b/clients/client-connectcases/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-connectcases/src/runtimeConfig.ts
+++ b/clients/client-connectcases/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-connecthealth/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connecthealth/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-connecthealth/src/runtimeConfig.shared.ts
+++ b/clients/client-connecthealth/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-connecthealth/src/runtimeConfig.ts
+++ b/clients/client-connecthealth/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-connectparticipant/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectparticipant/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-connectparticipant/src/runtimeConfig.shared.ts
+++ b/clients/client-connectparticipant/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-connectparticipant/src/runtimeConfig.ts
+++ b/clients/client-connectparticipant/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-controlcatalog/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-controlcatalog/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-controlcatalog/src/runtimeConfig.shared.ts
+++ b/clients/client-controlcatalog/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-controlcatalog/src/runtimeConfig.ts
+++ b/clients/client-controlcatalog/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-controltower/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-controltower/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-controltower/src/runtimeConfig.shared.ts
+++ b/clients/client-controltower/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-controltower/src/runtimeConfig.ts
+++ b/clients/client-controltower/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cost-and-usage-report-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cost-and-usage-report-service/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cost-and-usage-report-service/src/runtimeConfig.shared.ts
+++ b/clients/client-cost-and-usage-report-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cost-and-usage-report-service/src/runtimeConfig.ts
+++ b/clients/client-cost-and-usage-report-service/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cost-explorer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cost-explorer/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cost-explorer/src/runtimeConfig.shared.ts
+++ b/clients/client-cost-explorer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cost-explorer/src/runtimeConfig.ts
+++ b/clients/client-cost-explorer/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-cost-optimization-hub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cost-optimization-hub/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-cost-optimization-hub/src/runtimeConfig.shared.ts
+++ b/clients/client-cost-optimization-hub/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-cost-optimization-hub/src/runtimeConfig.ts
+++ b/clients/client-cost-optimization-hub/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-customer-profiles/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-customer-profiles/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-customer-profiles/src/runtimeConfig.shared.ts
+++ b/clients/client-customer-profiles/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-customer-profiles/src/runtimeConfig.ts
+++ b/clients/client-customer-profiles/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-data-pipeline/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-data-pipeline/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-data-pipeline/src/runtimeConfig.shared.ts
+++ b/clients/client-data-pipeline/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-data-pipeline/src/runtimeConfig.ts
+++ b/clients/client-data-pipeline/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-database-migration-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-database-migration-service/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-database-migration-service/src/runtimeConfig.shared.ts
+++ b/clients/client-database-migration-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-database-migration-service/src/runtimeConfig.ts
+++ b/clients/client-database-migration-service/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-databrew/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-databrew/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-databrew/src/runtimeConfig.shared.ts
+++ b/clients/client-databrew/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-databrew/src/runtimeConfig.ts
+++ b/clients/client-databrew/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-dataexchange/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dataexchange/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-dataexchange/src/runtimeConfig.shared.ts
+++ b/clients/client-dataexchange/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-dataexchange/src/runtimeConfig.ts
+++ b/clients/client-dataexchange/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-datasync/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-datasync/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-datasync/src/runtimeConfig.shared.ts
+++ b/clients/client-datasync/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-datasync/src/runtimeConfig.ts
+++ b/clients/client-datasync/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-datazone/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-datazone/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-datazone/src/runtimeConfig.shared.ts
+++ b/clients/client-datazone/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-datazone/src/runtimeConfig.ts
+++ b/clients/client-datazone/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-dax/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dax/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-dax/src/runtimeConfig.shared.ts
+++ b/clients/client-dax/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-dax/src/runtimeConfig.ts
+++ b/clients/client-dax/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-deadline/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-deadline/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-deadline/src/runtimeConfig.shared.ts
+++ b/clients/client-deadline/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-deadline/src/runtimeConfig.ts
+++ b/clients/client-deadline/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-detective/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-detective/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-detective/src/runtimeConfig.shared.ts
+++ b/clients/client-detective/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-detective/src/runtimeConfig.ts
+++ b/clients/client-detective/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-device-farm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-device-farm/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-device-farm/src/runtimeConfig.shared.ts
+++ b/clients/client-device-farm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-device-farm/src/runtimeConfig.ts
+++ b/clients/client-device-farm/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-devops-guru/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-devops-guru/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-devops-guru/src/runtimeConfig.shared.ts
+++ b/clients/client-devops-guru/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-devops-guru/src/runtimeConfig.ts
+++ b/clients/client-devops-guru/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-direct-connect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-direct-connect/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-direct-connect/src/runtimeConfig.shared.ts
+++ b/clients/client-direct-connect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-direct-connect/src/runtimeConfig.ts
+++ b/clients/client-direct-connect/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-directory-service-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-directory-service-data/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-directory-service-data/src/runtimeConfig.shared.ts
+++ b/clients/client-directory-service-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-directory-service-data/src/runtimeConfig.ts
+++ b/clients/client-directory-service-data/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-directory-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-directory-service/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-directory-service/src/runtimeConfig.shared.ts
+++ b/clients/client-directory-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-directory-service/src/runtimeConfig.ts
+++ b/clients/client-directory-service/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-dlm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dlm/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-dlm/src/runtimeConfig.shared.ts
+++ b/clients/client-dlm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-dlm/src/runtimeConfig.ts
+++ b/clients/client-dlm/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-docdb-elastic/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-docdb-elastic/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-docdb-elastic/src/runtimeConfig.shared.ts
+++ b/clients/client-docdb-elastic/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-docdb-elastic/src/runtimeConfig.ts
+++ b/clients/client-docdb-elastic/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-docdb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-docdb/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-docdb/src/runtimeConfig.shared.ts
+++ b/clients/client-docdb/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-docdb/src/runtimeConfig.ts
+++ b/clients/client-docdb/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-drs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-drs/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-drs/src/runtimeConfig.shared.ts
+++ b/clients/client-drs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-drs/src/runtimeConfig.ts
+++ b/clients/client-drs/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-dsql/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dsql/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-dsql/src/runtimeConfig.shared.ts
+++ b/clients/client-dsql/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-dsql/src/runtimeConfig.ts
+++ b/clients/client-dsql/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-dynamodb-streams/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dynamodb-streams/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-dynamodb-streams/src/runtimeConfig.shared.ts
+++ b/clients/client-dynamodb-streams/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-dynamodb-streams/src/runtimeConfig.ts
+++ b/clients/client-dynamodb-streams/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-dynamodb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dynamodb/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-dynamodb/src/runtimeConfig.shared.ts
+++ b/clients/client-dynamodb/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { DynamoDBJsonCodec } from "@aws-sdk/dynamodb-codec";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-dynamodb/src/runtimeConfig.ts
+++ b/clients/client-dynamodb/src/runtimeConfig.ts
@@ -2,8 +2,9 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
 import { NODE_ACCOUNT_ID_ENDPOINT_MODE_CONFIG_OPTIONS } from "@aws-sdk/core/account-id-endpoint";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS } from "@aws-sdk/middleware-endpoint-discovery";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-ebs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ebs/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ebs/src/runtimeConfig.shared.ts
+++ b/clients/client-ebs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ebs/src/runtimeConfig.ts
+++ b/clients/client-ebs/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ec2-instance-connect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ec2-instance-connect/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ec2-instance-connect/src/runtimeConfig.shared.ts
+++ b/clients/client-ec2-instance-connect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ec2-instance-connect/src/runtimeConfig.ts
+++ b/clients/client-ec2-instance-connect/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ec2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ec2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ec2/src/runtimeConfig.shared.ts
+++ b/clients/client-ec2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsEc2QueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ec2/src/runtimeConfig.ts
+++ b/clients/client-ec2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ecr-public/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ecr-public/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ecr-public/src/runtimeConfig.shared.ts
+++ b/clients/client-ecr-public/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ecr-public/src/runtimeConfig.ts
+++ b/clients/client-ecr-public/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ecr/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ecr/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ecr/src/runtimeConfig.shared.ts
+++ b/clients/client-ecr/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ecr/src/runtimeConfig.ts
+++ b/clients/client-ecr/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ecs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ecs/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ecs/src/runtimeConfig.shared.ts
+++ b/clients/client-ecs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ecs/src/runtimeConfig.ts
+++ b/clients/client-ecs/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-efs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-efs/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-efs/src/runtimeConfig.shared.ts
+++ b/clients/client-efs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-efs/src/runtimeConfig.ts
+++ b/clients/client-efs/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-eks-auth/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-eks-auth/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-eks-auth/src/runtimeConfig.shared.ts
+++ b/clients/client-eks-auth/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-eks-auth/src/runtimeConfig.ts
+++ b/clients/client-eks-auth/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-eks/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-eks/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-eks/src/runtimeConfig.shared.ts
+++ b/clients/client-eks/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-eks/src/runtimeConfig.ts
+++ b/clients/client-eks/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-elastic-beanstalk/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elastic-beanstalk/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-elastic-beanstalk/src/runtimeConfig.shared.ts
+++ b/clients/client-elastic-beanstalk/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-elastic-beanstalk/src/runtimeConfig.ts
+++ b/clients/client-elastic-beanstalk/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-elastic-load-balancing-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elastic-load-balancing-v2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-elastic-load-balancing-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-elastic-load-balancing-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-elastic-load-balancing-v2/src/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing-v2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-elastic-load-balancing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elastic-load-balancing/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-elastic-load-balancing/src/runtimeConfig.shared.ts
+++ b/clients/client-elastic-load-balancing/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-elastic-load-balancing/src/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-elasticache/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elasticache/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-elasticache/src/runtimeConfig.shared.ts
+++ b/clients/client-elasticache/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-elasticache/src/runtimeConfig.ts
+++ b/clients/client-elasticache/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-elasticsearch-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elasticsearch-service/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-elasticsearch-service/src/runtimeConfig.shared.ts
+++ b/clients/client-elasticsearch-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-elasticsearch-service/src/runtimeConfig.ts
+++ b/clients/client-elasticsearch-service/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-elementalinference/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elementalinference/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-elementalinference/src/runtimeConfig.shared.ts
+++ b/clients/client-elementalinference/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-elementalinference/src/runtimeConfig.ts
+++ b/clients/client-elementalinference/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-emr-containers/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-emr-containers/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-emr-containers/src/runtimeConfig.shared.ts
+++ b/clients/client-emr-containers/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-emr-containers/src/runtimeConfig.ts
+++ b/clients/client-emr-containers/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-emr-serverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-emr-serverless/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-emr-serverless/src/runtimeConfig.shared.ts
+++ b/clients/client-emr-serverless/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-emr-serverless/src/runtimeConfig.ts
+++ b/clients/client-emr-serverless/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-emr/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-emr/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-emr/src/runtimeConfig.shared.ts
+++ b/clients/client-emr/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-emr/src/runtimeConfig.ts
+++ b/clients/client-emr/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-entityresolution/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-entityresolution/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-entityresolution/src/runtimeConfig.shared.ts
+++ b/clients/client-entityresolution/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-entityresolution/src/runtimeConfig.ts
+++ b/clients/client-entityresolution/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-eventbridge/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-eventbridge/src/auth/httpAuthSchemeProvider.ts
@@ -8,7 +8,7 @@ import {
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { EndpointParameterInstructions, resolveParams } from "@smithy/middleware-endpoint";
 import {

--- a/clients/client-eventbridge/src/runtimeConfig.shared.ts
+++ b/clients/client-eventbridge/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-eventbridge/src/runtimeConfig.ts
+++ b/clients/client-eventbridge/src/runtimeConfig.ts
@@ -2,11 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import {
-  emitWarningIfUnsupportedVersion as awsCheckVersion,
-  NODE_AUTH_SCHEME_PREFERENCE_OPTIONS,
-  NODE_SIGV4A_CONFIG_OPTIONS,
-} from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS, NODE_SIGV4A_CONFIG_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-evs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-evs/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-evs/src/runtimeConfig.shared.ts
+++ b/clients/client-evs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-evs/src/runtimeConfig.ts
+++ b/clients/client-evs/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-finspace-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-finspace-data/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-finspace-data/src/runtimeConfig.shared.ts
+++ b/clients/client-finspace-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-finspace-data/src/runtimeConfig.ts
+++ b/clients/client-finspace-data/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-finspace/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-finspace/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-finspace/src/runtimeConfig.shared.ts
+++ b/clients/client-finspace/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-finspace/src/runtimeConfig.ts
+++ b/clients/client-finspace/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-firehose/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-firehose/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-firehose/src/runtimeConfig.shared.ts
+++ b/clients/client-firehose/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-firehose/src/runtimeConfig.ts
+++ b/clients/client-firehose/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-fis/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-fis/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-fis/src/runtimeConfig.shared.ts
+++ b/clients/client-fis/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-fis/src/runtimeConfig.ts
+++ b/clients/client-fis/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-fms/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-fms/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-fms/src/runtimeConfig.shared.ts
+++ b/clients/client-fms/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-fms/src/runtimeConfig.ts
+++ b/clients/client-fms/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-forecast/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-forecast/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-forecast/src/runtimeConfig.shared.ts
+++ b/clients/client-forecast/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-forecast/src/runtimeConfig.ts
+++ b/clients/client-forecast/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-forecastquery/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-forecastquery/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-forecastquery/src/runtimeConfig.shared.ts
+++ b/clients/client-forecastquery/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-forecastquery/src/runtimeConfig.ts
+++ b/clients/client-forecastquery/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-frauddetector/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-frauddetector/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-frauddetector/src/runtimeConfig.shared.ts
+++ b/clients/client-frauddetector/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-frauddetector/src/runtimeConfig.ts
+++ b/clients/client-frauddetector/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-freetier/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-freetier/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-freetier/src/runtimeConfig.shared.ts
+++ b/clients/client-freetier/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-freetier/src/runtimeConfig.ts
+++ b/clients/client-freetier/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-fsx/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-fsx/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-fsx/src/runtimeConfig.shared.ts
+++ b/clients/client-fsx/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-fsx/src/runtimeConfig.ts
+++ b/clients/client-fsx/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-gamelift/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-gamelift/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-gamelift/src/runtimeConfig.shared.ts
+++ b/clients/client-gamelift/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-gamelift/src/runtimeConfig.ts
+++ b/clients/client-gamelift/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-gameliftstreams/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-gameliftstreams/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-gameliftstreams/src/runtimeConfig.shared.ts
+++ b/clients/client-gameliftstreams/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-gameliftstreams/src/runtimeConfig.ts
+++ b/clients/client-gameliftstreams/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-geo-maps/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-geo-maps/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-geo-maps/src/runtimeConfig.shared.ts
+++ b/clients/client-geo-maps/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-geo-maps/src/runtimeConfig.ts
+++ b/clients/client-geo-maps/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-geo-places/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-geo-places/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-geo-places/src/runtimeConfig.shared.ts
+++ b/clients/client-geo-places/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-geo-places/src/runtimeConfig.ts
+++ b/clients/client-geo-places/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-geo-routes/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-geo-routes/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-geo-routes/src/runtimeConfig.shared.ts
+++ b/clients/client-geo-routes/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-geo-routes/src/runtimeConfig.ts
+++ b/clients/client-geo-routes/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-glacier/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-glacier/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-glacier/src/runtimeConfig.shared.ts
+++ b/clients/client-glacier/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-glacier/src/runtimeConfig.ts
+++ b/clients/client-glacier/src/runtimeConfig.ts
@@ -3,7 +3,8 @@
 import packageInfo from "../package.json"; // eslint-disable-line
 
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-node";
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-global-accelerator/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-global-accelerator/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-global-accelerator/src/runtimeConfig.shared.ts
+++ b/clients/client-global-accelerator/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-global-accelerator/src/runtimeConfig.ts
+++ b/clients/client-global-accelerator/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-glue/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-glue/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-glue/src/runtimeConfig.shared.ts
+++ b/clients/client-glue/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-glue/src/runtimeConfig.ts
+++ b/clients/client-glue/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-grafana/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-grafana/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-grafana/src/runtimeConfig.shared.ts
+++ b/clients/client-grafana/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-grafana/src/runtimeConfig.ts
+++ b/clients/client-grafana/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-greengrass/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-greengrass/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-greengrass/src/runtimeConfig.shared.ts
+++ b/clients/client-greengrass/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-greengrass/src/runtimeConfig.ts
+++ b/clients/client-greengrass/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-greengrassv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-greengrassv2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-greengrassv2/src/runtimeConfig.shared.ts
+++ b/clients/client-greengrassv2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-greengrassv2/src/runtimeConfig.ts
+++ b/clients/client-greengrassv2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-groundstation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-groundstation/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-groundstation/src/runtimeConfig.shared.ts
+++ b/clients/client-groundstation/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-groundstation/src/runtimeConfig.ts
+++ b/clients/client-groundstation/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-guardduty/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-guardduty/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-guardduty/src/runtimeConfig.shared.ts
+++ b/clients/client-guardduty/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-guardduty/src/runtimeConfig.ts
+++ b/clients/client-guardduty/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-health/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-health/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-health/src/runtimeConfig.shared.ts
+++ b/clients/client-health/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-health/src/runtimeConfig.ts
+++ b/clients/client-health/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-healthlake/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-healthlake/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-healthlake/src/runtimeConfig.shared.ts
+++ b/clients/client-healthlake/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-healthlake/src/runtimeConfig.ts
+++ b/clients/client-healthlake/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iam/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iam/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iam/src/runtimeConfig.shared.ts
+++ b/clients/client-iam/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iam/src/runtimeConfig.ts
+++ b/clients/client-iam/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-identitystore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-identitystore/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-identitystore/src/runtimeConfig.shared.ts
+++ b/clients/client-identitystore/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-identitystore/src/runtimeConfig.ts
+++ b/clients/client-identitystore/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-imagebuilder/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-imagebuilder/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-imagebuilder/src/runtimeConfig.shared.ts
+++ b/clients/client-imagebuilder/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-imagebuilder/src/runtimeConfig.ts
+++ b/clients/client-imagebuilder/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-inspector-scan/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-inspector-scan/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-inspector-scan/src/runtimeConfig.shared.ts
+++ b/clients/client-inspector-scan/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-inspector-scan/src/runtimeConfig.ts
+++ b/clients/client-inspector-scan/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-inspector/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-inspector/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-inspector/src/runtimeConfig.shared.ts
+++ b/clients/client-inspector/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-inspector/src/runtimeConfig.ts
+++ b/clients/client-inspector/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-inspector2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-inspector2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-inspector2/src/runtimeConfig.shared.ts
+++ b/clients/client-inspector2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-inspector2/src/runtimeConfig.ts
+++ b/clients/client-inspector2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-internetmonitor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-internetmonitor/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-internetmonitor/src/runtimeConfig.shared.ts
+++ b/clients/client-internetmonitor/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-internetmonitor/src/runtimeConfig.ts
+++ b/clients/client-internetmonitor/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-invoicing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-invoicing/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-invoicing/src/runtimeConfig.shared.ts
+++ b/clients/client-invoicing/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-invoicing/src/runtimeConfig.ts
+++ b/clients/client-invoicing/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iot-data-plane/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-data-plane/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iot-data-plane/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-data-plane/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iot-data-plane/src/runtimeConfig.ts
+++ b/clients/client-iot-data-plane/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iot-events-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-events-data/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iot-events-data/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-events-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iot-events-data/src/runtimeConfig.ts
+++ b/clients/client-iot-events-data/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iot-events/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-events/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iot-events/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-events/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iot-events/src/runtimeConfig.ts
+++ b/clients/client-iot-events/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iot-jobs-data-plane/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-jobs-data-plane/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iot-jobs-data-plane/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-jobs-data-plane/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iot-jobs-data-plane/src/runtimeConfig.ts
+++ b/clients/client-iot-jobs-data-plane/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iot-managed-integrations/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-managed-integrations/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iot-managed-integrations/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-managed-integrations/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iot-managed-integrations/src/runtimeConfig.ts
+++ b/clients/client-iot-managed-integrations/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iot-wireless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-wireless/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iot-wireless/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-wireless/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iot-wireless/src/runtimeConfig.ts
+++ b/clients/client-iot-wireless/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iot/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iot/src/runtimeConfig.shared.ts
+++ b/clients/client-iot/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iot/src/runtimeConfig.ts
+++ b/clients/client-iot/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iotdeviceadvisor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotdeviceadvisor/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iotdeviceadvisor/src/runtimeConfig.shared.ts
+++ b/clients/client-iotdeviceadvisor/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iotdeviceadvisor/src/runtimeConfig.ts
+++ b/clients/client-iotdeviceadvisor/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iotfleetwise/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotfleetwise/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iotfleetwise/src/runtimeConfig.shared.ts
+++ b/clients/client-iotfleetwise/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iotfleetwise/src/runtimeConfig.ts
+++ b/clients/client-iotfleetwise/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iotsecuretunneling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotsecuretunneling/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iotsecuretunneling/src/runtimeConfig.shared.ts
+++ b/clients/client-iotsecuretunneling/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iotsecuretunneling/src/runtimeConfig.ts
+++ b/clients/client-iotsecuretunneling/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iotsitewise/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotsitewise/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iotsitewise/src/runtimeConfig.shared.ts
+++ b/clients/client-iotsitewise/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iotsitewise/src/runtimeConfig.ts
+++ b/clients/client-iotsitewise/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iotthingsgraph/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotthingsgraph/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iotthingsgraph/src/runtimeConfig.shared.ts
+++ b/clients/client-iotthingsgraph/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iotthingsgraph/src/runtimeConfig.ts
+++ b/clients/client-iotthingsgraph/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-iottwinmaker/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iottwinmaker/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-iottwinmaker/src/runtimeConfig.shared.ts
+++ b/clients/client-iottwinmaker/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-iottwinmaker/src/runtimeConfig.ts
+++ b/clients/client-iottwinmaker/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ivs-realtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ivs-realtime/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ivs-realtime/src/runtimeConfig.shared.ts
+++ b/clients/client-ivs-realtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ivs-realtime/src/runtimeConfig.ts
+++ b/clients/client-ivs-realtime/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ivs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ivs/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ivs/src/runtimeConfig.shared.ts
+++ b/clients/client-ivs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ivs/src/runtimeConfig.ts
+++ b/clients/client-ivs/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ivschat/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ivschat/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ivschat/src/runtimeConfig.shared.ts
+++ b/clients/client-ivschat/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ivschat/src/runtimeConfig.ts
+++ b/clients/client-ivschat/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kafka/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kafka/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kafka/src/runtimeConfig.shared.ts
+++ b/clients/client-kafka/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kafka/src/runtimeConfig.ts
+++ b/clients/client-kafka/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kafkaconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kafkaconnect/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kafkaconnect/src/runtimeConfig.shared.ts
+++ b/clients/client-kafkaconnect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kafkaconnect/src/runtimeConfig.ts
+++ b/clients/client-kafkaconnect/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kendra-ranking/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kendra-ranking/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kendra-ranking/src/runtimeConfig.shared.ts
+++ b/clients/client-kendra-ranking/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kendra-ranking/src/runtimeConfig.ts
+++ b/clients/client-kendra-ranking/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kendra/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kendra/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kendra/src/runtimeConfig.shared.ts
+++ b/clients/client-kendra/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kendra/src/runtimeConfig.ts
+++ b/clients/client-kendra/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-keyspaces/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-keyspaces/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-keyspaces/src/runtimeConfig.shared.ts
+++ b/clients/client-keyspaces/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-keyspaces/src/runtimeConfig.ts
+++ b/clients/client-keyspaces/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-keyspacesstreams/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-keyspacesstreams/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-keyspacesstreams/src/runtimeConfig.shared.ts
+++ b/clients/client-keyspacesstreams/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-keyspacesstreams/src/runtimeConfig.ts
+++ b/clients/client-keyspacesstreams/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kinesis-analytics-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-analytics-v2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kinesis-analytics-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-analytics-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kinesis-analytics-v2/src/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics-v2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kinesis-analytics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-analytics/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kinesis-analytics/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-analytics/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kinesis-analytics/src/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kinesis-video-archived-media/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-archived-media/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kinesis-video-archived-media/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video-archived-media/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kinesis-video-archived-media/src/runtimeConfig.ts
+++ b/clients/client-kinesis-video-archived-media/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kinesis-video-media/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-media/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kinesis-video-media/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video-media/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kinesis-video-media/src/runtimeConfig.ts
+++ b/clients/client-kinesis-video-media/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kinesis-video-signaling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-signaling/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kinesis-video-signaling/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video-signaling/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kinesis-video-signaling/src/runtimeConfig.ts
+++ b/clients/client-kinesis-video-signaling/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kinesis-video-webrtc-storage/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kinesis-video-webrtc-storage/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kinesis-video-webrtc-storage/src/runtimeConfig.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kinesis-video/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kinesis-video/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kinesis-video/src/runtimeConfig.ts
+++ b/clients/client-kinesis-video/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kinesis/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kinesis/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kinesis/src/runtimeConfig.ts
+++ b/clients/client-kinesis/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-kms/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kms/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-kms/src/runtimeConfig.shared.ts
+++ b/clients/client-kms/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-kms/src/runtimeConfig.ts
+++ b/clients/client-kms/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-lakeformation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lakeformation/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-lakeformation/src/runtimeConfig.shared.ts
+++ b/clients/client-lakeformation/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-lakeformation/src/runtimeConfig.ts
+++ b/clients/client-lakeformation/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-lambda/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lambda/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-lambda/src/runtimeConfig.shared.ts
+++ b/clients/client-lambda/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-lambda/src/runtimeConfig.ts
+++ b/clients/client-lambda/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-launch-wizard/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-launch-wizard/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-launch-wizard/src/runtimeConfig.shared.ts
+++ b/clients/client-launch-wizard/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-launch-wizard/src/runtimeConfig.ts
+++ b/clients/client-launch-wizard/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-lex-model-building-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-model-building-service/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-lex-model-building-service/src/runtimeConfig.shared.ts
+++ b/clients/client-lex-model-building-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-lex-model-building-service/src/runtimeConfig.ts
+++ b/clients/client-lex-model-building-service/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-lex-models-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-models-v2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-lex-models-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-lex-models-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-lex-models-v2/src/runtimeConfig.ts
+++ b/clients/client-lex-models-v2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-lex-runtime-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-runtime-service/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-lex-runtime-service/src/runtimeConfig.shared.ts
+++ b/clients/client-lex-runtime-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-lex-runtime-service/src/runtimeConfig.ts
+++ b/clients/client-lex-runtime-service/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-lex-runtime-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-runtime-v2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-lex-runtime-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-lex-runtime-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-lex-runtime-v2/src/runtimeConfig.ts
+++ b/clients/client-lex-runtime-v2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-license-manager-linux-subscriptions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-license-manager-linux-subscriptions/src/runtimeConfig.shared.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-license-manager-linux-subscriptions/src/runtimeConfig.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-license-manager-user-subscriptions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-license-manager-user-subscriptions/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-license-manager-user-subscriptions/src/runtimeConfig.shared.ts
+++ b/clients/client-license-manager-user-subscriptions/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-license-manager-user-subscriptions/src/runtimeConfig.ts
+++ b/clients/client-license-manager-user-subscriptions/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-license-manager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-license-manager/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-license-manager/src/runtimeConfig.shared.ts
+++ b/clients/client-license-manager/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-license-manager/src/runtimeConfig.ts
+++ b/clients/client-license-manager/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-lightsail/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lightsail/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-lightsail/src/runtimeConfig.shared.ts
+++ b/clients/client-lightsail/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-lightsail/src/runtimeConfig.ts
+++ b/clients/client-lightsail/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-location/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-location/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-location/src/runtimeConfig.shared.ts
+++ b/clients/client-location/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-location/src/runtimeConfig.ts
+++ b/clients/client-location/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-lookoutequipment/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lookoutequipment/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-lookoutequipment/src/runtimeConfig.shared.ts
+++ b/clients/client-lookoutequipment/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-lookoutequipment/src/runtimeConfig.ts
+++ b/clients/client-lookoutequipment/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-m2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-m2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-m2/src/runtimeConfig.shared.ts
+++ b/clients/client-m2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-m2/src/runtimeConfig.ts
+++ b/clients/client-m2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-machine-learning/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-machine-learning/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-machine-learning/src/runtimeConfig.shared.ts
+++ b/clients/client-machine-learning/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-machine-learning/src/runtimeConfig.ts
+++ b/clients/client-machine-learning/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-macie2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-macie2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-macie2/src/runtimeConfig.shared.ts
+++ b/clients/client-macie2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-macie2/src/runtimeConfig.ts
+++ b/clients/client-macie2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mailmanager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mailmanager/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mailmanager/src/runtimeConfig.shared.ts
+++ b/clients/client-mailmanager/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mailmanager/src/runtimeConfig.ts
+++ b/clients/client-mailmanager/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-managedblockchain-query/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-managedblockchain-query/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-managedblockchain-query/src/runtimeConfig.shared.ts
+++ b/clients/client-managedblockchain-query/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-managedblockchain-query/src/runtimeConfig.ts
+++ b/clients/client-managedblockchain-query/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-managedblockchain/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-managedblockchain/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-managedblockchain/src/runtimeConfig.shared.ts
+++ b/clients/client-managedblockchain/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-managedblockchain/src/runtimeConfig.ts
+++ b/clients/client-managedblockchain/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-marketplace-agreement/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-agreement/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-marketplace-agreement/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-agreement/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-marketplace-agreement/src/runtimeConfig.ts
+++ b/clients/client-marketplace-agreement/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-marketplace-catalog/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-catalog/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-marketplace-catalog/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-catalog/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-marketplace-catalog/src/runtimeConfig.ts
+++ b/clients/client-marketplace-catalog/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-marketplace-commerce-analytics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-commerce-analytics/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-marketplace-commerce-analytics/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-commerce-analytics/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-marketplace-commerce-analytics/src/runtimeConfig.ts
+++ b/clients/client-marketplace-commerce-analytics/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-marketplace-deployment/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-deployment/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-marketplace-deployment/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-deployment/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-marketplace-deployment/src/runtimeConfig.ts
+++ b/clients/client-marketplace-deployment/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-marketplace-entitlement-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-entitlement-service/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-marketplace-entitlement-service/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-entitlement-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-marketplace-entitlement-service/src/runtimeConfig.ts
+++ b/clients/client-marketplace-entitlement-service/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-marketplace-metering/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-metering/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-marketplace-metering/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-metering/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-marketplace-metering/src/runtimeConfig.ts
+++ b/clients/client-marketplace-metering/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-marketplace-reporting/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-reporting/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-marketplace-reporting/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-reporting/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-marketplace-reporting/src/runtimeConfig.ts
+++ b/clients/client-marketplace-reporting/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mediaconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediaconnect/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mediaconnect/src/runtimeConfig.shared.ts
+++ b/clients/client-mediaconnect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mediaconnect/src/runtimeConfig.ts
+++ b/clients/client-mediaconnect/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mediaconvert/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediaconvert/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mediaconvert/src/runtimeConfig.shared.ts
+++ b/clients/client-mediaconvert/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mediaconvert/src/runtimeConfig.ts
+++ b/clients/client-mediaconvert/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-medialive/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-medialive/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-medialive/src/runtimeConfig.shared.ts
+++ b/clients/client-medialive/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-medialive/src/runtimeConfig.ts
+++ b/clients/client-medialive/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mediapackage-vod/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediapackage-vod/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mediapackage-vod/src/runtimeConfig.shared.ts
+++ b/clients/client-mediapackage-vod/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mediapackage-vod/src/runtimeConfig.ts
+++ b/clients/client-mediapackage-vod/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mediapackage/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediapackage/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mediapackage/src/runtimeConfig.shared.ts
+++ b/clients/client-mediapackage/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mediapackage/src/runtimeConfig.ts
+++ b/clients/client-mediapackage/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mediapackagev2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediapackagev2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mediapackagev2/src/runtimeConfig.shared.ts
+++ b/clients/client-mediapackagev2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mediapackagev2/src/runtimeConfig.ts
+++ b/clients/client-mediapackagev2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mediastore-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediastore-data/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mediastore-data/src/runtimeConfig.shared.ts
+++ b/clients/client-mediastore-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mediastore-data/src/runtimeConfig.ts
+++ b/clients/client-mediastore-data/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mediastore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediastore/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mediastore/src/runtimeConfig.shared.ts
+++ b/clients/client-mediastore/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mediastore/src/runtimeConfig.ts
+++ b/clients/client-mediastore/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mediatailor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediatailor/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mediatailor/src/runtimeConfig.shared.ts
+++ b/clients/client-mediatailor/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mediatailor/src/runtimeConfig.ts
+++ b/clients/client-mediatailor/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-medical-imaging/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-medical-imaging/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-medical-imaging/src/runtimeConfig.shared.ts
+++ b/clients/client-medical-imaging/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-medical-imaging/src/runtimeConfig.ts
+++ b/clients/client-medical-imaging/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-memorydb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-memorydb/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-memorydb/src/runtimeConfig.shared.ts
+++ b/clients/client-memorydb/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-memorydb/src/runtimeConfig.ts
+++ b/clients/client-memorydb/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mgn/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mgn/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mgn/src/runtimeConfig.shared.ts
+++ b/clients/client-mgn/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mgn/src/runtimeConfig.ts
+++ b/clients/client-mgn/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-migration-hub-refactor-spaces/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-migration-hub-refactor-spaces/src/runtimeConfig.shared.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-migration-hub-refactor-spaces/src/runtimeConfig.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-migration-hub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migration-hub/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-migration-hub/src/runtimeConfig.shared.ts
+++ b/clients/client-migration-hub/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-migration-hub/src/runtimeConfig.ts
+++ b/clients/client-migration-hub/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-migrationhub-config/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migrationhub-config/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-migrationhub-config/src/runtimeConfig.shared.ts
+++ b/clients/client-migrationhub-config/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-migrationhub-config/src/runtimeConfig.ts
+++ b/clients/client-migrationhub-config/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-migrationhuborchestrator/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migrationhuborchestrator/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-migrationhuborchestrator/src/runtimeConfig.shared.ts
+++ b/clients/client-migrationhuborchestrator/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-migrationhuborchestrator/src/runtimeConfig.ts
+++ b/clients/client-migrationhuborchestrator/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-migrationhubstrategy/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migrationhubstrategy/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-migrationhubstrategy/src/runtimeConfig.shared.ts
+++ b/clients/client-migrationhubstrategy/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-migrationhubstrategy/src/runtimeConfig.ts
+++ b/clients/client-migrationhubstrategy/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mpa/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mpa/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mpa/src/runtimeConfig.shared.ts
+++ b/clients/client-mpa/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mpa/src/runtimeConfig.ts
+++ b/clients/client-mpa/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mq/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mq/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mq/src/runtimeConfig.shared.ts
+++ b/clients/client-mq/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mq/src/runtimeConfig.ts
+++ b/clients/client-mq/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mturk/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mturk/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mturk/src/runtimeConfig.shared.ts
+++ b/clients/client-mturk/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mturk/src/runtimeConfig.ts
+++ b/clients/client-mturk/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mwaa-serverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mwaa-serverless/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mwaa-serverless/src/runtimeConfig.shared.ts
+++ b/clients/client-mwaa-serverless/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mwaa-serverless/src/runtimeConfig.ts
+++ b/clients/client-mwaa-serverless/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-mwaa/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mwaa/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-mwaa/src/runtimeConfig.shared.ts
+++ b/clients/client-mwaa/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-mwaa/src/runtimeConfig.ts
+++ b/clients/client-mwaa/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-neptune-graph/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-neptune-graph/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-neptune-graph/src/runtimeConfig.shared.ts
+++ b/clients/client-neptune-graph/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-neptune-graph/src/runtimeConfig.ts
+++ b/clients/client-neptune-graph/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-neptune/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-neptune/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-neptune/src/runtimeConfig.shared.ts
+++ b/clients/client-neptune/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-neptune/src/runtimeConfig.ts
+++ b/clients/client-neptune/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-neptunedata/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-neptunedata/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-neptunedata/src/runtimeConfig.shared.ts
+++ b/clients/client-neptunedata/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-neptunedata/src/runtimeConfig.ts
+++ b/clients/client-neptunedata/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-network-firewall/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-network-firewall/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-network-firewall/src/runtimeConfig.shared.ts
+++ b/clients/client-network-firewall/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-network-firewall/src/runtimeConfig.ts
+++ b/clients/client-network-firewall/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-networkflowmonitor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-networkflowmonitor/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-networkflowmonitor/src/runtimeConfig.shared.ts
+++ b/clients/client-networkflowmonitor/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-networkflowmonitor/src/runtimeConfig.ts
+++ b/clients/client-networkflowmonitor/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-networkmanager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-networkmanager/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-networkmanager/src/runtimeConfig.shared.ts
+++ b/clients/client-networkmanager/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-networkmanager/src/runtimeConfig.ts
+++ b/clients/client-networkmanager/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-networkmonitor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-networkmonitor/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-networkmonitor/src/runtimeConfig.shared.ts
+++ b/clients/client-networkmonitor/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-networkmonitor/src/runtimeConfig.ts
+++ b/clients/client-networkmonitor/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-notifications/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-notifications/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-notifications/src/runtimeConfig.shared.ts
+++ b/clients/client-notifications/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-notifications/src/runtimeConfig.ts
+++ b/clients/client-notifications/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-notificationscontacts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-notificationscontacts/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-notificationscontacts/src/runtimeConfig.shared.ts
+++ b/clients/client-notificationscontacts/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-notificationscontacts/src/runtimeConfig.ts
+++ b/clients/client-notificationscontacts/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-nova-act/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-nova-act/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-nova-act/src/runtimeConfig.shared.ts
+++ b/clients/client-nova-act/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-nova-act/src/runtimeConfig.ts
+++ b/clients/client-nova-act/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-oam/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-oam/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-oam/src/runtimeConfig.shared.ts
+++ b/clients/client-oam/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-oam/src/runtimeConfig.ts
+++ b/clients/client-oam/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-observabilityadmin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-observabilityadmin/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-observabilityadmin/src/runtimeConfig.shared.ts
+++ b/clients/client-observabilityadmin/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-observabilityadmin/src/runtimeConfig.ts
+++ b/clients/client-observabilityadmin/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-odb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-odb/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-odb/src/runtimeConfig.shared.ts
+++ b/clients/client-odb/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-odb/src/runtimeConfig.ts
+++ b/clients/client-odb/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-omics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-omics/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-omics/src/runtimeConfig.shared.ts
+++ b/clients/client-omics/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-omics/src/runtimeConfig.ts
+++ b/clients/client-omics/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-opensearch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-opensearch/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-opensearch/src/runtimeConfig.shared.ts
+++ b/clients/client-opensearch/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-opensearch/src/runtimeConfig.ts
+++ b/clients/client-opensearch/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-opensearchserverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-opensearchserverless/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-opensearchserverless/src/runtimeConfig.shared.ts
+++ b/clients/client-opensearchserverless/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-opensearchserverless/src/runtimeConfig.ts
+++ b/clients/client-opensearchserverless/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-organizations/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-organizations/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-organizations/src/runtimeConfig.shared.ts
+++ b/clients/client-organizations/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-organizations/src/runtimeConfig.ts
+++ b/clients/client-organizations/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-osis/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-osis/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-osis/src/runtimeConfig.shared.ts
+++ b/clients/client-osis/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-osis/src/runtimeConfig.ts
+++ b/clients/client-osis/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-outposts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-outposts/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-outposts/src/runtimeConfig.shared.ts
+++ b/clients/client-outposts/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-outposts/src/runtimeConfig.ts
+++ b/clients/client-outposts/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-panorama/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-panorama/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-panorama/src/runtimeConfig.shared.ts
+++ b/clients/client-panorama/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-panorama/src/runtimeConfig.ts
+++ b/clients/client-panorama/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-partnercentral-account/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-partnercentral-account/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-partnercentral-account/src/runtimeConfig.shared.ts
+++ b/clients/client-partnercentral-account/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-partnercentral-account/src/runtimeConfig.ts
+++ b/clients/client-partnercentral-account/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-partnercentral-benefits/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-partnercentral-benefits/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-partnercentral-benefits/src/runtimeConfig.shared.ts
+++ b/clients/client-partnercentral-benefits/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-partnercentral-benefits/src/runtimeConfig.ts
+++ b/clients/client-partnercentral-benefits/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-partnercentral-channel/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-partnercentral-channel/src/auth/httpAuthSchemeProvider.ts
@@ -8,7 +8,7 @@ import {
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { EndpointParameterInstructions, resolveParams } from "@smithy/middleware-endpoint";
 import {

--- a/clients/client-partnercentral-channel/src/runtimeConfig.shared.ts
+++ b/clients/client-partnercentral-channel/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-partnercentral-channel/src/runtimeConfig.ts
+++ b/clients/client-partnercentral-channel/src/runtimeConfig.ts
@@ -2,11 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import {
-  emitWarningIfUnsupportedVersion as awsCheckVersion,
-  NODE_AUTH_SCHEME_PREFERENCE_OPTIONS,
-  NODE_SIGV4A_CONFIG_OPTIONS,
-} from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS, NODE_SIGV4A_CONFIG_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-partnercentral-selling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-partnercentral-selling/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-partnercentral-selling/src/runtimeConfig.shared.ts
+++ b/clients/client-partnercentral-selling/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-partnercentral-selling/src/runtimeConfig.ts
+++ b/clients/client-partnercentral-selling/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-payment-cryptography-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-payment-cryptography-data/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-payment-cryptography-data/src/runtimeConfig.shared.ts
+++ b/clients/client-payment-cryptography-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-payment-cryptography-data/src/runtimeConfig.ts
+++ b/clients/client-payment-cryptography-data/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-payment-cryptography/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-payment-cryptography/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-payment-cryptography/src/runtimeConfig.shared.ts
+++ b/clients/client-payment-cryptography/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-payment-cryptography/src/runtimeConfig.ts
+++ b/clients/client-payment-cryptography/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-pca-connector-ad/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pca-connector-ad/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-pca-connector-ad/src/runtimeConfig.shared.ts
+++ b/clients/client-pca-connector-ad/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-pca-connector-ad/src/runtimeConfig.ts
+++ b/clients/client-pca-connector-ad/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-pca-connector-scep/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pca-connector-scep/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-pca-connector-scep/src/runtimeConfig.shared.ts
+++ b/clients/client-pca-connector-scep/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-pca-connector-scep/src/runtimeConfig.ts
+++ b/clients/client-pca-connector-scep/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-pcs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pcs/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-pcs/src/runtimeConfig.shared.ts
+++ b/clients/client-pcs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-pcs/src/runtimeConfig.ts
+++ b/clients/client-pcs/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-personalize-events/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-personalize-events/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-personalize-events/src/runtimeConfig.shared.ts
+++ b/clients/client-personalize-events/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-personalize-events/src/runtimeConfig.ts
+++ b/clients/client-personalize-events/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-personalize-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-personalize-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-personalize-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-personalize-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-personalize-runtime/src/runtimeConfig.ts
+++ b/clients/client-personalize-runtime/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-personalize/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-personalize/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-personalize/src/runtimeConfig.shared.ts
+++ b/clients/client-personalize/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-personalize/src/runtimeConfig.ts
+++ b/clients/client-personalize/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-pi/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pi/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-pi/src/runtimeConfig.shared.ts
+++ b/clients/client-pi/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-pi/src/runtimeConfig.ts
+++ b/clients/client-pi/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-pinpoint-email/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint-email/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-pinpoint-email/src/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint-email/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-pinpoint-email/src/runtimeConfig.ts
+++ b/clients/client-pinpoint-email/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-pinpoint-sms-voice-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-pinpoint-sms-voice-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-pinpoint-sms-voice-v2/src/runtimeConfig.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-pinpoint-sms-voice/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint-sms-voice/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-pinpoint-sms-voice/src/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint-sms-voice/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-pinpoint-sms-voice/src/runtimeConfig.ts
+++ b/clients/client-pinpoint-sms-voice/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-pinpoint/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-pinpoint/src/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-pinpoint/src/runtimeConfig.ts
+++ b/clients/client-pinpoint/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-pipes/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pipes/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-pipes/src/runtimeConfig.shared.ts
+++ b/clients/client-pipes/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-pipes/src/runtimeConfig.ts
+++ b/clients/client-pipes/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-polly/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-polly/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-polly/src/runtimeConfig.shared.ts
+++ b/clients/client-polly/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-polly/src/runtimeConfig.ts
+++ b/clients/client-polly/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-pricing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pricing/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-pricing/src/runtimeConfig.shared.ts
+++ b/clients/client-pricing/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-pricing/src/runtimeConfig.ts
+++ b/clients/client-pricing/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-proton/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-proton/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-proton/src/runtimeConfig.shared.ts
+++ b/clients/client-proton/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-proton/src/runtimeConfig.ts
+++ b/clients/client-proton/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-qapps/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qapps/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-qapps/src/runtimeConfig.shared.ts
+++ b/clients/client-qapps/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-qapps/src/runtimeConfig.ts
+++ b/clients/client-qapps/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-qbusiness/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qbusiness/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-qbusiness/src/runtimeConfig.shared.ts
+++ b/clients/client-qbusiness/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-qbusiness/src/runtimeConfig.ts
+++ b/clients/client-qbusiness/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-qconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qconnect/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-qconnect/src/runtimeConfig.shared.ts
+++ b/clients/client-qconnect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-qconnect/src/runtimeConfig.ts
+++ b/clients/client-qconnect/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-quicksight/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-quicksight/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-quicksight/src/runtimeConfig.shared.ts
+++ b/clients/client-quicksight/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-quicksight/src/runtimeConfig.ts
+++ b/clients/client-quicksight/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ram/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ram/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ram/src/runtimeConfig.shared.ts
+++ b/clients/client-ram/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ram/src/runtimeConfig.ts
+++ b/clients/client-ram/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-rbin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rbin/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-rbin/src/runtimeConfig.shared.ts
+++ b/clients/client-rbin/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-rbin/src/runtimeConfig.ts
+++ b/clients/client-rbin/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-rds-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rds-data/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-rds-data/src/runtimeConfig.shared.ts
+++ b/clients/client-rds-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-rds-data/src/runtimeConfig.ts
+++ b/clients/client-rds-data/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-rds/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rds/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-rds/src/runtimeConfig.shared.ts
+++ b/clients/client-rds/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-rds/src/runtimeConfig.ts
+++ b/clients/client-rds/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-redshift-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-redshift-data/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-redshift-data/src/runtimeConfig.shared.ts
+++ b/clients/client-redshift-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-redshift-data/src/runtimeConfig.ts
+++ b/clients/client-redshift-data/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-redshift-serverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-redshift-serverless/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-redshift-serverless/src/runtimeConfig.shared.ts
+++ b/clients/client-redshift-serverless/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-redshift-serverless/src/runtimeConfig.ts
+++ b/clients/client-redshift-serverless/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-redshift/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-redshift/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-redshift/src/runtimeConfig.shared.ts
+++ b/clients/client-redshift/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-redshift/src/runtimeConfig.ts
+++ b/clients/client-redshift/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-rekognition/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rekognition/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-rekognition/src/runtimeConfig.shared.ts
+++ b/clients/client-rekognition/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-rekognition/src/runtimeConfig.ts
+++ b/clients/client-rekognition/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-rekognitionstreaming/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rekognitionstreaming/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-rekognitionstreaming/src/runtimeConfig.shared.ts
+++ b/clients/client-rekognitionstreaming/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-rekognitionstreaming/src/runtimeConfig.ts
+++ b/clients/client-rekognitionstreaming/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-repostspace/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-repostspace/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-repostspace/src/runtimeConfig.shared.ts
+++ b/clients/client-repostspace/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-repostspace/src/runtimeConfig.ts
+++ b/clients/client-repostspace/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-resiliencehub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resiliencehub/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-resiliencehub/src/runtimeConfig.shared.ts
+++ b/clients/client-resiliencehub/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-resiliencehub/src/runtimeConfig.ts
+++ b/clients/client-resiliencehub/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-resource-explorer-2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resource-explorer-2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-resource-explorer-2/src/runtimeConfig.shared.ts
+++ b/clients/client-resource-explorer-2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-resource-explorer-2/src/runtimeConfig.ts
+++ b/clients/client-resource-explorer-2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-resource-groups-tagging-api/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resource-groups-tagging-api/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-resource-groups-tagging-api/src/runtimeConfig.shared.ts
+++ b/clients/client-resource-groups-tagging-api/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-resource-groups-tagging-api/src/runtimeConfig.ts
+++ b/clients/client-resource-groups-tagging-api/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-resource-groups/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resource-groups/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-resource-groups/src/runtimeConfig.shared.ts
+++ b/clients/client-resource-groups/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-resource-groups/src/runtimeConfig.ts
+++ b/clients/client-resource-groups/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-rolesanywhere/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rolesanywhere/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-rolesanywhere/src/runtimeConfig.shared.ts
+++ b/clients/client-rolesanywhere/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-rolesanywhere/src/runtimeConfig.ts
+++ b/clients/client-rolesanywhere/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-route-53-domains/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route-53-domains/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-route-53-domains/src/runtimeConfig.shared.ts
+++ b/clients/client-route-53-domains/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-route-53-domains/src/runtimeConfig.ts
+++ b/clients/client-route-53-domains/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-route-53/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route-53/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-route-53/src/runtimeConfig.shared.ts
+++ b/clients/client-route-53/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestXmlProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-route-53/src/runtimeConfig.ts
+++ b/clients/client-route-53/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-route53-recovery-cluster/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53-recovery-cluster/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-route53-recovery-cluster/src/runtimeConfig.shared.ts
+++ b/clients/client-route53-recovery-cluster/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-route53-recovery-cluster/src/runtimeConfig.ts
+++ b/clients/client-route53-recovery-cluster/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-route53-recovery-control-config/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53-recovery-control-config/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-route53-recovery-control-config/src/runtimeConfig.shared.ts
+++ b/clients/client-route53-recovery-control-config/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-route53-recovery-control-config/src/runtimeConfig.ts
+++ b/clients/client-route53-recovery-control-config/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-route53-recovery-readiness/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53-recovery-readiness/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-route53-recovery-readiness/src/runtimeConfig.shared.ts
+++ b/clients/client-route53-recovery-readiness/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-route53-recovery-readiness/src/runtimeConfig.ts
+++ b/clients/client-route53-recovery-readiness/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-route53globalresolver/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53globalresolver/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-route53globalresolver/src/runtimeConfig.shared.ts
+++ b/clients/client-route53globalresolver/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-route53globalresolver/src/runtimeConfig.ts
+++ b/clients/client-route53globalresolver/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-route53profiles/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53profiles/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-route53profiles/src/runtimeConfig.shared.ts
+++ b/clients/client-route53profiles/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-route53profiles/src/runtimeConfig.ts
+++ b/clients/client-route53profiles/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-route53resolver/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53resolver/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-route53resolver/src/runtimeConfig.shared.ts
+++ b/clients/client-route53resolver/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-route53resolver/src/runtimeConfig.ts
+++ b/clients/client-route53resolver/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-rtbfabric/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rtbfabric/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-rtbfabric/src/runtimeConfig.shared.ts
+++ b/clients/client-rtbfabric/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-rtbfabric/src/runtimeConfig.ts
+++ b/clients/client-rtbfabric/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-rum/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rum/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-rum/src/runtimeConfig.shared.ts
+++ b/clients/client-rum/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-rum/src/runtimeConfig.ts
+++ b/clients/client-rum/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-s3-control/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3-control/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-s3-control/src/runtimeConfig.shared.ts
+++ b/clients/client-s3-control/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestXmlProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-s3-control/src/runtimeConfig.ts
+++ b/clients/client-s3-control/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { NODE_USE_ARN_REGION_CONFIG_OPTIONS } from "@aws-sdk/middleware-bucket-endpoint";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-s3/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3/src/auth/httpAuthSchemeProvider.ts
@@ -8,7 +8,7 @@ import {
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { EndpointParameterInstructions, resolveParams } from "@smithy/middleware-endpoint";
 import {

--- a/clients/client-s3/src/runtimeConfig.shared.ts
+++ b/clients/client-s3/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { S3RestXmlProtocol } from "@aws-sdk/middleware-sdk-s3";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-s3/src/runtimeConfig.ts
+++ b/clients/client-s3/src/runtimeConfig.ts
@@ -2,11 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import {
-  emitWarningIfUnsupportedVersion as awsCheckVersion,
-  NODE_AUTH_SCHEME_PREFERENCE_OPTIONS,
-  NODE_SIGV4A_CONFIG_OPTIONS,
-} from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS, NODE_SIGV4A_CONFIG_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { NODE_USE_ARN_REGION_CONFIG_OPTIONS } from "@aws-sdk/middleware-bucket-endpoint";
 import {

--- a/clients/client-s3outposts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3outposts/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-s3outposts/src/runtimeConfig.shared.ts
+++ b/clients/client-s3outposts/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-s3outposts/src/runtimeConfig.ts
+++ b/clients/client-s3outposts/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-s3tables/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3tables/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-s3tables/src/runtimeConfig.shared.ts
+++ b/clients/client-s3tables/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-s3tables/src/runtimeConfig.ts
+++ b/clients/client-s3tables/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-s3vectors/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3vectors/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-s3vectors/src/runtimeConfig.shared.ts
+++ b/clients/client-s3vectors/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-s3vectors/src/runtimeConfig.ts
+++ b/clients/client-s3vectors/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sagemaker-a2i-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sagemaker-a2i-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sagemaker-a2i-runtime/src/runtimeConfig.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sagemaker-edge/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-edge/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sagemaker-edge/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-edge/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sagemaker-edge/src/runtimeConfig.ts
+++ b/clients/client-sagemaker-edge/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sagemaker-featurestore-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sagemaker-featurestore-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sagemaker-featurestore-runtime/src/runtimeConfig.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sagemaker-geospatial/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-geospatial/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sagemaker-geospatial/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-geospatial/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sagemaker-geospatial/src/runtimeConfig.ts
+++ b/clients/client-sagemaker-geospatial/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sagemaker-metrics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-metrics/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sagemaker-metrics/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-metrics/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sagemaker-metrics/src/runtimeConfig.ts
+++ b/clients/client-sagemaker-metrics/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sagemaker-runtime-http2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-runtime-http2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sagemaker-runtime-http2/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-runtime-http2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sagemaker-runtime-http2/src/runtimeConfig.ts
+++ b/clients/client-sagemaker-runtime-http2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-sagemaker-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sagemaker-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sagemaker-runtime/src/runtimeConfig.ts
+++ b/clients/client-sagemaker-runtime/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sagemaker/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sagemaker/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sagemaker/src/runtimeConfig.ts
+++ b/clients/client-sagemaker/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-savingsplans/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-savingsplans/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-savingsplans/src/runtimeConfig.shared.ts
+++ b/clients/client-savingsplans/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-savingsplans/src/runtimeConfig.ts
+++ b/clients/client-savingsplans/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-scheduler/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-scheduler/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-scheduler/src/runtimeConfig.shared.ts
+++ b/clients/client-scheduler/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-scheduler/src/runtimeConfig.ts
+++ b/clients/client-scheduler/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-schemas/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-schemas/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-schemas/src/runtimeConfig.shared.ts
+++ b/clients/client-schemas/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-schemas/src/runtimeConfig.ts
+++ b/clients/client-schemas/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-secrets-manager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-secrets-manager/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-secrets-manager/src/runtimeConfig.shared.ts
+++ b/clients/client-secrets-manager/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-secrets-manager/src/runtimeConfig.ts
+++ b/clients/client-secrets-manager/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-security-ir/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-security-ir/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-security-ir/src/runtimeConfig.shared.ts
+++ b/clients/client-security-ir/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-security-ir/src/runtimeConfig.ts
+++ b/clients/client-security-ir/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-securityhub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-securityhub/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-securityhub/src/runtimeConfig.shared.ts
+++ b/clients/client-securityhub/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-securityhub/src/runtimeConfig.ts
+++ b/clients/client-securityhub/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-securitylake/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-securitylake/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-securitylake/src/runtimeConfig.shared.ts
+++ b/clients/client-securitylake/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-securitylake/src/runtimeConfig.ts
+++ b/clients/client-securitylake/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-serverlessapplicationrepository/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-serverlessapplicationrepository/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-serverlessapplicationrepository/src/runtimeConfig.shared.ts
+++ b/clients/client-serverlessapplicationrepository/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-serverlessapplicationrepository/src/runtimeConfig.ts
+++ b/clients/client-serverlessapplicationrepository/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-service-catalog-appregistry/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-service-catalog-appregistry/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-service-catalog-appregistry/src/runtimeConfig.shared.ts
+++ b/clients/client-service-catalog-appregistry/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-service-catalog-appregistry/src/runtimeConfig.ts
+++ b/clients/client-service-catalog-appregistry/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-service-catalog/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-service-catalog/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-service-catalog/src/runtimeConfig.shared.ts
+++ b/clients/client-service-catalog/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-service-catalog/src/runtimeConfig.ts
+++ b/clients/client-service-catalog/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-service-quotas/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-service-quotas/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-service-quotas/src/runtimeConfig.shared.ts
+++ b/clients/client-service-quotas/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-service-quotas/src/runtimeConfig.ts
+++ b/clients/client-service-quotas/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-servicediscovery/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-servicediscovery/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-servicediscovery/src/runtimeConfig.shared.ts
+++ b/clients/client-servicediscovery/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-servicediscovery/src/runtimeConfig.ts
+++ b/clients/client-servicediscovery/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ses/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ses/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ses/src/runtimeConfig.shared.ts
+++ b/clients/client-ses/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ses/src/runtimeConfig.ts
+++ b/clients/client-ses/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sesv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sesv2/src/auth/httpAuthSchemeProvider.ts
@@ -8,7 +8,7 @@ import {
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { EndpointParameterInstructions, resolveParams } from "@smithy/middleware-endpoint";
 import {

--- a/clients/client-sesv2/src/runtimeConfig.shared.ts
+++ b/clients/client-sesv2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4ASigner, AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-sesv2/src/runtimeConfig.ts
+++ b/clients/client-sesv2/src/runtimeConfig.ts
@@ -2,11 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import {
-  emitWarningIfUnsupportedVersion as awsCheckVersion,
-  NODE_AUTH_SCHEME_PREFERENCE_OPTIONS,
-  NODE_SIGV4A_CONFIG_OPTIONS,
-} from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS, NODE_SIGV4A_CONFIG_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sfn/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sfn/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sfn/src/runtimeConfig.shared.ts
+++ b/clients/client-sfn/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sfn/src/runtimeConfig.ts
+++ b/clients/client-sfn/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-shield/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-shield/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-shield/src/runtimeConfig.shared.ts
+++ b/clients/client-shield/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-shield/src/runtimeConfig.ts
+++ b/clients/client-shield/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-signer-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-signer-data/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-signer-data/src/runtimeConfig.shared.ts
+++ b/clients/client-signer-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-signer-data/src/runtimeConfig.ts
+++ b/clients/client-signer-data/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-signer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-signer/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-signer/src/runtimeConfig.shared.ts
+++ b/clients/client-signer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-signer/src/runtimeConfig.ts
+++ b/clients/client-signer/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-signin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-signin/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-signin/src/runtimeConfig.shared.ts
+++ b/clients/client-signin/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-signin/src/runtimeConfig.ts
+++ b/clients/client-signin/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-simpledbv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-simpledbv2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-simpledbv2/src/runtimeConfig.shared.ts
+++ b/clients/client-simpledbv2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-simpledbv2/src/runtimeConfig.ts
+++ b/clients/client-simpledbv2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-simspaceweaver/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-simspaceweaver/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-simspaceweaver/src/runtimeConfig.shared.ts
+++ b/clients/client-simspaceweaver/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-simspaceweaver/src/runtimeConfig.ts
+++ b/clients/client-simspaceweaver/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-snow-device-management/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-snow-device-management/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-snow-device-management/src/runtimeConfig.shared.ts
+++ b/clients/client-snow-device-management/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-snow-device-management/src/runtimeConfig.ts
+++ b/clients/client-snow-device-management/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-snowball/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-snowball/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-snowball/src/runtimeConfig.shared.ts
+++ b/clients/client-snowball/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-snowball/src/runtimeConfig.ts
+++ b/clients/client-snowball/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sns/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sns/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sns/src/runtimeConfig.shared.ts
+++ b/clients/client-sns/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sns/src/runtimeConfig.ts
+++ b/clients/client-sns/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-socialmessaging/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-socialmessaging/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-socialmessaging/src/runtimeConfig.shared.ts
+++ b/clients/client-socialmessaging/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-socialmessaging/src/runtimeConfig.ts
+++ b/clients/client-socialmessaging/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sqs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sqs/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sqs/src/runtimeConfig.shared.ts
+++ b/clients/client-sqs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sqs/src/runtimeConfig.ts
+++ b/clients/client-sqs/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { ChecksumConstructor as __ChecksumConstructor, HashConstructor as __HashConstructor } from "@aws-sdk/types";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-sqs/test/SQS.e2e.spec.ts
+++ b/clients/client-sqs/test/SQS.e2e.spec.ts
@@ -1,5 +1,5 @@
 import { SQS } from "@aws-sdk/client-sqs";
-import { AwsJson1_0Protocol, AwsQueryProtocol } from "@aws-sdk/core";
+import { AwsJson1_0Protocol, AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { describe, expect, test as it } from "vitest";
 
 describe(

--- a/clients/client-ssm-contacts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-contacts/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ssm-contacts/src/runtimeConfig.shared.ts
+++ b/clients/client-ssm-contacts/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ssm-contacts/src/runtimeConfig.ts
+++ b/clients/client-ssm-contacts/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ssm-guiconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-guiconnect/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ssm-guiconnect/src/runtimeConfig.shared.ts
+++ b/clients/client-ssm-guiconnect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ssm-guiconnect/src/runtimeConfig.ts
+++ b/clients/client-ssm-guiconnect/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ssm-incidents/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-incidents/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ssm-incidents/src/runtimeConfig.shared.ts
+++ b/clients/client-ssm-incidents/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ssm-incidents/src/runtimeConfig.ts
+++ b/clients/client-ssm-incidents/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ssm-quicksetup/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-quicksetup/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ssm-quicksetup/src/runtimeConfig.shared.ts
+++ b/clients/client-ssm-quicksetup/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ssm-quicksetup/src/runtimeConfig.ts
+++ b/clients/client-ssm-quicksetup/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ssm-sap/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-sap/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ssm-sap/src/runtimeConfig.shared.ts
+++ b/clients/client-ssm-sap/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ssm-sap/src/runtimeConfig.ts
+++ b/clients/client-ssm-sap/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-ssm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-ssm/src/runtimeConfig.shared.ts
+++ b/clients/client-ssm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-ssm/src/runtimeConfig.ts
+++ b/clients/client-ssm/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sso-admin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sso-admin/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sso-admin/src/runtimeConfig.shared.ts
+++ b/clients/client-sso-admin/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-sso-admin/src/runtimeConfig.ts
+++ b/clients/client-sso-admin/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sso-oidc/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sso-oidc/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sso-oidc/src/runtimeConfig.shared.ts
+++ b/clients/client-sso-oidc/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-sso-oidc/src/runtimeConfig.ts
+++ b/clients/client-sso-oidc/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sso/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sso/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-sso/src/runtimeConfig.shared.ts
+++ b/clients/client-sso/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-sso/src/runtimeConfig.ts
+++ b/clients/client-sso/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {
   NODE_REGION_CONFIG_FILE_OPTIONS,

--- a/clients/client-storage-gateway/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-storage-gateway/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-storage-gateway/src/runtimeConfig.shared.ts
+++ b/clients/client-storage-gateway/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-storage-gateway/src/runtimeConfig.ts
+++ b/clients/client-storage-gateway/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-sts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sts/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import {
   type HandlerExecutionContext,
   type HttpAuthOption,

--- a/clients/client-sts/src/runtimeConfig.shared.ts
+++ b/clients/client-sts/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/clients/client-sts/src/runtimeConfig.ts
+++ b/clients/client-sts/src/runtimeConfig.ts
@@ -2,11 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import {
-  AwsSdkSigV4Signer,
-  emitWarningIfUnsupportedVersion as awsCheckVersion,
-  NODE_AUTH_SCHEME_PREFERENCE_OPTIONS,
-} from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { AwsSdkSigV4Signer, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-supplychain/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-supplychain/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-supplychain/src/runtimeConfig.shared.ts
+++ b/clients/client-supplychain/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-supplychain/src/runtimeConfig.ts
+++ b/clients/client-supplychain/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-support-app/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-support-app/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-support-app/src/runtimeConfig.shared.ts
+++ b/clients/client-support-app/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-support-app/src/runtimeConfig.ts
+++ b/clients/client-support-app/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-support/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-support/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-support/src/runtimeConfig.shared.ts
+++ b/clients/client-support/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-support/src/runtimeConfig.ts
+++ b/clients/client-support/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-swf/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-swf/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-swf/src/runtimeConfig.shared.ts
+++ b/clients/client-swf/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-swf/src/runtimeConfig.ts
+++ b/clients/client-swf/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-synthetics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-synthetics/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-synthetics/src/runtimeConfig.shared.ts
+++ b/clients/client-synthetics/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-synthetics/src/runtimeConfig.ts
+++ b/clients/client-synthetics/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-taxsettings/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-taxsettings/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-taxsettings/src/runtimeConfig.shared.ts
+++ b/clients/client-taxsettings/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-taxsettings/src/runtimeConfig.ts
+++ b/clients/client-taxsettings/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-textract/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-textract/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-textract/src/runtimeConfig.shared.ts
+++ b/clients/client-textract/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-textract/src/runtimeConfig.ts
+++ b/clients/client-textract/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-timestream-influxdb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-timestream-influxdb/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-timestream-influxdb/src/runtimeConfig.shared.ts
+++ b/clients/client-timestream-influxdb/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-timestream-influxdb/src/runtimeConfig.ts
+++ b/clients/client-timestream-influxdb/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-timestream-query/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-timestream-query/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-timestream-query/src/runtimeConfig.shared.ts
+++ b/clients/client-timestream-query/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-timestream-query/src/runtimeConfig.ts
+++ b/clients/client-timestream-query/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS } from "@aws-sdk/middleware-endpoint-discovery";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-timestream-write/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-timestream-write/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-timestream-write/src/runtimeConfig.shared.ts
+++ b/clients/client-timestream-write/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-timestream-write/src/runtimeConfig.ts
+++ b/clients/client-timestream-write/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS } from "@aws-sdk/middleware-endpoint-discovery";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-tnb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-tnb/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-tnb/src/runtimeConfig.shared.ts
+++ b/clients/client-tnb/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-tnb/src/runtimeConfig.ts
+++ b/clients/client-tnb/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-transcribe-streaming/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-transcribe-streaming/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-transcribe-streaming/src/runtimeConfig.shared.ts
+++ b/clients/client-transcribe-streaming/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-transcribe-streaming/src/runtimeConfig.ts
+++ b/clients/client-transcribe-streaming/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/clients/client-transcribe/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-transcribe/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-transcribe/src/runtimeConfig.shared.ts
+++ b/clients/client-transcribe/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-transcribe/src/runtimeConfig.ts
+++ b/clients/client-transcribe/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-transfer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-transfer/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-transfer/src/runtimeConfig.shared.ts
+++ b/clients/client-transfer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-transfer/src/runtimeConfig.ts
+++ b/clients/client-transfer/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-translate/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-translate/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-translate/src/runtimeConfig.shared.ts
+++ b/clients/client-translate/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-translate/src/runtimeConfig.ts
+++ b/clients/client-translate/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-trustedadvisor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-trustedadvisor/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-trustedadvisor/src/runtimeConfig.shared.ts
+++ b/clients/client-trustedadvisor/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-trustedadvisor/src/runtimeConfig.ts
+++ b/clients/client-trustedadvisor/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-uxc/package.json
+++ b/clients/client-uxc/package.json
@@ -10,9 +10,9 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
-    "test:index": "tsc --noEmit ./test/index-types.ts && node ./test/index-objects.spec.mjs",
     "extract:docs": "api-extractor run --local",
-    "generate:client": "node ../../scripts/generate-clients/single-service --solo uxc"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo uxc",
+    "test:index": "tsc --noEmit ./test/index-types.ts && node ./test/index-objects.spec.mjs"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-uxc/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-uxc/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-uxc/src/runtimeConfig.shared.ts
+++ b/clients/client-uxc/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-uxc/src/runtimeConfig.ts
+++ b/clients/client-uxc/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-verifiedpermissions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-verifiedpermissions/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-verifiedpermissions/src/runtimeConfig.shared.ts
+++ b/clients/client-verifiedpermissions/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-verifiedpermissions/src/runtimeConfig.ts
+++ b/clients/client-verifiedpermissions/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-voice-id/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-voice-id/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-voice-id/src/runtimeConfig.shared.ts
+++ b/clients/client-voice-id/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-voice-id/src/runtimeConfig.ts
+++ b/clients/client-voice-id/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-vpc-lattice/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-vpc-lattice/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-vpc-lattice/src/runtimeConfig.shared.ts
+++ b/clients/client-vpc-lattice/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-vpc-lattice/src/runtimeConfig.ts
+++ b/clients/client-vpc-lattice/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-waf-regional/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-waf-regional/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-waf-regional/src/runtimeConfig.shared.ts
+++ b/clients/client-waf-regional/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-waf-regional/src/runtimeConfig.ts
+++ b/clients/client-waf-regional/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-waf/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-waf/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-waf/src/runtimeConfig.shared.ts
+++ b/clients/client-waf/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-waf/src/runtimeConfig.ts
+++ b/clients/client-waf/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-wafv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wafv2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-wafv2/src/runtimeConfig.shared.ts
+++ b/clients/client-wafv2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-wafv2/src/runtimeConfig.ts
+++ b/clients/client-wafv2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-wellarchitected/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wellarchitected/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-wellarchitected/src/runtimeConfig.shared.ts
+++ b/clients/client-wellarchitected/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-wellarchitected/src/runtimeConfig.ts
+++ b/clients/client-wellarchitected/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-wickr/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wickr/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-wickr/src/runtimeConfig.shared.ts
+++ b/clients/client-wickr/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-wickr/src/runtimeConfig.ts
+++ b/clients/client-wickr/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-wisdom/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wisdom/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-wisdom/src/runtimeConfig.shared.ts
+++ b/clients/client-wisdom/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-wisdom/src/runtimeConfig.ts
+++ b/clients/client-wisdom/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-workdocs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workdocs/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-workdocs/src/runtimeConfig.shared.ts
+++ b/clients/client-workdocs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-workdocs/src/runtimeConfig.ts
+++ b/clients/client-workdocs/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-workmail/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workmail/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-workmail/src/runtimeConfig.shared.ts
+++ b/clients/client-workmail/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-workmail/src/runtimeConfig.ts
+++ b/clients/client-workmail/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-workmailmessageflow/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workmailmessageflow/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-workmailmessageflow/src/runtimeConfig.shared.ts
+++ b/clients/client-workmailmessageflow/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-workmailmessageflow/src/runtimeConfig.ts
+++ b/clients/client-workmailmessageflow/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-workspaces-instances/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces-instances/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-workspaces-instances/src/runtimeConfig.shared.ts
+++ b/clients/client-workspaces-instances/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-workspaces-instances/src/runtimeConfig.ts
+++ b/clients/client-workspaces-instances/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-workspaces-thin-client/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces-thin-client/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-workspaces-thin-client/src/runtimeConfig.shared.ts
+++ b/clients/client-workspaces-thin-client/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-workspaces-thin-client/src/runtimeConfig.ts
+++ b/clients/client-workspaces-thin-client/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-workspaces-web/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces-web/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-workspaces-web/src/runtimeConfig.shared.ts
+++ b/clients/client-workspaces-web/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-workspaces-web/src/runtimeConfig.ts
+++ b/clients/client-workspaces-web/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-workspaces/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-workspaces/src/runtimeConfig.shared.ts
+++ b/clients/client-workspaces/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-workspaces/src/runtimeConfig.ts
+++ b/clients/client-workspaces/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/clients/client-xray/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-xray/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/clients/client-xray/src/runtimeConfig.shared.ts
+++ b/clients/client-xray/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/clients/client-xray/src/runtimeConfig.ts
+++ b/clients/client-xray/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -156,8 +156,12 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
         Model model
     ) {
         if (isAwsService(settings, model) && target.equals(LanguageTarget.NODE)) {
-            writer.addDependency(AwsDependency.AWS_SDK_CORE);
-            writer.addImport("emitWarningIfUnsupportedVersion", "awsCheckVersion", AwsDependency.AWS_SDK_CORE);
+            writer.addImportSubmodule(
+                "emitWarningIfUnsupportedVersion",
+                "awsCheckVersion",
+                AwsDependency.AWS_SDK_CORE,
+                "/client"
+            );
             writer.write("awsCheckVersion(process.version);");
         }
         if (target.equals(LanguageTarget.NODE)) {
@@ -226,10 +230,11 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                                 "loadNodeConfig",
                                 TypeScriptDependency.NODE_CONFIG_PROVIDER
                             );
-                            writer.addImport(
+                            writer.addImportSubmodule(
                                 "NODE_AUTH_SCHEME_PREFERENCE_OPTIONS",
                                 null,
-                                AwsDependency.AWS_SDK_CORE
+                                AwsDependency.AWS_SDK_CORE,
+                                "/httpAuthSchemes"
                             );
                             writer.write("loadNodeConfig(NODE_AUTH_SCHEME_PREFERENCE_OPTIONS, loaderConfig)");
                         });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -112,8 +112,7 @@ final class AwsProtocolUtils {
      */
     static void generateJsonParseBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-        writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("parseJsonBody", "parseBody", AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule("parseJsonBody", "parseBody", AwsDependency.AWS_SDK_CORE, "/protocols");
     }
 
     static void generateJsonParseBodyWithQueryHeader(GenerationContext context) {
@@ -135,8 +134,7 @@ final class AwsProtocolUtils {
      */
     static void generateJsonParseErrorBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-        writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("parseJsonErrorBody", "parseErrorBody", AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule("parseJsonErrorBody", "parseErrorBody", AwsDependency.AWS_SDK_CORE, "/protocols");
     }
 
     /**
@@ -147,8 +145,7 @@ final class AwsProtocolUtils {
      */
     static void generateXmlParseBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-        writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("parseXmlBody", "parseBody", AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule("parseXmlBody", "parseBody", AwsDependency.AWS_SDK_CORE, "/protocols");
     }
 
     /**
@@ -159,8 +156,7 @@ final class AwsProtocolUtils {
      */
     static void generateXmlParseErrorBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-        writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("parseXmlErrorBody", "parseErrorBody", AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule("parseXmlErrorBody", "parseErrorBody", AwsDependency.AWS_SDK_CORE, "/protocols");
     }
 
     /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -99,8 +99,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
         TypeScriptWriter writer = context.getWriter();
         writer.addDependency(AwsDependency.XML_BUILDER);
 
-        writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("loadRestXmlErrorCode", null, AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule("loadRestXmlErrorCode", null, AwsDependency.AWS_SDK_CORE, "/protocols");
 
         writer.write(
             context.getStringStore().flushVariableDeclarationCode()

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
@@ -65,8 +65,13 @@ final class JsonMemberDeserVisitor extends MemberDeserVisitor {
 
     @Override
     public String unionShape(UnionShape shape) {
-        context.getWriter().addDependency(AwsDependency.AWS_SDK_CORE);
-        context.getWriter().addImport("awsExpectUnion", "__expectUnion", AwsDependency.AWS_SDK_CORE);
+        context.getWriter()
+            .addImportSubmodule(
+                "awsExpectUnion",
+                "__expectUnion",
+                AwsDependency.AWS_SDK_CORE,
+                "/protocols"
+            );
         return getDelegateDeserializer(shape, "__expectUnion(" + dataSource + ")");
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberSerVisitor.java
@@ -43,10 +43,9 @@ final class JsonMemberSerVisitor extends DocumentMemberSerVisitor {
         this.isAwsQueryCompat = context.getService().hasTrait(AwsQueryCompatibleTrait.class);
         this.serdeElisionEnabled = !this.isAwsQueryCompat && !context.getSettings().generateServerSdk();
         if (isAwsQueryCompat) {
-            writer.addDependency(AwsDependency.AWS_SDK_CORE);
-            writer.addImport("_toStr", null, AwsDependency.AWS_SDK_CORE);
-            writer.addImport("_toNum", null, AwsDependency.AWS_SDK_CORE);
-            writer.addImport("_toBool", null, AwsDependency.AWS_SDK_CORE);
+            writer.addImportSubmodule("_toStr", null, AwsDependency.AWS_SDK_CORE, "/protocols");
+            writer.addImportSubmodule("_toNum", null, AwsDependency.AWS_SDK_CORE, "/protocols");
+            writer.addImportSubmodule("_toBool", null, AwsDependency.AWS_SDK_CORE, "/protocols");
         }
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -56,8 +56,7 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
 
         TypeScriptWriter writer = context.getWriter();
         writer.addUseImports(getApplicationProtocol().getResponseType());
-        writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("loadRestJsonErrorCode", null, AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule("loadRestJsonErrorCode", null, AwsDependency.AWS_SDK_CORE, "/protocols");
 
         if (context.getService().hasTrait(AwsQueryCompatibleTrait.class)) {
             AwsProtocolUtils.generateJsonParseBodyWithQueryHeader(context);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -78,8 +78,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         TypeScriptWriter writer = context.getWriter();
         writer.addUseImports(getApplicationProtocol().getResponseType());
         writer.addImport("take", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
-        writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("loadRestJsonErrorCode", null, AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule("loadRestJsonErrorCode", null, AwsDependency.AWS_SDK_CORE, "/protocols");
 
         writer.write(
             context.getStringStore().flushVariableDeclarationCode()
@@ -129,8 +128,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
 
     @Override
     protected void importUnionDeserializer(TypeScriptWriter writer) {
-        writer.addDependency(AwsDependency.AWS_SDK_CORE);
-        writer.addImport("awsExpectUnion", "__expectUnion", AwsDependency.AWS_SDK_CORE);
+        writer.addImportSubmodule("awsExpectUnion", "__expectUnion", AwsDependency.AWS_SDK_CORE, "/protocols");
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
@@ -127,16 +127,16 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                             "sigv4aSigningRegionSet",
                             writer -> {
                                 writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                                writer.addDependency(AwsDependency.AWS_SDK_CORE);
                                 writer.addImport(
                                     "loadConfig",
                                     "loadNodeConfig",
                                     TypeScriptDependency.NODE_CONFIG_PROVIDER
                                 );
-                                writer.addImport(
+                                writer.addImportSubmodule(
                                     "NODE_SIGV4A_CONFIG_OPTIONS",
                                     null,
-                                    AwsDependency.AWS_SDK_CORE
+                                    AwsDependency.AWS_SDK_CORE,
+                                    "/httpAuthSchemes"
                                 );
                                 writer.write("loadNodeConfig(NODE_SIGV4A_CONFIG_OPTIONS, loaderConfig)");
                             }
@@ -200,28 +200,28 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                         .resolveConfigFunction(
                             Symbol.builder()
                                 .name("resolveAwsSdkSigV4Config")
-                                .namespace(AwsDependency.AWS_SDK_CORE.getPackageName(), "/")
+                                .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                 .addDependency(AwsDependency.AWS_SDK_CORE)
                                 .build()
                         )
                         .inputConfig(
                             Symbol.builder()
                                 .name("AwsSdkSigV4AuthInputConfig")
-                                .namespace(AwsDependency.AWS_SDK_CORE.getPackageName(), "/")
+                                .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                 .addDependency(AwsDependency.AWS_SDK_CORE)
                                 .build()
                         )
                         .previouslyResolved(
                             Symbol.builder()
                                 .name("AwsSdkSigV4PreviouslyResolved")
-                                .namespace(AwsDependency.AWS_SDK_CORE.getPackageName(), "/")
+                                .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                 .addDependency(AwsDependency.AWS_SDK_CORE)
                                 .build()
                         )
                         .resolvedConfig(
                             Symbol.builder()
                                 .name("AwsSdkSigV4AuthResolvedConfig")
-                                .namespace(AwsDependency.AWS_SDK_CORE.getPackageName(), "/")
+                                .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                 .addDependency(AwsDependency.AWS_SDK_CORE)
                                 .build()
                         )
@@ -230,8 +230,12 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                 .putDefaultSigner(
                     LanguageTarget.SHARED,
                     w -> w
-                        .addDependency(AwsDependency.AWS_SDK_CORE)
-                        .addImport("AwsSdkSigV4Signer", null, AwsDependency.AWS_SDK_CORE)
+                        .addImportSubmodule(
+                            "AwsSdkSigV4Signer",
+                            null,
+                            AwsDependency.AWS_SDK_CORE,
+                            "/httpAuthSchemes"
+                        )
                         .write("new AwsSdkSigV4Signer()")
                 )
                 .build();
@@ -247,28 +251,28 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                             .resolveConfigFunction(
                                 Symbol.builder()
                                     .name("resolveAwsSdkSigV4AConfig")
-                                    .namespace(AwsDependency.AWS_SDK_CORE.getPackageName(), "/")
+                                    .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                     .addDependency(AwsDependency.AWS_SDK_CORE)
                                     .build()
                             )
                             .inputConfig(
                                 Symbol.builder()
                                     .name("AwsSdkSigV4AAuthInputConfig")
-                                    .namespace(AwsDependency.AWS_SDK_CORE.getPackageName(), "/")
+                                    .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                     .addDependency(AwsDependency.AWS_SDK_CORE)
                                     .build()
                             )
                             .previouslyResolved(
                                 Symbol.builder()
                                     .name("AwsSdkSigV4APreviouslyResolved")
-                                    .namespace(AwsDependency.AWS_SDK_CORE.getPackageName(), "/")
+                                    .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                     .addDependency(AwsDependency.AWS_SDK_CORE)
                                     .build()
                             )
                             .resolvedConfig(
                                 Symbol.builder()
                                     .name("AwsSdkSigV4AAuthResolvedConfig")
-                                    .namespace(AwsDependency.AWS_SDK_CORE.getPackageName(), "/")
+                                    .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                     .addDependency(AwsDependency.AWS_SDK_CORE)
                                     .build()
                             )
@@ -277,8 +281,12 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                     .putDefaultSigner(
                         LanguageTarget.SHARED,
                         w -> w
-                            .addDependency(AwsDependency.AWS_SDK_CORE)
-                            .addImport("AwsSdkSigV4ASigner", null, AwsDependency.AWS_SDK_CORE)
+                            .addImportSubmodule(
+                                "AwsSdkSigV4ASigner",
+                                null,
+                                AwsDependency.AWS_SDK_CORE,
+                                "/httpAuthSchemes"
+                            )
                             .write("new AwsSdkSigV4ASigner()")
                     )
                     .build();

--- a/packages-internal/nested-clients/src/submodules/cognito-identity/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/cognito-identity/auth/httpAuthSchemeProvider.ts
@@ -3,8 +3,8 @@ import type {
   AwsSdkSigV4AuthInputConfig,
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
-} from "@aws-sdk/core";
-import { resolveAwsSdkSigV4Config } from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
+import { resolveAwsSdkSigV4Config } from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/packages-internal/nested-clients/src/submodules/cognito-identity/runtimeConfig.shared.ts
+++ b/packages-internal/nested-clients/src/submodules/cognito-identity/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/packages-internal/nested-clients/src/submodules/cognito-identity/runtimeConfig.ts
+++ b/packages-internal/nested-clients/src/submodules/cognito-identity/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../../../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {
   NODE_REGION_CONFIG_FILE_OPTIONS,

--- a/packages-internal/nested-clients/src/submodules/signin/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/signin/auth/httpAuthSchemeProvider.ts
@@ -3,8 +3,8 @@ import type {
   AwsSdkSigV4AuthInputConfig,
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
-} from "@aws-sdk/core";
-import { resolveAwsSdkSigV4Config } from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
+import { resolveAwsSdkSigV4Config } from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/packages-internal/nested-clients/src/submodules/signin/runtimeConfig.shared.ts
+++ b/packages-internal/nested-clients/src/submodules/signin/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/packages-internal/nested-clients/src/submodules/signin/runtimeConfig.ts
+++ b/packages-internal/nested-clients/src/submodules/signin/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../../../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/packages-internal/nested-clients/src/submodules/sso-oidc/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/sso-oidc/auth/httpAuthSchemeProvider.ts
@@ -3,8 +3,8 @@ import type {
   AwsSdkSigV4AuthInputConfig,
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
-} from "@aws-sdk/core";
-import { resolveAwsSdkSigV4Config } from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
+import { resolveAwsSdkSigV4Config } from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/packages-internal/nested-clients/src/submodules/sso-oidc/runtimeConfig.shared.ts
+++ b/packages-internal/nested-clients/src/submodules/sso-oidc/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/packages-internal/nested-clients/src/submodules/sso-oidc/runtimeConfig.ts
+++ b/packages-internal/nested-clients/src/submodules/sso-oidc/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../../../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {
   NODE_REGION_CONFIG_FILE_OPTIONS,

--- a/packages-internal/nested-clients/src/submodules/sso/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/sso/auth/httpAuthSchemeProvider.ts
@@ -3,8 +3,8 @@ import type {
   AwsSdkSigV4AuthInputConfig,
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
-} from "@aws-sdk/core";
-import { resolveAwsSdkSigV4Config } from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
+import { resolveAwsSdkSigV4Config } from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/packages-internal/nested-clients/src/submodules/sso/runtimeConfig.shared.ts
+++ b/packages-internal/nested-clients/src/submodules/sso/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/packages-internal/nested-clients/src/submodules/sso/runtimeConfig.ts
+++ b/packages-internal/nested-clients/src/submodules/sso/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../../../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {
   NODE_REGION_CONFIG_FILE_OPTIONS,

--- a/packages-internal/nested-clients/src/submodules/sts/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/sts/auth/httpAuthSchemeProvider.ts
@@ -3,8 +3,8 @@ import type {
   AwsSdkSigV4AuthInputConfig,
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
-} from "@aws-sdk/core";
-import { resolveAwsSdkSigV4Config } from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
+import { resolveAwsSdkSigV4Config } from "@aws-sdk/core/httpAuthSchemes";
 import type { Client } from "@smithy/types";
 import {
   type HandlerExecutionContext,

--- a/packages-internal/nested-clients/src/submodules/sts/runtimeConfig.shared.ts
+++ b/packages-internal/nested-clients/src/submodules/sts/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoAuthSigner } from "@smithy/core";
 import { NoOpLogger } from "@smithy/smithy-client";

--- a/packages-internal/nested-clients/src/submodules/sts/runtimeConfig.ts
+++ b/packages-internal/nested-clients/src/submodules/sts/runtimeConfig.ts
@@ -2,11 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../../../package.json"; // eslint-disable-line
 
-import {
-  AwsSdkSigV4Signer,
-  emitWarningIfUnsupportedVersion as awsCheckVersion,
-  NODE_AUTH_SCHEME_PREFERENCE_OPTIONS,
-} from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { AwsSdkSigV4Signer, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-ec2-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-ec2-schema/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-ec2-schema/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-ec2-schema/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsEc2QueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/private/aws-protocoltests-ec2-schema/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-ec2-schema/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-ec2/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-ec2/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core/protocols";
 import {
   HttpRequest,
   HttpRequest as __HttpRequest,

--- a/private/aws-protocoltests-ec2/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-ec2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";

--- a/private/aws-protocoltests-ec2/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-ec2/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-json-10-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-10-schema/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-json-10-schema/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-json-10-schema/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/private/aws-protocoltests-json-10-schema/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-json-10-schema/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-json-10/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-10/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
+++ b/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
@@ -4,7 +4,7 @@ import {
   loadRestJsonErrorCode,
   parseJsonBody as parseBody,
   parseJsonErrorBody as parseErrorBody,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/protocols";
 import {
   HttpRequest,
   HttpRequest as __HttpRequest,

--- a/private/aws-protocoltests-json-10/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-json-10/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";

--- a/private/aws-protocoltests-json-10/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-json-10/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-json-machinelearning/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-machinelearning/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-json-machinelearning/src/protocols/Aws_json1_1.ts
+++ b/private/aws-protocoltests-json-machinelearning/src/protocols/Aws_json1_1.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
+import {
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core/protocols";
 import { HttpRequest, HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {
   _json,

--- a/private/aws-protocoltests-json-machinelearning/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-json-machinelearning/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";

--- a/private/aws-protocoltests-json-machinelearning/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-json-machinelearning/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-json-schema-machinelearning/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-schema-machinelearning/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-json-schema-machinelearning/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-json-schema-machinelearning/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/private/aws-protocoltests-json-schema-machinelearning/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-json-schema-machinelearning/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-json-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-schema/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-json-schema/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-json-schema/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_1Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/private/aws-protocoltests-json-schema/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-json-schema/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-json/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
+++ b/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
@@ -4,7 +4,7 @@ import {
   loadRestJsonErrorCode,
   parseJsonBody as parseBody,
   parseJsonErrorBody as parseErrorBody,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/protocols";
 import {
   HttpRequest,
   HttpRequest as __HttpRequest,

--- a/private/aws-protocoltests-json/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-json/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";

--- a/private/aws-protocoltests-json/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-json/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-query-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-query-schema/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-query-schema/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-query-schema/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsQueryProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/private/aws-protocoltests-query-schema/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-query-schema/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-query/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-query/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
+import { parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core/protocols";
 import {
   HttpRequest,
   HttpRequest as __HttpRequest,

--- a/private/aws-protocoltests-query/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-query/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";

--- a/private/aws-protocoltests-query/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-query/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-restjson-apigateway/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-apigateway/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-restjson-apigateway/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson-apigateway/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
+import {
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core/protocols";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {

--- a/private/aws-protocoltests-restjson-apigateway/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-restjson-apigateway/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";

--- a/private/aws-protocoltests-restjson-apigateway/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restjson-apigateway/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-restjson-glacier/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-glacier/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-restjson-glacier/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson-glacier/src/protocols/Aws_restJson1.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { loadRestJsonErrorCode, parseJsonBody as parseBody, parseJsonErrorBody as parseErrorBody } from "@aws-sdk/core";
+import {
+  loadRestJsonErrorCode,
+  parseJsonBody as parseBody,
+  parseJsonErrorBody as parseErrorBody,
+} from "@aws-sdk/core/protocols";
 import { requestBuilder as rb } from "@smithy/core";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@smithy/protocol-http";
 import {

--- a/private/aws-protocoltests-restjson-glacier/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-restjson-glacier/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";

--- a/private/aws-protocoltests-restjson-glacier/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restjson-glacier/src/runtimeConfig.ts
@@ -3,7 +3,8 @@
 import packageInfo from "../package.json"; // eslint-disable-line
 
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-node";
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-restjson-schema-apigateway/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-schema-apigateway/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-restjson-schema-apigateway/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-restjson-schema-apigateway/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/private/aws-protocoltests-restjson-schema-apigateway/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restjson-schema-apigateway/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-restjson-schema-glacier/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-schema-glacier/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-restjson-schema-glacier/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-restjson-schema-glacier/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/private/aws-protocoltests-restjson-schema-glacier/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restjson-schema-glacier/src/runtimeConfig.ts
@@ -3,7 +3,8 @@
 import packageInfo from "../package.json"; // eslint-disable-line
 
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-node";
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-restjson-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-schema/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-restjson-schema/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-restjson-schema/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestJsonProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/private/aws-protocoltests-restjson-schema/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restjson-schema/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/private/aws-protocoltests-restjson/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -4,7 +4,7 @@ import {
   loadRestJsonErrorCode,
   parseJsonBody as parseBody,
   parseJsonErrorBody as parseErrorBody,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/protocols";
 import { requestBuilder as rb } from "@smithy/core";
 import { Int64 as __Int64 } from "@smithy/eventstream-codec";
 import {

--- a/private/aws-protocoltests-restjson/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-restjson/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";

--- a/private/aws-protocoltests-restjson/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restjson/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";

--- a/private/aws-protocoltests-restxml-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restxml-schema/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-restxml-schema/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-restxml-schema/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsRestXmlProtocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";

--- a/private/aws-protocoltests-restxml-schema/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restxml-schema/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-protocoltests-restxml/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restxml/src/auth/httpAuthSchemeProvider.ts
@@ -4,7 +4,7 @@ import {
   AwsSdkSigV4AuthResolvedConfig,
   AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
-import { loadRestXmlErrorCode, parseXmlBody as parseBody, parseXmlErrorBody as parseErrorBody } from "@aws-sdk/core";
+import {
+  loadRestXmlErrorCode,
+  parseXmlBody as parseBody,
+  parseXmlErrorBody as parseErrorBody,
+} from "@aws-sdk/core/protocols";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { requestBuilder as rb } from "@smithy/core";
 import {

--- a/private/aws-protocoltests-restxml/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-restxml/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { AwsSdkSigV4Signer } from "@aws-sdk/core";
+import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";

--- a/private/aws-protocoltests-restxml/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restxml/src/runtimeConfig.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { emitWarningIfUnsupportedVersion as awsCheckVersion, NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { emitWarningIfUnsupportedVersion as awsCheckVersion } from "@aws-sdk/core/client";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import {

--- a/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
@@ -4,7 +4,7 @@ import {
   loadRestJsonErrorCode,
   parseJsonBody as parseBody,
   parseJsonErrorBody as parseErrorBody,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/protocols";
 import {
   acceptMatches as __acceptMatches,
   NotAcceptableException as __NotAcceptableException,

--- a/private/aws-restjson-validation-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-validation-server/src/protocols/Aws_restJson1.ts
@@ -4,7 +4,7 @@ import {
   loadRestJsonErrorCode,
   parseJsonBody as parseBody,
   parseJsonErrorBody as parseErrorBody,
-} from "@aws-sdk/core";
+} from "@aws-sdk/core/protocols";
 import {
   acceptMatches as __acceptMatches,
   NotAcceptableException as __NotAcceptableException,

--- a/private/weather/src/runtimeConfig.ts
+++ b/private/weather/src/runtimeConfig.ts
@@ -2,7 +2,7 @@
 // @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json"; // eslint-disable-line
 
-import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core";
+import { NODE_AUTH_SCHEME_PREFERENCE_OPTIONS } from "@aws-sdk/core/httpAuthSchemes";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { createDefaultUserAgentProvider, NODE_APP_ID_CONFIG_OPTIONS } from "@aws-sdk/util-user-agent-node";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@smithy/config-resolver";


### PR DESCRIPTION
### Issue
n/a, but ties back to when the `@aws-sdk/core` package was established and created the submodule system around https://github.com/aws/aws-sdk-js-v3/pull/5351

### Description
changes all generated imports of aws-sdk/core to use a specific submodule.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
