### PR TITLE
fix(client-sts): override IDPCommunicationError to be retryable

### DIFF
--- a/clients/client-sts/src/models/errors.ts
+++ b/clients/client-sts/src/models/errors.ts
@@ -151,6 +151,7 @@ export class InvalidIdentityTokenException extends __BaseException {
 export class IDPCommunicationErrorException extends __BaseException {
   readonly name = "IDPCommunicationErrorException" as const;
   readonly $fault = "client" as const;
+  $retryable = {};
   /**
    * @internal
    */

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSTSAuthCustomizations.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSTSAuthCustomizations.java
@@ -21,8 +21,11 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.AuthTrait;
+import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.OptionalAuthTrait;
+import software.amazon.smithy.model.traits.RetryableTrait;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
@@ -49,6 +52,8 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
     private static final Logger LOGGER = Logger.getLogger(AddSTSAuthCustomizations.class.getName());
     private static final ShapeId STS_SERVICE =
         ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615");
+    private static final ShapeId IDP_COMMUNICATION_ERROR_EXCEPTION =
+        ShapeId.from("com.amazonaws.sts#IDPCommunicationErrorException");
     private static final Set<ShapeId> OPTIONAL_AUTH_OPERATIONS = Set.of(
         ShapeId.from("com.amazonaws.sts#AssumeRoleWithWebIdentity"),
         ShapeId.from("com.amazonaws.sts#AssumeRoleWithSAML")
@@ -79,7 +84,9 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
 
     @Override
     public Model preprocessModel(Model model, TypeScriptSettings settings) {
-        return backfillOptionalAuthOperations(model, settings);
+        model = backfillOptionalAuthOperations(model, settings);
+        model = addRetryableToIdpCommunicationError(model);
+        return model;
     }
 
     private Model backfillOptionalAuthOperations(Model model, TypeScriptSettings settings) {
@@ -92,6 +99,20 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
                         .toBuilder()
                         .addTrait(new OptionalAuthTrait())
                         .addTrait(new AuthTrait(Collections.emptySet()))
+                        .build()
+                )
+                .build();
+        }
+        return model;
+    }
+
+    private Model addRetryableToIdpCommunicationError(Model model) {
+        StructureShape shape = model.expectShape(IDP_COMMUNICATION_ERROR_EXCEPTION, StructureShape.class);
+        if (shape.hasTrait(ErrorTrait.ID) && !shape.hasTrait(RetryableTrait.ID)) {
+            return model.toBuilder()
+                .addShape(
+                    shape.toBuilder()
+                        .addTrait(RetryableTrait.builder().build())
                         .build()
                 )
                 .build();

--- a/packages-internal/core/integ/retry-customizations.integ.spec.ts
+++ b/packages-internal/core/integ/retry-customizations.integ.spec.ts
@@ -1,6 +1,10 @@
+import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 import { DynamoDBStreams } from "@aws-sdk/client-dynamodb-streams";
+import { STS } from "@aws-sdk/client-sts";
+import { HttpResponse } from "@smithy/protocol-http";
 import { AdaptiveRetryStrategy, Retry, StandardRetryStrategy } from "@smithy/util-retry";
+import { Readable } from "node:stream";
 import { beforeAll, describe, expect, test as it } from "vitest";
 
 describe("retry customization", () => {
@@ -55,4 +59,96 @@ describe("retry customization", () => {
       });
     });
   }
+
+  describe("STS", () => {
+    it("IDPCommunicationError is retryable", async () => {
+      const sts = new STS({
+        region: "us-west-2",
+        credentials: {
+          accessKeyId: "INTEG",
+          secretAccessKey: "INTEG",
+        },
+      });
+
+      requireRequestsFrom(sts)
+        .toMatch({
+          hostname: /./,
+        })
+        .respondWith(
+          new HttpResponse({
+            statusCode: 400,
+            headers: {
+              "content-type": "text/xml",
+            },
+            body: Readable.from(
+              Buffer.from(
+                `
+<ErrorResponse>
+    <Error>
+        <Type>Sender</Type>
+        <Code>IDPCommunicationError</Code>
+        <Message>Oh No 1</Message>
+    </Error>
+    <RequestId>c6104cbe-af31-11e0-8154-cbc7ccf896c7</RequestId>
+</ErrorResponse>
+            `.trim()
+              )
+            ),
+          }),
+          new HttpResponse({
+            statusCode: 400,
+            headers: {
+              "content-type": "text/xml",
+            },
+            body: Readable.from(
+              Buffer.from(
+                `
+<ErrorResponse>
+    <Error>
+        <Type>Sender</Type>
+        <Code>IDPCommunicationError</Code>
+        <Message>Oh No 2</Message>
+    </Error>
+    <RequestId>c6104cbe-af31-11e0-8154-cbc7ccf896c7</RequestId>
+</ErrorResponse>
+            `.trim()
+              )
+            ),
+          }),
+          new HttpResponse({
+            statusCode: 200,
+            headers: {
+              "content-type": "text/xml",
+            },
+            body: Readable.from(
+              Buffer.from(
+                `
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+  <SourceIdentity>Alice</SourceIdentity>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/demo/TestAR</Arn>
+      <AssumedRoleId>ARO123EXAMPLE123:TestAR</AssumedRoleId>
+    </AssumedRoleUser>
+    <Credentials>
+      <AccessKeyId>akid</AccessKeyId>
+      <SecretAccessKey>sak</SecretAccessKey>
+      <SessionToken>token</SessionToken>
+      <Expiration>2050-11-09T13:34:41Z</Expiration>
+    </Credentials>
+  </AssumeRoleResult>
+  <ResponseMetadata>
+    <RequestId>c6104cbe-af31-11e0-8154-cbc7ccf896c7</RequestId>
+  </ResponseMetadata>
+</AssumeRoleResponse>
+            `.trim()
+              )
+            ),
+          })
+        );
+
+      const id = await sts.getCallerIdentity({});
+      expect(id.$metadata.attempts).toEqual(3);
+    });
+  });
 });

--- a/packages-internal/nested-clients/src/submodules/sts/models/errors.ts
+++ b/packages-internal/nested-clients/src/submodules/sts/models/errors.ts
@@ -151,6 +151,7 @@ export class InvalidIdentityTokenException extends __BaseException {
 export class IDPCommunicationErrorException extends __BaseException {
   readonly name = "IDPCommunicationErrorException" as const;
   readonly $fault = "client" as const;
+  $retryable = {};
   /**
    * @internal
    */


### PR DESCRIPTION
### Issue
JS-6800

### Description
Using model preprocessing, set STS' IDPCommunicationError to be retryable in accordance to the Retry 2.1 spec.

### Testing
CI, new integ tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
