### PR TITLE
test(client-kinesis): tolerance for flaky H2 session ordering assertion in E2E test

### DIFF
--- a/clients/client-kinesis/test/Kinesis.e2e.spec.ts
+++ b/clients/client-kinesis/test/Kinesis.e2e.spec.ts
@@ -272,7 +272,8 @@ describe("@aws-sdk/client-kinesis", () => {
           expect(totalRequests).toBeGreaterThanOrEqual(53 + 17);
         }
         for (let i = 1; i < batch.length; ++i) {
-          expect(batch[i - 1].totalRequests).toBeGreaterThanOrEqual(batch[i].totalRequests);
+          // Allow a tolerance of 2 for non-deterministic HTTP/2 request distribution.
+          expect(batch[i - 1].totalRequests).toBeGreaterThanOrEqual(batch[i].totalRequests - 2);
         }
       }
     });


### PR DESCRIPTION
### Issue
Internal JS-6812

### Description
HTTP/2 request distribution across sessions doesn't seem to be perfectly deterministic probably due to stream scheduling or network factors. A tolerance of 2 still validates the "front-loaded" distribution behavior while eliminating the flakiness. In failing tests, it was only off by 1, so 2 seems like a safe bet.

### Testing
PR build.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
