### PR TITLE
fix(xml-builder): inline nodable/entities for dist format compatibility

### DIFF
--- a/packages-internal/xml-builder/src/xml-external/nodable_entities.spec.ts
+++ b/packages-internal/xml-builder/src/xml-external/nodable_entities.spec.ts
@@ -1,0 +1,637 @@
+/**
+ * EntityDecoder test suite — adapted from @nodable/entities reference tests.
+ * https://github.com/nodable/val-parsers/blob/main/Entity/specs/EntityDecoder.test.js
+ */
+import { describe, expect, test as it } from "vitest";
+
+import {
+  type EntityDecoder as EntityDecoderType,
+  COMMON_HTML,
+  CURRENCY,
+  EntityDecoderImpl as EntityDecoder,
+  XML as XML_ENTITIES,
+} from "./nodable_entities";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function make(opts: any): EntityDecoderType {
+  return new EntityDecoder(opts);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Fast path
+// ---------------------------------------------------------------------------
+describe("fast path — no & in string", () => {
+  const r = make({});
+
+  it("returns same reference when no & present", () => {
+    const s = "hello world";
+    expect(r.decode(s)).toBe(s);
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(r.decode("")).toBe("");
+  });
+
+  it("handles non-string input gracefully", () => {
+    expect(r.decode(null as any)).toBe(null);
+    expect(r.decode(undefined as any)).toBe(undefined);
+    expect(r.decode(42 as any)).toBe(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Built-in XML entities (always active via XML_ENTITIES in base map)
+// ---------------------------------------------------------------------------
+describe("built-in XML entities", () => {
+  const r = make({});
+
+  it("replaces &lt;", () => expect(r.decode("&lt;")).toBe("<"));
+  it("replaces &gt;", () => expect(r.decode("&gt;")).toBe(">"));
+  it("replaces &quot;", () => expect(r.decode("&quot;")).toBe('"'));
+  it("replaces &apos;", () => expect(r.decode("&apos;")).toBe("'"));
+  it("replaces &amp;", () => expect(r.decode("&amp;")).toBe("&"));
+
+  it("replaces multiple in one string", () => {
+    expect(r.decode("a &lt; b &gt; c")).toBe("a < b > c");
+  });
+
+  it("&amp;lt; does not double-expand — single pass resolves left-to-right", () => {
+    expect(r.decode("&amp;lt;")).toBe("&lt;");
+  });
+
+  it("&amp;amp; resolves to &amp;, not &", () => {
+    expect(r.decode("&amp;amp;")).toBe("&amp;");
+  });
+
+  it("decimal numeric ref &#60; → <", () => {
+    expect(r.decode("&#60;")).toBe("<");
+  });
+
+  it("hex numeric ref &#x3E; → >", () => {
+    expect(r.decode("&#x3E;")).toBe(">");
+  });
+
+  it("decimal numeric ref left unchanged when numericAllowed: false", () => {
+    const r2 = make({ numericAllowed: false });
+    expect(r2.decode("&#60;")).toBe("&#60;");
+  });
+
+  it("hex numeric ref left unchanged when numericAllowed: false", () => {
+    const r2 = make({ numericAllowed: false });
+    expect(r2.decode("&#x3E;")).toBe("&#x3E;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. namedEntities — extending the base map
+// ---------------------------------------------------------------------------
+describe("namedEntities option", () => {
+  it("entities in namedEntities are resolved", () => {
+    const r = make({ namedEntities: { foo: "BAR" } });
+    expect(r.decode("&foo;")).toBe("BAR");
+  });
+
+  it("XML_ENTITIES remain active when namedEntities is set", () => {
+    const r = make({ namedEntities: { foo: "BAR" } });
+    expect(r.decode("&lt;")).toBe("<");
+  });
+
+  it("namedEntities can override XML_ENTITIES", () => {
+    const r = make({ namedEntities: { lt: "LESSTHAN" } });
+    expect(r.decode("&lt;")).toBe("LESSTHAN");
+  });
+
+  it("accepts legacy { regex, val } objects in namedEntities", () => {
+    const r = make({ namedEntities: { br: { regex: /&br;/g, val: "\n" } } });
+    expect(r.decode("line1&br;line2")).toBe("line1\nline2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Named entity groups via namedEntities
+// ---------------------------------------------------------------------------
+describe("COMMON_HTML group", () => {
+  const r = make({ namedEntities: COMMON_HTML });
+
+  it("&nbsp;", () => expect(r.decode("&nbsp;")).toBe("\u00a0"));
+  it("&copy;", () => expect(r.decode("&copy;")).toBe("\u00a9"));
+  it("&reg;", () => expect(r.decode("&reg;")).toBe("\u00ae"));
+  it("&trade;", () => expect(r.decode("&trade;")).toBe("\u2122"));
+  it("&mdash;", () => expect(r.decode("&mdash;")).toBe("\u2014"));
+  it("&ndash;", () => expect(r.decode("&ndash;")).toBe("\u2013"));
+  it("&hellip;", () => expect(r.decode("&hellip;")).toBe("\u2026"));
+});
+
+describe("CURRENCY group", () => {
+  const r = make({ namedEntities: CURRENCY });
+
+  it("&cent;", () => expect(r.decode("&cent;")).toBe("\u00a2"));
+  it("&pound;", () => expect(r.decode("&pound;")).toBe("\u00a3"));
+  it("&yen;", () => expect(r.decode("&yen;")).toBe("\u00a5"));
+  it("&euro;", () => expect(r.decode("&euro;")).toBe("\u20ac"));
+  it("&inr;", () => expect(r.decode("&inr;")).toBe("\u20b9"));
+});
+
+describe("numeric references — native resolution", () => {
+  const r = make({});
+
+  it("decimal &#65; → A", () => expect(r.decode("&#65;")).toBe("A"));
+  it("decimal with leading zeros &#0065; → A", () => expect(r.decode("&#0065;")).toBe("A"));
+  it("hex &#x41; → A", () => expect(r.decode("&#x41;")).toBe("A"));
+  it("hex uppercase &#X41; → A (x is case-insensitive)", () => {
+    expect(r.decode("&#X41;")).toBe("A");
+  });
+  it("emoji via decimal &#128512;", () => expect(r.decode("&#128512;")).toBe("😀"));
+  it("emoji via hex &#x1F600;", () => expect(r.decode("&#x1F600;")).toBe("😀"));
+  it("decimal with many leading zeros &#00065;", () => expect(r.decode("&#00065;")).toBe("A"));
+  it("hex with leading zeros &#x00041;", () => expect(r.decode("&#x00041;")).toBe("A"));
+});
+
+describe("composed namedEntities groups", () => {
+  const r = make({ namedEntities: { ...COMMON_HTML, ...CURRENCY } });
+
+  it("both groups active", () => {
+    expect(r.decode("&copy; &euro;")).toBe("\u00a9 \u20ac");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. External entities — persistent and input/runtime
+// ---------------------------------------------------------------------------
+describe("persistent external entities (setExternalEntities)", () => {
+  it("basic persistent entity", () => {
+    const r = make({});
+    r.setExternalEntities({ foo: "bar" });
+    expect(r.decode("&foo;")).toBe("bar");
+  });
+
+  it("numeric persistent entity throws", () => {
+    const r = make({});
+    expect(() => r.setExternalEntities({ "#xD": "bar" })).toThrow();
+  });
+
+  it("multiple persistent entities", () => {
+    const r = make({});
+    r.setExternalEntities({ foo: "FOO", baz: "BAZ" });
+    expect(r.decode("&foo; and &baz;")).toBe("FOO and BAZ");
+  });
+
+  it("entity name with dot is accepted", () => {
+    const r = make({});
+    r.setExternalEntities({ "my.entity": "VALUE" });
+    expect(r.decode("&my.entity;")).toBe("VALUE");
+  });
+
+  it("accepts pre-built { regex, val } objects", () => {
+    const r = make({});
+    r.setExternalEntities({ custom: { regex: /&custom;/g, val: "CUSTOM_VALUE" } });
+    expect(r.decode("&custom;")).toBe("CUSTOM_VALUE");
+  });
+
+  it("throws on invalid entity name character", () => {
+    const r = make({});
+    expect(() => r.setExternalEntities({ "bad&name": "x" })).toThrow();
+  });
+
+  it("addExternalEntity appends without wiping existing entries", () => {
+    const r = make({});
+    r.setExternalEntities({ a: "AAA" });
+    r.addExternalEntity("b", "BBB");
+    expect(r.decode("&a; &b;")).toBe("AAA BBB");
+  });
+
+  it("persistent entities survive reset()", () => {
+    const r = make({});
+    r.setExternalEntities({ brand: "Acme" });
+    r.reset();
+    expect(r.decode("&brand;")).toBe("Acme");
+  });
+});
+
+describe("input / runtime entities (addInputEntities)", () => {
+  it("basic input entity", () => {
+    const r = make({});
+    r.addInputEntities({ foo: "bar" });
+    expect(r.decode("&foo;")).toBe("bar");
+  });
+
+  it("accepts DocTypeReader { regx, val } objects", () => {
+    const r = make({});
+    r.addInputEntities({ ent: { regx: /&ent;/g, val: "RESOLVED" } });
+    expect(r.decode("&ent;")).toBe("RESOLVED");
+  });
+
+  it("addInputEntities resets counters", () => {
+    const r = make({ limit: { maxTotalExpansions: 5, applyLimitsTo: "external" } });
+    r.addInputEntities({ x: "X" });
+    r.decode("&x;&x;&x;"); // 3 expansions
+    r.addInputEntities({ x: "X" }); // resets counter
+    expect(() => r.decode("&x;&x;&x;&x;&x;")).not.toThrow(); // exactly 5 — ok
+  });
+
+  it("reset() wipes input entities", () => {
+    const r = make({});
+    r.addInputEntities({ docEnt: "VALUE" });
+    expect(r.decode("&docEnt;")).toBe("VALUE");
+    r.reset();
+    expect(r.decode("&docEnt;")).toBe("&docEnt;");
+  });
+
+  it("input entities do not bleed across documents", () => {
+    const r = make({});
+    r.addInputEntities({ tmp: "DOC1" });
+    r.reset();
+    expect(r.decode("&tmp;")).toBe("&tmp;");
+  });
+});
+
+describe("entity priority order", () => {
+  it("input beats external when both define the same name", () => {
+    const r = make({});
+    r.setExternalEntities({ ent: "EXTERNAL" });
+    r.addInputEntities({ ent: "INPUT" });
+    expect(r.decode("&ent;")).toBe("INPUT");
+  });
+
+  it("external beats base when both define the same name", () => {
+    const r = make({});
+    r.setExternalEntities({ lt: "LESSTHAN" });
+    expect(r.decode("&lt;")).toBe("LESSTHAN");
+  });
+
+  it("base is used when neither input nor external defines the name", () => {
+    const r = make({});
+    expect(r.decode("&lt;")).toBe("<");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Security limits
+// ---------------------------------------------------------------------------
+describe("maxTotalExpansions", () => {
+  it("throws when limit exceeded (external tier)", () => {
+    const r = make({ limit: { maxTotalExpansions: 3, applyLimitsTo: "external" } });
+    r.addInputEntities({ x: "X" });
+    expect(() => r.decode("&x;&x;&x;&x;")).toThrow(/expansion count limit/);
+  });
+
+  it("does not throw when exactly at limit", () => {
+    const r = make({ limit: { maxTotalExpansions: 3, applyLimitsTo: "external" } });
+    r.addInputEntities({ x: "X" });
+    expect(() => r.decode("&x;&x;&x;")).not.toThrow();
+  });
+
+  it("0 = unlimited", () => {
+    const r = make({ limit: { maxTotalExpansions: 0, applyLimitsTo: "external" } });
+    r.addInputEntities({ x: "X" });
+    const big = "&x;".repeat(10_000);
+    expect(() => r.decode(big)).not.toThrow();
+  });
+
+  it("Infinity = unlimited", () => {
+    const r = make({ limit: { maxTotalExpansions: Infinity, applyLimitsTo: "external" } });
+    r.addInputEntities({ x: "X" });
+    const big = "&x;".repeat(10_000);
+    expect(() => r.decode(big)).not.toThrow();
+  });
+
+  it("base entities not tracked when applyLimitsTo: external", () => {
+    const r = make({ limit: { maxTotalExpansions: 1, applyLimitsTo: "external" } });
+    expect(() => r.decode("&lt;&gt;&lt;&gt;&lt;&gt;")).not.toThrow();
+  });
+
+  it("base entities tracked when applyLimitsTo: base", () => {
+    const r = make({ limit: { maxTotalExpansions: 2, applyLimitsTo: "base" } });
+    expect(() => r.decode("&lt;&gt;&lt;")).toThrow(/expansion count limit/);
+  });
+
+  it("base entities tracked when applyLimitsTo: all", () => {
+    const r = make({ limit: { maxTotalExpansions: 2, applyLimitsTo: "all" } });
+    expect(() => r.decode("&lt;&gt;&lt;")).toThrow(/expansion count limit/);
+  });
+
+  it("namedEntities group tracked when applyLimitsTo: base", () => {
+    const r = make({
+      namedEntities: COMMON_HTML,
+      limit: { maxTotalExpansions: 2, applyLimitsTo: "base" },
+    });
+    expect(() => r.decode("&copy;&copy;&copy;")).toThrow(/expansion count limit/);
+  });
+});
+
+describe("maxExpandedLength", () => {
+  it("throws when expanded length exceeded", () => {
+    const r = make({ limit: { maxExpandedLength: 5, applyLimitsTo: "external" } });
+    r.addInputEntities({ x: "XXXXXXXXXX" });
+    expect(() => r.decode("&x;")).toThrow(/length limit/);
+  });
+
+  it("does not throw when exactly at limit", () => {
+    const r = make({ limit: { maxExpandedLength: 5, applyLimitsTo: "external" } });
+    r.addInputEntities({ x: "XXXXXXXX" });
+    expect(() => r.decode("&x;")).not.toThrow();
+  });
+
+  it("cumulative across multiple replacements", () => {
+    const r = make({ limit: { maxExpandedLength: 10, applyLimitsTo: "external" } });
+    r.addInputEntities({ x: "XXXXX" });
+    expect(() => r.decode("&x;&x;")).not.toThrow();
+  });
+});
+
+describe("applyLimitsTo: array", () => {
+  it("limits both external and base when both specified", () => {
+    const r = make({
+      namedEntities: COMMON_HTML,
+      limit: { maxTotalExpansions: 1, applyLimitsTo: ["external", "base"] },
+    });
+    r.addInputEntities({ x: "X" });
+    expect(() => r.decode("&x;&copy;")).toThrow(/expansion count limit/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. postCheck hook
+// ---------------------------------------------------------------------------
+describe("postCheck", () => {
+  it("called with resolved and original", () => {
+    let args: { resolved: string; original: string } | undefined;
+    const r = make({
+      postCheck: (resolved: string, original: string) => {
+        args = { resolved, original };
+        return resolved;
+      },
+    });
+    r.decode("&lt;");
+    expect(args!.original).toBe("&lt;");
+    expect(args!.resolved).toBe("<");
+  });
+
+  it("returning original rejects expansion", () => {
+    const r = make({
+      postCheck: (resolved: string, original: string) => (/</.test(resolved) ? original : resolved),
+    });
+    expect(r.decode("&lt;")).toBe("&lt;"); // rejected
+    expect(r.decode("&amp;")).toBe("&"); // allowed
+  });
+
+  it("can sanitize resolved string", () => {
+    const r = make({
+      postCheck: (resolved: string) => {
+        expect(resolved).toBe("hello <script>");
+        return "hello ";
+      },
+    });
+    expect(r.decode("hello &lt;script&gt;")).toBe("hello ");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. reset()
+// ---------------------------------------------------------------------------
+describe("reset()", () => {
+  it("clears input entities", () => {
+    const r = make({});
+    r.addInputEntities({ tmp: "DOC1" });
+    r.reset();
+    expect(r.decode("&tmp;")).toBe("&tmp;");
+  });
+
+  it("resets totalExpansions counter", () => {
+    const r = make({ limit: { maxTotalExpansions: 2, applyLimitsTo: "external" } });
+    r.addInputEntities({ x: "X" });
+    r.decode("&x;&x;"); // exhaust counter
+    r.reset();
+    r.addInputEntities({ x: "X" });
+    expect(() => r.decode("&x;&x;")).not.toThrow();
+  });
+
+  it("does NOT clear persistent external entities", () => {
+    const r = make({});
+    r.setExternalEntities({ brand: "Acme" });
+    r.reset();
+    expect(r.decode("&brand;")).toBe("Acme");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Edge cases
+// ---------------------------------------------------------------------------
+describe("edge cases", () => {
+  it("unknown entity is left unchanged", () => {
+    const r = make({});
+    expect(r.decode("&unknown;")).toBe("&unknown;");
+  });
+
+  it("partial entity ref without closing ; is left unchanged", () => {
+    const r = make({});
+    expect(r.decode("&lt")).toBe("&lt");
+  });
+
+  it("entity at start of string", () => {
+    const r = make({});
+    expect(r.decode("&lt;hello")).toBe("<hello");
+  });
+
+  it("entity at end of string", () => {
+    const r = make({});
+    expect(r.decode("hello&gt;")).toBe("hello>");
+  });
+
+  it("consecutive entities with no whitespace", () => {
+    const r = make({});
+    expect(r.decode("&lt;&gt;")).toBe("<>");
+  });
+
+  it("very long string with no entities — same reference returned", () => {
+    const r = make({});
+    const s = "a".repeat(100_000);
+    expect(r.decode(s)).toBe(s);
+  });
+
+  it("lone & with no token is left unchanged", () => {
+    const r = make({});
+    expect(r.decode("& ")).toBe("& ");
+  });
+
+  it("numeric refs with leading zeros", () => {
+    const r = make({});
+    expect(r.decode("&#00065;")).toBe("A");
+    expect(r.decode("&#x00041;")).toBe("A");
+  });
+
+  it("out-of-range numeric ref is left unchanged", () => {
+    const r = make({});
+    expect(r.decode("&#1114112;")).toBe("&#1114112;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Exports
+// ---------------------------------------------------------------------------
+describe("exports", () => {
+  it("XML_ENTITIES is a plain object with expected keys", () => {
+    expect(typeof XML_ENTITIES).toBe("object");
+    expect(XML_ENTITIES).toHaveProperty("lt");
+    expect(XML_ENTITIES).toHaveProperty("gt");
+    expect(XML_ENTITIES).toHaveProperty("quot");
+    expect(XML_ENTITIES).toHaveProperty("apos");
+    expect(XML_ENTITIES).toHaveProperty("amp");
+  });
+
+  it("all named entity groups are plain objects", () => {
+    for (const g of [COMMON_HTML, CURRENCY]) {
+      expect(typeof g).toBe("object");
+      expect(g).not.toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. Remove and Leave options
+// ---------------------------------------------------------------------------
+describe("remove and leave options", () => {
+  it("remove: removes specified entities", () => {
+    const r = make({ remove: ["nbsp", "copy"] });
+    expect(r.decode("a&nbsp;b&copy;c")).toBe("abc");
+  });
+
+  it("leave: leaves specified entities as literals", () => {
+    const r = make({ leave: ["nbsp", "copy"] });
+    expect(r.decode("a&nbsp;b&copy;c")).toBe("a&nbsp;b&copy;c");
+  });
+
+  it("remove takes precedence over leave", () => {
+    const r = make({ remove: ["nbsp"], leave: ["nbsp"] });
+    expect(r.decode("a&nbsp;b")).toBe("ab");
+  });
+
+  it("remove applies to base entities", () => {
+    const r = make({ remove: ["lt"] });
+    expect(r.decode("a&lt;b")).toBe("ab");
+  });
+
+  it("leave applies to base entities", () => {
+    const r = make({ leave: ["lt"] });
+    expect(r.decode("a&lt;b")).toBe("a&lt;b");
+  });
+
+  it("remove applies to named entities", () => {
+    const r = make({ remove: ["copy"], namedEntities: COMMON_HTML });
+    expect(r.decode("a&copy;b")).toBe("ab");
+  });
+
+  it("leave applies to named entities", () => {
+    const r = make({ leave: ["copy"], namedEntities: COMMON_HTML });
+    expect(r.decode("a&copy;b")).toBe("a&copy;b");
+  });
+
+  it("remove applies to numeric entities", () => {
+    const r = make({ remove: ["#160"] });
+    expect(r.decode("a&#160;b")).toBe("ab");
+  });
+
+  it("leave applies to numeric entities", () => {
+    const r = make({ leave: ["#160"] });
+    expect(r.decode("a&#160;b")).toBe("a&#160;b");
+  });
+
+  it("remove applies to external entities", () => {
+    const r = make({ remove: ["foo"], namedEntities: { foo: "bar" } });
+    expect(r.decode("a&foo;b")).toBe("ab");
+  });
+
+  it("leave applies to external entities", () => {
+    const r = make({ leave: ["foo"], namedEntities: { foo: "bar" } });
+    expect(r.decode("a&foo;b")).toBe("a&foo;b");
+  });
+
+  it("remove applies to input entities", () => {
+    const r = make({ remove: ["foo"] });
+    r.addInputEntities({ foo: "bar" });
+    expect(r.decode("a&foo;b")).toBe("ab");
+  });
+
+  it("leave applies to input entities", () => {
+    const r = make({ leave: ["foo"] });
+    r.addInputEntities({ foo: "bar" });
+    expect(r.decode("a&foo;b")).toBe("a&foo;b");
+  });
+
+  it("remove applies to unknown entities (replaces with empty string)", () => {
+    const r = make({ remove: ["unknown"] });
+    expect(r.decode("a&unknown;b")).toBe("ab");
+  });
+
+  it("leave applies to unknown entities (leaves as literal)", () => {
+    const r = make({ leave: ["unknown"] });
+    expect(r.decode("a&unknown;b")).toBe("a&unknown;b");
+  });
+
+  it("remove and leave can be combined", () => {
+    const r = make({ remove: ["nbsp"], leave: ["copy"] });
+    expect(r.decode("a&nbsp;b&copy;c")).toBe("ab&copy;c");
+  });
+
+  it("remove and leave arrays can be empty", () => {
+    const r = make({ remove: [], leave: [] });
+    expect(r.decode("a&nbsp;b&copy;c")).toBe("a&nbsp;b&copy;c");
+  });
+
+  it("remove and leave arrays can be null/undefined (treated as empty)", () => {
+    const r1 = make({ remove: null, leave: null });
+    expect(r1.decode("a&nbsp;b")).toBe("a&nbsp;b");
+
+    const r2 = make({ remove: undefined, leave: undefined });
+    expect(r2.decode("a&nbsp;b")).toBe("a&nbsp;b");
+  });
+
+  it("remove and leave arrays can contain duplicates (handled by Set)", () => {
+    const r = make({ remove: ["nbsp", "nbsp"], leave: ["copy", "copy"] });
+    expect(r.decode("a&nbsp;b&copy;c")).toBe("ab&copy;c");
+  });
+
+  it("remove and leave arrays can contain non-string values (ignored)", () => {
+    const r = make({ remove: ["nbsp", 123, null, undefined], leave: ["copy", 456, false] });
+    expect(r.decode("a&nbsp;b&copy;c")).toBe("ab&copy;c");
+  });
+
+  it("remove and leave arrays can contain mixed entity types", () => {
+    const r = make({ remove: ["nbsp", "#160"], leave: ["copy", "&copy;"] });
+    expect(r.decode("a&nbsp;b&#160;c&copy;d&amp;e")).toBe("abc&copy;d&e");
+  });
+
+  it("remove and leave arrays can contain entity names with special chars", () => {
+    const r = make({ remove: ["my.entity"], leave: ["another.entity"] });
+    r.setExternalEntities({ "my.entity": "REMOVE", "another.entity": "LEAVE" });
+    expect(r.decode("a&my.entity;b&another.entity;c")).toBe("ab&another.entity;c");
+  });
+
+  it("remove and leave arrays can contain numeric entity strings", () => {
+    const r = make({ remove: ["#160"], leave: ["#169"] });
+    expect(r.decode("a&#160;b&#169;c")).toBe("ab&#169;c");
+  });
+
+  it("remove and leave arrays can contain hex numeric entity strings", () => {
+    const r = make({ remove: ["#x20"], leave: ["#x26"] });
+    expect(r.decode("a&#x20;b&#x26;c")).toBe("ab&#x26;c");
+  });
+
+  it("remove and leave arrays can contain mixed numeric formats", () => {
+    const r = make({ remove: ["#160", "#x20"], leave: ["#169", "#x26"] });
+    expect(r.decode("a&#160;b&#x20;c&#169;d&#x26;e")).toBe("abc&#169;d&#x26;e");
+  });
+
+  it("remove and leave arrays can contain mixed entity types and formats", () => {
+    const r = make({
+      remove: ["nbsp", "#160", "#x20", "unknown"],
+      leave: ["copy", "#169", "#x26", "another.entity"],
+      namedEntities: { copy: "\u00a9", another: "ANOTHER" },
+    });
+    expect(r.decode("a&nbsp;b&#160;c&#x20;d&copy;e&#169;f&#x26;g&another.entity;&another;h&unknown;i")).toBe(
+      "abcd&copy;e&#169;f&#x26;g&another.entity;ANOTHERhi"
+    );
+  });
+});

--- a/packages-internal/xml-builder/src/xml-external/nodable_entities.ts
+++ b/packages-internal/xml-builder/src/xml-external/nodable_entities.ts
@@ -1,0 +1,465 @@
+/**
+ * Contains code from \@nodable/entities v2.1.0
+ * Copyright (c) Amit Gupta (https://solothought.com)
+ * https://github.com/nodable/val-parsers
+ *
+ * This file bundles the EntityDecoder class and the named-entity maps
+ * (XML, COMMON_HTML, CURRENCY).
+ *
+ * This is a temporary solution while using this particular custom
+ * EntityDecoder class. The module-only nature of the original version
+ * is incompatible with some of our users' applications.
+ *
+ * Given that our CJS dist must call `require` to bring in the module, and
+ * because the EntityDecoder class and object are inaccessible via the runtime object surface
+ * of the XMLParser, we must inline the package.
+ *
+ * Q: Why is this necessary given that fast-xml-parser itself uses \@nodable/entities?
+ * A: FXP only uses \@nodable/entities when imported in ESM mode. When importing FXP
+ *    via require, a bundled version is used, unaffected by the module-only nature
+ *    of the entities package.
+ */
+
+// ---------------------------------------------------------------------------
+// Named-entity maps
+// ---------------------------------------------------------------------------
+
+export const XML: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  quot: '"',
+};
+
+export const COMMON_HTML: Record<string, string> = {
+  nbsp: "\u00a0",
+  copy: "\u00a9",
+  reg: "\u00ae",
+  trade: "\u2122",
+  mdash: "\u2014",
+  ndash: "\u2013",
+  hellip: "\u2026",
+  laquo: "\u00ab",
+  raquo: "\u00bb",
+  lsquo: "\u2018",
+  rsquo: "\u2019",
+  ldquo: "\u201c",
+  rdquo: "\u201d",
+  bull: "\u2022",
+  para: "\u00b6",
+  sect: "\u00a7",
+  deg: "\u00b0",
+  frac12: "\u00bd",
+  frac14: "\u00bc",
+  frac34: "\u00be",
+};
+
+export const CURRENCY: Record<string, string> = {
+  cent: "\u00a2",
+  pound: "\u00a3",
+  curren: "\u00a4",
+  yen: "\u00a5",
+  euro: "\u20ac",
+  dollar: "$",
+  fnof: "\u0192",
+  inr: "\u20b9",
+  af: "\u060b",
+  birr: "\u1265\u122d",
+  peso: "\u20b1",
+  rub: "\u20bd",
+  won: "\u20a9",
+  yuan: "\u00a5",
+  cedil: "\u00b8",
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type EntityValFn = (match: string, captured: string, ...rest: unknown[]) => string;
+
+type ApplyLimitsTo = "external" | "base" | "all" | Array<"external" | "base">;
+
+interface EntityDecoderLimitOptions {
+  maxTotalExpansions?: number;
+  maxExpandedLength?: number;
+  applyLimitsTo?: ApplyLimitsTo;
+}
+
+interface EntityDecoderNCROptions {
+  xmlVersion?: 1.0 | 1.1;
+  onNCR?: "allow" | "leave" | "remove" | "throw";
+  nullNCR?: "remove" | "throw";
+}
+
+interface EntityDecoderOptions {
+  namedEntities?: Record<string, string | { regex: RegExp; val: string | EntityValFn }> | null;
+  postCheck?: ((resolved: string, original: string) => string) | null;
+  numericAllowed?: boolean;
+  leave?: string[];
+  remove?: string[];
+  limit?: EntityDecoderLimitOptions;
+  ncr?: EntityDecoderNCROptions;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SPECIAL_CHARS = new Set("!?\\/[]$%{}^&*()<>|+");
+
+function validateEntityName(name: string): string {
+  if (name[0] === "#") {
+    throw new Error(`[EntityReplacer] Invalid character '#' in entity name: "${name}"`);
+  }
+  for (const ch of name) {
+    if (SPECIAL_CHARS.has(ch)) {
+      throw new Error(`[EntityReplacer] Invalid character '${ch}' in entity name: "${name}"`);
+    }
+  }
+  return name;
+}
+
+function mergeEntityMaps(...maps: Array<Record<string, any> | null | undefined>): Record<string, string> {
+  const out: Record<string, string> = Object.create(null);
+  for (const map of maps) {
+    if (!map) {
+      continue;
+    }
+    for (const key of Object.keys(map)) {
+      const raw = map[key];
+      if (typeof raw === "string") {
+        out[key] = raw;
+      } else if (raw && typeof raw === "object" && raw.val !== undefined) {
+        const val = raw.val;
+        if (typeof val === "string") {
+          out[key] = val;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Limit-tier constants
+// ---------------------------------------------------------------------------
+
+const LIMIT_TIER_EXTERNAL = "external";
+const LIMIT_TIER_BASE = "base";
+const LIMIT_TIER_ALL = "all";
+
+function parseLimitTiers(raw: string | string[] | undefined): Set<string> {
+  if (!raw || raw === LIMIT_TIER_EXTERNAL) {
+    return new Set([LIMIT_TIER_EXTERNAL]);
+  }
+  if (raw === LIMIT_TIER_ALL) {
+    return new Set([LIMIT_TIER_ALL]);
+  }
+  if (raw === LIMIT_TIER_BASE) {
+    return new Set([LIMIT_TIER_BASE]);
+  }
+  if (Array.isArray(raw)) {
+    return new Set(raw);
+  }
+  return new Set([LIMIT_TIER_EXTERNAL]);
+}
+
+// ---------------------------------------------------------------------------
+// NCR helpers
+// ---------------------------------------------------------------------------
+
+const NCR_LEVEL: Record<string, number> = Object.freeze({ allow: 0, leave: 1, remove: 2, throw: 3 });
+
+const XML10_ALLOWED_C0 = new Set([0x09, 0x0a, 0x0d]);
+
+function parseNCRConfig(ncr?: EntityDecoderNCROptions): {
+  xmlVersion: number;
+  onLevel: number;
+  nullLevel: number;
+} {
+  if (!ncr) {
+    return { xmlVersion: 1.0, onLevel: NCR_LEVEL.allow, nullLevel: NCR_LEVEL.remove };
+  }
+  const xmlVersion = ncr.xmlVersion === 1.1 ? 1.1 : 1.0;
+  const onLevel = NCR_LEVEL[ncr.onNCR ?? "allow"] ?? NCR_LEVEL.allow;
+  const nullLevel = NCR_LEVEL[ncr.nullNCR ?? "remove"] ?? NCR_LEVEL.remove;
+  const clampedNull = Math.max(nullLevel, NCR_LEVEL.remove);
+  return { xmlVersion, onLevel, nullLevel: clampedNull };
+}
+
+// ---------------------------------------------------------------------------
+// EntityDecoder interface & implementation
+// ---------------------------------------------------------------------------
+
+export interface EntityDecoder {
+  setExternalEntities(map: Record<string, string | { regex: RegExp; val: string | EntityValFn }>): void;
+  addExternalEntity(key: string, value: string): void;
+  addInputEntities(map: Record<string, string | { regx?: RegExp; regex?: RegExp; val: string | EntityValFn }>): void;
+  reset(): this;
+  decode(str: string): string;
+  setXmlVersion(version: string): void;
+}
+
+export const EntityDecoderImpl: new (options?: EntityDecoderOptions) => EntityDecoder = class EntityDecoderImpl
+  implements EntityDecoder
+{
+  private readonly _limit: EntityDecoderLimitOptions;
+  private readonly _maxTotalExpansions: number;
+  private readonly _maxExpandedLength: number;
+  private readonly _postCheck: (resolved: string, original: string) => string;
+  private readonly _limitTiers: Set<string>;
+  private readonly _numericAllowed: boolean;
+  private readonly _baseMap: Record<string, string>;
+  private _externalMap: Record<string, string>;
+  private _inputMap: Record<string, string>;
+  private _totalExpansions: number;
+  private _expandedLength: number;
+  private readonly _removeSet: Set<string>;
+  private readonly _leaveSet: Set<string>;
+  private _ncrXmlVersion: number;
+  private readonly _ncrOnLevel: number;
+  private readonly _ncrNullLevel: number;
+
+  public constructor(options: EntityDecoderOptions = {}) {
+    this._limit = options.limit || {};
+    this._maxTotalExpansions = this._limit.maxTotalExpansions || 0;
+    this._maxExpandedLength = this._limit.maxExpandedLength || 0;
+    this._postCheck = typeof options.postCheck === "function" ? options.postCheck : (r) => r;
+    this._limitTiers = parseLimitTiers(this._limit.applyLimitsTo ?? LIMIT_TIER_EXTERNAL);
+    this._numericAllowed = options.numericAllowed ?? true;
+    this._baseMap = mergeEntityMaps(XML, options.namedEntities || null);
+    this._externalMap = Object.create(null);
+    this._inputMap = Object.create(null);
+    this._totalExpansions = 0;
+    this._expandedLength = 0;
+    this._removeSet = new Set(options.remove && Array.isArray(options.remove) ? options.remove : []);
+    this._leaveSet = new Set(options.leave && Array.isArray(options.leave) ? options.leave : []);
+    const ncrCfg = parseNCRConfig(options.ncr);
+    this._ncrXmlVersion = ncrCfg.xmlVersion;
+    this._ncrOnLevel = ncrCfg.onLevel;
+    this._ncrNullLevel = ncrCfg.nullLevel;
+  }
+
+  public setExternalEntities(map: Record<string, string | { regex: RegExp; val: string | EntityValFn }>): void {
+    if (map) {
+      for (const key of Object.keys(map)) {
+        validateEntityName(key);
+      }
+    }
+    this._externalMap = mergeEntityMaps(map);
+  }
+
+  public addExternalEntity(key: string, value: string): void {
+    validateEntityName(key);
+    if (typeof value === "string" && value.indexOf("&") === -1) {
+      this._externalMap[key] = value;
+    }
+  }
+
+  public addInputEntities(
+    map: Record<string, string | { regx?: RegExp; regex?: RegExp; val: string | EntityValFn }>
+  ): void {
+    this._totalExpansions = 0;
+    this._expandedLength = 0;
+    this._inputMap = mergeEntityMaps(map);
+  }
+
+  public reset(): this {
+    this._inputMap = Object.create(null);
+    this._totalExpansions = 0;
+    this._expandedLength = 0;
+    return this;
+  }
+
+  public setXmlVersion(version: string): void {
+    this._ncrXmlVersion = version === "1.1" || (version as any) === 1.1 ? 1.1 : 1.0;
+  }
+
+  public decode(str: string): string {
+    if (typeof str !== "string" || str.length === 0) {
+      return str;
+    }
+
+    const original = str;
+    const chunks: string[] = [];
+    const len = str.length;
+    let last = 0;
+    let i = 0;
+
+    const limitExpansions = this._maxTotalExpansions > 0;
+    const limitLength = this._maxExpandedLength > 0;
+    const checkLimits = limitExpansions || limitLength;
+
+    while (i < len) {
+      if (str.charCodeAt(i) !== 38 /* & */) {
+        i++;
+        continue;
+      }
+
+      let j = i + 1;
+      while (j < len && str.charCodeAt(j) !== 59 /* ; */ && j - i <= 32) {
+        j++;
+      }
+
+      if (j >= len || str.charCodeAt(j) !== 59) {
+        i++;
+        continue;
+      }
+
+      const token = str.slice(i + 1, j);
+      if (token.length === 0) {
+        i++;
+        continue;
+      }
+
+      let replacement: string | undefined;
+      let tier: string | undefined;
+
+      if (this._removeSet.has(token)) {
+        replacement = "";
+        if (tier === undefined) {
+          tier = LIMIT_TIER_EXTERNAL;
+        }
+      } else if (this._leaveSet.has(token)) {
+        i++;
+        continue;
+      } else if (token.charCodeAt(0) === 35 /* # */) {
+        const ncrResult = this._resolveNCR(token);
+        if (ncrResult === undefined) {
+          i++;
+          continue;
+        }
+        replacement = ncrResult;
+        tier = LIMIT_TIER_BASE;
+      } else {
+        const resolved = this._resolveName(token);
+        replacement = resolved?.value;
+        tier = resolved?.tier;
+      }
+
+      if (replacement === undefined) {
+        i++;
+        continue;
+      }
+
+      if (i > last) {
+        chunks.push(str.slice(last, i));
+      }
+      chunks.push(replacement);
+      last = j + 1;
+      i = last;
+
+      if (checkLimits && this._tierCounts(tier!)) {
+        if (limitExpansions) {
+          this._totalExpansions++;
+          if (this._totalExpansions > this._maxTotalExpansions) {
+            throw new Error(
+              `[EntityReplacer] Entity expansion count limit exceeded: ` +
+                `${this._totalExpansions} > ${this._maxTotalExpansions}`
+            );
+          }
+        }
+        if (limitLength) {
+          const delta = replacement.length - (token.length + 2);
+          if (delta > 0) {
+            this._expandedLength += delta;
+            if (this._expandedLength > this._maxExpandedLength) {
+              throw new Error(
+                `[EntityReplacer] Expanded content length limit exceeded: ` +
+                  `${this._expandedLength} > ${this._maxExpandedLength}`
+              );
+            }
+          }
+        }
+      }
+    }
+
+    if (last < len) {
+      chunks.push(str.slice(last));
+    }
+
+    const result = chunks.length === 0 ? str : chunks.join("");
+    return this._postCheck(result, original);
+  }
+
+  // --- private methods ---
+
+  private _tierCounts(tier: string): boolean {
+    if (this._limitTiers.has(LIMIT_TIER_ALL)) {
+      return true;
+    }
+    return this._limitTiers.has(tier);
+  }
+
+  private _resolveName(name: string): { value: string; tier: string } | undefined {
+    if (name in this._inputMap) {
+      return { value: this._inputMap[name], tier: LIMIT_TIER_EXTERNAL };
+    }
+    if (name in this._externalMap) {
+      return { value: this._externalMap[name], tier: LIMIT_TIER_EXTERNAL };
+    }
+    if (name in this._baseMap) {
+      return { value: this._baseMap[name], tier: LIMIT_TIER_BASE };
+    }
+    return undefined;
+  }
+
+  private _classifyNCR(cp: number): number {
+    if (cp === 0) {
+      return this._ncrNullLevel;
+    }
+    if (cp >= 0xd800 && cp <= 0xdfff) {
+      return NCR_LEVEL.remove;
+    }
+    if (this._ncrXmlVersion === 1.0) {
+      if (cp >= 0x01 && cp <= 0x1f && !XML10_ALLOWED_C0.has(cp)) {
+        return NCR_LEVEL.remove;
+      }
+    }
+    return -1;
+  }
+
+  private _applyNCRAction(action: number, token: string, cp: number): string | undefined {
+    switch (action) {
+      case NCR_LEVEL.allow:
+        return String.fromCodePoint(cp);
+      case NCR_LEVEL.remove:
+        return "";
+      case NCR_LEVEL.leave:
+        return undefined;
+      case NCR_LEVEL.throw:
+        throw new Error(
+          `[EntityDecoder] Prohibited numeric character reference ` +
+            `&${token}; (U+${cp.toString(16).toUpperCase().padStart(4, "0")})`
+        );
+      default:
+        return String.fromCodePoint(cp);
+    }
+  }
+
+  private _resolveNCR(token: string): string | undefined {
+    const second = token.charCodeAt(1);
+    let cp: number;
+    if (second === 120 /* x */ || second === 88 /* X */) {
+      cp = parseInt(token.slice(2), 16);
+    } else {
+      cp = parseInt(token.slice(1), 10);
+    }
+
+    if (Number.isNaN(cp) || cp < 0 || cp > 0x10ffff) {
+      return undefined;
+    }
+
+    const minimum = this._classifyNCR(cp);
+
+    if (!this._numericAllowed && minimum < NCR_LEVEL.remove) {
+      return undefined;
+    }
+
+    const effective = minimum === -1 ? this._ncrOnLevel : Math.max(this._ncrOnLevel, minimum);
+
+    return this._applyNCRAction(effective, token, cp);
+  }
+};

--- a/packages-internal/xml-builder/src/xml-parser.ts
+++ b/packages-internal/xml-builder/src/xml-parser.ts
@@ -1,10 +1,6 @@
-// todo: package types are incorrect wrt exports.
-import type EntityDecoder from "@nodable/entities";
-import { COMMON_HTML, CURRENCY, XML } from "@nodable/entities";
 import { XMLParser } from "fast-xml-parser";
 
-// todo: package types are incorrect wrt exports.
-const { EntityDecoder: EntityDecoderImpl } = require("@nodable/entities");
+import { type EntityDecoder, COMMON_HTML, CURRENCY, EntityDecoderImpl, XML } from "./xml-external/nodable_entities";
 
 /**
  * Custom entity decoder that preserves C0 control characters (e.g. U+0015)


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7967

### Description
We are using https://www.npmjs.com/package/@nodable/entities to perform an override of the XML 1.0 spec as explained in https://github.com/aws/aws-sdk-js-v3/issues/7949.

This PR inlines the `@nodable/entities` package. This is because the package is module only and cannot safely in all environments be `require`'d by our dist-cjs code.

We are able to do so with `fast-xml-parser` because it provides a bundled distribution for CJS use, but we cannot access the EntityDecoder class from this bundle.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
