### PR TITLE
feat(client-dynamodb): performance improvements in JSON serialization

### DIFF
--- a/packages-internal/core/src/submodules/protocols/json/JsonShapeSerializer.ts
+++ b/packages-internal/core/src/submodules/protocols/json/JsonShapeSerializer.ts
@@ -36,16 +36,6 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
     this.buffer = this._write(this.rootSchema, value);
   }
 
-  /**
-   * @internal
-   */
-  public writeDiscriminatedDocument(schema: Schema, value: unknown): void {
-    this.write(schema, value);
-    if (typeof this.buffer === "object") {
-      this.buffer.__type = NormalizedSchema.of(schema).getName(true);
-    }
-  }
-
   public flush(): string {
     const { rootSchema, useReplacer } = this;
     this.rootSchema = undefined;
@@ -63,7 +53,17 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
   }
 
   /**
-   * Order if-statements by order of likelihood.
+   * @internal
+   */
+  public writeDiscriminatedDocument(schema: Schema, value: unknown): void {
+    this.write(schema, value);
+    if (typeof this.buffer === "object") {
+      this.buffer.__type = NormalizedSchema.of(schema).getName(true);
+    }
+  }
+
+  /**
+   * Order if-statements by likelihood.
    */
   protected _write(schema: Schema, value: unknown, container?: NormalizedSchema): any {
     const isObject = value !== null && typeof value === "object";

--- a/packages-internal/dynamodb-codec/package.json
+++ b/packages-internal/dynamodb-codec/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@aws-sdk/core": "workspace:^3.973.27",
     "@smithy/core": "^3.23.14",
-    "@smithy/smithy-client": "^4.12.9",
     "@smithy/types": "^4.14.0",
     "@smithy/util-base64": "^4.3.2",
     "tslib": "^2.6.2"

--- a/packages-internal/dynamodb-codec/src/codec/DynamoDBJsonCodec.spec.ts
+++ b/packages-internal/dynamodb-codec/src/codec/DynamoDBJsonCodec.spec.ts
@@ -41,7 +41,10 @@ describe(DynamoDBJsonCodec.name, () => {
         N: "123",
       },
       boolean: {
-        B: false,
+        BOOL: false,
+      },
+      blobby: {
+        B: new Uint8Array([0, 1, 2, 3, 4, 5, 6]),
       },
       stringSet: {
         SS: ["a", "b", "c"],
@@ -75,7 +78,10 @@ describe(DynamoDBJsonCodec.name, () => {
         N: "123",
       },
       boolean: {
-        B: false,
+        BOOL: false,
+      },
+      blobby: {
+        B: "AAECAwQFBg==",
       },
       stringSet: {
         SS: ["a", "b", "c"],

--- a/packages-internal/dynamodb-codec/src/codec/DynamoDBJsonCodec.ts
+++ b/packages-internal/dynamodb-codec/src/codec/DynamoDBJsonCodec.ts
@@ -1,6 +1,5 @@
 import { JsonCodec, JsonShapeDeserializer, JsonShapeSerializer } from "@aws-sdk/core/protocols";
 import { NormalizedSchema } from "@smithy/core/schema";
-import { _json } from "@smithy/smithy-client";
 import type { Schema } from "@smithy/types";
 import { fromBase64, toBase64 } from "@smithy/util-base64";
 
@@ -68,15 +67,19 @@ type SerializedAttributeValue = {
  */
 class DynamoDBJsonShapeSerializer extends JsonShapeSerializer {
   /**
+   * The input value is not safe to mutate. There may be frames between this serializer and when
+   * the request handler reads the object, in which mutations will derail the request.
    * @override
    */
   protected _write(schema: Schema, value: unknown, container?: NormalizedSchema): any {
     const ns = NormalizedSchema.of(schema);
+
     if (ns.isStructSchema() && ns.getName(true) === ATTRIBUTE_VALUE) {
       if (value && typeof value === "object") {
         const av = value as AttributeValueInput;
-        const out: SerializedAttributeValue = _json(av);
+        const out: SerializedAttributeValue = this.copyRemoveNulls(av);
         const base64Encode = this.serdeContext?.base64Encoder ?? toBase64;
+
         if (av.B instanceof Uint8Array) {
           out.B = base64Encode(av.B);
         }
@@ -84,7 +87,13 @@ class DynamoDBJsonShapeSerializer extends JsonShapeSerializer {
           out.BS = av.BS.map(base64Encode);
         }
         if (Array.isArray(av.L)) {
-          out.L = av.L.filter((v) => v != null).map((v) => this._write(ns, v, container));
+          const list = [];
+          for (const v of av.L) {
+            if (v != null) {
+              list.push(this._write(ns, v, container));
+            }
+          }
+          out.L = list;
         }
         if (av.M && typeof av.M === "object") {
           out.M = {};
@@ -99,6 +108,35 @@ class DynamoDBJsonShapeSerializer extends JsonShapeSerializer {
     }
     return super._write(ns, value, container);
   }
+
+  private copyRemoveNulls(v: any): any {
+    if (typeof v !== "object") {
+      return v;
+    }
+    if (v === null) {
+      return {};
+    }
+    if (Array.isArray(v)) {
+      const out: any = [];
+      for (const item of v) {
+        if (item != null) {
+          out.push(this.copyRemoveNulls(item));
+        }
+      }
+      return out;
+    }
+    const out: any = {};
+    for (const [k, _v] of Object.entries(v)) {
+      if (_v != null) {
+        if (["B", "BS", "L", "M"].includes(k)) {
+          // handled by mutating serializer.
+          continue;
+        }
+        out[k] = this.copyRemoveNulls(_v);
+      }
+    }
+    return out;
+  }
 }
 
 /**
@@ -106,15 +144,20 @@ class DynamoDBJsonShapeSerializer extends JsonShapeSerializer {
  */
 class DynamoDBJsonShapeDeserializer extends JsonShapeDeserializer {
   /**
+   * The incoming value is safe to mutate. It is always created by the parser
+   * right before entry to this function and not owned or referenceable by anyone else.
+   *
    * @override
    */
   protected _read(schema: Schema, value: unknown): any {
     const ns = NormalizedSchema.of(schema);
+
     if (ns.isStructSchema() && ns.getName(true) === ATTRIBUTE_VALUE) {
       if (value && typeof value === "object") {
         const av = value as SerializedAttributeValue;
-        const out: AttributeValueOutput = _json(av);
+        const out: AttributeValueOutput = av as any;
         const base64Decoder = this.serdeContext?.base64Decoder ?? fromBase64;
+
         if (typeof av.B === "string") {
           out.B = base64Decoder(av.B);
         }
@@ -125,9 +168,8 @@ class DynamoDBJsonShapeDeserializer extends JsonShapeDeserializer {
           out.L = av.L.map((v) => this._read(ns, v));
         }
         if (av.M && typeof av.M === "object") {
-          out.M = {};
           for (const [k, v] of Object.entries(av.M)) {
-            out.M[k] = this._read(ns, v);
+            out.M![k] = this._read(ns, v);
           }
         }
         return out;

--- a/yarn.lock
+++ b/yarn.lock
@@ -24233,7 +24233,6 @@ __metadata:
   dependencies:
     "@aws-sdk/core": "workspace:^3.973.27"
     "@smithy/core": "npm:^3.23.14"
-    "@smithy/smithy-client": "npm:^4.12.9"
     "@smithy/types": "npm:^4.14.0"
     "@smithy/util-base64": "npm:^4.3.2"
     "@tsconfig/recommended": "npm:1.0.1"


### PR DESCRIPTION
### Issue
n/a

### Description
Improve JSON serde performance for DynamoDB. This does not apply to other JSON-based clients.

Highlight - main serialization time reduced from 196ms to 38ms in benchmark. Total workload runtime reduced from ~1400ms to ~1200ms.

Benchmark conditions: developer machine, 500x putItem + 500x getItem (1000 total requests) under maximum concurrency, each item being 24kb.

### Testing
CI includes dynamodb e2e tests.

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
