### PR TITLE
chore(codegen): smithy-aws-typescript-codegen 0.49.1

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 [Commit logs](https://github.com/aws/aws-sdk-js-v3/commits/main/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen)
 
+## 0.49.1 (2026-04-30)
+
+### Chores
+
+- Upgraded to smithy-typescript 0.49.1 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0491-2026-04-30))
+
 ## 0.49.0 (2026-04-28)
 
 ### Chores
 
-- Upgraded to smithy-typescript 0.49.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0480-2026-04-28))
+- Upgraded to smithy-typescript 0.49.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0490-2026-04-28))
 
 ## 0.48.0 (2026-04-08)
 

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -37,7 +37,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.49.0"
+    version = "0.49.1"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.49.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.49.1")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/74516bb871b0f65b4eca3af8b280ed217e4f217f...31358fa7bc02721b54a02fb0ece52064abe29143
-  SMITHY_TS_COMMIT: "31358fa7bc02721b54a02fb0ece52064abe29143",
+  // https://github.com/smithy-lang/smithy-typescript/compare/31358fa7bc02721b54a02fb0ece52064abe29143...ffa66773c40741dfe9aef8dd43dbe683e9253f55
+  SMITHY_TS_COMMIT: "ffa66773c40741dfe9aef8dd43dbe683e9253f55",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
version bump only to match smithy-ts https://github.com/smithy-lang/smithy-typescript/pull/1990