### PR TITLE
chore(packages-internal): set submodule for core imports

### DIFF
--- a/packages-internal/middleware-flexible-checksums/src/flexibleChecksumsInputMiddleware.spec.ts
+++ b/packages-internal/middleware-flexible-checksums/src/flexibleChecksumsInputMiddleware.spec.ts
@@ -1,11 +1,11 @@
-import { setFeature } from "@aws-sdk/core";
+import { setFeature } from "@aws-sdk/core/client";
 import { afterEach, describe, expect, test as it, vi } from "vitest";
 
 import type { PreviouslyResolved } from "./configuration";
-import { DEFAULT_CHECKSUM_ALGORITHM, RequestChecksumCalculation, ResponseChecksumValidation } from "./constants";
+import { RequestChecksumCalculation, ResponseChecksumValidation } from "./constants";
 import { flexibleChecksumsInputMiddleware } from "./flexibleChecksumsInputMiddleware";
 
-vi.mock("@aws-sdk/core");
+vi.mock("@aws-sdk/core/client");
 
 describe(flexibleChecksumsInputMiddleware.name, () => {
   const mockNext = vi.fn();

--- a/packages-internal/middleware-flexible-checksums/src/flexibleChecksumsInputMiddleware.ts
+++ b/packages-internal/middleware-flexible-checksums/src/flexibleChecksumsInputMiddleware.ts
@@ -1,4 +1,4 @@
-import { setFeature } from "@aws-sdk/core";
+import { setFeature } from "@aws-sdk/core/client";
 import type {
   HandlerExecutionContext,
   MetadataBearer,

--- a/packages-internal/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages-internal/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -1,4 +1,4 @@
-import { setFeature } from "@aws-sdk/core";
+import { setFeature } from "@aws-sdk/core/client";
 import { HttpRequest } from "@smithy/protocol-http";
 import type {
   BuildHandler,

--- a/packages-internal/middleware-sdk-s3/src/s3-express/functions/s3ExpressMiddleware.ts
+++ b/packages-internal/middleware-sdk-s3/src/s3-express/functions/s3ExpressMiddleware.ts
@@ -1,4 +1,4 @@
-import { setFeature } from "@aws-sdk/core";
+import { setFeature } from "@aws-sdk/core/client";
 import type { AwsCredentialIdentity } from "@aws-sdk/types";
 import { HttpRequest } from "@smithy/protocol-http";
 import type {

--- a/packages-internal/middleware-user-agent/src/check-features.ts
+++ b/packages-internal/middleware-user-agent/src/check-features.ts
@@ -1,5 +1,5 @@
-import { setFeature } from "@aws-sdk/core";
 import type { AccountIdEndpointMode } from "@aws-sdk/core/account-id-endpoint";
+import { setFeature } from "@aws-sdk/core/client";
 import type {
   AttributedAwsCredentialIdentity,
   AwsHandlerExecutionContext,


### PR DESCRIPTION
### Issue
follows https://github.com/aws/aws-sdk-js-v3/pull/7896

### Description
corrects manual imports of aws-sdk/core to have the specific submodule.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
