### PR TITLE
fix(util-dynamodb): narrow NativeAttributeValue to remove implicit any (#7526)

### DIFF
--- a/packages-internal/util-dynamodb/src/NativeAttributeValue.spec.ts
+++ b/packages-internal/util-dynamodb/src/NativeAttributeValue.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test as it } from "vitest";
+
+import type { NativeAttributeValue } from "./models";
+import { NumberValue } from "./NumberValue";
+
+/**
+ * Regression tests for https://github.com/aws/aws-sdk-js-v3/issues/7526
+ *
+ * Prior to the fix, the `NativeAttributeValue` union included
+ * `InstanceType<{ new (...args: any[]): any }>` which TypeScript widened the
+ * entire union to `any`, defeating type checking for users of the
+ * DynamoDB Document Client. The fix removes that widening branch.
+ *
+ * These tests are primarily compile-time assertions. They verify that:
+ *   - Valid DynamoDB-compatible values still assign cleanly.
+ *   - Values that should never be valid (functions, symbols) are now
+ *     rejected by the type checker.
+ *
+ * The runtime expectations are trivial (`true`) — the real assertions
+ * happen at type-check time via the `// @ts-expect-error` markers.
+ */
+
+// Helper: an identity-typed sink that forces `value` to be assignable to
+// `NativeAttributeValue`. Using a function rather than a `const` annotation
+// ensures the assignment is checked even when invoked with literal values.
+const acceptsNativeAttributeValue = (value: NativeAttributeValue): NativeAttributeValue => value;
+
+describe("NativeAttributeValue type", () => {
+  it("accepts string values", () => {
+    const value: NativeAttributeValue = "hello";
+    expect(acceptsNativeAttributeValue(value)).toBe("hello");
+  });
+
+  it("accepts number values", () => {
+    const value: NativeAttributeValue = 42;
+    expect(acceptsNativeAttributeValue(value)).toBe(42);
+  });
+
+  it("accepts boolean values", () => {
+    const value: NativeAttributeValue = true;
+    expect(acceptsNativeAttributeValue(value)).toBe(true);
+  });
+
+  it("accepts null", () => {
+    const value: NativeAttributeValue = null;
+    expect(acceptsNativeAttributeValue(value)).toBeNull();
+  });
+
+  it("accepts undefined", () => {
+    const value: NativeAttributeValue = undefined;
+    expect(acceptsNativeAttributeValue(value)).toBeUndefined();
+  });
+
+  it("accepts bigint values", () => {
+    const value: NativeAttributeValue = BigInt(1);
+    expect(acceptsNativeAttributeValue(value)).toBe(BigInt(1));
+  });
+
+  it("accepts NumberValue instances", () => {
+    const value: NativeAttributeValue = NumberValue.from("123");
+    expect(acceptsNativeAttributeValue(value)).toBeInstanceOf(NumberValue);
+  });
+
+  it("accepts Uint8Array (binary)", () => {
+    const value: NativeAttributeValue = new Uint8Array([1, 2, 3]);
+    expect(acceptsNativeAttributeValue(value)).toBeInstanceOf(Uint8Array);
+  });
+
+  it("accepts ArrayBuffer (binary)", () => {
+    const value: NativeAttributeValue = new ArrayBuffer(4);
+    expect(acceptsNativeAttributeValue(value)).toBeInstanceOf(ArrayBuffer);
+  });
+
+  it("accepts string Set", () => {
+    const value: NativeAttributeValue = new Set(["a", "b"]);
+    expect(acceptsNativeAttributeValue(value)).toBeInstanceOf(Set);
+  });
+
+  it("accepts number Set", () => {
+    const value: NativeAttributeValue = new Set([1, 2, 3]);
+    expect(acceptsNativeAttributeValue(value)).toBeInstanceOf(Set);
+  });
+
+  it("accepts plain object (map)", () => {
+    const value: NativeAttributeValue = { pk: "a", sk: 1, nested: { flag: true } };
+    expect(acceptsNativeAttributeValue(value)).toEqual({ pk: "a", sk: 1, nested: { flag: true } });
+  });
+
+  it("accepts arrays (list)", () => {
+    const value: NativeAttributeValue = [1, "two", null, { nested: true }];
+    expect(acceptsNativeAttributeValue(value)).toEqual([1, "two", null, { nested: true }]);
+  });
+
+  it("rejects function values at the type level", () => {
+    const fn = () => "not a valid attribute";
+    // @ts-expect-error functions are not valid DynamoDB attribute values; before
+    // the fix, this assignment was silently accepted because the union had
+    // collapsed to `any`.
+    const value: NativeAttributeValue = fn;
+    expect(typeof value).toBe("function");
+  });
+
+  it("rejects symbol values at the type level", () => {
+    const sym = Symbol("not a valid attribute");
+    // @ts-expect-error symbols are not valid DynamoDB attribute values; before
+    // the fix, this assignment was silently accepted because the union had
+    // collapsed to `any`.
+    const value: NativeAttributeValue = sym;
+    expect(typeof value).toBe("symbol");
+  });
+
+  it("preserves narrowing — values typed as NativeAttributeValue cannot be assigned to string without a cast", () => {
+    // Use a function parameter to defeat literal-type narrowing.
+    const consume = (attr: NativeAttributeValue): string => {
+      // @ts-expect-error before the fix, NativeAttributeValue resolved to `any`
+      // and would assign freely to `string` without a cast. After the fix the
+      // union no longer includes `any`, so this assignment requires narrowing.
+      const asString: string = attr;
+      return asString;
+    };
+    expect(consume("hello")).toBe("hello");
+  });
+});

--- a/packages-internal/util-dynamodb/src/convertToAttr.ts
+++ b/packages-internal/util-dynamodb/src/convertToAttr.ts
@@ -10,7 +10,11 @@ import { NumberValue } from "./NumberValue";
  * @param data - The data to convert to a DynamoDB AttributeValue.
  * @param options - An optional configuration object for `convertToAttr`.
  */
-export const convertToAttr = (data: NativeAttributeValue, options?: marshallOptions): AttributeValue => {
+export const convertToAttr = (input: NativeAttributeValue, options?: marshallOptions): AttributeValue => {
+  // This function performs a runtime type dispatch, so we widen the input
+  // to `any` locally to avoid having to manually narrow against every branch
+  // of the public NativeAttributeValue union.
+  const data: any = input;
   if (data === undefined) {
     throw new Error(`Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.`);
   } else if (data === null && typeof data === "object") {

--- a/packages-internal/util-dynamodb/src/marshall.ts
+++ b/packages-internal/util-dynamodb/src/marshall.ts
@@ -96,7 +96,7 @@ export function marshall(data: any, options?: marshallOptions): any;
  */
 export function marshall(data: unknown, options?: marshallOptions): AttributeValue.$UnknownMember;
 export function marshall(data: unknown, options?: marshallOptions) {
-  const attributeValue: AttributeValue = convertToAttr(data, options);
+  const attributeValue: AttributeValue = convertToAttr(data as NativeAttributeValue, options);
   const [key, value] = Object.entries(attributeValue)[0];
 
   switch (key) {

--- a/packages-internal/util-dynamodb/src/models.ts
+++ b/packages-internal/util-dynamodb/src/models.ts
@@ -17,8 +17,7 @@ export type NativeAttributeValue =
   | NativeScalarAttributeValue
   | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[]
-  | Set<number | bigint | NumberValue | string | NativeAttributeBinary | undefined>
-  | InstanceType<{ new (...args: any[]): any }>; // accepts any class instance with options.convertClassInstanceToMap
+  | Set<number | bigint | NumberValue | string | NativeAttributeBinary | undefined>;
 
 /**
  * @public

--- a/packages-internal/util-dynamodb/src/unmarshall.ts
+++ b/packages-internal/util-dynamodb/src/unmarshall.ts
@@ -37,7 +37,7 @@ export const unmarshall = (
   options?: unmarshallOptions
 ): Record<string, NativeAttributeValue> => {
   if (options?.convertWithoutMapWrapper) {
-    return convertToNative(data as AttributeValue, options);
+    return convertToNative(data as AttributeValue, options) as Record<string, NativeAttributeValue>;
   }
   return convertToNative({ M: data as Record<string, AttributeValue> }, options) as Record<
     string,


### PR DESCRIPTION
## Issue

Fixes #7526 — `NativeAttributeValue` type resolves to `any`.

## Description

The `NativeAttributeValue` union exported from `@aws-sdk/util-dynamodb` (and re-exported by `@aws-sdk/lib-dynamodb`) included `InstanceType<{ new (...args: any[]): any }>` as a union member. TypeScript widens `InstanceType<{ new (...args: any[]): any }>` to `any`, which collapsed the entire union to `any` and silently disabled type-checking for every consumer of the DynamoDB Document Client (`PutCommand`, `UpdateCommand`, `marshall`, `convertToAttr`, etc.).

The maintainer (@kuhe) identified the fix in a comment on the issue: remove that member from the union. This PR removes it and resolves the latent typecheck errors that surfaced inside the package once the implicit `any` was no longer absorbing them — three small internal cast adjustments in `convertToAttr.ts`, `marshall.ts`, and `unmarshall.ts`. No runtime behavior changes.

**Files changed:**
- `packages-internal/util-dynamodb/src/models.ts` — the actual type fix (drop the `InstanceType<...>` union member that widened to `any`).
- `packages-internal/util-dynamodb/src/convertToAttr.ts` — small local-cast adjustment to satisfy the now-stricter union.
- `packages-internal/util-dynamodb/src/marshall.ts` — small cast adjustment.
- `packages-internal/util-dynamodb/src/unmarshall.ts` — small cast adjustment.
- `packages-internal/util-dynamodb/src/NativeAttributeValue.spec.ts` — new regression spec.

**Note on breaking-ness:** This is a type-only change. Runtime behavior is identical. Downstream users currently passing arbitrary class instances directly into `marshall`/`convertToAttr` (relying on `convertClassInstanceToMap`) will now see compile errors at the call site. The maintainer flagged the original bug as "breaking"; this PR follows their guidance.

_generated by AI tools, and reviewed by Mohanraj Venkatesan_

## Testing

Added `packages-internal/util-dynamodb/src/NativeAttributeValue.spec.ts` with 16 Vitest cases:
- 13 positive assignments covering every supported native type (string, number, boolean, null, undefined, bigint, `NumberValue`, `Uint8Array`, `ArrayBuffer`, `Set` variants, map, list).
- 3 `// @ts-expect-error` regressions that verify the union no longer collapses to `any` (function, symbol, and a parameter-not-narrowed case).

Verified the regression tests catch the original bug: temporarily restoring the offending union member produces 3 `TS2578: Unused '@ts-expect-error' directive` errors, exactly as expected.

Local results:
- `npx vitest run` in `packages-internal/util-dynamodb` — **388/388 pass** (372 pre-existing + 16 new).
- `npx tsc --noEmit -p tsconfig.types.json` — only pre-existing baseline errors remain (4 `@aws-sdk/client-dynamodb` module-resolution errors due to missing local `dist-*/` outputs, plus one pre-existing unused-directive). No new errors introduced.

## Checklist

- [x] Linked to the original issue (#7526).
- [x] Added a regression test that fails on `main` and passes with this fix.
- [x] All existing tests in the affected package still pass (`vitest run`: 388/388).
- [x] No new `tsc --noEmit` errors introduced.
- [x] Husky pre-commit hooks pass (lint-staged, lint:versions, lint:dependencies, lint:api).
- [x] AI disclosure included in Description per repo policy.