### PR TITLE
test(endpoints): migrate from jest to vitest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-integration: bundles
 	make test-endpoints
 
 test-endpoints:
-	npx jest -c ./tests/endpoints-2.0/jest.config.js --bail --verbose false
+	npx vitest run -c ./tests/endpoints-2.0/vitest.config.mts --bail 1
 
 # run all e2e tests (real services).
 test-e2e: bundles

--- a/tests/endpoints-2.0/endpoints-integration.spec.ts
+++ b/tests/endpoints-2.0/endpoints-integration.spec.ts
@@ -3,6 +3,7 @@ import { EndpointV2, RelativeMiddlewareOptions } from "@smithy/types";
 import { EndpointParams, resolveEndpoint } from "@smithy/util-endpoints";
 import { existsSync, readdirSync } from "fs";
 import { join } from "path";
+import { describe, expect, it } from "vitest";
 
 import { EndpointExpectation, ServiceModel, ServiceNamespace } from "./integration-test-types";
 import { HttpRequest } from "@smithy/protocol-http";

--- a/tests/endpoints-2.0/jest.config.js
+++ b/tests/endpoints-2.0/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts"],
-};

--- a/tests/endpoints-2.0/vitest.config.mts
+++ b/tests/endpoints-2.0/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/endpoints-2.0/**/*.spec.ts"],
+    environment: "node",
+    globals: true,
+  },
+});

--- a/tests/endpoints-2.0/vitest.config.mts
+++ b/tests/endpoints-2.0/vitest.config.mts
@@ -4,6 +4,5 @@ export default defineConfig({
   test: {
     include: ["tests/endpoints-2.0/**/*.spec.ts"],
     environment: "node",
-    globals: true,
   },
 });


### PR DESCRIPTION
### Issue
Noticed in https://github.com/aws/aws-sdk-js-v3/pull/7906

### Description
Migrates endpoint tests from jest to vitest

### Testing

#### Before

Tests are run using jest
```console
$ aws-sdk-js-v3> make test-endpoints
npx jest -c ./tests/endpoints-2.0/jest.config.js --bail --verbose false
 PASS  tests/endpoints-2.0/endpoints-integration.spec.ts (22.277 s)

Test Suites: 1 passed, 1 total
Tests:       5 skipped, 13901 passed, 13906 total
Snapshots:   0 total
Time:        22.367 s
Ran all test suites.
```

#### After

Tests are run using vitest
```console
$ aws-sdk-js-v3> make test-endpoints
...
 Test Files  1 passed (1)
      Tests  13901 passed | 5 skipped (13906)
   Start at  18:21:06
   Duration  7.81s (transform 50ms, setup 0ms, import 5.52s, tests 1.94s, environment 0ms)
```

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
