### PR TITLE
chore(xml-builder): up fast-xml-parser to 5.7.1

### DIFF
--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -4,7 +4,7 @@
   "description": "XML utilities for the AWS SDK",
   "dependencies": {
     "@smithy/types": "^4.14.1",
-    "fast-xml-parser": "5.5.8",
+    "fast-xml-parser": "5.7.1",
     "tslib": "^2.6.2"
   },
   "scripts": {

--- a/packages-internal/xml-builder/src/xml-parser.spec.ts
+++ b/packages-internal/xml-builder/src/xml-parser.spec.ts
@@ -207,6 +207,16 @@ describe("xml parsing", () => {
     expect(parseXMLBrowser(xml)).toEqual(parseXML(xml));
   });
 
+  it("should resolve numeric character references for CR and LF", () => {
+    const xml = `<Response><Message>line1&#xD;&#10;line2&#x0A;line3</Message></Response>`;
+    const object = parseXML(xml);
+    expect(object).toEqual({
+      Response: {
+        Message: "line1\r\nline2\nline3",
+      },
+    });
+  });
+
   it("throws on parsing error", () => {
     const xmlSamples = [`<unclosed`, `<unmatched></matched>`];
 

--- a/packages-internal/xml-builder/src/xml-parser.ts
+++ b/packages-internal/xml-builder/src/xml-parser.ts
@@ -20,8 +20,6 @@ const parser = new XMLParser({
   tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
   maxNestedTags: Infinity,
 });
-parser.addEntity("#xD", "\r");
-parser.addEntity("#10", "\n");
 
 /**
  * @internal

--- a/private/aws-protocoltests-restxml-schema/package.json
+++ b/private/aws-protocoltests-restxml-schema/package.json
@@ -62,7 +62,7 @@
     "@smithy/util-stream": "^4.5.24",
     "@smithy/util-utf8": "^4.2.2",
     "entities": "2.2.0",
-    "fast-xml-parser": "5.5.8",
+    "fast-xml-parser": "5.7.1",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restxml-schema/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml-schema/test/functional/restxml.spec.ts
@@ -8581,18 +8581,21 @@ const compareEquivalentXmlBodies = (
 ): Object => {
   const parseConfig = {
     attributeNamePrefix: "",
+    processEntities: {
+      enabled: true,
+      maxTotalExpansions: Infinity,
+    },
     htmlEntities: true,
     ignoreAttributes: false,
     ignoreDeclaration: true,
     parseTagValue: false,
     trimValues: false,
     tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+    maxNestedTags: Infinity,
   };
 
   const parseXmlBody = (body: string) => {
     const parser = new XMLParser(parseConfig);
-    parser.addEntity("#xD", "\r");
-    parser.addEntity("#10", "\n");
     const parsedObj = parser.parse(body);
     const textNodeName = "#text";
     const key = Object.keys(parsedObj)[0];

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -64,7 +64,7 @@
     "@smithy/util-utf8": "^4.2.2",
     "@smithy/uuid": "^1.1.2",
     "entities": "2.2.0",
-    "fast-xml-parser": "5.5.8",
+    "fast-xml-parser": "5.7.1",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
@@ -8581,18 +8581,21 @@ const compareEquivalentXmlBodies = (
 ): Object => {
   const parseConfig = {
     attributeNamePrefix: "",
+    processEntities: {
+      enabled: true,
+      maxTotalExpansions: Infinity,
+    },
     htmlEntities: true,
     ignoreAttributes: false,
     ignoreDeclaration: true,
     parseTagValue: false,
     trimValues: false,
     tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+    maxNestedTags: Infinity,
   };
 
   const parseXmlBody = (body: string) => {
     const parser = new XMLParser(parseConfig);
-    parser.addEntity("#xD", "\r");
-    parser.addEntity("#10", "\n");
     const parsedObj = parser.parse(body);
     const textNodeName = "#text";
     const key = Object.keys(parsedObj)[0];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,7 +1176,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:5.5.8"
+    fast-xml-parser: "npm:5.7.1"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -1236,7 +1236,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:5.5.8"
+    fast-xml-parser: "npm:5.7.1"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -25487,7 +25487,7 @@ __metadata:
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
-    fast-xml-parser: "npm:5.5.8"
+    fast-xml-parser: "npm:5.7.1"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -28554,6 +28554,13 @@ __metadata:
     "@emnapi/runtime": "npm:^1.4.3"
     "@tybys/wasm-util": "npm:^0.10.0"
   checksum: 10c0/6d07922c0613aab30c6a497f4df297ca7c54e5b480e00035e0209b872d5c6aab7162fc49477267556109c2c7ed1eb9c65a174e27e9b87568106a87b0a6e3ca7d
+  languageName: node
+  linkType: hard
+
+"@nodable/entities@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@nodable/entities@npm:2.1.0"
+  checksum: 10c0/5a4cba2b61a5b6c726328b18b1de6d033cae4a658a118644bf31e0bcbda126ea7b69385043dc556cf1ed859b9ca220e82b81b5e5c48ef1b519fb8ec104575dee
   languageName: node
   linkType: hard
 
@@ -34565,25 +34572,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "fast-xml-builder@npm:1.1.4"
+"fast-xml-builder@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "fast-xml-builder@npm:1.1.5"
   dependencies:
     path-expression-matcher: "npm:^1.1.3"
-  checksum: 10c0/d5dfc0660f7f886b9f42747e6aa1d5e16c090c804b322652f65a5d7ffb93aa00153c3e1276cd053629f9f4c4f625131dc6886677394f7048e827e63b97b18927
+  checksum: 10c0/b814ba5559cb3140de46d2846045607ab4d4c0bfc312a49d22c91efb9f7cd7004971314841e5823eeb467a5bf403e3ade8371b7912200e111df027d42ae51715
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.5.8":
-  version: 5.5.8
-  resolution: "fast-xml-parser@npm:5.5.8"
+"fast-xml-parser@npm:5.7.1":
+  version: 5.7.1
+  resolution: "fast-xml-parser@npm:5.7.1"
   dependencies:
-    fast-xml-builder: "npm:^1.1.4"
-    path-expression-matcher: "npm:^1.2.0"
-    strnum: "npm:^2.2.0"
+    "@nodable/entities": "npm:^2.1.0"
+    fast-xml-builder: "npm:^1.1.5"
+    path-expression-matcher: "npm:^1.5.0"
+    strnum: "npm:^2.2.3"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/b0eb5b5b4b02bb2dfac2fac4c19ce834017553e1f74499929a196b67bfe0741389a89dca4662c97bff138646d7c5fd985af59c7a216c433717e854de3355638c
+  checksum: 10c0/b8b54e33060da5fc5ce26fdc73c4728f18415f9be9a774f1406b03265a5b411b742c39dba0127c3f0f31fad5b3ee11f51be79aa16df160f69fd5e4b902bfbb85
   languageName: node
   linkType: hard
 
@@ -39353,10 +39361,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-expression-matcher@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "path-expression-matcher@npm:1.2.0"
-  checksum: 10c0/86c661dfb265ed5dd1ddd9188f0dfbecf4ec4dc3ea6cabab081d3a2ba285054d9767a641a233bd6fd694fd89f7d0ef94913032feddf5365252700b02db4bf4e1
+"path-expression-matcher@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "path-expression-matcher@npm:1.5.0"
+  checksum: 10c0/646cb5bc66cd7d809a52288336f3ac1e6223f156fd8e912936e490e590f7f93e8056d4fd25fcbcc7da61bb698fa520112cb050372a3f65e7b79bd4afa0f77610
   languageName: node
   linkType: hard
 
@@ -41287,10 +41295,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^2.2.0":
-  version: 2.2.1
-  resolution: "strnum@npm:2.2.1"
-  checksum: 10c0/2773632d58f71ef35a3e9111da6533ba5f7da10edcb86ff5c19e0194c017d22509bc6c5cad4902535de384462170f830dc67e2cbd8060d3375f52466a22fb169
+"strnum@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "strnum@npm:2.2.3"
+  checksum: 10c0/1ee78101f1cd73a5b32f63cfd0be501bd246801a002f5987efef903a49e9297d1b63574e302ab3c06ee5e715c524d6cbdfef010e372ec1ea848e0179836cc208
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue
FAQ: https://github.com/aws/aws-sdk-js-v3/issues/7366

Today's CVE: https://github.com/aws/aws-sdk-js-v3/issues/7949

- [x] Breaking changes are mentioned so this PR will need to be updated.

### Description
See FAQ

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
