### PR TITLE
fix(scripts/compilation): set dynamicImportInCjs: false to restore Jest compatibility

### DIFF
--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -233,6 +233,7 @@ module.exports = class Inliner {
       exports: "named",
       preserveModules: false,
       externalLiveBindings: false,
+      dynamicImportInCjs: false,
     };
 
     const bundle = await rollup.rollup(inputOptions(variantExternalsForRollup));


### PR DESCRIPTION
## Description

Rollup (introduced in #7406) leaves dynamic `import()` calls in the `dist-cjs` output by default.  
This broke Jest tests everywhere that uses `@aws-sdk/*` packages (especially credential providers) with the error:

> A dynamic import callback was invoked without --experimental-vm-modules

See issue #7420.

This PR restores the old esbuild behavior by setting `dynamicImportInCjs: false` in `scripts/compilation/Inliner.js`.

## Testing

- Ran `yarn turbo run build --filter=@aws-sdk/credential-provider-node...`
- Verified `grep -r "import(" packages-internal/credential-provider-node/dist-cjs/` returns no matches
- Ran scoped tests: `yarn turbo run test --filter=@aws-sdk/credential-provider-node` → all passing

No client code or generated files were changed, so no `yarn generate-clients` was needed.

## Related Issues

- Fixes #7420
- References #7406 (the PR that introduced the regression)