### PR TITLE
test(client-dynamodb): e2e test table cleanup

### DIFF
--- a/clients/client-dynamodb/test/dynamodb-features.e2e.spec.ts
+++ b/clients/client-dynamodb/test/dynamodb-features.e2e.spec.ts
@@ -19,18 +19,38 @@ describe(DynamoDB.name, () => {
 
     // Wait for table to be active
     await waitUntilTableExists({ client, maxWaitTime: 300 }, { TableName: sharedTableName });
-  }, 60000);
+  }, 360_000);
 
   afterAll(async () => {
-    // Cleanup shared table
+    const prefix = "aws-sdk-js-integration-";
+    const eightHoursAgo = Date.now() - 8 * 60 * 60 * 1000;
+
     if (sharedTableName) {
-      try {
-        await client.deleteTable({ TableName: sharedTableName });
-      } catch (error) {
-        // Ignore errors during cleanup
-      }
+      await client.deleteTable({ TableName: sharedTableName }).catch(() => {});
     }
-  });
+
+    let lastTable: string | undefined;
+    do {
+      const list = await client.listTables({
+        ...(lastTable ? { ExclusiveStartTableName: lastTable } : {}),
+      });
+      const tables = list.TableNames ?? [];
+      lastTable = list.LastEvaluatedTableName;
+
+      for (const name of tables) {
+        if (!name.startsWith(prefix) || name === sharedTableName) {
+          continue;
+        }
+        try {
+          const desc = await client.describeTable({ TableName: name });
+          if (desc?.Table?.CreationDateTime?.getTime?.() ?? -Infinity < eightHoursAgo) {
+            await client.deleteTable({ TableName: name }).catch(() => {});
+            console.log("Deleted", name);
+          }
+        } catch {}
+      }
+    } while (lastTable);
+  }, 120_000);
 
   describe("Creating a table", () => {
     it("should verify table exists and is active", async () => {

--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -1,22 +1,18 @@
-import {
-  BillingMode,
+import type {
   CreateTableCommandOutput,
   DeleteItemCommandOutput,
   DescribeTableCommandOutput,
-  DynamoDB,
   GetItemCommandOutput,
-  waitUntilTableExists,
 } from "@aws-sdk/client-dynamodb";
-import {
+import { BillingMode, DynamoDB, waitUntilTableExists } from "@aws-sdk/client-dynamodb";
+import type {
   BatchExecuteStatementCommandOutput,
   BatchGetCommandOutput,
   BatchWriteCommandOutput,
-  DynamoDBDocument,
   ExecuteStatementCommandOutput,
   ExecuteTransactionCommandOutput,
   GetCommandInput,
   GetCommandOutput,
-  NumberValue,
   PutCommandOutput,
   QueryCommandInput,
   QueryCommandOutput,
@@ -26,8 +22,9 @@ import {
   TransactWriteCommandOutput,
   UpdateCommandOutput,
 } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocument, NumberValue } from "@aws-sdk/lib-dynamodb";
 import { HttpRequest } from "@smithy/protocol-http";
-import { afterAll, beforeAll, describe, expect, test as it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
 
 // expected running time: table creation (~20s) + operations 10s
 
@@ -586,10 +583,33 @@ describe(
     }, 180_000);
 
     afterAll(async () => {
-      await dynamodb.deleteTable({
-        TableName,
-      });
-    });
+      const prefix = "js-sdk-dynamodb-test-";
+      const eightHoursAgo = Date.now() - 8 * 60 * 60 * 1000;
+
+      await dynamodb.deleteTable({ TableName }).catch(() => {});
+
+      let lastTable: string | undefined;
+      do {
+        const list = await dynamodb.listTables({
+          ...(lastTable ? { ExclusiveStartTableName: lastTable } : {}),
+        });
+        const tables = list.TableNames ?? [];
+        lastTable = list.LastEvaluatedTableName;
+
+        for (const name of tables) {
+          if (!name.startsWith(prefix) || name === TableName) {
+            continue;
+          }
+          try {
+            const desc = await dynamodb.describeTable({ TableName: name });
+            if (desc?.Table?.CreationDateTime?.getTime?.() ?? -Infinity < eightHoursAgo) {
+              await dynamodb.deleteTable({ TableName: name }).catch(() => {});
+              console.log("Deleted", name);
+            }
+          } catch {}
+        }
+      } while (lastTable);
+    }, 120_000);
 
     describe("updateTransformFunction", () => {
       it("modifies all fields of an object", () => {


### PR DESCRIPTION
### Issue
n/a

### Description
ddb test table cleanup is now by prefix so tables don't get missed for whatever reason if the test run's specific table is not deleted.

Deletion won't interrupt running tests because it gives a buffer of 8 hours.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
