### PR TITLE
chore(client-sts): reduce circular imports

### DIFF
--- a/clients/client-accessanalyzer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-accessanalyzer/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-account/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-account/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-acm-pca/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-acm-pca/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-acm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-acm/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-aiops/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-aiops/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-amp/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amp/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-amplify/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amplify/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-amplifybackend/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amplifybackend/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-amplifyuibuilder/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-amplifyuibuilder/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-api-gateway/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-api-gateway/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-apigatewaymanagementapi/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-apigatewaymanagementapi/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-apigatewayv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-apigatewayv2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-app-mesh/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-app-mesh/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-appconfig/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appconfig/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-appconfigdata/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appconfigdata/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-appfabric/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appfabric/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-appflow/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appflow/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-appintegrations/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appintegrations/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-application-auto-scaling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-auto-scaling/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-application-discovery-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-discovery-service/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-application-insights/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-insights/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-application-signals/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-application-signals/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-applicationcostprofiler/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-applicationcostprofiler/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-apprunner/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-apprunner/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-appstream/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appstream/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-appsync/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-appsync/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-arc-region-switch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-arc-region-switch/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-arc-zonal-shift/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-arc-zonal-shift/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-artifact/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-artifact/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-athena/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-athena/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-auditmanager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-auditmanager/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-auto-scaling-plans/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-auto-scaling-plans/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-auto-scaling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-auto-scaling/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-b2bi/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-b2bi/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-backup-gateway/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-backup-gateway/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-backup/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-backup/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-backupsearch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-backupsearch/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-batch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-batch/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bcm-dashboards/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bcm-dashboards/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bcm-data-exports/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bcm-data-exports/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bcm-pricing-calculator/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bcm-pricing-calculator/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bcm-recommended-actions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bcm-recommended-actions/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bedrock-agent-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-agent-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bedrock-agent/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-agent/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bedrock-agentcore-control/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-agentcore-control/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bedrock-agentcore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-agentcore/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bedrock-data-automation-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-data-automation-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bedrock-data-automation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-data-automation/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-bedrock-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type { FromSsoInit } from "@aws-sdk/token-providers";

--- a/clients/client-bedrock/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-bedrock/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type { FromSsoInit } from "@aws-sdk/token-providers";

--- a/clients/client-billing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-billing/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-billingconductor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-billingconductor/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-braket/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-braket/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-budgets/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-budgets/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-chatbot/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chatbot/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-chime-sdk-identity/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-identity/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-chime-sdk-media-pipelines/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-chime-sdk-meetings/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-meetings/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-chime-sdk-messaging/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-messaging/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-chime-sdk-voice/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime-sdk-voice/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-chime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-chime/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cleanrooms/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cleanrooms/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cleanroomsml/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cleanroomsml/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloud9/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloud9/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudcontrol/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudcontrol/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-clouddirectory/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-clouddirectory/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudformation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudformation/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudfront-keyvaluestore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/auth/httpAuthSchemeProvider.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AAuthInputConfig,
-  AwsSdkSigV4AAuthResolvedConfig,
-  AwsSdkSigV4APreviouslyResolved,
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AAuthInputConfig,
+  type AwsSdkSigV4AAuthResolvedConfig,
+  type AwsSdkSigV4APreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
@@ -26,10 +26,10 @@ import type {
 import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
 
 import {
+  type CloudFrontKeyValueStoreClientResolvedConfig,
   CloudFrontKeyValueStoreClientConfig,
-  CloudFrontKeyValueStoreClientResolvedConfig,
 } from "../CloudFrontKeyValueStoreClient";
-import { EndpointParameters } from "../endpoint/EndpointParameters";
+import type { EndpointParameters } from "../endpoint/EndpointParameters";
 import { defaultEndpointResolver } from "../endpoint/endpointResolver";
 
 /**

--- a/clients/client-cloudfront/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudfront/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudhsm-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudhsm-v2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudhsm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudhsm/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudsearch-domain/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudsearch-domain/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudsearch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudsearch/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudtrail-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudtrail-data/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudtrail/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudtrail/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudwatch-events/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudwatch-events/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudwatch-logs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudwatch-logs/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cloudwatch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cloudwatch/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codeartifact/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeartifact/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codebuild/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codebuild/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codecommit/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codecommit/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codeconnections/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeconnections/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codedeploy/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codedeploy/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codeguru-reviewer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeguru-reviewer/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codeguru-security/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeguru-security/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codeguruprofiler/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codeguruprofiler/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codepipeline/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codepipeline/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codestar-connections/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codestar-connections/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-codestar-notifications/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-codestar-notifications/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cognito-identity-provider/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cognito-identity-provider/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cognito-identity/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cognito-identity/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cognito-sync/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cognito-sync/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-comprehend/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-comprehend/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-comprehendmedical/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-comprehendmedical/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-compute-optimizer-automation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-compute-optimizer-automation/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-compute-optimizer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-compute-optimizer/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-config-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-config-service/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-connect-contact-lens/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connect-contact-lens/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-connect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connect/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-connectcampaigns/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectcampaigns/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-connectcampaignsv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectcampaignsv2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-connectcases/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectcases/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-connecthealth/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connecthealth/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-connectparticipant/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-connectparticipant/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-controlcatalog/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-controlcatalog/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-controltower/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-controltower/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cost-and-usage-report-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cost-and-usage-report-service/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cost-explorer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cost-explorer/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-cost-optimization-hub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-cost-optimization-hub/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-customer-profiles/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-customer-profiles/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-data-pipeline/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-data-pipeline/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-database-migration-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-database-migration-service/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-databrew/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-databrew/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-dataexchange/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dataexchange/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-datasync/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-datasync/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-datazone/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-datazone/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-dax/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dax/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-deadline/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-deadline/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-detective/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-detective/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-device-farm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-device-farm/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-devops-agent/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-devops-agent/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-devops-guru/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-devops-guru/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-direct-connect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-direct-connect/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-directory-service-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-directory-service-data/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-directory-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-directory-service/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-dlm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dlm/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-docdb-elastic/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-docdb-elastic/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-docdb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-docdb/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-drs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-drs/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-dsql/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dsql/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-dynamodb-streams/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dynamodb-streams/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-dynamodb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-dynamodb/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ebs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ebs/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ec2-instance-connect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ec2-instance-connect/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ec2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ec2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ecr-public/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ecr-public/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ecr/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ecr/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ecs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ecs/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-efs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-efs/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-eks-auth/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-eks-auth/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-eks/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-eks/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-elastic-beanstalk/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elastic-beanstalk/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-elastic-load-balancing-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elastic-load-balancing-v2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-elastic-load-balancing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elastic-load-balancing/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-elasticache/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elasticache/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-elasticsearch-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elasticsearch-service/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-elementalinference/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-elementalinference/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-emr-containers/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-emr-containers/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-emr-serverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-emr-serverless/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-emr/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-emr/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-entityresolution/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-entityresolution/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-eventbridge/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-eventbridge/src/auth/httpAuthSchemeProvider.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AAuthInputConfig,
-  AwsSdkSigV4AAuthResolvedConfig,
-  AwsSdkSigV4APreviouslyResolved,
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AAuthInputConfig,
+  type AwsSdkSigV4AAuthResolvedConfig,
+  type AwsSdkSigV4APreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
@@ -25,9 +25,9 @@ import type {
 } from "@smithy/types";
 import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
+import type { EndpointParameters } from "../endpoint/EndpointParameters";
 import { defaultEndpointResolver } from "../endpoint/endpointResolver";
-import { EventBridgeClientConfig, EventBridgeClientResolvedConfig } from "../EventBridgeClient";
+import { type EventBridgeClientResolvedConfig, EventBridgeClientConfig } from "../EventBridgeClient";
 
 /**
  * @internal

--- a/clients/client-evs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-evs/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-finspace-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-finspace-data/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-finspace/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-finspace/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-firehose/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-firehose/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-fis/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-fis/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-fms/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-fms/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-forecast/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-forecast/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-forecastquery/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-forecastquery/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-frauddetector/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-frauddetector/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-freetier/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-freetier/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-fsx/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-fsx/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-gamelift/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-gamelift/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-gameliftstreams/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-gameliftstreams/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-geo-maps/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-geo-maps/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-geo-places/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-geo-places/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-geo-routes/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-geo-routes/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-glacier/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-glacier/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-global-accelerator/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-global-accelerator/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-glue/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-glue/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-grafana/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-grafana/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-greengrass/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-greengrass/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-greengrassv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-greengrassv2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-groundstation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-groundstation/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-guardduty/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-guardduty/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-health/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-health/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-healthlake/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-healthlake/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iam/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iam/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-identitystore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-identitystore/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-imagebuilder/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-imagebuilder/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-inspector-scan/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-inspector-scan/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-inspector/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-inspector/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-inspector2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-inspector2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-internetmonitor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-internetmonitor/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-invoicing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-invoicing/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iot-data-plane/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-data-plane/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iot-events-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-events-data/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iot-events/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-events/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iot-jobs-data-plane/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-jobs-data-plane/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iot-managed-integrations/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-managed-integrations/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iot-wireless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot-wireless/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iot/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iot/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iotdeviceadvisor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotdeviceadvisor/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iotfleetwise/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotfleetwise/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iotsecuretunneling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotsecuretunneling/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iotsitewise/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotsitewise/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iotthingsgraph/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iotthingsgraph/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-iottwinmaker/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-iottwinmaker/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ivs-realtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ivs-realtime/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ivs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ivs/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ivschat/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ivschat/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kafka/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kafka/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kafkaconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kafkaconnect/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kendra-ranking/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kendra-ranking/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kendra/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kendra/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-keyspaces/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-keyspaces/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-keyspacesstreams/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-keyspacesstreams/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kinesis-analytics-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-analytics-v2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kinesis-analytics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-analytics/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kinesis-video-archived-media/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-archived-media/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kinesis-video-media/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-media/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kinesis-video-signaling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-signaling/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kinesis-video-webrtc-storage/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kinesis-video/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis-video/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kinesis/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kinesis/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-kms/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-kms/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-lakeformation/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lakeformation/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-lambda/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lambda/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-launch-wizard/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-launch-wizard/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-lex-model-building-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-model-building-service/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-lex-models-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-models-v2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-lex-runtime-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-runtime-service/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-lex-runtime-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lex-runtime-v2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-license-manager-linux-subscriptions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-license-manager-user-subscriptions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-license-manager-user-subscriptions/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-license-manager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-license-manager/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-lightsail/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lightsail/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-location/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-location/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-lookoutequipment/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-lookoutequipment/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-m2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-m2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-machine-learning/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-machine-learning/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-macie2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-macie2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mailmanager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mailmanager/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-managedblockchain-query/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-managedblockchain-query/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-managedblockchain/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-managedblockchain/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-marketplace-agreement/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-agreement/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-marketplace-catalog/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-catalog/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-marketplace-commerce-analytics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-commerce-analytics/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-marketplace-deployment/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-deployment/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-marketplace-entitlement-service/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-entitlement-service/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-marketplace-metering/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-metering/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-marketplace-reporting/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-marketplace-reporting/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mediaconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediaconnect/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mediaconvert/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediaconvert/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-medialive/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-medialive/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mediapackage-vod/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediapackage-vod/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mediapackage/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediapackage/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mediapackagev2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediapackagev2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mediastore-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediastore-data/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mediastore/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediastore/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mediatailor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mediatailor/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-medical-imaging/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-medical-imaging/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-memorydb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-memorydb/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mgn/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mgn/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-migration-hub-refactor-spaces/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-migration-hub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migration-hub/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-migrationhub-config/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migrationhub-config/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-migrationhuborchestrator/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migrationhuborchestrator/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-migrationhubstrategy/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-migrationhubstrategy/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mpa/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mpa/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mq/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mq/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mturk/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mturk/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mwaa-serverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mwaa-serverless/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-mwaa/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-mwaa/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-neptune-graph/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-neptune-graph/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-neptune/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-neptune/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-neptunedata/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-neptunedata/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-network-firewall/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-network-firewall/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-networkflowmonitor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-networkflowmonitor/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-networkmanager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-networkmanager/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-networkmonitor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-networkmonitor/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-notifications/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-notifications/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-notificationscontacts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-notificationscontacts/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-nova-act/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-nova-act/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-oam/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-oam/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-observabilityadmin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-observabilityadmin/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-odb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-odb/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-omics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-omics/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-opensearch/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-opensearch/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-opensearchserverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-opensearchserverless/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-organizations/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-organizations/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-osis/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-osis/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-outposts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-outposts/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-panorama/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-panorama/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-partnercentral-account/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-partnercentral-account/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-partnercentral-benefits/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-partnercentral-benefits/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-partnercentral-channel/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-partnercentral-channel/src/auth/httpAuthSchemeProvider.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AAuthInputConfig,
-  AwsSdkSigV4AAuthResolvedConfig,
-  AwsSdkSigV4APreviouslyResolved,
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AAuthInputConfig,
+  type AwsSdkSigV4AAuthResolvedConfig,
+  type AwsSdkSigV4APreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
@@ -25,11 +25,11 @@ import type {
 } from "@smithy/types";
 import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
+import type { EndpointParameters } from "../endpoint/EndpointParameters";
 import { defaultEndpointResolver } from "../endpoint/endpointResolver";
 import {
+  type PartnerCentralChannelClientResolvedConfig,
   PartnerCentralChannelClientConfig,
-  PartnerCentralChannelClientResolvedConfig,
 } from "../PartnerCentralChannelClient";
 
 /**

--- a/clients/client-partnercentral-selling/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-partnercentral-selling/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-payment-cryptography-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-payment-cryptography-data/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-payment-cryptography/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-payment-cryptography/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-pca-connector-ad/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pca-connector-ad/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-pca-connector-scep/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pca-connector-scep/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-pcs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pcs/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-personalize-events/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-personalize-events/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-personalize-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-personalize-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-personalize/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-personalize/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-pi/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pi/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-pinpoint-email/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint-email/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-pinpoint-sms-voice-v2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-pinpoint-sms-voice/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint-sms-voice/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-pinpoint/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pinpoint/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-pipes/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pipes/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-polly/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-polly/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-pricing/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-pricing/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-proton/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-proton/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-qapps/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qapps/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-qbusiness/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qbusiness/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-qconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-qconnect/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-quicksight/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-quicksight/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ram/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ram/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-rbin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rbin/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-rds-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rds-data/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-rds/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rds/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-redshift-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-redshift-data/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-redshift-serverless/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-redshift-serverless/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-redshift/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-redshift/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-rekognition/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rekognition/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-rekognitionstreaming/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rekognitionstreaming/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-repostspace/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-repostspace/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-resiliencehub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resiliencehub/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-resource-explorer-2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resource-explorer-2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-resource-groups-tagging-api/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resource-groups-tagging-api/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-resource-groups/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-resource-groups/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-rolesanywhere/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rolesanywhere/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-route-53-domains/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route-53-domains/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-route-53/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route-53/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-route53-recovery-cluster/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53-recovery-cluster/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-route53-recovery-control-config/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53-recovery-control-config/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-route53-recovery-readiness/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53-recovery-readiness/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-route53globalresolver/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53globalresolver/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-route53profiles/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53profiles/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-route53resolver/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-route53resolver/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-rtbfabric/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rtbfabric/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-rum/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-rum/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-s3-control/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3-control/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-s3/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3/src/auth/httpAuthSchemeProvider.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AAuthInputConfig,
-  AwsSdkSigV4AAuthResolvedConfig,
-  AwsSdkSigV4APreviouslyResolved,
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AAuthInputConfig,
+  type AwsSdkSigV4AAuthResolvedConfig,
+  type AwsSdkSigV4APreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
@@ -25,9 +25,9 @@ import type {
 } from "@smithy/types";
 import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
+import type { EndpointParameters } from "../endpoint/EndpointParameters";
 import { defaultEndpointResolver } from "../endpoint/endpointResolver";
-import { S3ClientConfig, S3ClientResolvedConfig } from "../S3Client";
+import { type S3ClientResolvedConfig, S3ClientConfig } from "../S3Client";
 
 /**
  * @internal

--- a/clients/client-s3outposts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3outposts/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-s3tables/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3tables/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-s3vectors/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-s3vectors/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sagemaker-a2i-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sagemaker-edge/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-edge/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sagemaker-featurestore-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sagemaker-geospatial/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-geospatial/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sagemaker-metrics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-metrics/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sagemaker-runtime-http2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-runtime-http2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sagemaker-runtime/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker-runtime/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sagemaker/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sagemaker/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-savingsplans/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-savingsplans/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-scheduler/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-scheduler/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-schemas/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-schemas/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-secrets-manager/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-secrets-manager/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-security-ir/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-security-ir/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-securityhub/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-securityhub/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-securitylake/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-securitylake/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-serverlessapplicationrepository/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-serverlessapplicationrepository/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-service-catalog-appregistry/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-service-catalog-appregistry/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-service-catalog/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-service-catalog/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-service-quotas/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-service-quotas/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-servicediscovery/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-servicediscovery/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ses/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ses/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sesv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sesv2/src/auth/httpAuthSchemeProvider.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AAuthInputConfig,
-  AwsSdkSigV4AAuthResolvedConfig,
-  AwsSdkSigV4APreviouslyResolved,
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AAuthInputConfig,
+  type AwsSdkSigV4AAuthResolvedConfig,
+  type AwsSdkSigV4APreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4AConfig,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
@@ -25,9 +25,9 @@ import type {
 } from "@smithy/types";
 import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
+import type { EndpointParameters } from "../endpoint/EndpointParameters";
 import { defaultEndpointResolver } from "../endpoint/endpointResolver";
-import { SESv2ClientConfig, SESv2ClientResolvedConfig } from "../SESv2Client";
+import { type SESv2ClientResolvedConfig, SESv2ClientConfig } from "../SESv2Client";
 
 /**
  * @internal

--- a/clients/client-sfn/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sfn/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-shield/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-shield/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-signer-data/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-signer-data/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-signer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-signer/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-signin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-signin/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-simpledbv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-simpledbv2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-simspaceweaver/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-simspaceweaver/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-snow-device-management/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-snow-device-management/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-snowball/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-snowball/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sns/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sns/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-socialmessaging/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-socialmessaging/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sqs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sqs/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ssm-contacts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-contacts/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ssm-guiconnect/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-guiconnect/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ssm-incidents/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-incidents/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ssm-quicksetup/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-quicksetup/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ssm-sap/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm-sap/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-ssm/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-ssm/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sso-admin/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sso-admin/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sso-oidc/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sso-oidc/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sso/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sso/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-storage-gateway/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-storage-gateway/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-sts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sts/src/auth/httpAuthSchemeProvider.ts
@@ -1,12 +1,11 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {
-  Client,
   HandlerExecutionContext,
   HttpAuthOption,
   HttpAuthScheme,
@@ -17,7 +16,7 @@ import type {
 } from "@smithy/types";
 import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
 
-import { type STSClientResolvedConfig, STSClient, STSClientConfig } from "../STSClient";
+import { type STSClientResolvedConfig, STSClientConfig } from "../STSClient";
 
 /**
  * @internal
@@ -104,28 +103,10 @@ export const defaultSTSHttpAuthSchemeProvider: STSHttpAuthSchemeProvider = (auth
   return options;
 };
 
-export interface StsAuthInputConfig {}
-
-export interface StsAuthResolvedConfig {
-  /**
-   * Reference to STSClient class constructor.
-   * @internal
-   */
-  stsClientCtor: new (clientConfig: any) => Client<any, any, any>;
-}
-
-export const resolveStsAuthConfig = <T>(
-  input: T & StsAuthInputConfig
-): T & StsAuthResolvedConfig => Object.assign(input, {
-
-  stsClientCtor: STSClient,
-
-});
-
 /**
  * @public
  */
-export interface HttpAuthSchemeInputConfig extends StsAuthInputConfig, AwsSdkSigV4AuthInputConfig {
+export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig {
   /**
    * A comma-separated list of case-sensitive auth scheme names.
    * An auth scheme name is a fully qualified auth scheme ID with the namespace prefix trimmed.
@@ -150,7 +131,7 @@ export interface HttpAuthSchemeInputConfig extends StsAuthInputConfig, AwsSdkSig
 /**
  * @internal
  */
-export interface HttpAuthSchemeResolvedConfig extends StsAuthResolvedConfig, AwsSdkSigV4AuthResolvedConfig {
+export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedConfig {
   /**
    * A comma-separated list of case-sensitive auth scheme names.
    * An auth scheme name is a fully qualified auth scheme ID with the namespace prefix trimmed.
@@ -178,9 +159,8 @@ export interface HttpAuthSchemeResolvedConfig extends StsAuthResolvedConfig, Aws
 export const resolveHttpAuthSchemeConfig = <T>(
   config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveStsAuthConfig(config);
-  const config_1 = resolveAwsSdkSigV4Config(config_0);
-  return Object.assign(config_1, {
+  const config_0 = resolveAwsSdkSigV4Config(config);
+  return Object.assign(config_0, {
     authSchemePreference: normalizeProvider(config.authSchemePreference ?? []),
   }) as T & HttpAuthSchemeResolvedConfig;
 };

--- a/clients/client-sts/src/defaultRoleAssumers.ts
+++ b/clients/client-sts/src/defaultRoleAssumers.ts
@@ -1,17 +1,15 @@
 // smithy-typescript generated code
 // Please do not touch this file. It's generated from template in:
 // https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.ts
-import { Pluggable } from "@smithy/types";
+import type { Pluggable } from "@smithy/types";
 
+import type { RoleAssumer, RoleAssumerWithWebIdentity, STSRoleAssumerOptions } from "./defaultStsRoleAssumers";
 import {
-  DefaultCredentialProvider,
   getDefaultRoleAssumer as StsGetDefaultRoleAssumer,
   getDefaultRoleAssumerWithWebIdentity as StsGetDefaultRoleAssumerWithWebIdentity,
-  RoleAssumer,
-  RoleAssumerWithWebIdentity,
-  STSRoleAssumerOptions,
 } from "./defaultStsRoleAssumers";
-import { ServiceInputTypes, ServiceOutputTypes, STSClient, STSClientConfig } from "./STSClient";
+import type { ServiceInputTypes, ServiceOutputTypes, STSClientConfig } from "./STSClient";
+import { STSClient } from "./STSClient";
 
 const getCustomizableStsClientCtor = (
   baseCtor: new (config: STSClientConfig) => STSClient,
@@ -45,23 +43,3 @@ export const getDefaultRoleAssumerWithWebIdentity = (
   stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[]
 ): RoleAssumerWithWebIdentity =>
   StsGetDefaultRoleAssumerWithWebIdentity(stsOptions, getCustomizableStsClientCtor(STSClient, stsPlugins));
-
-/**
- * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
- * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
- * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
- * dependencies.
- *
- * @internal
- *
- * @deprecated this is no longer needed. Use the defaultProvider directly,
- * which will load STS if needed.
- */
-export const decorateDefaultCredentialProvider =
-  (provider: DefaultCredentialProvider): DefaultCredentialProvider =>
-  (input: any) =>
-    provider({
-      roleAssumer: getDefaultRoleAssumer(input),
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(input),
-      ...input,
-    });

--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -4,14 +4,13 @@
 import { setCredentialFeature } from "@aws-sdk/core/client";
 import { stsRegionDefaultResolver } from "@aws-sdk/region-config-resolver";
 import type { CredentialProviderOptions } from "@aws-sdk/types";
-import { AwsCredentialIdentity, Logger, Provider } from "@smithy/types";
+import type { AwsCredentialIdentity, Logger, Provider } from "@smithy/types";
 
-import { AssumeRoleCommand, AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
-import {
-  AssumeRoleWithWebIdentityCommand,
-  AssumeRoleWithWebIdentityCommandInput,
-} from "./commands/AssumeRoleWithWebIdentityCommand";
-import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSClient";
+import type { AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
+import { AssumeRoleCommand } from "./commands/AssumeRoleCommand";
+import type { AssumeRoleWithWebIdentityCommandInput } from "./commands/AssumeRoleWithWebIdentityCommand";
+import { AssumeRoleWithWebIdentityCommand } from "./commands/AssumeRoleWithWebIdentityCommand";
+import type { STSClient, STSClientConfig } from "./STSClient";
 
 /**
  * @public
@@ -217,31 +216,6 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     return credentials;
   };
 };
-
-/**
- * @internal
- */
-export type DefaultCredentialProvider = (input: any) => Provider<AwsCredentialIdentity>;
-
-/**
- * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
- * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
- * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
- * dependencies.
- *
- * @internal
- */
-export const decorateDefaultCredentialProvider =
-  (provider: DefaultCredentialProvider): DefaultCredentialProvider =>
-  (input: STSClientResolvedConfig) =>
-    provider({
-      roleAssumer: getDefaultRoleAssumer(input, input.stsClientCtor as new (options: STSClientConfig) => STSClient),
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(
-        input,
-        input.stsClientCtor as new (options: STSClientConfig) => STSClient
-      ),
-      ...input,
-    });
 
 const isH2 = (requestHandler: any): boolean => {
   return requestHandler?.metadata?.handlerProtocol === "h2";

--- a/clients/client-supplychain/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-supplychain/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-support-app/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-support-app/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-support/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-support/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-swf/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-swf/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-synthetics/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-synthetics/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-taxsettings/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-taxsettings/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-textract/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-textract/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-timestream-influxdb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-timestream-influxdb/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-timestream-query/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-timestream-query/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-timestream-write/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-timestream-write/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-tnb/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-tnb/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-transcribe-streaming/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-transcribe-streaming/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-transcribe/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-transcribe/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-transfer/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-transfer/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-translate/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-translate/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-trustedadvisor/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-trustedadvisor/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-uxc/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-uxc/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-verifiedpermissions/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-verifiedpermissions/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-voice-id/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-voice-id/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-vpc-lattice/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-vpc-lattice/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-waf-regional/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-waf-regional/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-waf/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-waf/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-wafv2/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wafv2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-wellarchitected/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wellarchitected/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-wickr/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wickr/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-wisdom/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-wisdom/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-workdocs/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workdocs/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-workmail/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workmail/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-workmailmessageflow/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workmailmessageflow/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-workspaces-instances/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces-instances/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-workspaces-thin-client/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces-thin-client/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-workspaces-web/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces-web/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-workspaces/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-workspaces/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/clients/client-xray/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-xray/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSTSAuthCustomizations.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSTSAuthCustomizations.java
@@ -197,41 +197,6 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
                        """)
                 .popState();
         });
-
-        codegenContext.writerDelegator().useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
-            ServiceShape service = codegenContext.settings().getService(codegenContext.model());
-            Symbol serviceSymbol = codegenContext.symbolProvider().toSymbol(service);
-            w.addRelativeImport(
-                serviceSymbol.getName(),
-                null,
-                Paths.get(".", serviceSymbol.getNamespace())
-            );
-            w.addRelativeImport(
-                serviceSymbol.getName() + "Config",
-                null,
-                Paths.get(".", serviceSymbol.getNamespace())
-            );
-            w.write("export interface StsAuthInputConfig {}\n");
-            w.openBlock(
-                "export interface StsAuthResolvedConfig {",
-                "}\n",
-                () -> w
-                    .writeDocs("""
-                               Reference to STSClient class constructor.
-                               @internal""")
-                    .addTypeImport("Client", null, TypeScriptDependency.SMITHY_TYPES)
-                    .write("stsClientCtor: new (clientConfig: any) => Client<any, any, any>;")
-            );
-            w.openBlock("""
-                        export const resolveStsAuthConfig = <T>(
-                          input: T & StsAuthInputConfig
-                        ): T & StsAuthResolvedConfig => Object.assign(input, {
-                        """, "});", () -> {
-                w.write("""
-                        stsClientCtor: STSClient,
-                        """);
-            });
-        });
     }
 
     @Override
@@ -252,28 +217,6 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
                         .write("""
                                async (idProps) => await \
                                credentialDefaultProvider(idProps?.__config || {})()""")
-                )
-                .addResolveConfigFunction(
-                    ResolveConfigFunction.builder()
-                        .resolveConfigFunction(
-                            Symbol.builder()
-                                .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
-                                .name("resolveStsAuthConfig")
-                                .build()
-                        )
-                        .inputConfig(
-                            Symbol.builder()
-                                .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
-                                .name("StsAuthInputConfig")
-                                .build()
-                        )
-                        .resolvedConfig(
-                            Symbol.builder()
-                                .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
-                                .name("StsAuthResolvedConfig")
-                                .build()
-                        )
-                        .build()
                 )
                 .build();
             supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider.java
@@ -178,7 +178,7 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                             }
                         }
                     );
-                    w.addImport("EndpointParameters", null, EndpointsV2Generator.ENDPOINT_PARAMETERS_DEPENDENCY);
+                    w.addTypeImport("EndpointParameters", null, EndpointsV2Generator.ENDPOINT_PARAMETERS_DEPENDENCY);
                     w.writeDocs("@internal");
                     w.openBlock(
                         """
@@ -228,8 +228,11 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                         );
                     Map<String, HttpAuthSchemeParameter> httpAuthSchemeParameters =
                         AuthUtils.collectHttpAuthSchemeParameters(effectiveHttpAuthSchemes.values());
-                    Symbol serviceSymbol = s.getSymbolProvider().toSymbol(s.getService());
-                    w.addRelativeImport(
+                    Symbol serviceSymbol = s.getSymbolProvider().toSymbol(s.getService())
+                        .toBuilder()
+                        .putProperty("typeOnly", true)
+                        .build();
+                    w.addRelativeTypeImport(
                         serviceSymbol.getName() + "ResolvedConfig",
                         null,
                         Paths.get(".", serviceSymbol.getNamespace())

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeSigV4Auth.java
@@ -207,6 +207,7 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                         .inputConfig(
                             Symbol.builder()
                                 .name("AwsSdkSigV4AuthInputConfig")
+                                .putProperty("typeOnly", true)
                                 .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                 .addDependency(AwsDependency.AWS_SDK_CORE)
                                 .build()
@@ -214,6 +215,7 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                         .previouslyResolved(
                             Symbol.builder()
                                 .name("AwsSdkSigV4PreviouslyResolved")
+                                .putProperty("typeOnly", true)
                                 .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                 .addDependency(AwsDependency.AWS_SDK_CORE)
                                 .build()
@@ -221,6 +223,7 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                         .resolvedConfig(
                             Symbol.builder()
                                 .name("AwsSdkSigV4AuthResolvedConfig")
+                                .putProperty("typeOnly", true)
                                 .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                 .addDependency(AwsDependency.AWS_SDK_CORE)
                                 .build()
@@ -258,6 +261,7 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                             .inputConfig(
                                 Symbol.builder()
                                     .name("AwsSdkSigV4AAuthInputConfig")
+                                    .putProperty("typeOnly", true)
                                     .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                     .addDependency(AwsDependency.AWS_SDK_CORE)
                                     .build()
@@ -265,6 +269,7 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                             .previouslyResolved(
                                 Symbol.builder()
                                     .name("AwsSdkSigV4APreviouslyResolved")
+                                    .putProperty("typeOnly", true)
                                     .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                     .addDependency(AwsDependency.AWS_SDK_CORE)
                                     .build()
@@ -272,6 +277,7 @@ public class AwsSdkCustomizeSigV4Auth implements HttpAuthTypeScriptIntegration {
                             .resolvedConfig(
                                 Symbol.builder()
                                     .name("AwsSdkSigV4AAuthResolvedConfig")
+                                    .putProperty("typeOnly", true)
                                     .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/httpAuthSchemes", "/")
                                     .addDependency(AwsDependency.AWS_SDK_CORE)
                                     .build()

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
@@ -1,10 +1,10 @@
 import { NodeHttp2Handler, NodeHttpHandler, streamCollector } from "@smithy/node-http-handler";
 import { HttpResponse } from "@smithy/protocol-http";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 import { afterAll, beforeAll, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import type { AssumeRoleCommandInput } from "../src/commands/AssumeRoleCommand";
-import { AssumeRoleWithWebIdentityCommandInput } from "../src/commands/AssumeRoleWithWebIdentityCommand";
+import type { AssumeRoleWithWebIdentityCommandInput } from "../src/commands/AssumeRoleWithWebIdentityCommand";
 import { getDefaultRoleAssumer, getDefaultRoleAssumerWithWebIdentity } from "../src/defaultRoleAssumers";
 
 const mockHandle = vi.fn().mockResolvedValue({

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.ts
@@ -1,14 +1,12 @@
-import { Pluggable } from "@smithy/types";
+import type { Pluggable } from "@smithy/types";
 
+import type { RoleAssumer, RoleAssumerWithWebIdentity, STSRoleAssumerOptions } from "./defaultStsRoleAssumers";
 import {
-  DefaultCredentialProvider,
   getDefaultRoleAssumer as StsGetDefaultRoleAssumer,
   getDefaultRoleAssumerWithWebIdentity as StsGetDefaultRoleAssumerWithWebIdentity,
-  RoleAssumer,
-  RoleAssumerWithWebIdentity,
-  STSRoleAssumerOptions,
 } from "./defaultStsRoleAssumers";
-import { ServiceInputTypes, ServiceOutputTypes, STSClient, STSClientConfig } from "./STSClient";
+import type { ServiceInputTypes, ServiceOutputTypes, STSClientConfig } from "./STSClient";
+import { STSClient } from "./STSClient";
 
 const getCustomizableStsClientCtor = (
   baseCtor: new (config: STSClientConfig) => STSClient,
@@ -42,23 +40,3 @@ export const getDefaultRoleAssumerWithWebIdentity = (
   stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[]
 ): RoleAssumerWithWebIdentity =>
   StsGetDefaultRoleAssumerWithWebIdentity(stsOptions, getCustomizableStsClientCtor(STSClient, stsPlugins));
-
-/**
- * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
- * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
- * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
- * dependencies.
- *
- * @internal
- *
- * @deprecated this is no longer needed. Use the defaultProvider directly,
- * which will load STS if needed.
- */
-export const decorateDefaultCredentialProvider =
-  (provider: DefaultCredentialProvider): DefaultCredentialProvider =>
-  (input: any) =>
-    provider({
-      roleAssumer: getDefaultRoleAssumer(input),
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(input),
-      ...input,
-    });

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -1,14 +1,13 @@
 import { setCredentialFeature } from "@aws-sdk/core/client";
 import { stsRegionDefaultResolver } from "@aws-sdk/region-config-resolver";
 import type { CredentialProviderOptions } from "@aws-sdk/types";
-import { AwsCredentialIdentity, Logger, Provider } from "@smithy/types";
+import type { AwsCredentialIdentity, Logger, Provider } from "@smithy/types";
 
-import { AssumeRoleCommand, AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
-import {
-  AssumeRoleWithWebIdentityCommand,
-  AssumeRoleWithWebIdentityCommandInput,
-} from "./commands/AssumeRoleWithWebIdentityCommand";
-import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSClient";
+import type { AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
+import { AssumeRoleCommand } from "./commands/AssumeRoleCommand";
+import type { AssumeRoleWithWebIdentityCommandInput } from "./commands/AssumeRoleWithWebIdentityCommand";
+import { AssumeRoleWithWebIdentityCommand } from "./commands/AssumeRoleWithWebIdentityCommand";
+import type { STSClient, STSClientConfig } from "./STSClient";
 
 /**
  * @public
@@ -214,31 +213,6 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     return credentials;
   };
 };
-
-/**
- * @internal
- */
-export type DefaultCredentialProvider = (input: any) => Provider<AwsCredentialIdentity>;
-
-/**
- * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
- * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
- * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
- * dependencies.
- *
- * @internal
- */
-export const decorateDefaultCredentialProvider =
-  (provider: DefaultCredentialProvider): DefaultCredentialProvider =>
-  (input: STSClientResolvedConfig) =>
-    provider({
-      roleAssumer: getDefaultRoleAssumer(input, input.stsClientCtor as new (options: STSClientConfig) => STSClient),
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(
-        input,
-        input.stsClientCtor as new (options: STSClientConfig) => STSClient
-      ),
-      ...input,
-    });
 
 const isH2 = (requestHandler: any): boolean => {
   return requestHandler?.metadata?.handlerProtocol === "h2";

--- a/packages-internal/nested-clients/src/submodules/cognito-identity/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/cognito-identity/auth/httpAuthSchemeProvider.ts
@@ -1,10 +1,10 @@
 // smithy-typescript generated code
-import type {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+import {
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
+  resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
-import { resolveAwsSdkSigV4Config } from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/packages-internal/nested-clients/src/submodules/signin/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/signin/auth/httpAuthSchemeProvider.ts
@@ -1,10 +1,10 @@
 // smithy-typescript generated code
-import type {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+import {
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
+  resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
-import { resolveAwsSdkSigV4Config } from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/packages-internal/nested-clients/src/submodules/sso-oidc/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/sso-oidc/auth/httpAuthSchemeProvider.ts
@@ -1,10 +1,10 @@
 // smithy-typescript generated code
-import type {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+import {
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
+  resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
-import { resolveAwsSdkSigV4Config } from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/packages-internal/nested-clients/src/submodules/sso/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/sso/auth/httpAuthSchemeProvider.ts
@@ -1,10 +1,10 @@
 // smithy-typescript generated code
-import type {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+import {
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
+  resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
-import { resolveAwsSdkSigV4Config } from "@aws-sdk/core/httpAuthSchemes";
 import type {
   HandlerExecutionContext,
   HttpAuthOption,

--- a/packages-internal/nested-clients/src/submodules/sts/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/sts/auth/httpAuthSchemeProvider.ts
@@ -1,12 +1,11 @@
 // smithy-typescript generated code
-import type {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+import {
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
+  resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
-import { resolveAwsSdkSigV4Config } from "@aws-sdk/core/httpAuthSchemes";
 import type {
-  Client,
   HandlerExecutionContext,
   HttpAuthOption,
   HttpAuthScheme,
@@ -18,7 +17,7 @@ import type {
 import { getSmithyContext, normalizeProvider } from "@smithy/util-middleware";
 
 import type { STSClientConfig } from "../STSClient";
-import { type STSClientResolvedConfig, STSClient } from "../STSClient";
+import { type STSClientResolvedConfig } from "../STSClient";
 
 /**
  * @internal
@@ -103,25 +102,10 @@ export const defaultSTSHttpAuthSchemeProvider: STSHttpAuthSchemeProvider = (auth
   return options;
 };
 
-export interface StsAuthInputConfig {}
-
-export interface StsAuthResolvedConfig {
-  /**
-   * Reference to STSClient class constructor.
-   * @internal
-   */
-  stsClientCtor: new (clientConfig: any) => Client<any, any, any>;
-}
-
-export const resolveStsAuthConfig = <T>(input: T & StsAuthInputConfig): T & StsAuthResolvedConfig =>
-  Object.assign(input, {
-    stsClientCtor: STSClient,
-  });
-
 /**
  * @public
  */
-export interface HttpAuthSchemeInputConfig extends StsAuthInputConfig, AwsSdkSigV4AuthInputConfig {
+export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig {
   /**
    * A comma-separated list of case-sensitive auth scheme names.
    * An auth scheme name is a fully qualified auth scheme ID with the namespace prefix trimmed.
@@ -146,7 +130,7 @@ export interface HttpAuthSchemeInputConfig extends StsAuthInputConfig, AwsSdkSig
 /**
  * @internal
  */
-export interface HttpAuthSchemeResolvedConfig extends StsAuthResolvedConfig, AwsSdkSigV4AuthResolvedConfig {
+export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedConfig {
   /**
    * A comma-separated list of case-sensitive auth scheme names.
    * An auth scheme name is a fully qualified auth scheme ID with the namespace prefix trimmed.
@@ -174,9 +158,8 @@ export interface HttpAuthSchemeResolvedConfig extends StsAuthResolvedConfig, Aws
 export const resolveHttpAuthSchemeConfig = <T>(
   config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveStsAuthConfig(config);
-  const config_1 = resolveAwsSdkSigV4Config(config_0);
-  return Object.assign(config_1, {
+  const config_0 = resolveAwsSdkSigV4Config(config);
+  return Object.assign(config_0, {
     authSchemePreference: normalizeProvider(config.authSchemePreference ?? []),
   }) as T & HttpAuthSchemeResolvedConfig;
 };

--- a/packages-internal/nested-clients/src/submodules/sts/defaultRoleAssumers.ts
+++ b/packages-internal/nested-clients/src/submodules/sts/defaultRoleAssumers.ts
@@ -3,12 +3,7 @@
 // https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.ts
 import type { Pluggable } from "@smithy/types";
 
-import type {
-  DefaultCredentialProvider,
-  RoleAssumer,
-  RoleAssumerWithWebIdentity,
-  STSRoleAssumerOptions,
-} from "./defaultStsRoleAssumers";
+import type { RoleAssumer, RoleAssumerWithWebIdentity, STSRoleAssumerOptions } from "./defaultStsRoleAssumers";
 import {
   getDefaultRoleAssumer as StsGetDefaultRoleAssumer,
   getDefaultRoleAssumerWithWebIdentity as StsGetDefaultRoleAssumerWithWebIdentity,
@@ -48,23 +43,3 @@ export const getDefaultRoleAssumerWithWebIdentity = (
   stsPlugins?: Pluggable<ServiceInputTypes, ServiceOutputTypes>[]
 ): RoleAssumerWithWebIdentity =>
   StsGetDefaultRoleAssumerWithWebIdentity(stsOptions, getCustomizableStsClientCtor(STSClient, stsPlugins));
-
-/**
- * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
- * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
- * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
- * dependencies.
- *
- * @internal
- *
- * @deprecated this is no longer needed. Use the defaultProvider directly,
- * which will load STS if needed.
- */
-export const decorateDefaultCredentialProvider =
-  (provider: DefaultCredentialProvider): DefaultCredentialProvider =>
-  (input: any) =>
-    provider({
-      roleAssumer: getDefaultRoleAssumer(input),
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(input),
-      ...input,
-    });

--- a/packages-internal/nested-clients/src/submodules/sts/defaultStsRoleAssumers.ts
+++ b/packages-internal/nested-clients/src/submodules/sts/defaultStsRoleAssumers.ts
@@ -10,7 +10,7 @@ import type { AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
 import { AssumeRoleCommand } from "./commands/AssumeRoleCommand";
 import type { AssumeRoleWithWebIdentityCommandInput } from "./commands/AssumeRoleWithWebIdentityCommand";
 import { AssumeRoleWithWebIdentityCommand } from "./commands/AssumeRoleWithWebIdentityCommand";
-import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSClient";
+import type { STSClient, STSClientConfig } from "./STSClient";
 
 /**
  * @public
@@ -216,31 +216,6 @@ export const getDefaultRoleAssumerWithWebIdentity = (
     return credentials;
   };
 };
-
-/**
- * @internal
- */
-export type DefaultCredentialProvider = (input: any) => Provider<AwsCredentialIdentity>;
-
-/**
- * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
- * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
- * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
- * dependencies.
- *
- * @internal
- */
-export const decorateDefaultCredentialProvider =
-  (provider: DefaultCredentialProvider): DefaultCredentialProvider =>
-  (input: STSClientResolvedConfig) =>
-    provider({
-      roleAssumer: getDefaultRoleAssumer(input, input.stsClientCtor as new (options: STSClientConfig) => STSClient),
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(
-        input,
-        input.stsClientCtor as new (options: STSClientConfig) => STSClient
-      ),
-      ...input,
-    });
 
 const isH2 = (requestHandler: any): boolean => {
   return requestHandler?.metadata?.handlerProtocol === "h2";

--- a/private/aws-protocoltests-ec2-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-ec2-schema/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-ec2/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-ec2/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-json-10-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-10-schema/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-json-10/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-10/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-json-machinelearning/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-machinelearning/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-json-schema-machinelearning/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-schema-machinelearning/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-json-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json-schema/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-json/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-json/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-query-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-query-schema/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-query/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-query/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-restjson-apigateway/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-apigateway/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-restjson-glacier/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-glacier/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-restjson-schema-apigateway/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-schema-apigateway/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-restjson-schema-glacier/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-schema-glacier/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-restjson-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson-schema/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-restjson/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restjson/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-restxml-schema/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restxml-schema/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {

--- a/private/aws-protocoltests-restxml/src/auth/httpAuthSchemeProvider.ts
+++ b/private/aws-protocoltests-restxml/src/auth/httpAuthSchemeProvider.ts
@@ -1,8 +1,8 @@
 // smithy-typescript generated code
 import {
-  AwsSdkSigV4AuthInputConfig,
-  AwsSdkSigV4AuthResolvedConfig,
-  AwsSdkSigV4PreviouslyResolved,
+  type AwsSdkSigV4AuthInputConfig,
+  type AwsSdkSigV4AuthResolvedConfig,
+  type AwsSdkSigV4PreviouslyResolved,
   resolveAwsSdkSigV4Config,
 } from "@aws-sdk/core/httpAuthSchemes";
 import type {


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7904

### Description
There is an initialization ordering bug in esbuild when it interacts with the SDK. I think it may be related to a circular file import in the STS client and its nested version.

This PR removes the circular dependency.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
