### PR TITLE
fix(cloudfront-signer): preserve URL encoding of resource path (#7571)

### DIFF
--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -383,6 +383,57 @@ describe("getSignedUrl", () => {
       expect(verifySignature(signatureQueryParam, policy)).toBeTruthy();
     });
   });
+
+  describe("should URL-encode special characters in the resource path (regression for #7571)", () => {
+    it("encodes a raw space in the resource path as %20", () => {
+      const urlWithSpace = "https://d111111abcdef8.cloudfront.net/My File.pdf";
+      const result = getSignedUrl({
+        url: urlWithSpace,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+        passphrase,
+      });
+      expect(result).toContain("/My%20File.pdf");
+      expect(result).not.toContain("/My File.pdf");
+    });
+
+    it("does not double-encode a path that is already percent-encoded", () => {
+      const urlAlreadyEncoded = "https://d111111abcdef8.cloudfront.net/My%20File.pdf";
+      const result = getSignedUrl({
+        url: urlAlreadyEncoded,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+        passphrase,
+      });
+      expect(result).toContain("/My%20File.pdf");
+      expect(result).not.toContain("/My%2520File.pdf");
+    });
+
+    it("encodes the path and produces a signature that matches a policy whose resource uses the encoded path", () => {
+      const urlWithSpace = "https://d111111abcdef8.cloudfront.net/My File.pdf";
+      const result = getSignedUrl({
+        url: urlWithSpace,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+        passphrase,
+      });
+      const expectedResource = "https://d111111abcdef8.cloudfront.net/My%20File.pdf";
+      const policyStr = JSON.stringify({
+        Statement: [
+          {
+            Resource: expectedResource,
+            Condition: { DateLessThan: { "AWS:EpochTime": epochDateLessThan } },
+          },
+        ],
+      });
+      const parsedUrl = parseUrl(result);
+      const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+      expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
+    });
+  });
 });
 
 describe("getSignedCookies", () => {

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -113,11 +113,13 @@ export function getSignedUrl({
     throw new Error("@aws-sdk/cloudfront-signer: Please provide 'url' or 'policy'.");
   }
 
+  const encodedUrl = url ? encodeBaseUrlQuery(url) : undefined;
+
   if (policy) {
     cloudfrontSignBuilder.setCustomPolicy(policy);
   } else {
     cloudfrontSignBuilder.setPolicyParameters({
-      url,
+      url: encodedUrl,
       dateLessThan,
       dateGreaterThan,
       ipAddress,
@@ -125,8 +127,8 @@ export function getSignedUrl({
   }
 
   let baseUrl: string | undefined;
-  if (url) {
-    baseUrl = url;
+  if (encodedUrl) {
+    baseUrl = encodedUrl;
   } else if (policy) {
     const resources = getPolicyResources(policy!);
     if (!resources[0]) {
@@ -134,7 +136,7 @@ export function getSignedUrl({
         "@aws-sdk/cloudfront-signer: No URL provided and unable to determine URL from first policy statement resource."
       );
     }
-    baseUrl = resources[0].replace("*://", "https://");
+    baseUrl = encodeBaseUrlQuery(resources[0].replace("*://", "https://"));
   }
 
   const startFlag = baseUrl!.includes("?") ? "&" : "?";
@@ -143,20 +145,29 @@ export function getSignedUrl({
     .map(([key, value]) => `${extendedEncodeURIComponent(key)}=${extendedEncodeURIComponent(value)}`)
     .join("&");
 
-  function encodeBaseUrlQuery(url: string) {
-    if (url.includes("?")) {
-      const [hostAndPath, query] = url.split("?");
-      const params = [...new URLSearchParams(query).entries()]
-        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-        .join("&");
-      return `${hostAndPath}?${params}`;
-    }
-    return url;
-  }
-
-  const urlString = encodeBaseUrlQuery(baseUrl!) + startFlag + params;
+  const urlString = baseUrl + startFlag + params;
 
   return getResource(urlString);
+}
+
+/**
+ * Encodes the host-and-path portion of a URL such that characters that must
+ * be percent-encoded for the URL to be valid (e.g. spaces -> %20) are
+ * encoded, while existing percent-encoded sequences are preserved (no
+ * double-encoding) and query-string parameter values are re-encoded
+ * consistently. Path segments such as "." and ".." are not normalized.
+ *
+ * @internal
+ */
+function encodeBaseUrlQuery(url: string): string {
+  if (url.includes("?")) {
+    const [hostAndPath, query] = url.split("?");
+    const params = [...new URLSearchParams(query).entries()]
+      .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+      .join("&");
+    return `${encodeBaseUrlPath(hostAndPath)}?${params}`;
+  }
+  return encodeBaseUrlPath(url);
 }
 
 /**
@@ -183,7 +194,7 @@ export function getSignedCookies({
     cloudfrontSignBuilder.setCustomPolicy(policy);
   } else {
     cloudfrontSignBuilder.setPolicyParameters({
-      url,
+      url: url ? encodeBaseUrlQuery(url) : url,
       dateLessThan,
       dateGreaterThan,
       ipAddress,
@@ -257,6 +268,44 @@ interface CloudfrontAttributes {
 function getPolicyResources(policy: string | Policy) {
   const parsedPolicy: Policy = typeof policy === "string" ? JSON.parse(policy) : policy;
   return (parsedPolicy?.Statement ?? []).map((s) => s.Resource);
+}
+
+/**
+ * Encodes characters in the host-and-path portion of a URL that must be
+ * percent-encoded for the URL to be valid (e.g. spaces -> %20), without
+ * double-encoding sequences that are already percent-encoded and without
+ * normalizing path segments such as "." and "..".
+ *
+ * @internal
+ */
+function encodeBaseUrlPath(hostAndPath: string): string {
+  const schemeIndex = hostAndPath.indexOf("://");
+  if (schemeIndex === -1) {
+    return encodePathPreservingEncoded(hostAndPath);
+  }
+  const schemeAndAuthorityEnd = hostAndPath.indexOf("/", schemeIndex + 3);
+  if (schemeAndAuthorityEnd === -1) {
+    return hostAndPath;
+  }
+  const schemeAndAuthority = hostAndPath.slice(0, schemeAndAuthorityEnd);
+  const path = hostAndPath.slice(schemeAndAuthorityEnd);
+  return schemeAndAuthority + encodePathPreservingEncoded(path);
+}
+
+/**
+ * Percent-encodes characters in `path` that require encoding, while leaving
+ * existing percent-encoded sequences (%XX) untouched so callers that have
+ * already encoded their path are not double-encoded.
+ *
+ * @internal
+ */
+function encodePathPreservingEncoded(path: string): string {
+  return path.replace(/%[0-9A-Fa-f]{2}|[^A-Za-z0-9\-._~!$&'()*+,;=:@/]/g, (match) => {
+    if (match.length === 3 && match[0] === "%") {
+      return match;
+    }
+    return encodeURIComponent(match);
+  });
 }
 
 /**


### PR DESCRIPTION
### Issue
#7571

### Description
PR #7237 replaced `new URL(baseUrl)` with raw string concatenation to stop the `URL` object from normalizing path segments such as `.` and `..`. As a side effect, the `URL` constructor's automatic percent-encoding of unsafe path characters (notably spaces -> `%20`) was lost, so `getSignedUrl({ url: "https://.../My File.pdf" })` returned a URL with a literal space in the path, breaking the signature once a client encoded the space before sending.

This PR adds two internal helpers in `packages/cloudfront-signer/src/sign.ts`:

- `encodeBaseUrlPath` - splits scheme+authority from path and only encodes the path portion.
- `encodePathPreservingEncoded` - percent-encodes characters outside the RFC 3986 path-allowed set while leaving existing `%XX` sequences untouched (no double-encoding).

The existing `encodeBaseUrlQuery` helper was hoisted out of `getSignedUrl`, extended to also encode the host-and-path, and applied once at the top of `getSignedUrl` so the policy resource and the final signed URL stay in sync. `getSignedCookies` and the `policy`-extracted `baseUrl` path are routed through the same encoder. `.` and `..` segments remain in the allowed set, preserving the original PR #7237 behavior.

Files changed:
- `packages/cloudfront-signer/src/sign.ts`
- `packages/cloudfront-signer/src/sign.spec.ts`

_generated by AI tools, and reviewed by Mohanraj Venkatesan_

### Testing
Three regression tests added in `packages/cloudfront-signer/src/sign.spec.ts`:

1. `encodes a raw space in the resource path as %20` - reproduces the bug; asserts the result contains `/My%20File.pdf`.
2. `does not double-encode a path that is already percent-encoded` - input `/My%20File.pdf` stays `%20` (not `%2520`).
3. `encodes the path and produces a signature that matches a policy whose resource uses the encoded path` - verifies the RSA-SHA1 signature against the encoded resource.

Result: `Tests 31 passed (31)` (28 pre-existing + 3 new). All previously-existing tests continue to pass, including those covering `.`/`..` path segments from PR #7237.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.