### PR TITLE
fix(scripts): default generate-client-tarball-since to origin/main

### DIFF
--- a/scripts/generate-client-tarball/generate-client-tarball-since.mjs
+++ b/scripts/generate-client-tarball/generate-client-tarball-since.mjs
@@ -17,12 +17,9 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, "..", "..");
-const commitHash = process.argv[2];
+const commitHash = process.argv[2] ?? execSync("git rev-parse origin/main", { cwd: rootDir, encoding: "utf-8" }).trim();
 
-if (!commitHash) {
-  console.error("Usage: yarn generate:client:tarball:since <commit-hash>");
-  process.exit(1);
-}
+console.log(`Generating tarball for clients since ${commitHash}`);
 
 function getChangedClients(sinceCommit) {
   const diffOutput = execSync(`git log ${sinceCommit}..HEAD --format=%s`, {


### PR DESCRIPTION
### Description
default commit hash in generate-client-tarball-since script to latest commit in origin/main

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
