### PR TITLE
fix(lib-storage): use Math.ceil in default partSize calculation.

### DIFF
--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -854,7 +854,7 @@ describe(Upload.name, () => {
 
       // Should use calculated part size based on total size and MAX_PARTS
       const MIN_PART_SIZE = 1024 * 1024 * 5; // 5MB - same as Upload.MIN_PART_SIZE
-      const expectedPartSize = Math.max(MIN_PART_SIZE, Math.floor(largeBuffer.length / 10_000));
+      const expectedPartSize = Math.max(MIN_PART_SIZE, Math.ceil(largeBuffer.length / 10_000));
       expect((upload as any).partSize).toBe(expectedPartSize);
     });
 
@@ -968,6 +968,15 @@ describe(Upload.name, () => {
           client: new S3({}),
         });
       }).toThrow("Queue size: Must have at least one uploading queue.");
+    });
+
+    it("should calculate default partSize using ceil so part count never exceeds 10,000", () => {
+      const totalBytes = 52_428_800_001; // 10,000 * 5 MiB + 1 byte
+      const upload = new Upload({
+        params: { ...params, Body: Buffer.alloc(0), ContentLength: totalBytes },
+        client: new S3({}),
+      });
+      expect((upload as any).expectedPartsCount).toBeLessThanOrEqual(10_000);
     });
   });
 

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -109,7 +109,7 @@ export class Upload extends EventEmitter {
     this.abortController = options.abortController ?? new AbortController();
 
     this.partSize =
-      options.partSize || Math.max(Upload.MIN_PART_SIZE, Math.floor((this.totalBytes || 0) / this.MAX_PARTS));
+      options.partSize || Math.max(Upload.MIN_PART_SIZE, Math.ceil((this.totalBytes || 0) / this.MAX_PARTS));
 
     if (this.totalBytes !== undefined) {
       this.expectedPartsCount = Math.ceil(this.totalBytes / this.partSize);


### PR DESCRIPTION
### Issue
Internal V2196771094

### Description
When no partSize is provided, the Upload class uses `Math.max(MIN_PART_SIZE, Math.floor(largeBuffer.length / 10_000))` to calculate the default. Rounding down makes the part size too small by 1 byte for certain file sizes, causing the upload to split into 10,001 parts and fail (S3 allows max 10,000).

Fixed by changing `Math.floor` to `Math.ceil`, so the part size rounds up and the part count stays within the 10,000 limit.

### Testing
$ yarn test
```
 ✓ src/byteLength.spec.ts (12 tests) 6ms
 ✓ src/byteLengthSource.spec.ts (12 tests) 7ms
 ✓ src/chunks/getChunkUint8Array.spec.ts (6 tests) 11ms
 ✓ src/index.spec.ts (2 tests) 4ms
 ✓ src/chunks/getDataReadable.spec.ts (3 tests) 153ms
 ✓ src/chunks/getDataReadableStream.spec.ts (4 tests) 156ms
 ✓ src/Upload.spec.ts (52 tests) 24006ms
     ✓ should add tags to the object if tags have been added multi-part  23546ms

 Test Files  7 passed (7)
      Tests  91 passed (91)
   Start at  14:46:09
   Duration  24.49s (transform 1.32s, setup 0ms, import 1.78s, tests 24.34s, environment 1ms)
```

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
