### PR TITLE
chore(scripts): create dummy tarball when no new commits

### DIFF
--- a/scripts/generate-client-tarball/generate-client-tarball-since.mjs
+++ b/scripts/generate-client-tarball/generate-client-tarball-since.mjs
@@ -11,7 +11,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -29,6 +29,9 @@ function getChangedClients(sinceCommit) {
 
   if (!diffOutput) {
     console.info(`No output for: git log ${sinceCommit}..HEAD --format=%s`);
+    const dummyPath = join(rootDir, "clients", "dummy-tarball.tgz");
+    writeFileSync(dummyPath, "");
+    console.log(`No changed clients. Created dummy tarball at ${dummyPath}`);
     return [];
   }
 


### PR DESCRIPTION
### Issue
Internal JS-6768

### Description
When there are no new commits since the given hash, `yarn generate:client:tarball:since` produces no .tgz files. This causes preview build to fail because the JsSdkV3PreviewClientTarball artifact expects **/*.tgz under clients/.

This change writes an empty dummy .tgz file so the artifact glob always has a match.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
