### PR TITLE
test: increase vitest hook timeouts in e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test-endpoints:
 
 # run all e2e tests (real services).
 test-e2e: bundles
-	yarn g:vitest run -c vitest.config.e2e.mts --retry=4 --test-timeout=60000
+	yarn g:vitest run -c vitest.config.e2e.mts --retry=4 --test-timeout=60000 --hook-timeout=60000
 	make test-browser-cross-platform
 	make test-bundlers
 	make test-canary
@@ -79,7 +79,7 @@ test-x: test-browser-cross-platform
 # e2e tests run in browser, but using tests that also run in Node.js
 test-browser-cross-platform:
 	node ./scripts/browser-testing/writeTestCredentials.mjs
-	yarn g:vitest run -c vitest.config.cross-platform.e2e.mts --retry=4 --test-timeout=60000; \
+	yarn g:vitest run -c vitest.config.cross-platform.e2e.mts --retry=4 --test-timeout=60000 --hook-timeout=60000; \
 		EXIT_CODE=$$?; \
 		make reset-test-credentials; \
 		exit $$EXIT_CODE;

--- a/tests/canary/canary-runner.js
+++ b/tests/canary/canary-runner.js
@@ -43,7 +43,7 @@ const packageJson = {
   name: "canary-aws-sdk-js-v3",
   private: true,
   scripts: {
-    canary: "vitest run --retry=4 --test-timeout=60000",
+    canary: "vitest run --retry=4 --test-timeout=60000 --hook-timeout=60000",
   },
   devDependencies: {
     ...Object.fromEntries([...dependencies].sort().map((dep) => [dep, "latest"])),


### PR DESCRIPTION
### Issue
P407593326

### Description
increase hook timeouts for e2e (vitest)

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
