### PR TITLE
chore(codegen): bump codegen version to 0.48.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Smithy AWS Typescript Codegen Changelog
 
-## 0.47.0 (2026-03-05)
+## 0.48.0 (2026-04-08)
+
+### Chores
+
+- Upgraded to smithy-typescript 0.48.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0480-2026-04-08))
+- Imported dependencies from core submodules instead of root ([#7896](https://github.com/aws/aws-sdk-js-v3/pull/7896))
+- Changed runtime imports to type imports ([#7897](https://github.com/aws/aws-sdk-js-v3/pull/7897))
+
+## 0.47.0 (2026-03-17)
 
 ### Features
 

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -37,7 +37,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.47.0"
+    version = "0.48.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.47.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.48.0")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/dfec1b6f4a49745b2f4873e8cc03ab3f150ba96b...8776710ac30f9ed4fcb322d2dec0ade3f0f7de5e
-  SMITHY_TS_COMMIT: "8776710ac30f9ed4fcb322d2dec0ade3f0f7de5e",
+  // https://github.com/smithy-lang/smithy-typescript/compare/8776710ac30f9ed4fcb322d2dec0ade3f0f7de5e...754a468623a453d9bf9ad8a056192cc8a5627303
+  SMITHY_TS_COMMIT: "754a468623a453d9bf9ad8a056192cc8a5627303",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
### Issue
https://github.com/smithy-lang/smithy-typescript/pull/1946

### Description
Bumps codegen version to 0.48.0

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
