### PR TITLE
chore(core/client): retry behavior control flag

### DIFF
--- a/packages-internal/core/integ/retry.integ.spec.js
+++ b/packages-internal/core/integ/retry.integ.spec.js
@@ -1,0 +1,15 @@
+const { Retry } = require("@smithy/util-retry");
+const { strictEqual } = require("node:assert");
+
+if (process.env.AWS_NEW_RETRIES_2026 === "true") {
+  strictEqual(false, Retry.v2026, "AWS_NEW_RETRIES_2026 should be inactive until @aws-sdk/core/client imported.");
+  require("@aws-sdk/core/client");
+  strictEqual(true, Retry.v2026, "AWS_NEW_RETRIES_2026 should have activated Retry.v2026.");
+  console.log("AWS_NEW_RETRIES_2026 has activated Retry.v2026.");
+} else if (process.env.SMITHY_NEW_RETRIES_2026 === "true") {
+  strictEqual(true, Retry.v2026, "SMITHY_NEW_RETRIES_2026 should have activated Retry.v2026.");
+  console.log("SMITHY_NEW_RETRIES_2026 has activated Retry.v2026.");
+} else {
+  strictEqual(false, Retry.v2026, "Retry.v2026 should be inactive.");
+  console.log("Retry.v2026 is off by default.");
+}

--- a/packages-internal/core/package.json
+++ b/packages-internal/core/package.json
@@ -12,9 +12,10 @@
     "lint": "node ../../scripts/validation/submodules-linter.js --pkg core",
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
     "extract:docs": "api-extractor run --local",
+    "test:temp:retry": "SMITHY_NEW_RETRIES_2026=true node ./integ/retry.integ.spec && AWS_NEW_RETRIES_2026=true node ./integ/retry.integ.spec && node ./integ/retry.integ.spec",
     "test": "yarn g:vitest run",
     "test:watch": "yarn g:vitest watch",
-    "test:integration": "yarn g:vitest run -c vitest.config.integ.mts",
+    "test:integration": "yarn g:vitest run -c vitest.config.integ.mts && yarn test:temp:retry",
     "test:integration:watch": "yarn g:vitest watch -c vitest.config.integ.mts"
   },
   "main": "./dist-cjs/index.js",
@@ -92,6 +93,7 @@
     "@smithy/types": "^4.14.1",
     "@smithy/util-base64": "^4.3.2",
     "@smithy/util-middleware": "^4.2.14",
+    "@smithy/util-retry": "^4.3.2",
     "@smithy/util-utf8": "^4.2.2",
     "tslib": "^2.6.2"
   },

--- a/packages-internal/core/src/submodules/client/setFeature.ts
+++ b/packages-internal/core/src/submodules/client/setFeature.ts
@@ -1,8 +1,16 @@
 import type { AwsHandlerExecutionContext, AwsSdkFeatures } from "@aws-sdk/types";
+import { Retry } from "@smithy/util-retry";
 
 /**
- * @internal
+ * This is temporary code which reads AWS_NEW_RETRIES_2026
+ * and conditionally activates the v2026 retry behavior flag.
+ * todo: this will be removed at a later date.
+ */
+Retry.v2026 ||= typeof process === "object" && process.env?.AWS_NEW_RETRIES_2026 === "true";
+
+/**
  * Indicates to the request context that a given feature is active.
+ * @internal
  *
  * @param context - handler execution context.
  * @param feature - readable name of feature.

--- a/yarn.lock
+++ b/yarn.lock
@@ -23923,6 +23923,7 @@ __metadata:
     "@smithy/types": "npm:^4.14.1"
     "@smithy/util-base64": "npm:^4.3.2"
     "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-retry": "npm:^4.3.2"
     "@smithy/util-utf8": "npm:^4.2.2"
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"


### PR DESCRIPTION
### Issue
part of JS-6800

### Description
Create an AWS env flag for retry behavior. This functions as an alternative to the base Smithy env flag.

### Testing
Pure-JS integration test (because the process.env value is not read more than once). 

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
