### PR TITLE
chore(xml-builder): manual version bump for 3.972.21 release

### DIFF
--- a/packages-internal/core/package.json
+++ b/packages-internal/core/package.json
@@ -83,7 +83,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "workspace:^3.973.8",
-    "@aws-sdk/xml-builder": "workspace:^3.972.20",
+    "@aws-sdk/xml-builder": "workspace:^3.972.21",
     "@smithy/core": "^3.23.17",
     "@smithy/node-config-provider": "^4.3.14",
     "@smithy/property-provider": "^4.2.14",

--- a/packages-internal/xml-builder/CHANGELOG.md
+++ b/packages-internal/xml-builder/CHANGELOG.md
@@ -5,20 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+# 3.972.21 (2026-04-27)
+### Bug Fixes
+* **xml-builder:** fix(xml-builder): inline nodable/entities for dist format compatibility ([#7968](https://github.com/aws/aws-sdk-js-v3/issues/7968))
 
 
 

--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-sdk/xml-builder",
-  "version": "3.972.20",
+  "version": "3.972.21",
   "description": "XML utilities for the AWS SDK",
   "dependencies": {
     "@nodable/entities": "2.1.0",

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -33,7 +33,7 @@
     "@aws-sdk/util-endpoints": "workspace:^3.996.8",
     "@aws-sdk/util-user-agent-browser": "workspace:^3.972.10",
     "@aws-sdk/util-user-agent-node": "workspace:^3.973.22",
-    "@aws-sdk/xml-builder": "workspace:^3.972.20",
+    "@aws-sdk/xml-builder": "workspace:^3.972.21",
     "@smithy/config-resolver": "^4.4.17",
     "@smithy/core": "^3.23.17",
     "@smithy/fetch-http-handler": "^5.3.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,7 +1201,7 @@ __metadata:
     "@aws-sdk/util-endpoints": "workspace:^3.996.8"
     "@aws-sdk/util-user-agent-browser": "workspace:^3.972.10"
     "@aws-sdk/util-user-agent-node": "workspace:^3.973.22"
-    "@aws-sdk/xml-builder": "workspace:^3.972.20"
+    "@aws-sdk/xml-builder": "workspace:^3.972.21"
     "@smithy/config-resolver": "npm:^4.4.17"
     "@smithy/core": "npm:^3.23.17"
     "@smithy/fetch-http-handler": "npm:^5.3.17"
@@ -23927,7 +23927,7 @@ __metadata:
   resolution: "@aws-sdk/core@workspace:packages-internal/core"
   dependencies:
     "@aws-sdk/types": "workspace:^3.973.8"
-    "@aws-sdk/xml-builder": "workspace:^3.972.20"
+    "@aws-sdk/xml-builder": "workspace:^3.972.21"
     "@smithy/core": "npm:^3.23.17"
     "@smithy/node-config-provider": "npm:^4.3.14"
     "@smithy/property-provider": "npm:^4.2.14"
@@ -25479,7 +25479,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/xml-builder@workspace:^3.972.20, @aws-sdk/xml-builder@workspace:packages-internal/xml-builder":
+"@aws-sdk/xml-builder@workspace:^3.972.21, @aws-sdk/xml-builder@workspace:packages-internal/xml-builder":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/xml-builder@workspace:packages-internal/xml-builder"
   dependencies:


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/pull/7968

### Description
manual version bump to match release of https://github.com/aws/aws-sdk-js-v3/pull/7968 for xml-builder.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
