### PR TITLE
fix(core): replace Object.entries with for-in loops in shape serde

### DIFF
--- a/packages-internal/core/src/submodules/protocols/json/JsonShapeDeserializer.ts
+++ b/packages-internal/core/src/submodules/protocols/json/JsonShapeDeserializer.ts
@@ -80,7 +80,8 @@ export class JsonShapeDeserializer extends SerdeContextConfig implements ShapeDe
         } else if (typeof record.__type === "string") {
           // This if-block is for backwards compatibility support and should not be copied
           // to other implementations.
-          for (const [k, v] of Object.entries(record)) {
+          for (const k in record) {
+            const v = record[k];
             const t = jsonName ? nameMap![k] ?? k : k;
             if (!(t in out)) {
               // we have no type information, so copy as-is from JSON object.
@@ -101,8 +102,8 @@ export class JsonShapeDeserializer extends SerdeContextConfig implements ShapeDe
       if (ns.isMapSchema()) {
         const mapMember = ns.getValueSchema();
         const out = {} as any;
-        for (const [_k, _v] of Object.entries(value)) {
-          out[_k] = this._read(mapMember, _v);
+        for (const _k in value) {
+          out[_k] = this._read(mapMember, (value as Record<string, unknown>)[_k]);
         }
         return out;
       }
@@ -166,7 +167,8 @@ export class JsonShapeDeserializer extends SerdeContextConfig implements ShapeDe
     if (ns.isDocumentSchema()) {
       if (isObject) {
         const out = Array.isArray(value) ? [] : ({} as any);
-        for (const [k, v] of Object.entries(value)) {
+        for (const k in value) {
+          const v = (value as Record<string, unknown>)[k];
           if (v instanceof NumericValue) {
             out[k] = v;
           } else {

--- a/packages-internal/core/src/submodules/protocols/json/JsonShapeSerializer.ts
+++ b/packages-internal/core/src/submodules/protocols/json/JsonShapeSerializer.ts
@@ -102,7 +102,8 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
         } else if (typeof record.__type === "string") {
           // This if-block is for backwards compatibility support and should not be copied
           // to other implementations.
-          for (const [k, v] of Object.entries(record)) {
+          for (const k in record) {
+            const v = record[k];
             const targetKey = jsonName ? nameMap![k] ?? k : k;
             if (!(targetKey in out)) {
               // we have no type information, so serialize with Document rules.
@@ -129,7 +130,8 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
         const mapMember = ns.getValueSchema();
         const out = {} as any;
         const sparse = !!ns.getMergedTraits().sparse;
-        for (const [_k, _v] of Object.entries(value)) {
+        for (const _k in value as Record<string, unknown>) {
+          const _v = (value as Record<string, unknown>)[_k];
           if (sparse || _v != null) {
             out[_k] = this._write(mapMember, _v);
           }
@@ -205,7 +207,8 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
     if (ns.isDocumentSchema()) {
       if (isObject) {
         const out = Array.isArray(value) ? [] : ({} as any);
-        for (const [k, v] of Object.entries(value)) {
+        for (const k in value as Record<string, unknown>) {
+          const v = (value as Record<string, unknown>)[k];
           if (v instanceof NumericValue) {
             this.useReplacer = true;
             out[k] = v;

--- a/packages-internal/core/src/submodules/protocols/json/experimental/SinglePassJsonShapeSerializer.ts
+++ b/packages-internal/core/src/submodules/protocols/json/experimental/SinglePassJsonShapeSerializer.ts
@@ -93,7 +93,8 @@ export class SinglePassJsonShapeSerializer extends SerdeContextConfig implements
       }
     } else if (ns.isMapSchema() || ns.isDocumentSchema()) {
       b += "{";
-      for (const [k, v] of Object.entries(value)) {
+      for (const k in value) {
+        const v = (value as Record<string, unknown>)[k];
         if (v != null || sparse) {
           b += `"${k}":${this.writeValue(ns, v)}`;
           b += ",";

--- a/packages-internal/core/src/submodules/protocols/query/QueryShapeSerializer.ts
+++ b/packages-internal/core/src/submodules/protocols/query/QueryShapeSerializer.ts
@@ -119,7 +119,8 @@ export class QueryShapeSerializer extends SerdeContextConfig implements ShapeSer
         const memberSchema = ns.getValueSchema();
         const flat = ns.getMergedTraits().xmlFlattened;
         let i = 1;
-        for (const [k, v] of Object.entries(value)) {
+        for (const k in value) {
+          const v = (value as Record<string, unknown>)[k];
           if (v == null) {
             continue;
           }

--- a/packages-internal/core/src/submodules/protocols/xml/XmlShapeSerializer.ts
+++ b/packages-internal/core/src/submodules/protocols/xml/XmlShapeSerializer.ts
@@ -248,7 +248,8 @@ export class XmlShapeSerializer extends SerdeContextConfig implements ShapeSeria
     };
 
     if (flat) {
-      for (const [key, val] of Object.entries(map as object)) {
+      for (const key in map) {
+        const val = map[key];
         if (sparse || val != null) {
           const entry = XmlNode.of(mapTraits.xmlName ?? mapMember.getMemberName());
           addKeyValue(entry, key, val);
@@ -265,7 +266,8 @@ export class XmlShapeSerializer extends SerdeContextConfig implements ShapeSeria
         container.addChildNode(mapNode);
       }
 
-      for (const [key, val] of Object.entries(map as object)) {
+      for (const key in map) {
+        const val = map[key];
         if (sparse || val != null) {
           const entry = XmlNode.of("entry");
           addKeyValue(entry, key, val);


### PR DESCRIPTION
### Issue
Internal JS-6645

### Description
* Replaces Object.entries with for-in loops in shape serde
* Missed in https://github.com/aws/aws-sdk-js-v3/pull/7939

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
