### PR TITLE
test: endpoint resolution cache

### DIFF
--- a/test-endpoint-resolution-cache.mjs
+++ b/test-endpoint-resolution-cache.mjs
@@ -1,0 +1,20 @@
+import { strictEqual } from "node:assert";
+
+import { defaultEndpointResolver } from "./clients/client-s3/dist-cjs/endpoint/endpointResolver.js";
+
+const endpointParams = {
+  Accelerate: false,
+  Bucket: "bucket-name",
+  ForcePathStyle: false,
+  Region: "us-west-2",
+  UseDualStack: false,
+  UseFIPS: false,
+};
+
+for (let i = 0; i < 5; i++) {
+  const start = performance.now();
+  const result = defaultEndpointResolver(endpointParams);
+  const end = performance.now();
+  console.log(`time taken to resolve endpoint: ${((end - start) * 1_000_000).toFixed(0)} ns `);
+  strictEqual(result.url.toString(), "https://bucket-name.s3.us-west-2.amazonaws.com/");
+}


### PR DESCRIPTION
### Issue
Internal JS-6645

### Description

Test code for validating endpoint resolution cache

### Testing

For subsequent calls, the endpoint is obtained from cache, and is nearly instantaneous
```console
$ node test-endpoint-resolution-cache.mjs
time taken to resolve endpoint: 5311477 ns 
time taken to resolve endpoint: 362917 ns 
time taken to resolve endpoint: 10970 ns 
time taken to resolve endpoint: 5600 ns 
time taken to resolve endpoint: 9351 ns 
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
