### PR TITLE
test(util-endpoints): run test cases provided in AWS models

### DIFF
--- a/packages-internal/util-endpoints/src/resolveEndpoint.integ.spec.ts
+++ b/packages-internal/util-endpoints/src/resolveEndpoint.integ.spec.ts
@@ -1,11 +1,56 @@
 import "./aws";
 
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, test as it } from "vitest";
 
 import { resolveEndpoint } from "./resolveEndpoint";
 import { EndpointError } from "./types";
+
+const runTestCases = (testCases: any[], ruleSetObject: any) => {
+  for (const testCase of testCases) {
+    const { documentation, params = {} } = testCase;
+    (testCase.skip ? it.skip : it)(documentation, () => {
+      const _expect = testCase.expect;
+
+      const { endpoint, error } = _expect;
+
+      if (endpoint) {
+        const result = resolveEndpoint(ruleSetObject, { endpointParams: params });
+        const expected = {
+          ...endpoint,
+          url: new URL(endpoint.url),
+        };
+
+        // Normalize: add empty headers/properties to expected if resolver returns them
+        if (!("headers" in expected) && "headers" in result) {
+          expected.headers = {};
+        }
+        if (!("properties" in expected) && "properties" in result) {
+          expected.properties = {};
+        }
+
+        // Normalize trailing slashes in URL paths for comparison.
+        // The URL constructor may normalize paths differently than the resolver.
+        if (result.url?.pathname !== expected.url?.pathname) {
+          const normalize = (url: URL) => {
+            const normalized = new URL(url.href);
+            normalized.pathname = normalized.pathname.replace(/\/+$/, "") || "/";
+            return normalized;
+          };
+          result.url = normalize(result.url);
+          expected.url = normalize(expected.url);
+        }
+
+        expect(result).toStrictEqual(expected);
+      }
+
+      if (error) {
+        expect(() => resolveEndpoint(ruleSetObject, { endpointParams: params })).toThrowError(new EndpointError(error));
+      }
+    });
+  }
+};
 
 describe(resolveEndpoint.name, () => {
   const mocksDir = resolve(__dirname, "__mocks__");
@@ -23,28 +68,30 @@ describe(resolveEndpoint.name, () => {
     if (existsSync(testCasesFile)) {
       const ruleSetObject = require(rulesFile);
       const { testCases } = require(testCasesFile);
-
-      for (const testCase of testCases) {
-        const { documentation, params } = testCase;
-        (testCase.skip ? it.skip : it)(documentation, () => {
-          const _expect = testCase.expect;
-
-          const { endpoint, error } = _expect;
-
-          if (endpoint) {
-            expect(resolveEndpoint(ruleSetObject, { endpointParams: params })).toStrictEqual({
-              ...endpoint,
-              url: new URL(endpoint.url),
-            });
-          }
-
-          if (error) {
-            expect(() => resolveEndpoint(ruleSetObject, { endpointParams: params })).toThrowError(
-              new EndpointError(error)
-            );
-          }
-        });
-      }
+      runTestCases(testCases, ruleSetObject);
     }
   });
+
+  const awsModelsDir = resolve(__dirname, "..", "..", "..", "codegen", "sdk-codegen", "aws-models");
+
+  if (existsSync(awsModelsDir)) {
+    const modelFiles = readdirSync(awsModelsDir).filter((fileName) => fileName.endsWith(".json"));
+
+    describe.each(modelFiles)("aws-models/%s", (modelFile) => {
+      const modelPath = resolve(awsModelsDir, modelFile);
+      const model = JSON.parse(readFileSync(modelPath, "utf-8"));
+      const shapes = model.shapes || {};
+
+      for (const shapeValue of Object.values(shapes)) {
+        const traits = (shapeValue as any)?.traits || {};
+        const ruleSetObject = traits["smithy.rules#endpointRuleSet"];
+        const endpointTests = traits["smithy.rules#endpointTests"];
+
+        if (ruleSetObject && endpointTests) {
+          const { testCases } = endpointTests;
+          runTestCases(testCases, ruleSetObject);
+        }
+      }
+    });
+  }
 });

--- a/packages-internal/util-endpoints/src/resolveEndpoint.integ.spec.ts
+++ b/packages-internal/util-endpoints/src/resolveEndpoint.integ.spec.ts
@@ -11,9 +11,7 @@ const runTestCases = (testCases: any[], ruleSetObject: any) => {
   for (const testCase of testCases) {
     const { documentation, params = {} } = testCase;
     it(documentation, () => {
-      const _expect = testCase.expect;
-
-      const { endpoint, error } = _expect;
+      const { endpoint, error } = testCase.expect;
 
       if (endpoint) {
         const result = resolveEndpoint(ruleSetObject, { endpointParams: params });

--- a/packages-internal/util-endpoints/src/resolveEndpoint.integ.spec.ts
+++ b/packages-internal/util-endpoints/src/resolveEndpoint.integ.spec.ts
@@ -10,7 +10,7 @@ import { EndpointError } from "./types";
 const runTestCases = (testCases: any[], ruleSetObject: any) => {
   for (const testCase of testCases) {
     const { documentation, params = {} } = testCase;
-    (testCase.skip ? it.skip : it)(documentation, () => {
+    it(documentation, () => {
       const _expect = testCase.expect;
 
       const { endpoint, error } = _expect;


### PR DESCRIPTION
### Issue
N/A

### Description
Runs test cases provided in AWS models

### Testing

#### Before

Tests are only run on cases provided in specification description
```console
$ util-endpoints> yarn test:integration src/resolveEndpoint.integ.spec.ts
...
 Test Files  1 passed (1)
      Tests  38 passed (38)
   Start at  14:43:02
   Duration  259ms (transform 87ms, setup 0ms, import 121ms, tests 17ms, environment 0ms)
```

#### After

Tests are also run on cases provided in AWS models
```console
$ util-endpoints> yarn test:integration src/resolveEndpoint.integ.spec.ts
...
 Test Files  1 passed (1)
      Tests  13944 passed (13944)
   Start at  15:39:57
   Duration  3.37s (transform 95ms, setup 0ms, import 1.56s, tests 1.48s, environment 0ms)
```

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
