### PR TITLE
chore(workflows): migrate git-sync SSH key from GitHub secret to Secrets Manager via OIDC

### DIFF
--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -2,23 +2,52 @@ name: git-sync-with-mirror
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   git-sync:
     runs-on: ubuntu-latest
-
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::231016596583:role/github-actions-git-sync-role
+          aws-region: us-west-2
+
+      - name: Fetch SSH keys from Secrets Manager
+        id: secrets
+        run: |
+          source_key=$(aws secretsmanager get-secret-value \
+            --secret-id prod/aws-javascript-sdk-team/github/ssh-keys/aws-sdk-js-v3-deploy-key \
+            --query SecretString --output text)
+          echo "::add-mask::$source_key"
+          {
+            echo "SOURCE_SSH_KEY<<ENDOFKEY"
+            echo "$source_key"
+            echo "ENDOFKEY"
+          } >> "$GITHUB_OUTPUT"
+
+          dest_key=$(aws secretsmanager get-secret-value \
+            --secret-id prod/aws-javascript-sdk-team/github/ssh-keys/private-aws-sdk-js-v3-deploy-key \
+            --query SecretString --output text)
+          echo "::add-mask::$dest_key"
+          {
+            echo "DEST_SSH_KEY<<ENDOFKEY"
+            echo "$dest_key"
+            echo "ENDOFKEY"
+          } >> "$GITHUB_OUTPUT"
+
       - name: git-sync
-        env:
-          git_sync_destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }}
-          git_sync_ssh_private_key: ${{ secrets.GIT_SYNC_SSH_PRIVATE_KEY }}
-        if: env.git_sync_destination_repo && env.git_sync_ssh_private_key
         uses: wei/git-sync@v3
         with:
           source_repo: "git@github.com:aws/aws-sdk-js-v3.git"
           source_branch: "main"
-          destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }} 
+          destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }}
           destination_branch: "main"
-          ssh_private_key: ${{ secrets.GIT_SYNC_SSH_PRIVATE_KEY }}
+          source_ssh_private_key: ${{ steps.secrets.outputs.SOURCE_SSH_KEY }}
+          destination_ssh_private_key: ${{ steps.secrets.outputs.DEST_SSH_KEY }}


### PR DESCRIPTION
### Issue
Internal JS-6698

### Description
Migrates the git-sync workflow from using a GitHub repo secret to fetching the SSH key at runtime from Secrets Manager via OIDC role assumption.


### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
