### PR TITLE
chore(core/client): emit warning for Node.js 20.x end-of-support

### DIFF
--- a/packages-internal/core/src/submodules/client/emitWarningIfUnsupportedVersion.spec.ts
+++ b/packages-internal/core/src/submodules/client/emitWarningIfUnsupportedVersion.spec.ts
@@ -4,7 +4,8 @@ import { emitWarningIfUnsupportedVersion, state } from "./emitWarningIfUnsupport
 
 describe("emitWarningIfUnsupportedVersion", () => {
   const emitWarning = process.emitWarning;
-  const supportedVersion = "20.0.0";
+  const supportedVersion = "22.0.0";
+  const supportedMajorVersion = parseInt(supportedVersion.substring(0, supportedVersion.indexOf(".")));
 
   beforeEach(() => {});
 
@@ -38,11 +39,12 @@ describe("emitWarningIfUnsupportedVersion", () => {
       // Verify that the warning was emitted.
       expect(process.emitWarning).toHaveBeenCalledTimes(1);
       expect(process.emitWarning).toHaveBeenCalledWith(
-        `NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
-no longer support Node.js ${unsupportedVersion} in January 2026.
+        `NodeVersionSupportWarning: The AWS SDK for JavaScript (v3)
+versions published after the first week of January 2027
+will require node >=${supportedMajorVersion}. You are running node ${unsupportedVersion}.
 
-To continue receiving updates to AWS services, bug fixes, and security
-updates please upgrade to a supported Node.js LTS version.
+To continue receiving updates to AWS services, bug fixes,
+and security updates please upgrade to node >=${supportedMajorVersion}.
 
 More information can be found at: https://a.co/c895JFp`
       );

--- a/packages-internal/core/src/submodules/client/emitWarningIfUnsupportedVersion.ts
+++ b/packages-internal/core/src/submodules/client/emitWarningIfUnsupportedVersion.ts
@@ -4,24 +4,36 @@ export const state = {
 };
 
 /**
- * @internal
- *
  * Emits warning if the provided Node.js version string is
  * pending deprecation by AWS SDK JSv3.
+ * @internal
  *
  * @param version - The Node.js version string.
  */
 export const emitWarningIfUnsupportedVersion = (version: string) => {
-  if (version && !state.warningEmitted && parseInt(version.substring(1, version.indexOf("."))) < 20) {
-    state.warningEmitted = true;
-    process.emitWarning(
-      `NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
-no longer support Node.js ${version} in January 2026.
+  if (version && !state.warningEmitted) {
+    if (process.env.AWS_SDK_JS_NODE_VERSION_SUPPORT_WARNING_DISABLED === "true") {
+      state.warningEmitted = true;
+      return;
+    }
+    const userMajorVersion = parseInt(version.substring(1, version.indexOf(".")));
 
-To continue receiving updates to AWS services, bug fixes, and security
-updates please upgrade to a supported Node.js LTS version.
+    // (For text spacing)
+    // Recommended minimum major version.
+    const vv = 22;
+
+    if (userMajorVersion < vv) {
+      state.warningEmitted = true;
+      process.emitWarning(
+        `NodeVersionSupportWarning: The AWS SDK for JavaScript (v3)
+versions published after the first week of January 2027
+will require node >=${vv}. You are running node ${version}.
+
+To continue receiving updates to AWS services, bug fixes,
+and security updates please upgrade to node >=${vv}.
 
 More information can be found at: https://a.co/c895JFp`
-    );
+      );
+    }
   }
 };


### PR DESCRIPTION
### Issue
V2193324121

### Description
warn when using Node.js < 22. 

### Testing
updated unit tests

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
