### PR TITLE
fix(client-s3): retry errors with 200 status code

### DIFF
--- a/clients/client-s3/src/commands/GetBucketPolicyCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketPolicyCommand.ts
@@ -1,5 +1,4 @@
 // smithy-typescript generated code
-import { getThrow200ExceptionsPlugin } from "@aws-sdk/middleware-sdk-s3";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { Command as $Command } from "@smithy/smithy-client";
 import type { MetadataBearer as __MetadataBearer } from "@smithy/types";
@@ -159,10 +158,7 @@ export class GetBucketPolicyCommand extends $Command
     Bucket: { type: "contextParams", name: "Bucket" },
   })
   .m(function (this: any, Command: any, cs: any, config: S3ClientResolvedConfig, o: any) {
-    return [
-      getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-      getThrow200ExceptionsPlugin(config),
-    ];
+    return [getEndpointPlugin(config, Command.getEndpointParameterInstructions())];
   })
   .s("AmazonS3", "GetBucketPolicy", {})
   .n("S3Client", "GetBucketPolicyCommand")

--- a/clients/client-s3/src/commands/SelectObjectContentCommand.ts
+++ b/clients/client-s3/src/commands/SelectObjectContentCommand.ts
@@ -1,5 +1,4 @@
 // smithy-typescript generated code
-import { getThrow200ExceptionsPlugin } from "@aws-sdk/middleware-sdk-s3";
 import { getSsecPlugin } from "@aws-sdk/middleware-ssec";
 import { getEndpointPlugin } from "@smithy/middleware-endpoint";
 import { Command as $Command } from "@smithy/smithy-client";
@@ -253,7 +252,6 @@ export class SelectObjectContentCommand extends $Command
   .m(function (this: any, Command: any, cs: any, config: S3ClientResolvedConfig, o: any) {
     return [
       getEndpointPlugin(config, Command.getEndpointParameterInstructions()),
-      getThrow200ExceptionsPlugin(config),
       getSsecPlugin(config),
     ];
   })

--- a/clients/client-s3/test/unit/S3.spec.ts
+++ b/clients/client-s3/test/unit/S3.spec.ts
@@ -174,6 +174,7 @@ describe("Throw 200 response", () => {
         response,
       }),
     },
+    maxAttempts: 1,
   });
 
   const params = {
@@ -281,7 +282,7 @@ describe("regional endpoints", () => {
 });
 
 describe("signing", () => {
-  it("handler recieves properly encoded path with default signingEscapePath client config option", async () => {
+  it("handler receives properly encoded path with default signingEscapePath client config option", async () => {
     const requestHandler: HttpHandler = {
       handle: async (request, handlerOptions) => {
         expect(request.path).to.equal("/some%20file.txt");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -416,7 +416,7 @@ public final class AddS3Config implements TypeScriptIntegration {
                     Optional<ShapeId> output = o.getOutput();
                     if (output.isPresent()) {
                         Shape outputShape = m.expectShape(output.get());
-                        boolean hasStreamingBlobOutputPayload = outputShape.getAllMembers()
+                        boolean hasIncompatiblePayload = outputShape.getAllMembers()
                             .values()
                             .stream()
                             .anyMatch(
@@ -427,13 +427,13 @@ public final class AddS3Config implements TypeScriptIntegration {
                                     }
                                     Shape shape = m.expectShape(memberShape.getTarget());
                                     boolean isBlob = shape.isBlobShape();
-                                    if (!isBlob) {
-                                        return false;
-                                    }
-                                    return shape.hasTrait(StreamingTrait.class);
+                                    boolean isUnion = shape.isUnionShape();
+                                    boolean isString = shape.isStringShape();
+
+                                    return (shape.hasTrait(StreamingTrait.class) && (isBlob || isUnion)) || isString;
                                 }
                             );
-                        if (hasStreamingBlobOutputPayload) {
+                        if (hasIncompatiblePayload) {
                             return false;
                         }
                     }

--- a/packages-internal/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/xml/AwsRestXmlProtocol.ts
@@ -51,7 +51,6 @@ export class AwsRestXmlProtocol extends HttpBindingProtocol {
     this.codec = new XmlCodec(settings);
     this.serializer = new HttpInterceptingShapeSerializer(this.codec.createSerializer(), settings);
     this.deserializer = new HttpInterceptingShapeDeserializer(this.codec.createDeserializer(), settings);
-    this.compositeErrorRegistry;
   }
 
   public getPayloadCodec(): XmlCodec {

--- a/packages-internal/middleware-sdk-s3/package.json
+++ b/packages-internal/middleware-sdk-s3/package.json
@@ -9,13 +9,13 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
-    "test": "yarn g:vitest run",
     "test:types": "tsc -p tsconfig.test.json",
-    "test:integration": "yarn g:vitest run -c vitest.config.integ.mts && yarn test:types",
-    "test:e2e": "yarn g:vitest run -c vitest.config.e2e.mts --mode development",
     "extract:docs": "api-extractor run --local",
+    "test": "yarn g:vitest run",
     "test:watch": "yarn g:vitest watch",
+    "test:integration": "yarn g:vitest run -c vitest.config.integ.mts && yarn test:types",
     "test:integration:watch": "yarn g:vitest watch -c vitest.config.integ.mts",
+    "test:e2e": "yarn g:vitest run -c vitest.config.e2e.mts --mode development",
     "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.mts"
   },
   "main": "./dist-cjs/index.js",
@@ -63,6 +63,13 @@
   "files": [
     "dist-*/**"
   ],
+  "browser": {
+    "./dist-es/toStream": "./dist-es/toStream.browser"
+  },
+  "react-native": {
+    "./dist-es/toStream": "./dist-es/toStream.browser",
+    "./dist-cjs/toStream": "./dist-cjs/toStream.browser"
+  },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages-internal/middleware-sdk-s3",
   "repository": {
     "type": "git",

--- a/packages-internal/middleware-sdk-s3/src/throw-200-exceptions.e2e.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/throw-200-exceptions.e2e.spec.ts
@@ -1,6 +1,9 @@
 import { S3 } from "@aws-sdk/client-s3";
 import { type GetCallerIdentityCommandOutput, STS } from "@aws-sdk/client-sts";
-import { afterAll, beforeAll, describe, test as it } from "vitest";
+import { NodeHttpHandler } from "@aws-sdk/config/requestHandler";
+import { HttpResponse } from "@smithy/protocol-http";
+import { Readable } from "node:stream";
+import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
 
 describe("S3 throw 200 exceptions", () => {
   const config = {
@@ -40,17 +43,55 @@ describe("S3 throw 200 exceptions", () => {
     s3.destroy();
   });
 
-  it("should split stream successfully for less than 3kb payload and greater than 3kb payload", async () => {
-    for (let i = 0; i < 10; ++i) {
-      await s3.listObjects({
-        Bucket,
-      });
+  it("should retry exceptions thrown from the 200-error middleware", async () => {
+    let attempt = 0;
 
-      await s3.putObject({
-        Bucket,
-        Key: i + "long-text-".repeat(10),
-        Body: "abcd",
-      });
-    }
+    const s3_2 = new S3({
+      ...config,
+      // Set credentials to avoid the requestHandler having to make any
+      // calls other than CopyObject.
+      credentials: async () => s3.config.credentials(),
+      requestHandler: new (class extends NodeHttpHandler {
+        async handle(request: any, options: any) {
+          attempt++;
+          if (attempt <= 2) {
+            return {
+              response: new HttpResponse({
+                statusCode: 200,
+                headers: { "content-type": "application/xml" },
+                body: Readable.from(
+                  Buffer.from(
+                    `
+<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>InternalError</Code>
+  <Message>We encountered an internal error. Please try again.</Message>
+  <RequestId>FAKE</RequestId>
+</Error>
+    `.trim()
+                  )
+                ),
+              }),
+            };
+          }
+          return super.handle(request, options);
+        }
+      })(),
+    });
+
+    const Key = `throw-200-test-${randId}`;
+    await s3.putObject({ Bucket, Key, Body: "hello" });
+
+    const result = await s3_2.copyObject({
+      Bucket,
+      Key: `${Key}-copy`,
+      CopySource: `${Bucket}/${Key}`,
+    });
+
+    expect(attempt).toEqual(3);
+    expect(result.$metadata.attempts).toEqual(3);
+    expect(result.CopyObjectResult).toBeDefined();
+
+    await s3.deleteObject({ Bucket, Key: `${Key}-copy` });
   });
 }, 100_000);

--- a/packages-internal/middleware-sdk-s3/src/throw-200-exceptions.integ.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/throw-200-exceptions.integ.spec.ts
@@ -1,0 +1,130 @@
+import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
+import { S3 } from "@aws-sdk/client-s3";
+import { HttpResponse } from "@smithy/protocol-http";
+import { Readable } from "node:stream";
+import { describe, expect, test as it } from "vitest";
+
+const credentials = { accessKeyId: "INTEG", secretAccessKey: "INTEG" };
+
+const xmlError = `
+  <?xml version="1.0" encoding="UTF-8"?>
+  <Error>
+    <Code>InternalError</Code>
+    <Message>We encountered an internal error. Please try again.</Message>
+    <RequestId>EXAMPLE</RequestId>
+  </Error>
+`.trim();
+
+function streamBody(content: string) {
+  return Readable.from(Buffer.from(content));
+}
+
+const matcher = { hostname: /./ };
+
+describe("200-status errors", () => {
+  it("should retry on CopyObject 200 with Error XML body", async () => {
+    const client = new S3({ region: "us-west-2", credentials });
+
+    requireRequestsFrom(client)
+      .toMatch(matcher)
+      .respondWith(
+        new HttpResponse({
+          statusCode: 200,
+          headers: {},
+          body: streamBody(xmlError),
+        }),
+        new HttpResponse({
+          statusCode: 200,
+          headers: {},
+          body: streamBody(xmlError),
+        }),
+        new HttpResponse({
+          statusCode: 200,
+          headers: {},
+          body: streamBody(
+            `
+<?xml version="1.0" encoding="UTF-8"?>
+<CopyObjectResult>
+  <ETag>&quot;etag&quot;</ETag>
+  <LastModified>2026-01-01T00:00:00.000Z</LastModified>
+</CopyObjectResult>
+`.trim()
+          ),
+        })
+      );
+
+    await client.copyObject({ Bucket: "bucket", Key: "key", CopySource: "src-bucket/src-key" });
+  });
+
+  it("should retry on CompleteMultipartUpload 200 with Error XML body", async () => {
+    const client = new S3({ region: "us-west-2", credentials });
+
+    requireRequestsFrom(client)
+      .toMatch(matcher)
+      .respondWith(
+        new HttpResponse({
+          statusCode: 200,
+          headers: {},
+          body: streamBody(xmlError),
+        }),
+        new HttpResponse({
+          statusCode: 200,
+          headers: {},
+          body: streamBody(xmlError),
+        }),
+        new HttpResponse({
+          statusCode: 200,
+          headers: {},
+          body: streamBody(
+            `
+<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUploadResult>
+   <Location>string</Location>
+   <Bucket>string</Bucket>
+   <Key>string</Key>
+   <ETag>string</ETag>
+   <ChecksumCRC32>string</ChecksumCRC32>
+   <ChecksumCRC32C>string</ChecksumCRC32C>
+   <ChecksumCRC64NVME>string</ChecksumCRC64NVME>
+   <ChecksumSHA1>string</ChecksumSHA1>
+   <ChecksumSHA256>string</ChecksumSHA256>
+   <ChecksumType>string</ChecksumType>
+</CompleteMultipartUploadResult>
+`.trim()
+          ),
+        })
+      );
+
+    await client.completeMultipartUpload({
+      Bucket: "bucket",
+      Key: "key",
+      UploadId: "upload-id",
+      MultipartUpload: { Parts: [] },
+    });
+  });
+
+  it("should not throw on CopyObject 200 with success XML body", async () => {
+    const client = new S3({ region: "us-west-2", credentials, maxAttempts: 1 });
+
+    requireRequestsFrom(client)
+      .toMatch(matcher)
+      .respondWith(
+        new HttpResponse({
+          statusCode: 200,
+          headers: {},
+          body: streamBody(
+            `
+<?xml version="1.0" encoding="UTF-8"?>
+<CopyObjectResult>
+  <ETag>&quot;etag&quot;</ETag>
+  <LastModified>2026-01-01T00:00:00.000Z</LastModified>
+</CopyObjectResult>
+`.trim()
+          ),
+        })
+      );
+
+    const result = await client.copyObject({ Bucket: "bucket", Key: "key", CopySource: "src-bucket/src-key" });
+    expect(result.$metadata.httpStatusCode).toBe(200);
+  });
+});

--- a/packages-internal/middleware-sdk-s3/src/throw-200-exceptions.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/throw-200-exceptions.spec.ts
@@ -1,3 +1,4 @@
+import { streamCollector } from "@smithy/node-http-handler";
 import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { toUtf8 } from "@smithy/util-utf8";
 import { Readable } from "node:stream";
@@ -10,6 +11,7 @@ describe("throw200ExceptionsMiddlewareOptions", () => {
   const mockResponse = vi.fn();
   const mockConfig = {
     utf8Encoder: toUtf8,
+    streamCollector,
   };
 
   beforeEach(() => {
@@ -119,11 +121,10 @@ describe("throw200ExceptionsMiddlewareOptions", () => {
     });
 
     /**
-     * This is an exception to the specification. We cannot afford to read
-     * a streaming body for its entire duration just to check for an extremely unlikely
-     * terminating XML tag if the stream is very long.
+     * The body is fully collected, so even a long Error XML body
+     * will be detected and the status code rewritten.
      */
-    it("should not throw if the Error tag is on an excessively long body", async () => {
+    it("should throw if the Error tag is on an excessively long body", async () => {
       const errorBody = `<?xml version="1.0" encoding="UTF-8"?>
 <Error xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  ${"a".repeat(3000)}
@@ -144,7 +145,7 @@ describe("throw200ExceptionsMiddlewareOptions", () => {
       });
       expect(HttpResponse.isInstance(response)).toBe(true);
       // @ts-ignore
-      expect(response.statusCode).toEqual(200);
+      expect(response.statusCode).toBeGreaterThanOrEqual(400);
     });
   });
 });

--- a/packages-internal/middleware-sdk-s3/src/throw-200-exceptions.ts
+++ b/packages-internal/middleware-sdk-s3/src/throw-200-exceptions.ts
@@ -3,13 +3,16 @@ import type {
   DeserializeMiddleware,
   Encoder,
   HandlerExecutionContext,
+  MetadataBearer,
   Pluggable,
   RelativeMiddlewareOptions,
   StreamCollector,
 } from "@smithy/types";
-import { headStream, splitStream } from "@smithy/util-stream";
+
+import { toStream } from "./toStream";
 
 type PreviouslyResolved = {
+  streamCollector: StreamCollector;
   utf8Encoder: Encoder;
 };
 
@@ -21,13 +24,6 @@ const THROW_IF_EMPTY_BODY: Record<string, boolean> = {
   UploadPartCopyCommand: true,
   CompleteMultipartUploadCommand: true,
 };
-
-/**
- * @internal
- * We will check at most this many bytes from the stream when looking for
- * an error-like 200 status.
- */
-const MAX_BYTES_TO_INSPECT = 3000;
 
 /**
  * In case of an internal error/terminated connection, S3 operations may return 200 errors. CopyObject, UploadPartCopy,
@@ -43,51 +39,32 @@ export const throw200ExceptionsMiddleware =
     if (!HttpResponse.isInstance(response)) {
       return result;
     }
-    const { statusCode, body: sourceBody } = response;
+    const { statusCode, body } = response;
+
+    // This middleware applies to 2xx.
     if (statusCode < 200 || statusCode >= 300) {
       return result;
     }
 
-    const isSplittableStream =
-      typeof sourceBody?.stream === "function" ||
-      typeof sourceBody?.pipe === "function" ||
-      typeof sourceBody?.tee === "function";
+    const bodyBytes: Uint8Array = await collectBody(body, config);
+    response.body = toStream(bodyBytes);
 
-    if (!isSplittableStream) {
-      return result;
-    }
-
-    let bodyCopy = sourceBody;
-    let body = sourceBody;
-
-    if (sourceBody && typeof sourceBody === "object" && !(sourceBody instanceof Uint8Array)) {
-      [bodyCopy, body] = await splitStream(sourceBody);
-    }
-    // restore split body to the response for deserialization.
-    response.body = body;
-
-    const bodyBytes: Uint8Array = await collectBody(bodyCopy, {
-      streamCollector: async (stream: any) => {
-        return headStream(stream, MAX_BYTES_TO_INSPECT);
-      },
-    });
-    if (typeof bodyCopy?.destroy === "function") {
-      // discard partially-read Node.js Stream.
-      bodyCopy.destroy();
+    // Throw on 200 response with empty body, legacy behavior allowlist.
+    if (bodyBytes.length === 0 && THROW_IF_EMPTY_BODY[context.commandName!]) {
+      const err = new Error("S3 aborted request") as Error & MetadataBearer;
+      err.$metadata = {
+        httpStatusCode: 503,
+      };
+      err.name = "InternalError";
+      throw err;
     }
 
     const bodyStringTail = config.utf8Encoder(bodyBytes.subarray(bodyBytes.length - 16));
 
-    // Throw on 200 response with empty body, legacy behavior allowlist.
-    if (bodyBytes.length === 0 && THROW_IF_EMPTY_BODY[context.commandName!]) {
-      const err = new Error("S3 aborted request");
-      err.name = "InternalError";
-      throw err;
-    }
     // Generalized throw-on-200 for top level Error element and non-streaming response.
     if (bodyStringTail && bodyStringTail.endsWith("</Error>")) {
-      // Set the error code to 4XX so that error deserializer can parse them
-      response.statusCode = 400;
+      // Synthetic 503 to indicate retryable.
+      response.statusCode = 503;
     }
 
     return result;

--- a/packages-internal/middleware-sdk-s3/src/toStream.browser.ts
+++ b/packages-internal/middleware-sdk-s3/src/toStream.browser.ts
@@ -1,0 +1,11 @@
+/**
+ * @internal
+ */
+export function toStream(bytes: Uint8Array): ReadableStream {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}

--- a/packages-internal/middleware-sdk-s3/src/toStream.ts
+++ b/packages-internal/middleware-sdk-s3/src/toStream.ts
@@ -1,0 +1,8 @@
+import { Readable } from "node:stream";
+
+/**
+ * @internal
+ */
+export function toStream(bytes: Uint8Array): Readable {
+  return Readable.from(Buffer.from(bytes));
+}


### PR DESCRIPTION
### Issue
JS-6800

### Description
Retry for errors thrown by the S3 200-status error middleware.

### Testing
new integration tests, CI

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [x] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [ ] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
