### PR TITLE
fix(clients): re-enable default http2 session concurrency

### DIFF
--- a/clients/client-bedrock-runtime/src/runtimeConfig.ts
+++ b/clients/client-bedrock-runtime/src/runtimeConfig.ts
@@ -85,10 +85,7 @@ export const getRuntimeConfig = (config: BedrockRuntimeClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-bedrock-runtime/src/runtimeConfig.ts
+++ b/clients/client-bedrock-runtime/src/runtimeConfig.ts
@@ -80,10 +80,7 @@ export const getRuntimeConfig = (config: BedrockRuntimeClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-bedrock-runtime/test/BedrockRuntime.e2e.spec.ts
+++ b/clients/client-bedrock-runtime/test/BedrockRuntime.e2e.spec.ts
@@ -1,3 +1,4 @@
+import type { ListAsyncInvokesCommandOutput } from "@aws-sdk/client-bedrock-runtime";
 import { BedrockRuntime } from "@aws-sdk/client-bedrock-runtime";
 import { SignatureV4 } from "@smithy/signature-v4";
 import { toBase64, toUtf8 } from "@smithy/core/serde";
@@ -7,6 +8,9 @@ describe("BedrockRuntime", () => {
   const client = new BedrockRuntime({
     region: "us-west-2",
     credentials: aws?.testCredentials,
+    requestHandler: {
+      maxConcurrentStreams: 3,
+    },
   });
 
   let signerCredentialProviderSpy: any;
@@ -68,6 +72,7 @@ describe("BedrockRuntime", () => {
     const inputEnd = new Promise((r) => {
       resolve = r;
     });
+    const listAsyncInvokesOutputs: ListAsyncInvokesCommandOutput[] = [];
 
     const response = await client.invokeModelWithBidirectionalStream({
       modelId,
@@ -177,6 +182,15 @@ describe("BedrockRuntime", () => {
               },
             };
 
+            // At midpoint, fire parallel requests over the same client
+            // to verify HTTP/2 session concurrency doesn't interfere with the ongoing stream.
+            if (it === 10) {
+              const results = await Promise.all(
+                Array.from({ length: 8 }, () => client.listAsyncInvokes({ maxResults: 1 }))
+              );
+              listAsyncInvokesOutputs.push(...results);
+            }
+
             if (it % 15 === 3) {
               yields.push("contentEnd");
               yield {
@@ -264,6 +278,40 @@ describe("BedrockRuntime", () => {
       "promptEnd",
       "sessionEnd",
     ]);
+
+    // Verify parallel requests completed successfully during the bidirectional stream.
+    expect(listAsyncInvokesOutputs).toHaveLength(8);
+    for (const result of listAsyncInvokesOutputs) {
+      expect(result.$metadata.httpStatusCode).toBe(200);
+    }
+
+    const h2SessionState = (client.config.requestHandler as any).connectionManager?.debug?.();
+    if (h2SessionState) {
+      expect(h2SessionState).toMatchObject({
+        "https://bedrock-runtime.us-west-2.amazonaws.com/": {
+          sessions: [
+            {
+              active: expect.any(Number),
+              id: expect.any(Number),
+              maxConcurrent: 3,
+              totalRequests: 3,
+            },
+            {
+              active: expect.any(Number),
+              id: expect.any(Number),
+              maxConcurrent: 3,
+              totalRequests: 3,
+            },
+            {
+              active: expect.any(Number),
+              id: expect.any(Number),
+              maxConcurrent: 2,
+              totalRequests: 2,
+            },
+          ],
+        },
+      });
+    }
 
     // There are no other response fields currently.
     // Therefore, there is no difference in assertions for WebSocket and HTTP2.

--- a/clients/client-bedrock-runtime/test/BedrockRuntime.e2e.spec.ts
+++ b/clients/client-bedrock-runtime/test/BedrockRuntime.e2e.spec.ts
@@ -1,3 +1,4 @@
+import type { ListAsyncInvokesCommandOutput } from "@aws-sdk/client-bedrock-runtime";
 import { BedrockRuntime } from "@aws-sdk/client-bedrock-runtime";
 import { SignatureV4 } from "@smithy/signature-v4";
 import { toBase64 } from "@smithy/util-base64";
@@ -8,6 +9,9 @@ describe("BedrockRuntime", () => {
   const client = new BedrockRuntime({
     region: "us-west-2",
     credentials: aws?.testCredentials,
+    requestHandler: {
+      maxConcurrentStreams: 3,
+    },
   });
 
   let signerCredentialProviderSpy: any;
@@ -69,6 +73,7 @@ describe("BedrockRuntime", () => {
     const inputEnd = new Promise((r) => {
       resolve = r;
     });
+    const listAsyncInvokesOutputs: ListAsyncInvokesCommandOutput[] = [];
 
     const response = await client.invokeModelWithBidirectionalStream({
       modelId,
@@ -178,6 +183,15 @@ describe("BedrockRuntime", () => {
               },
             };
 
+            // At midpoint, fire parallel requests over the same client
+            // to verify HTTP/2 session concurrency doesn't interfere with the ongoing stream.
+            if (it === 10) {
+              const results = await Promise.all(
+                Array.from({ length: 8 }, () => client.listAsyncInvokes({ maxResults: 1 }))
+              );
+              listAsyncInvokesOutputs.push(...results);
+            }
+
             if (it % 15 === 3) {
               yields.push("contentEnd");
               yield {
@@ -265,6 +279,40 @@ describe("BedrockRuntime", () => {
       "promptEnd",
       "sessionEnd",
     ]);
+
+    // Verify parallel requests completed successfully during the bidirectional stream.
+    expect(listAsyncInvokesOutputs).toHaveLength(8);
+    for (const result of listAsyncInvokesOutputs) {
+      expect(result.$metadata.httpStatusCode).toBe(200);
+    }
+
+    const h2SessionState = (client.config.requestHandler as any).connectionManager?.debug?.();
+    if (h2SessionState) {
+      expect(h2SessionState).toMatchObject({
+        "https://bedrock-runtime.us-west-2.amazonaws.com/": {
+          sessions: [
+            {
+              active: expect.any(Number),
+              id: expect.any(Number),
+              maxConcurrent: 3,
+              totalRequests: 3,
+            },
+            {
+              active: expect.any(Number),
+              id: expect.any(Number),
+              maxConcurrent: 3,
+              totalRequests: 3,
+            },
+            {
+              active: expect.any(Number),
+              id: expect.any(Number),
+              maxConcurrent: 2,
+              totalRequests: 2,
+            },
+          ],
+        },
+      });
+    }
 
     // There are no other response fields currently.
     // Therefore, there is no difference in assertions for WebSocket and HTTP2.

--- a/clients/client-connecthealth/src/runtimeConfig.ts
+++ b/clients/client-connecthealth/src/runtimeConfig.ts
@@ -60,10 +60,7 @@ export const getRuntimeConfig = (config: ConnectHealthClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-connecthealth/src/runtimeConfig.ts
+++ b/clients/client-connecthealth/src/runtimeConfig.ts
@@ -55,10 +55,7 @@ export const getRuntimeConfig = (config: ConnectHealthClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-kinesis/src/runtimeConfig.ts
+++ b/clients/client-kinesis/src/runtimeConfig.ts
@@ -58,10 +58,7 @@ export const getRuntimeConfig = (config: KinesisClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-kinesis/src/runtimeConfig.ts
+++ b/clients/client-kinesis/src/runtimeConfig.ts
@@ -53,10 +53,7 @@ export const getRuntimeConfig = (config: KinesisClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-lex-runtime-v2/src/runtimeConfig.ts
+++ b/clients/client-lex-runtime-v2/src/runtimeConfig.ts
@@ -60,10 +60,7 @@ export const getRuntimeConfig = (config: LexRuntimeV2ClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-lex-runtime-v2/src/runtimeConfig.ts
+++ b/clients/client-lex-runtime-v2/src/runtimeConfig.ts
@@ -55,10 +55,7 @@ export const getRuntimeConfig = (config: LexRuntimeV2ClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-polly/src/runtimeConfig.ts
+++ b/clients/client-polly/src/runtimeConfig.ts
@@ -60,10 +60,7 @@ export const getRuntimeConfig = (config: PollyClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-polly/src/runtimeConfig.ts
+++ b/clients/client-polly/src/runtimeConfig.ts
@@ -55,10 +55,7 @@ export const getRuntimeConfig = (config: PollyClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-qbusiness/src/runtimeConfig.ts
+++ b/clients/client-qbusiness/src/runtimeConfig.ts
@@ -60,10 +60,7 @@ export const getRuntimeConfig = (config: QBusinessClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-qbusiness/src/runtimeConfig.ts
+++ b/clients/client-qbusiness/src/runtimeConfig.ts
@@ -55,10 +55,7 @@ export const getRuntimeConfig = (config: QBusinessClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-sagemaker-runtime-http2/src/runtimeConfig.ts
+++ b/clients/client-sagemaker-runtime-http2/src/runtimeConfig.ts
@@ -60,10 +60,7 @@ export const getRuntimeConfig = (config: SageMakerRuntimeHTTP2ClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-sagemaker-runtime-http2/src/runtimeConfig.ts
+++ b/clients/client-sagemaker-runtime-http2/src/runtimeConfig.ts
@@ -55,10 +55,7 @@ export const getRuntimeConfig = (config: SageMakerRuntimeHTTP2ClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-transcribe-streaming/src/runtimeConfig.ts
+++ b/clients/client-transcribe-streaming/src/runtimeConfig.ts
@@ -60,10 +60,7 @@ export const getRuntimeConfig = (config: TranscribeStreamingClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-transcribe-streaming/src/runtimeConfig.ts
+++ b/clients/client-transcribe-streaming/src/runtimeConfig.ts
@@ -55,10 +55,7 @@ export const getRuntimeConfig = (config: TranscribeStreamingClientConfig) => {
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}
     ),
-    requestHandler: RequestHandler.create(config?.requestHandler ?? (async () => ({
-      ...await defaultConfigProvider(),
-      disableConcurrentStreams: true
-    }))),
+    requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig(

--- a/clients/client-transcribe-streaming/test/TranscribeStreaming.e2e.spec.ts
+++ b/clients/client-transcribe-streaming/test/TranscribeStreaming.e2e.spec.ts
@@ -53,13 +53,49 @@ describe("TranscribeStream client", { retry: 4 }, () => {
 
           expect(result.TranscriptResultStream).toBeDefined();
           const transcripts: any[] = [];
+          let parallelRequestsDone = false;
           for await (const event of result.TranscriptResultStream!) {
             transcripts.push(event);
+
+            // After receiving the first event, fire parallel read requests over the same client
+            // to verify HTTP/2 session concurrency doesn't interfere with the ongoing stream.
+            if (!parallelRequestsDone && transcripts.length === 1 && i === 0) {
+              parallelRequestsDone = true;
+              const results = await Promise.allSettled(
+                Array.from({ length: 3 }, () => client.getMedicalScribeStream({ SessionId: "non-existent-session-id" }))
+              );
+              for (const r of results) {
+                // A rejected request with a service error still proves the HTTP/2 round-trip succeeded
+                // concurrently with the active stream.
+                expect(r.status === "rejected" ? r.reason?.name : r.status).toMatch(/InternalFailure/);
+              }
+            }
           }
 
           expect(transcripts.filter((event) => event["TranscriptEvent"]).length).toBeGreaterThan(0);
         })
       );
+
+      const h2SessionState = (client.config.requestHandler as any).connectionManager?.debug?.();
+      if (h2SessionState) {
+        expect(h2SessionState).toMatchObject({
+          "https://transcribestreaming.us-west-2.amazonaws.com/": {
+            sessions: [
+              {
+                active: expect.any(Number),
+                id: expect.any(Number),
+                maxConcurrent: 3,
+                totalRequests: expect.any(Number),
+              },
+            ],
+          },
+        });
+        expect(
+          h2SessionState["https://transcribestreaming.us-west-2.amazonaws.com/"].sessions
+            .map((s: any) => s.totalRequests)
+            .reduce((a: number, b: number) => a + b, 0)
+        ).toEqual(45);
+      }
     }
   );
 });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
@@ -42,11 +42,7 @@ public class AddHttp2Dependency implements TypeScriptIntegration {
                         "RequestHandler",
                         TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER
                     );
-                    writer.openBlock("RequestHandler.create(config?.requestHandler ?? (async () => ({", "})))", () -> {
-                        writer.write("...await defaultConfigProvider(),");
-                        // TODO: remove this when root cause of #3809 is found
-                        writer.write("disableConcurrentStreams: true");
-                    });
+                    writer.write("RequestHandler.create(config?.requestHandler ?? defaultConfigProvider)");
                 });
             default:
                 return Collections.emptyMap();


### PR DESCRIPTION
### Issue
#3809 😐 

### Description
Enable http2 session concurrency by default.

This does not apply to event stream operations - those use isolated http2 sessions in Node.js.

### Testing
CI and recently added e2e tests in 
- https://github.com/aws/aws-sdk-js-v3/pull/7947
- https://github.com/aws/aws-sdk-js-v3/pull/7948
- https://github.com/aws/aws-sdk-js-v3/pull/7941

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [x] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [ ] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
