### PR TITLE
fix(eventstream-handler-node): use static credentials in event signing streams

### DIFF
--- a/clients/client-bedrock-runtime/test/BedrockRuntime.e2e.spec.ts
+++ b/clients/client-bedrock-runtime/test/BedrockRuntime.e2e.spec.ts
@@ -1,10 +1,29 @@
 import { BedrockRuntime } from "@aws-sdk/client-bedrock-runtime";
+import { SignatureV4 } from "@smithy/signature-v4";
 import { toBase64 } from "@smithy/util-base64";
 import { toUtf8 } from "@smithy/util-utf8";
-import { describe, expect, test as it } from "vitest";
+import { beforeEach, describe, expect, test as it, vi } from "vitest";
 
 describe("BedrockRuntime", () => {
-  const client = new BedrockRuntime({ region: "us-west-2", credentials: aws?.testCredentials });
+  const client = new BedrockRuntime({
+    region: "us-west-2",
+    credentials: aws?.testCredentials,
+  });
+
+  let signerCredentialProviderSpy: any;
+
+  beforeEach(async () => {
+    const wsSigv4: any = await client.config.signer();
+    const sigv4: SignatureV4 & any = wsSigv4.signer;
+
+    // artificially make the signer factory return the same observable instance.
+    (client.config as any).eventStreamPayloadHandler.messageSigner = async () => wsSigv4;
+
+    expect(wsSigv4.signer).toBeInstanceOf(SignatureV4);
+    signerCredentialProviderSpy = vi.spyOn(sigv4, "credentialProvider").mockImplementation(async () => {
+      return client.config.credentials();
+    });
+  });
 
   function s(data: any) {
     return Buffer.from(JSON.stringify(data));
@@ -265,5 +284,10 @@ describe("BedrockRuntime", () => {
     // Not asserting this strictly to leave room for model behavior changes.
     expect(responseChunks.length).toBeGreaterThanOrEqual(2);
     expect(responseChunks.some((c) => c === "usageEvent")).toBeTruthy();
+
+    // there are ~44 calls in this execution when the event signing stream does not use static credentials.
+    if (!process.env.AWS_SDK_TEST_CANARY) {
+      expect(signerCredentialProviderSpy).not.toHaveBeenCalled();
+    }
   });
 }, 60_000);

--- a/packages-internal/eventstream-handler-node/src/EventSigningTransformStream.spec.ts
+++ b/packages-internal/eventstream-handler-node/src/EventSigningTransformStream.spec.ts
@@ -12,6 +12,121 @@ describe("EventSigningStream", () => {
     Date = originalDate;
   });
 
+  it("should pass eventStreamCredentials to messageSigner.sign when credentials are provided", async () => {
+    const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
+    const message: Message = { headers: {}, body: fromUtf8("foo") };
+    const inputChunk = eventStreamCodec.encode(message);
+
+    const mockCredentials = { accessKeyId: "AKID", secretAccessKey: "SECRET", sessionToken: "TOKEN" };
+    const credentialsProvider = vi.fn().mockResolvedValue(mockCredentials);
+
+    const mockMessageSigner = vi.fn().mockReturnValue({ message, signature: "7369676e617475726531" } as SignedMessage);
+
+    const now = new Date(1546045446000);
+    function MockDate(input?: any): Date {
+      return input ? new originalDate(input) : now;
+    }
+    MockDate.now = () => now.getTime();
+    global.Date = MockDate as any;
+
+    const signingStream = new EventSigningTransformStream({
+      priorSignature: "initial",
+      messageSigner: { sign: mockMessageSigner, signMessage: mockMessageSigner },
+      eventStreamCodec,
+      systemClockOffsetProvider: async () => 0,
+      credentials: credentialsProvider,
+    });
+
+    let resolve: (value?: unknown) => void;
+    const done = new Promise((r) => (resolve = r));
+    signingStream.on("data", () => {});
+    signingStream.on("end", () => {
+      expect(credentialsProvider).toHaveBeenCalledOnce();
+      expect(mockMessageSigner.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ eventStreamCredentials: mockCredentials })
+      );
+      resolve();
+    });
+    signingStream.write(inputChunk);
+    signingStream.end();
+    await done;
+  });
+
+  it("should not pass eventStreamCredentials when credentials are not provided", async () => {
+    const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
+    const message: Message = { headers: {}, body: fromUtf8("foo") };
+    const inputChunk = eventStreamCodec.encode(message);
+
+    const mockMessageSigner = vi.fn().mockReturnValue({ message, signature: "7369676e617475726531" } as SignedMessage);
+
+    const now = new Date(1546045446000);
+    function MockDate(input?: any): Date {
+      return input ? new originalDate(input) : now;
+    }
+    MockDate.now = () => now.getTime();
+    global.Date = MockDate as any;
+
+    const signingStream = new EventSigningTransformStream({
+      priorSignature: "initial",
+      messageSigner: { sign: mockMessageSigner, signMessage: mockMessageSigner },
+      eventStreamCodec,
+      systemClockOffsetProvider: async () => 0,
+    });
+
+    let resolve: (value?: unknown) => void;
+    const done = new Promise((r) => (resolve = r));
+    signingStream.on("data", () => {});
+    signingStream.on("end", () => {
+      expect(mockMessageSigner.mock.calls[0][1].eventStreamCredentials).toBeUndefined();
+      resolve();
+    });
+    signingStream.write(inputChunk);
+    signingStream.end();
+    await done;
+  });
+
+  it("should resolve credentials only once for multiple chunks", async () => {
+    const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
+    const message: Message = { headers: {}, body: fromUtf8("foo") };
+    const inputChunk = eventStreamCodec.encode(message);
+
+    const mockCredentials = { accessKeyId: "AKID", secretAccessKey: "SECRET" };
+    const credentialsProvider = vi.fn().mockResolvedValue(mockCredentials);
+
+    let callCount = 0;
+    const mockMessageSigner = vi.fn().mockImplementation(() => ({
+      message,
+      signature: "7369676e617475726" + callCount++,
+    }));
+
+    const now = new Date(1546045446000);
+    function MockDate(input?: any): Date {
+      return input ? new originalDate(input) : now;
+    }
+    MockDate.now = () => now.getTime();
+    global.Date = MockDate as any;
+
+    const signingStream = new EventSigningTransformStream({
+      priorSignature: "initial",
+      messageSigner: { sign: mockMessageSigner, signMessage: mockMessageSigner },
+      eventStreamCodec,
+      systemClockOffsetProvider: async () => 0,
+      credentials: credentialsProvider,
+    });
+
+    let resolve: (value?: unknown) => void;
+    const done = new Promise((r) => (resolve = r));
+    signingStream.on("data", () => {});
+    signingStream.on("end", () => {
+      expect(credentialsProvider).toHaveBeenCalledOnce();
+      resolve();
+    });
+    signingStream.write(inputChunk);
+    signingStream.write(inputChunk);
+    signingStream.end();
+    await done;
+  });
+
   it("should sign an eventstream payload properly", async () => {
     const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
     const message1: Message = {

--- a/packages-internal/eventstream-handler-node/src/EventSigningTransformStream.ts
+++ b/packages-internal/eventstream-handler-node/src/EventSigningTransformStream.ts
@@ -1,3 +1,4 @@
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import type { EventStreamCodec } from "@smithy/eventstream-codec";
 import type { MessageHeaders, MessageSigner, Provider } from "@smithy/types";
 import { type TransformCallback, type TransformOptions, Transform } from "node:stream";
@@ -10,6 +11,7 @@ export interface EventSigningStreamOptions extends TransformOptions {
   messageSigner: MessageSigner;
   eventStreamCodec: EventStreamCodec;
   systemClockOffsetProvider: Provider<number>;
+  credentials?: AwsCredentialIdentityProvider;
 }
 
 /**
@@ -21,6 +23,7 @@ export class EventSigningTransformStream extends Transform {
   private messageSigner: MessageSigner;
   private eventStreamCodec: EventStreamCodec;
   private readonly systemClockOffsetProvider: Provider<number>;
+  private readonly staticCredentials?: Promise<AwsCredentialIdentity>;
 
   constructor(options: EventSigningStreamOptions) {
     super({
@@ -34,6 +37,7 @@ export class EventSigningTransformStream extends Transform {
     this.eventStreamCodec = options.eventStreamCodec;
     this.messageSigner = options.messageSigner;
     this.systemClockOffsetProvider = options.systemClockOffsetProvider;
+    this.staticCredentials = options.credentials?.();
   }
 
   async _transform(chunk: Uint8Array, encoding: string, callback: TransformCallback): Promise<void> {
@@ -52,6 +56,7 @@ export class EventSigningTransformStream extends Transform {
         },
         {
           signingDate: now,
+          eventStreamCredentials: await this.staticCredentials,
         }
       );
       this.priorSignature = signedMessage.signature;

--- a/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.spec.ts
+++ b/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.spec.ts
@@ -145,6 +145,56 @@ describe(EventStreamPayloadHandler.name, () => {
     });
   });
 
+  it("should pass credentials to EventSigningTransformStream when provided", async () => {
+    const priorSignature = "1234567890";
+    const authorization = `AWS4-HMAC-SHA256 Credential=AKID/20200510/us-west-2/foo/aws4_request, SignedHeaders=host, Signature=${priorSignature}`;
+    const mockCredentials = vi.fn().mockResolvedValue({ accessKeyId: "AKID", secretAccessKey: "SECRET" });
+
+    const mockRequest = {
+      body: new PassThrough(),
+      headers: { authorization },
+    } as any;
+
+    const handler = new EventStreamPayloadHandler({
+      messageSigner: () => Promise.resolve(mockMessageSigner),
+      utf8Decoder: mockUtf8Decoder,
+      utf8Encoder: mockUtf8encoder,
+      credentials: mockCredentials,
+    });
+
+    await handler.handle(mockNextHandler, {
+      request: mockRequest,
+      input: {},
+    });
+
+    expect(EventSigningTransformStream).toHaveBeenCalledWith(expect.objectContaining({ credentials: mockCredentials }));
+  });
+
+  it("should not pass credentials to EventSigningTransformStream when not provided", async () => {
+    const priorSignature = "1234567890";
+    const authorization = `AWS4-HMAC-SHA256 Credential=AKID/20200510/us-west-2/foo/aws4_request, SignedHeaders=host, Signature=${priorSignature}`;
+
+    const mockRequest = {
+      body: new PassThrough(),
+      headers: { authorization },
+    } as any;
+
+    const handler = new EventStreamPayloadHandler({
+      messageSigner: () => Promise.resolve(mockMessageSigner),
+      utf8Decoder: mockUtf8Decoder,
+      utf8Encoder: mockUtf8encoder,
+    });
+
+    await handler.handle(mockNextHandler, {
+      request: mockRequest,
+      input: {},
+    });
+
+    expect(EventSigningTransformStream).toHaveBeenCalledWith(
+      expect.not.objectContaining({ credentials: expect.anything() })
+    );
+  });
+
   it("should start piping regardless of whether the downstream resolves", async () => {
     const authorization =
       "AWS4-HMAC-SHA256 Credential=AKID/20200510/us-west-2/foo/aws4_request, SignedHeaders=host, Signature=1234567890";

--- a/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.ts
+++ b/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.ts
@@ -1,3 +1,4 @@
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import { EventStreamCodec } from "@smithy/eventstream-codec";
 import type {
   Decoder,
@@ -24,6 +25,7 @@ export interface EventStreamPayloadHandlerOptions {
   utf8Encoder: Encoder;
   utf8Decoder: Decoder;
   systemClockOffset?: number;
+  credentials?: AwsCredentialIdentityProvider;
 }
 
 /**
@@ -33,11 +35,13 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
   private readonly messageSigner: Provider<MessageSigner>;
   private readonly eventStreamCodec: EventStreamCodec;
   private readonly systemClockOffsetProvider: Provider<number>;
+  private readonly credentials?: AwsCredentialIdentityProvider;
 
   constructor(options: EventStreamPayloadHandlerOptions) {
     this.messageSigner = options.messageSigner;
     this.eventStreamCodec = new EventStreamCodec(options.utf8Encoder, options.utf8Decoder);
     this.systemClockOffsetProvider = async () => options.systemClockOffset ?? 0;
+    this.credentials = options.credentials;
   }
 
   async handle<T extends MetadataBearer>(
@@ -69,6 +73,7 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
       eventStreamCodec: this.eventStreamCodec,
       messageSigner: await this.messageSigner(),
       systemClockOffsetProvider: this.systemClockOffsetProvider,
+      credentials: this.credentials,
     });
 
     // this promise rejects on pipeline error, resolves after http layer completes

--- a/packages-internal/eventstream-handler-node/src/eventStreamPayloadHandlerProvider.ts
+++ b/packages-internal/eventstream-handler-node/src/eventStreamPayloadHandlerProvider.ts
@@ -1,3 +1,4 @@
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import type { Decoder, Encoder, EventStreamPayloadHandlerProvider, MessageSigner, Provider } from "@smithy/types";
 
 import { EventStreamPayloadHandler } from "./EventStreamPayloadHandler";
@@ -10,4 +11,5 @@ export const eventStreamPayloadHandlerProvider: EventStreamPayloadHandlerProvide
   utf8Decoder: Decoder;
   messageSigner: Provider<MessageSigner>;
   systemClockOffset?: number;
+  credentials?: AwsCredentialIdentityProvider;
 }) => new EventStreamPayloadHandler(options);

--- a/packages-internal/middleware-eventstream/src/eventStreamConfiguration.ts
+++ b/packages-internal/middleware-eventstream/src/eventStreamConfiguration.ts
@@ -1,3 +1,4 @@
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import type {
   Decoder,
   Encoder,
@@ -29,6 +30,7 @@ interface PreviouslyResolved {
   utf8Decoder: Decoder;
   signer: any; //Should be Provider<EventSigner>; But this would unblock the client
   eventStreamPayloadHandlerProvider: EventStreamPayloadHandlerProvider;
+  credentials?: AwsCredentialIdentityProvider;
 }
 
 export function resolveEventStreamConfig<T>(

--- a/packages-internal/middleware-websocket/src/ws-eventstream/EventSigningTransformStream.spec.ts
+++ b/packages-internal/middleware-websocket/src/ws-eventstream/EventSigningTransformStream.spec.ts
@@ -12,6 +12,135 @@ describe(EventSigningTransformStream.name, () => {
     window.Date = originalDate;
   });
 
+  it("should pass eventStreamCredentials to messageSigner.sign when credentials are provided", async () => {
+    const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
+    const message: Message = { headers: {}, body: fromUtf8("foo") };
+    const inputChunk = eventStreamCodec.encode(message);
+
+    const mockCredentials = { accessKeyId: "AKID", secretAccessKey: "SECRET", sessionToken: "TOKEN" };
+    const credentialsProvider = vi.fn().mockResolvedValue(mockCredentials);
+    const mockMessageSigner = vi
+      .fn()
+      .mockResolvedValue({ message, signature: "7369676e617475726531" } as SignedMessage);
+
+    const now = new Date(1546045446000);
+    function MockDate(input?: any): Date {
+      return input ? new originalDate(input) : now;
+    }
+    MockDate.now = () => now.getTime();
+    window.Date = MockDate as any;
+
+    const signingStream = new EventSigningTransformStream(
+      "initial",
+      { sign: mockMessageSigner, signMessage: mockMessageSigner },
+      eventStreamCodec,
+      async () => 0,
+      credentialsProvider
+    );
+
+    const reader = signingStream.readable.getReader();
+    const readPromise = reader.read();
+
+    const writer = signingStream.writable.getWriter();
+    await writer.write(inputChunk);
+    await readPromise;
+    await writer.close();
+    await writer.closed;
+
+    expect(credentialsProvider).toHaveBeenCalledOnce();
+    expect(mockMessageSigner.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ eventStreamCredentials: mockCredentials })
+    );
+  });
+
+  it("should not pass eventStreamCredentials when credentials are not provided", async () => {
+    const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
+    const message: Message = { headers: {}, body: fromUtf8("foo") };
+    const inputChunk = eventStreamCodec.encode(message);
+
+    const mockMessageSigner = vi
+      .fn()
+      .mockResolvedValue({ message, signature: "7369676e617475726531" } as SignedMessage);
+
+    const now = new Date(1546045446000);
+    function MockDate(input?: any): Date {
+      return input ? new originalDate(input) : now;
+    }
+    MockDate.now = () => now.getTime();
+    window.Date = MockDate as any;
+
+    const signingStream = new EventSigningTransformStream(
+      "initial",
+      { sign: mockMessageSigner, signMessage: mockMessageSigner },
+      eventStreamCodec,
+      async () => 0
+    );
+
+    const reader = signingStream.readable.getReader();
+    const readPromise = reader.read();
+
+    const writer = signingStream.writable.getWriter();
+    await writer.write(inputChunk);
+    await readPromise;
+    await writer.close();
+    await writer.closed;
+
+    expect(mockMessageSigner.mock.calls[0][1].eventStreamCredentials).toBeUndefined();
+  });
+
+  it("should resolve credentials only once for multiple chunks", async () => {
+    const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
+    const message: Message = { headers: {}, body: fromUtf8("foo") };
+    const inputChunk = eventStreamCodec.encode(message);
+
+    const mockCredentials = { accessKeyId: "AKID", secretAccessKey: "SECRET" };
+    const credentialsProvider = vi.fn().mockResolvedValue(mockCredentials);
+
+    let callCount = 0;
+    const mockMessageSigner = vi.fn().mockImplementation(async () => ({
+      message,
+      signature: "7369676e617475726" + callCount++,
+    }));
+
+    const now = new Date(1546045446000);
+    function MockDate(input?: any): Date {
+      return input ? new originalDate(input) : now;
+    }
+    MockDate.now = () => now.getTime();
+    window.Date = MockDate as any;
+
+    const signingStream = new EventSigningTransformStream(
+      "initial",
+      { sign: mockMessageSigner, signMessage: mockMessageSigner },
+      eventStreamCodec,
+      async () => 0,
+      credentialsProvider
+    );
+
+    const output: Array<any> = [];
+    const reader = signingStream.readable.getReader();
+    const push = () => {
+      reader.read().then(({ done, value }) => {
+        if (!done) {
+          output.push(value);
+          push();
+        }
+      });
+    };
+    push();
+
+    const writer = signingStream.writable.getWriter();
+    await writer.ready;
+    await writer.write(inputChunk);
+    await writer.ready;
+    await writer.write(inputChunk);
+    await writer.ready;
+    await writer.close();
+    await writer.closed;
+
+    expect(credentialsProvider).toHaveBeenCalledOnce();
+  });
+
   it("should sign a eventstream payload properly", async () => {
     const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
     const inputChunks: Array<Uint8Array> = (

--- a/packages-internal/middleware-websocket/src/ws-eventstream/EventSigningTransformStream.ts
+++ b/packages-internal/middleware-websocket/src/ws-eventstream/EventSigningTransformStream.ts
@@ -1,3 +1,4 @@
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import type { EventStreamCodec } from "@smithy/eventstream-codec";
 import type { MessageHeaders, MessageSigner, Provider } from "@smithy/types";
 import { fromHex } from "@smithy/util-hex-encoding";
@@ -25,9 +26,11 @@ export class EventSigningTransformStream extends TransformStream<Uint8Array, Uin
     initialSignature: string,
     messageSigner: MessageSigner,
     eventStreamCodec: EventStreamCodec,
-    systemClockOffsetProvider: Provider<number>
+    systemClockOffsetProvider: Provider<number>,
+    credentials?: AwsCredentialIdentityProvider
   ) {
     let priorSignature = initialSignature;
+    const staticCredentials: Promise<AwsCredentialIdentity> | undefined = credentials?.();
     super({
       start() {},
       async transform(chunk, controller) {
@@ -46,6 +49,7 @@ export class EventSigningTransformStream extends TransformStream<Uint8Array, Uin
             },
             {
               signingDate: now,
+              eventStreamCredentials: await staticCredentials,
             }
           );
           priorSignature = signedMessage.signature;

--- a/packages-internal/middleware-websocket/src/ws-eventstream/EventStreamPayloadHandler.spec.ts
+++ b/packages-internal/middleware-websocket/src/ws-eventstream/EventStreamPayloadHandler.spec.ts
@@ -133,6 +133,70 @@ describe(EventStreamPayloadHandler.name, () => {
     );
   });
 
+  it("should pass credentials through to event signer when provided", async () => {
+    const priorSignature = "1234567890";
+    const authorization = `AWS4-HMAC-SHA256 Credential=AKID/20200510/us-west-2/foo/aws4_request, SignedHeaders=host, Signature=${priorSignature}`;
+    const mockCredentials = vi.fn().mockResolvedValue({ accessKeyId: "AKID", secretAccessKey: "SECRET" });
+
+    const mockRequest = {
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([0, 1, 2, 3]));
+          controller.close();
+        },
+      }),
+      headers: { authorization },
+    } as any;
+
+    const handler = new EventStreamPayloadHandler({
+      messageSigner: () => Promise.resolve(mockSigner),
+      utf8Decoder: fromUtf8,
+      utf8Encoder: toUtf8,
+      credentials: mockCredentials,
+    });
+
+    await handler.handle(mockNextHandler, {
+      request: mockRequest,
+      input: {},
+    });
+
+    expect(mockSigner.sign).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventStreamCredentials: expect.objectContaining({ accessKeyId: "AKID" }) })
+    );
+  });
+
+  it("should not pass eventStreamCredentials when credentials are not provided", async () => {
+    const priorSignature = "1234567890";
+    const authorization = `AWS4-HMAC-SHA256 Credential=AKID/20200510/us-west-2/foo/aws4_request, SignedHeaders=host, Signature=${priorSignature}`;
+
+    const mockRequest = {
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([0, 1, 2, 3]));
+          controller.close();
+        },
+      }),
+      headers: { authorization },
+    } as any;
+
+    const handler = new EventStreamPayloadHandler({
+      messageSigner: () => Promise.resolve(mockSigner),
+      utf8Decoder: fromUtf8,
+      utf8Encoder: toUtf8,
+    });
+
+    await handler.handle(mockNextHandler, {
+      request: mockRequest,
+      input: {},
+    });
+
+    expect(mockSigner.sign).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({ eventStreamCredentials: expect.anything() })
+    );
+  });
+
   it("should start piping regardless of whether the downstream resolves", async () => {
     const authorization =
       "AWS4-HMAC-SHA256 Credential=AKID/20200510/us-west-2/foo/aws4_request, SignedHeaders=host, Signature=1234567890";

--- a/packages-internal/middleware-websocket/src/ws-eventstream/EventStreamPayloadHandler.ts
+++ b/packages-internal/middleware-websocket/src/ws-eventstream/EventStreamPayloadHandler.ts
@@ -1,3 +1,4 @@
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import { EventStreamCodec } from "@smithy/eventstream-codec";
 import type {
   Decoder,
@@ -23,6 +24,7 @@ export interface EventStreamPayloadHandlerOptions {
   utf8Encoder: Encoder;
   utf8Decoder: Decoder;
   systemClockOffset?: number;
+  credentials?: AwsCredentialIdentityProvider;
 }
 
 /**
@@ -32,11 +34,13 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
   private readonly messageSigner: Provider<MessageSigner>;
   private readonly eventStreamCodec: EventStreamCodec;
   private readonly systemClockOffsetProvider: Provider<number>;
+  private readonly credentials?: AwsCredentialIdentityProvider;
 
   constructor(options: EventStreamPayloadHandlerOptions) {
     this.messageSigner = options.messageSigner;
     this.eventStreamCodec = new EventStreamCodec(options.utf8Encoder, options.utf8Decoder);
     this.systemClockOffsetProvider = async () => options.systemClockOffset ?? 0;
+    this.credentials = options.credentials;
   }
 
   public async handle<T extends MetadataBearer>(
@@ -65,7 +69,8 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
       priorSignature,
       await this.messageSigner(),
       this.eventStreamCodec,
-      this.systemClockOffsetProvider
+      this.systemClockOffsetProvider,
+      this.credentials
     );
 
     payload.pipeThrough(signingStream).pipeThrough(placeHolderStream);

--- a/packages-internal/middleware-websocket/src/ws-eventstream/eventStreamPayloadHandlerProvider.ts
+++ b/packages-internal/middleware-websocket/src/ws-eventstream/eventStreamPayloadHandlerProvider.ts
@@ -1,3 +1,4 @@
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import type { Decoder, Encoder, EventStreamPayloadHandlerProvider, MessageSigner, Provider } from "@smithy/types";
 
 import { EventStreamPayloadHandler } from "./EventStreamPayloadHandler";
@@ -10,4 +11,5 @@ export const eventStreamPayloadHandlerProvider: EventStreamPayloadHandlerProvide
   utf8Decoder: Decoder;
   messageSigner: Provider<MessageSigner>;
   systemClockOffset?: number;
+  credentials?: AwsCredentialIdentityProvider;
 }) => new EventStreamPayloadHandler(options);

--- a/tests/canary/canary-runner.js
+++ b/tests/canary/canary-runner.js
@@ -43,7 +43,7 @@ const packageJson = {
   name: "canary-aws-sdk-js-v3",
   private: true,
   scripts: {
-    canary: "vitest run --retry=4 --test-timeout=60000 --hook-timeout=60000",
+    canary: "AWS_SDK_TEST_CANARY=1 vitest run --retry=4 --test-timeout=60000 --hook-timeout=60000",
   },
   devDependencies: {
     ...Object.fromEntries([...dependencies].sort().map((dep) => [dep, "latest"])),


### PR DESCRIPTION
### Issue
JS-6779

- [x] needs codegen update

### Description
event stream payload handlers that use signing will use static credentials for the duration of the request (same lifecycle as EventSigningTransformStream). 

### Testing
new e2e test in BedrockRuntime that works in both browser and Node.js

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
