### PR TITLE
chore(scripts): add codegen flag for PR creation

### DIFF
--- a/scripts/generate-clients/build-smithy-typescript.js
+++ b/scripts/generate-clients/build-smithy-typescript.js
@@ -2,7 +2,23 @@
 const { access, rm } = require("node:fs/promises");
 const { spawnProcess } = require("../utils/spawn-process");
 
+/**
+ * @param {string} repo
+ * @param {string} commit
+ */
 const buildSmithyTypeScript = async (repo, commit) => {
+  await runWithSpecificSmithyTypeScriptVersion(repo, commit, async () => {
+    // Build smithy-typescript and publish to maven local
+    await spawnProcess("./gradlew", ["clean", "publishToMavenLocal"], { cwd: repo });
+  });
+};
+
+/**
+ * @param {string} repo
+ * @param {string} commit
+ * @param {Function} task
+ */
+const runWithSpecificSmithyTypeScriptVersion = async (repo, commit, task) => {
   let deleteSmithyTsRepo = false;
 
   // Check out smithy-typescript at repo, if it does not exist.
@@ -31,8 +47,7 @@ const buildSmithyTypeScript = async (repo, commit) => {
   }
   await spawnProcess("git", ["checkout", "-b", tempBranchName, commit], { cwd: repo });
 
-  // Build smithy-typescript and publish to maven local
-  await spawnProcess("./gradlew", ["clean", "publishToMavenLocal"], { cwd: repo });
+  await task();
 
   if (deleteSmithyTsRepo) {
     await rm(repo, { recursive: true, force: true });
@@ -43,4 +58,4 @@ const buildSmithyTypeScript = async (repo, commit) => {
   }
 };
 
-module.exports = { buildSmithyTypeScript };
+module.exports = { buildSmithyTypeScript, runWithSpecificSmithyTypeScriptVersion };

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -12,7 +12,7 @@ const {
   DEFAULT_CODE_GEN_INPUT_DIR,
   TEMP_CODE_GEN_INPUT_DIR,
 } = require("./code-gen-dir");
-const { buildSmithyTypeScript } = require("./build-smithy-typescript");
+const { buildSmithyTypeScript, runWithSpecificSmithyTypeScriptVersion } = require("./build-smithy-typescript");
 const { SMITHY_TS_COMMIT } = require("./config");
 const { spawnProcess } = require("../utils/spawn-process");
 
@@ -20,6 +20,7 @@ const REPO_ROOT = path.join(__dirname, "..", "..");
 const SMITHY_TS_DIR = path.normalize(path.join(__dirname, "..", "..", "..", "smithy-typescript"));
 const SDK_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "clients"));
 const PRIVATE_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "private"));
+const start = Date.now();
 
 const {
   models,
@@ -33,6 +34,7 @@ const {
   commit,
   d: noSmithyCheckout,
   p: protocolTestsOnly,
+  x: pullRequest,
 } = yargs(process.argv.slice(2))
   .alias("m", "models")
   .string("m")
@@ -51,6 +53,9 @@ const {
   .alias("d", "noSmithyCheckout")
   .boolean("d")
   .describe("d", "use existing Smithy version instead of target hash")
+  .alias("x", "pullRequest")
+  .boolean("x")
+  .describe("x", "command was invoked by developer creating a pull request")
   .alias("p", "protocolTestsOnly")
   .boolean("p")
   .describe("p", "Generate protocol tests only")
@@ -129,7 +134,15 @@ const {
       await generateNestedClients();
     }
 
-    require("../runtime-dependency-version-check/runtime-dep-version-check");
+    if (!noSmithyCheckout && pullRequest) {
+      await runWithSpecificSmithyTypeScriptVersion(repo, commit, async () => {
+        process.argv.push("--set-smithy-version");
+        require("../runtime-dependency-version-check/runtime-dep-version-check");
+      });
+    } else {
+      require("../runtime-dependency-version-check/runtime-dep-version-check");
+    }
+
     await spawnProcess("yarn", ["install", "--no-immutable"], {
       cwd: REPO_ROOT,
       stdio: "inherit",
@@ -141,6 +154,11 @@ const {
       stdio: "inherit",
       env: { ...process.env },
     });
+
+    if (!noSmithyCheckout && pullRequest) {
+      const end = Date.now();
+      console.log(`Codegen completed in ${((end - start) / 1000) | 0}s. Run git commit.`);
+    }
   } catch (e) {
     console.log(e);
     process.exit(1);


### PR DESCRIPTION
### Issue
n/a

### Description
This adds `yarn generate-clients -x` for developers to create codegen sync PRs. This uses a co-located smithy-ts checkout to set the canonical package versions for packages that aren't code-generated.

### Testing
Created https://github.com/aws/aws-sdk-js-v3/pull/7916 with this change.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
