### PR TITLE
fix(xml-builder): use xml 1.1 parsing behavior for entities

### DIFF
--- a/clients/client-s3/test/e2e/s3-object-features.e2e.spec.ts
+++ b/clients/client-s3/test/e2e/s3-object-features.e2e.spec.ts
@@ -100,7 +100,8 @@ describe("@aws-sdk/client-s3", () => {
         "\n \n",
         "a\r\n b\n c\r",
         "a\r\u0085 b\u0085",
-        "a\r\u2028 b\u0085 c\u2028",
+        "a\r\u2028 b\u0085 c\u2028 d\x15",
+        "special_c0_\x15\x15\x15\x15",
       ];
 
       beforeAll(async () => {
@@ -126,15 +127,44 @@ describe("@aws-sdk/client-s3", () => {
         }
       });
 
+      it("can list objects with special character keys", async () => {
+        const listObjects = await client.listObjects({
+          Bucket,
+          Prefix: "special_c0_",
+        });
+
+        expect(listObjects.Contents?.length).toBeGreaterThanOrEqual(1);
+        expect(listObjects.Contents?.[0].Key).toEqual("special_c0_\x15\x15\x15\x15");
+      });
+
       it("can delete keys containing special characters", async () => {
+        const [firstHalf, secondHalf] = [keys.slice(0, 4), keys.slice(4)];
+
         await client.deleteObjects({
           Bucket,
           Delete: {
-            Objects: keys.map((Key) => ({
+            Objects: firstHalf.map((Key) => ({
               Key,
             })),
           },
         });
+
+        // S3 cannot delete the keys using DeleteObjects because the keys would be part
+        // of the XML payload and are rejected, specifically the \x15 C0 control char
+        // not valid in XML 1.0.
+
+        // This is despite the keys being listable (in a supposedly XML-1.0 ListObjects response payload).
+        // and individually deletable.
+        const p = [];
+        for (const key of secondHalf) {
+          p.push(
+            client.deleteObject({
+              Bucket,
+              Key: key,
+            })
+          );
+        }
+        await Promise.all(p);
 
         await Promise.all(
           keys.map(async (Key) => {

--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -3,8 +3,9 @@
   "version": "3.972.19",
   "description": "XML utilities for the AWS SDK",
   "dependencies": {
+    "@nodable/entities": "2.1.0",
     "@smithy/types": "^4.14.1",
-    "fast-xml-parser": "5.7.1",
+    "fast-xml-parser": "5.7.2",
     "tslib": "^2.6.2"
   },
   "scripts": {

--- a/packages-internal/xml-builder/src/xml-parser.spec.ts
+++ b/packages-internal/xml-builder/src/xml-parser.spec.ts
@@ -217,6 +217,28 @@ describe("xml parsing", () => {
     });
   });
 
+  it("should preserve control characters like \\x15 in text content despite xml 1.0 decl", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Response><Key>prefix&#x15;suffix</Key></Response>`;
+    const object = parseXML(xml);
+    expect(object).toEqual({
+      Response: {
+        Key: "prefix\x15suffix",
+      },
+    });
+  });
+
+  it("should preserve control characters like \\x15 in text content despite xml 1.0 decl (browser)", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Response><Key>prefix&#x15;suffix</Key></Response>`;
+    const object = parseXMLBrowser(xml);
+    expect(object).toEqual({
+      Response: {
+        Key: "prefix\x15suffix",
+      },
+    });
+  });
+
   it("throws on parsing error", () => {
     const xmlSamples = [`<unclosed`, `<unmatched></matched>`];
 

--- a/packages-internal/xml-builder/src/xml-parser.ts
+++ b/packages-internal/xml-builder/src/xml-parser.ts
@@ -1,4 +1,28 @@
+// todo: package types are incorrect wrt exports.
+import type EntityDecoder from "@nodable/entities";
+import { COMMON_HTML, CURRENCY, XML } from "@nodable/entities";
 import { XMLParser } from "fast-xml-parser";
+
+// todo: package types are incorrect wrt exports.
+const { EntityDecoder: EntityDecoderImpl } = require("@nodable/entities");
+
+/**
+ * Custom entity decoder that preserves C0 control characters (e.g. U+0015)
+ * which XML 1.0 strict mode would strip. AWS services may return these
+ * characters in responses despite XML 1.0 declaration.
+ *
+ * @internal
+ */
+const entityDecoder: EntityDecoder = new EntityDecoderImpl({
+  namedEntities: { ...XML, ...COMMON_HTML, ...CURRENCY },
+  numericAllowed: true,
+  limit: {
+    maxTotalExpansions: Infinity,
+  },
+  ncr: {
+    xmlVersion: 1.1,
+  },
+});
 
 /**
  * Because this is only used against trusted server responses,
@@ -13,6 +37,27 @@ const parser = new XMLParser({
     maxTotalExpansions: Infinity,
   },
   htmlEntities: true,
+  entityDecoder: {
+    setExternalEntities: (entities: Record<string, string>): void => {
+      entityDecoder.setExternalEntities(entities);
+    },
+    addInputEntities: (entities: Record<string, string>): void => {
+      entityDecoder.addInputEntities(entities);
+    },
+    reset: (): void => {
+      entityDecoder.reset();
+    },
+    decode: (text: string): string => {
+      return entityDecoder.decode(text);
+    },
+    /**
+     * The previous XML parser allowed C0 control chars despite
+     * any presence of the xml 1.0 declaration `<?xml version="1.0" encoding="UTF-8"?>`.
+     * We will avoid having the xml version set by the incoming payload
+     * as a workaround.
+     */
+    setXmlVersion: (version: string) => void {},
+  },
   ignoreAttributes: false,
   ignoreDeclaration: true,
   parseTagValue: false,

--- a/private/aws-protocoltests-restxml-schema/package.json
+++ b/private/aws-protocoltests-restxml-schema/package.json
@@ -62,7 +62,7 @@
     "@smithy/util-stream": "^4.5.25",
     "@smithy/util-utf8": "^4.2.2",
     "entities": "2.2.0",
-    "fast-xml-parser": "5.7.1",
+    "fast-xml-parser": "5.7.2",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -64,7 +64,7 @@
     "@smithy/util-utf8": "^4.2.2",
     "@smithy/uuid": "^1.1.2",
     "entities": "2.2.0",
-    "fast-xml-parser": "5.7.1",
+    "fast-xml-parser": "5.7.2",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,7 +1176,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:5.7.1"
+    fast-xml-parser: "npm:5.7.2"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -1236,7 +1236,7 @@ __metadata:
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
     entities: "npm:2.2.0"
-    fast-xml-parser: "npm:5.7.1"
+    fast-xml-parser: "npm:5.7.2"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -25483,11 +25483,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk/xml-builder@workspace:packages-internal/xml-builder"
   dependencies:
+    "@nodable/entities": "npm:2.1.0"
     "@smithy/types": "npm:^4.14.1"
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
-    fast-xml-parser: "npm:5.7.1"
+    fast-xml-parser: "npm:5.7.2"
     premove: "npm:4.0.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
@@ -28557,7 +28558,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodable/entities@npm:^2.1.0":
+"@nodable/entities@npm:2.1.0, @nodable/entities@npm:^2.1.0":
   version: 2.1.0
   resolution: "@nodable/entities@npm:2.1.0"
   checksum: 10c0/5a4cba2b61a5b6c726328b18b1de6d033cae4a658a118644bf31e0bcbda126ea7b69385043dc556cf1ed859b9ca220e82b81b5e5c48ef1b519fb8ec104575dee
@@ -34581,9 +34582,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.7.1":
-  version: 5.7.1
-  resolution: "fast-xml-parser@npm:5.7.1"
+"fast-xml-parser@npm:5.7.2":
+  version: 5.7.2
+  resolution: "fast-xml-parser@npm:5.7.2"
   dependencies:
     "@nodable/entities": "npm:^2.1.0"
     fast-xml-builder: "npm:^1.1.5"
@@ -34591,7 +34592,7 @@ __metadata:
     strnum: "npm:^2.2.3"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/b8b54e33060da5fc5ce26fdc73c4728f18415f9be9a774f1406b03265a5b411b742c39dba0127c3f0f31fad5b3ee11f51be79aa16df160f69fd5e4b902bfbb85
+  checksum: 10c0/d48439ce0700add82f5e7c6ccc5a1f06483beb7cd8e88caa83c6406843e52f14988e60d05cbb3a86ffe07e073807674c807e0764d94a280e1c96d7e2011dae8e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7949

### Description
Parse XML 1.1 C0 control chars that can appear in S3 XML responses (such as Object keys) that otherwise declare XML 1.0.

### Testing
added unit, e2e tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
