### PR TITLE
test(util-endpoints): remove bail option on endpoint tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-integration: bundles
 	make test-endpoints
 
 test-endpoints:
-	npx vitest run -c ./tests/endpoints-2.0/vitest.config.mts --bail 1
+	npx vitest run -c ./tests/endpoints-2.0/vitest.config.mts
 
 # run all e2e tests (real services).
 test-e2e: bundles


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/pull/7931

### Description
Since there isn't much of a time difference between running all the endpoint tests and stopping at the first failure. Showing all failures gives a clearer picture of what went wrong.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
