### PR TITLE
test(client-dynamodb): fix table cleanup criteria

### DIFF
--- a/clients/client-dynamodb/test/dynamodb-features.e2e.spec.ts
+++ b/clients/client-dynamodb/test/dynamodb-features.e2e.spec.ts
@@ -73,7 +73,7 @@ describe(DynamoDB.name, () => {
         }
         try {
           const desc = await client.describeTable({ TableName: name });
-          if (desc?.Table?.CreationDateTime?.getTime?.() ?? -Infinity < eightHoursAgo) {
+          if ((desc?.Table?.CreationDateTime?.getTime?.() ?? Infinity) < eightHoursAgo) {
             await client.deleteTable({ TableName: name }).catch(() => {});
             console.log("Deleted", name);
           }

--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -624,7 +624,7 @@ describe(
           }
           try {
             const desc = await dynamodb.describeTable({ TableName: name });
-            if (desc?.Table?.CreationDateTime?.getTime?.() ?? -Infinity < eightHoursAgo) {
+            if ((desc?.Table?.CreationDateTime?.getTime?.() ?? Infinity) < eightHoursAgo) {
               await dynamodb.deleteTable({ TableName: name }).catch(() => {});
               console.log("Deleted", name);
             }


### PR DESCRIPTION
Avoid accidentally deleting a fresh table from another test.