### PR TITLE
chore(clients): add AWS retry customizations for DynamoDB, SQS, SFN, SWF

### DIFF
--- a/clients/client-dynamodb-streams/src/runtimeConfig.shared.ts
+++ b/clients/client-dynamodb-streams/src/runtimeConfig.shared.ts
@@ -5,6 +5,7 @@ import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";
 import { fromBase64, toBase64 } from "@smithy/util-base64";
+import { Retry, StandardRetryStrategy } from "@smithy/util-retry";
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
 
 import { defaultDynamoDBStreamsHttpAuthSchemeProvider } from "./auth/httpAuthSchemeProvider";
@@ -41,6 +42,14 @@ export const getRuntimeConfig = (config: DynamoDBStreamsClientConfig) => {
       version: "2012-08-10",
       serviceTarget: "DynamoDBStreams_20120810",
     },
+    retryStrategy: config?.retryStrategy ?? (
+      config?.maxAttempts == null && config?.retryMode == null && Retry.v2026
+        ? new StandardRetryStrategy({
+            maxAttempts: 4,
+            baseDelay: 25,
+          })
+        : undefined
+    ),
     serviceId: config?.serviceId ?? "DynamoDB Streams",
     urlParser: config?.urlParser ?? parseUrl,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,

--- a/clients/client-dynamodb/src/runtimeConfig.shared.ts
+++ b/clients/client-dynamodb/src/runtimeConfig.shared.ts
@@ -6,6 +6,7 @@ import { NoOpLogger } from "@smithy/smithy-client";
 import type { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";
 import { fromBase64, toBase64 } from "@smithy/util-base64";
+import { Retry, StandardRetryStrategy } from "@smithy/util-retry";
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
 
 import { defaultDynamoDBHttpAuthSchemeProvider } from "./auth/httpAuthSchemeProvider";
@@ -43,6 +44,14 @@ export const getRuntimeConfig = (config: DynamoDBClientConfig) => {
       serviceTarget: "DynamoDB_20120810",
       jsonCodec: new DynamoDBJsonCodec(),
     },
+    retryStrategy: config?.retryStrategy ?? (
+      config?.maxAttempts == null && config?.retryMode == null && Retry.v2026
+        ? new StandardRetryStrategy({
+            maxAttempts: 4,
+            baseDelay: 25,
+          })
+        : undefined
+    ),
     serviceId: config?.serviceId ?? "DynamoDB",
     urlParser: config?.urlParser ?? parseUrl,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,

--- a/clients/client-sfn/src/commands/GetActivityTaskCommand.ts
+++ b/clients/client-sfn/src/commands/GetActivityTaskCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getLongPollPlugin } from "@aws-sdk/core/client";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { Command as $Command } from "@smithy/smithy-client";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -105,7 +106,10 @@ export class GetActivityTaskCommand extends $Command
   >()
   .ep(commonParams)
   .m(function (this: any, Command: any, cs: any, config: SFNClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+    return [
+      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      getLongPollPlugin(config),
+    ];
   })
   .s("AWSStepFunctions", "GetActivityTask", {})
   .n("SFNClient", "GetActivityTaskCommand")

--- a/clients/client-sqs/src/commands/ReceiveMessageCommand.ts
+++ b/clients/client-sqs/src/commands/ReceiveMessageCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getLongPollPlugin } from "@aws-sdk/core/client";
 import { getReceiveMessagePlugin } from "@aws-sdk/middleware-sdk-sqs";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -218,6 +219,7 @@ export class ReceiveMessageCommand extends $Command
   .m(function (this: any, Command: any, cs: any, config: SQSClientResolvedConfig, o: any) {
     return [
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      getLongPollPlugin(config),
       getReceiveMessagePlugin(config),
     ];
   })

--- a/clients/client-swf/src/commands/PollForActivityTaskCommand.ts
+++ b/clients/client-swf/src/commands/PollForActivityTaskCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getLongPollPlugin } from "@aws-sdk/core/client";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { Command as $Command } from "@smithy/smithy-client";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -128,7 +129,10 @@ export class PollForActivityTaskCommand extends $Command
   >()
   .ep(commonParams)
   .m(function (this: any, Command: any, cs: any, config: SWFClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+    return [
+      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      getLongPollPlugin(config),
+    ];
   })
   .s("SimpleWorkflowService", "PollForActivityTask", {})
   .n("SWFClient", "PollForActivityTaskCommand")

--- a/clients/client-swf/src/commands/PollForDecisionTaskCommand.ts
+++ b/clients/client-swf/src/commands/PollForDecisionTaskCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getLongPollPlugin } from "@aws-sdk/core/client";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { Command as $Command } from "@smithy/smithy-client";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -524,7 +525,10 @@ export class PollForDecisionTaskCommand extends $Command
   >()
   .ep(commonParams)
   .m(function (this: any, Command: any, cs: any, config: SWFClientResolvedConfig, o: any) {
-    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
+    return [
+      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
+      getLongPollPlugin(config),
+    ];
   })
   .s("SimpleWorkflowService", "PollForDecisionTask", {})
   .n("SWFClient", "PollForDecisionTaskCommand")

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddRetryCustomizations.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddRetryCustomizations.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds long poll designator for specific operations.
+ * Adds custom retryStrategy for DynamoDB.
+ */
+@SmithyInternalApi
+public class AddRetryCustomizations implements TypeScriptIntegration {
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return List.of(
+            RuntimeClientPlugin.builder()
+                .pluginFunction(
+                    Symbol.builder()
+                        .namespace(AwsDependency.AWS_SDK_CORE.getPackageName() + "/client", "/")
+                        .name("getLongPollPlugin")
+                        .addDependency(AwsDependency.AWS_SDK_CORE)
+                        .build()
+                )
+                .operationPredicate((m, s, o) -> isLongPoll(s, o))
+                .build()
+        );
+    }
+
+    @Override
+    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        LanguageTarget target
+    ) {
+        if (LanguageTarget.SHARED.equals(target) && isDynamoDB(settings.getService(model))) {
+            return Map.of(
+                "retryStrategy",
+                (w) -> {
+                    w.addImport("StandardRetryStrategy", null, TypeScriptDependency.UTIL_RETRY);
+                    w.addImport("Retry", null, TypeScriptDependency.UTIL_RETRY);
+
+                    // todo(retry): Retry.v2026 condition can be removed when made permanent.
+                    w.write("""
+                            (
+                              config?.maxAttempts == null && config?.retryMode == null && Retry.v2026
+                                ? new StandardRetryStrategy({
+                                    maxAttempts: 4,
+                                    baseDelay: 25,
+                                  })
+                                : undefined
+                            )""");
+                }
+            );
+        }
+        return Collections.emptyMap();
+    }
+
+    private static boolean isDynamoDB(Shape serviceShape) {
+        String sdkId = serviceShape.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
+        return sdkId.equals("DynamoDB") || sdkId.equals("DynamoDB Streams");
+    }
+
+    private static boolean isLongPoll(ServiceShape service, OperationShape operation) {
+        String sdkId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
+        String opName = operation.getId().getName(service);
+        return switch (sdkId) {
+            case "SQS" -> opName.equals("ReceiveMessage");
+            case "SWF" -> opName.equals("PollForActivityTask") || opName.equals("PollForDecisionTask");
+            case "SFN" -> opName.equals("GetActivityTask");
+            default -> false;
+        };
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -6,6 +6,7 @@ software.amazon.smithy.aws.typescript.codegen.AddServiceCustomizationPlugins
 software.amazon.smithy.aws.typescript.codegen.AddAwsAuthPlugin
 software.amazon.smithy.aws.typescript.codegen.AddTokenAuthPlugin
 software.amazon.smithy.aws.typescript.codegen.AddProtocols
+software.amazon.smithy.aws.typescript.codegen.AddRetryCustomizations
 software.amazon.smithy.aws.typescript.codegen.AwsEndpointGeneratorIntegration
 software.amazon.smithy.aws.typescript.codegen.AddDefaultAwsEndpointRuleSet
 software.amazon.smithy.aws.typescript.codegen.AddNimbleCustomizations

--- a/packages-internal/core/integ/retry-customizations.integ.spec.ts
+++ b/packages-internal/core/integ/retry-customizations.integ.spec.ts
@@ -1,0 +1,58 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+import { DynamoDBStreams } from "@aws-sdk/client-dynamodb-streams";
+import { AdaptiveRetryStrategy, Retry, StandardRetryStrategy } from "@smithy/util-retry";
+import { beforeAll, describe, expect, test as it } from "vitest";
+
+describe("retry customization", () => {
+  for (const DDBCtor of [DynamoDB, DynamoDBStreams]) {
+    describe(DDBCtor.name, () => {
+      beforeAll(async () => {
+        Retry.v2026 = true;
+      });
+
+      it("has a custom retry strategy when no maxAttempts or retryMode are set", async () => {
+        const streams = new DDBCtor({
+          region: "us-west-2",
+          credentials: {
+            accessKeyId: "INTEG",
+            secretAccessKey: "INTEG",
+          },
+        });
+        const retryStrategy = await streams.config.retryStrategy();
+        expect(retryStrategy).toBeInstanceOf(StandardRetryStrategy);
+
+        expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(4);
+        expect((retryStrategy as any).baseDelay).toBe(25);
+      });
+
+      it("uses derived retryStrategy when retryMode is set", async () => {
+        const streams = new DDBCtor({
+          region: "us-west-2",
+          credentials: {
+            accessKeyId: "INTEG",
+            secretAccessKey: "INTEG",
+          },
+          retryMode: "adaptive",
+        });
+        const retryStrategy = await streams.config.retryStrategy();
+        expect(retryStrategy).toBeInstanceOf(AdaptiveRetryStrategy);
+      });
+
+      it("uses derived retryStrategy when maxAttempts is set", async () => {
+        const streams = new DDBCtor({
+          region: "us-west-2",
+          credentials: {
+            accessKeyId: "INTEG",
+            secretAccessKey: "INTEG",
+          },
+          maxAttempts: 5,
+        });
+        const retryStrategy = await streams.config.retryStrategy();
+        expect(retryStrategy).toBeInstanceOf(StandardRetryStrategy);
+
+        expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(5);
+        expect((retryStrategy as any).baseDelay).toBe(50);
+      });
+    });
+  }
+});

--- a/packages-internal/core/src/submodules/client/index.ts
+++ b/packages-internal/core/src/submodules/client/index.ts
@@ -1,4 +1,5 @@
 export * from "./emitWarningIfUnsupportedVersion";
+export { getLongPollPlugin } from "./longPollMiddleware";
 export * from "./setCredentialFeature";
 export * from "./setFeature";
 export * from "./setTokenFeature";

--- a/packages-internal/core/src/submodules/client/longPollMiddleware.spec.ts
+++ b/packages-internal/core/src/submodules/client/longPollMiddleware.spec.ts
@@ -1,0 +1,16 @@
+import type { HandlerExecutionContext } from "@smithy/types";
+import { describe, expect, test as it } from "vitest";
+
+import { longPollMiddleware } from "./longPollMiddleware";
+
+describe("long poll middleware", () => {
+  it("sets long poll mode on request context", async () => {
+    const context = {} as HandlerExecutionContext;
+
+    const handler = longPollMiddleware();
+    const next = (async () => {}) as any;
+    const mwFunction = handler(next, context);
+    await mwFunction({} as any);
+    expect(context.__retryLongPoll).toBe(true);
+  });
+});

--- a/packages-internal/core/src/submodules/client/longPollMiddleware.ts
+++ b/packages-internal/core/src/submodules/client/longPollMiddleware.ts
@@ -1,0 +1,43 @@
+import type {
+  HandlerExecutionContext,
+  InitializeHandler,
+  InitializeHandlerArguments,
+  InitializeHandlerOptions,
+  InitializeHandlerOutput,
+  MetadataBearer,
+  Pluggable,
+} from "@smithy/types";
+
+/**
+ * This middleware is attached to operations designated as long-polling.
+ * @internal
+ */
+export const longPollMiddleware =
+  () =>
+  <Output extends MetadataBearer = MetadataBearer>(
+    next: InitializeHandler<any, Output>,
+    context: HandlerExecutionContext
+  ): InitializeHandler<any, Output> =>
+  async (args: InitializeHandlerArguments<any>): Promise<InitializeHandlerOutput<Output>> => {
+    context.__retryLongPoll = true;
+    return next(args);
+  };
+
+/**
+ * @internal
+ */
+export const longPollMiddlewareOptions: InitializeHandlerOptions = {
+  name: "longPollMiddleware",
+  tags: ["RETRY"],
+  step: "initialize",
+  override: true,
+};
+
+/**
+ * @internal
+ */
+export const getLongPollPlugin = (options: {}): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.add(longPollMiddleware(), longPollMiddlewareOptions);
+  },
+});

--- a/packages-internal/middleware-sdk-sqs/src/sqs-long-poll.integ.spec.ts
+++ b/packages-internal/middleware-sdk-sqs/src/sqs-long-poll.integ.spec.ts
@@ -1,0 +1,113 @@
+import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
+import { SQS } from "@aws-sdk/client-sqs";
+import { HttpResponse } from "@aws-sdk/config/requestHandler";
+import { StandardRetryStrategy } from "@aws-sdk/config/retryStrategy";
+import type { RetryErrorInfo, StandardRetryBackoffStrategy, StandardRetryToken } from "@smithy/types";
+import { Retry } from "@smithy/util-retry";
+import { performance } from "node:perf_hooks";
+import { beforeEach, describe, expect, test as it } from "vitest";
+
+class DeterministicRetryBackoffStrategy implements StandardRetryBackoffStrategy {
+  protected x: number = Retry.delay();
+
+  public computeNextBackoffDelay(i: number): number {
+    const b = 1;
+    const r = 2;
+    const t_i = b * Math.min(this.x * r ** i, 20_000);
+    return Math.floor(t_i);
+  }
+
+  public setDelayBase(delay: number): void {
+    this.x = delay;
+  }
+}
+
+describe("SQS", () => {
+  beforeEach(() => {
+    Retry.v2026 = true;
+  });
+
+  describe("long poll", () => {
+    function createRetryableErrorResponse() {
+      return new HttpResponse({
+        statusCode: 500,
+      });
+    }
+
+    it("performs retry in a long poll mode", async () => {
+      const sqs = new SQS({
+        region: "us-west-2",
+        credentials: {
+          accessKeyId: "MOCK",
+          secretAccessKey: "MOCK",
+        },
+        retryStrategy: new (class extends StandardRetryStrategy {
+          public async acquireInitialRetryToken(scope: string) {
+            expect(scope).toEqual(":longpoll");
+            const token = await super.acquireInitialRetryToken(scope);
+            expect(token.isLongPoll?.()).toBe(true);
+            return token;
+          }
+
+          public async refreshRetryTokenForRetry(
+            token: StandardRetryToken,
+            errorInfo: RetryErrorInfo
+          ): Promise<StandardRetryToken> {
+            try {
+              return await super.refreshRetryTokenForRetry(token, errorInfo);
+            } catch (e: any) {
+              expect(e.$backoff).toBeGreaterThanOrEqual(1);
+              throw e;
+            }
+          }
+        })({
+          maxAttempts: 3,
+          backoff: new DeterministicRetryBackoffStrategy(),
+        }),
+      });
+
+      requireRequestsFrom(sqs)
+        .toMatch({
+          hostname: /^sqs.us-west-2.amazonaws.com$/,
+        })
+        .respondWith(createRetryableErrorResponse());
+
+      let i = 0;
+      while (true) {
+        const requestBegins = performance.now();
+
+        const receive = await sqs
+          .receiveMessage({
+            QueueUrl: "https://sqs.us-west-2.amazonaws.com/000000000000/Glorp",
+          })
+          .catch((_) => _);
+
+        const requestRetriesExhausted = performance.now();
+
+        const data = {
+          attempts: receive?.$metadata?.attempts,
+          totalRetryDelay: receive?.$metadata?.totalRetryDelay,
+          timeElapsed: requestRetriesExhausted - requestBegins,
+        };
+
+        expect(data.attempts).toEqual(3);
+        expect(data.totalRetryDelay).toEqual(150);
+        expect(data.timeElapsed).toBeGreaterThanOrEqual(350);
+
+        if (++i >= 1) {
+          break;
+        }
+      }
+
+      const requestIterations = 1;
+      const requestMatcherAssertionsPerRequest = 3; // includes retries.
+      const retryLifecycleAssertionsPerRequest = 3;
+      const metadataAssertionsPerRequest = 3;
+
+      expect.assertions(
+        requestIterations *
+          (requestMatcherAssertionsPerRequest + retryLifecycleAssertionsPerRequest + metadataAssertionsPerRequest)
+      );
+    });
+  });
+}, 30_000);

--- a/scripts/validation/api.json
+++ b/scripts/validation/api.json
@@ -53,7 +53,8 @@
     "setTokenFeature": "function, since <=3.930.0",
     "state": "object, since <=3.930.0",
     "validateSigningProperties": "function, since <=3.930.0",
-    "QueryShapeSerializer": "function, since 3.973.15"
+    "QueryShapeSerializer": "function, since 3.973.15",
+    "getLongPollPlugin": "function, since 3.973.26"
   },
   "@aws-sdk/crc64-nvme-crt": {
     "CrtCrc64Nvme": "function, since <=3.930.0"


### PR DESCRIPTION
### Issue
implements AWS portion of https://github.com/smithy-lang/smithy-typescript/pull/1922
follows https://github.com/aws/aws-sdk-js-v3/pull/7916

### Description
- new retry behavior is currently gated behind `SMITHY_NEW_RETRIES_2026` process.env entry. It is read only once at start-up, so changing the value is not possible.
	- if enabled, DynamoDB and DynamoDB Streams will default to 4 maximum attempts per request instead of 3 (default for most clients).
	- DynamoDB family of clients will also retry slightly faster between attempts
	- For certain long polling operations like SQS ReceiveMessage that may run in a tight loop, the SDK will perform a backoff to prevent the loop from iterating too quickly in the event of a service outage. 

You can read more about the upcoming retry behavior changes in https://github.com/smithy-lang/smithy-typescript/pull/1922. The gist of it is that the behavior has been designed to give your requests the optimal chance of success and recovery speed in a variety of error scenarios. 

### Enabling `SMITHY_NEW_RETRIES_2026` after process start

This is an internal API and may be removed in the future.

```ts
import { Retry } from "@smithy/util-retry";

Retry.v2026 = true;
```

### Testing
new e2e/integration tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [x] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [ ] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
