### PR TITLE
chore: derestrict commit message linting

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,5 +2,8 @@ module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "type-enum": [2, "always", ["feat", "fix", "docs", "test", "chore"]],
+    "subject-case": [0],
+    "header-max-length": [0],
+    "body-max-line-length": [0],
   },
 };


### PR DESCRIPTION
This removes the default restriction from conventional commits on the commit message casing and message lengths.

Reasons:
- if I want to refer to a class name in the commit message, the commit message needs to allow upper case in the first word. It is a false positive on title casing.
- the commit messages coming from service model updates are already not subject to message lengths. I need to be descriptive in the commit message because customers rely on our release notes to detect important changes, and they can't all be short like "chore(clients): updated the sdk".