### PR TITLE
fix(lib-storage): error early when full-object Checksum* is supplied with multipart Upload (#6742)

### DIFF
--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -508,6 +508,122 @@ describe(Upload.name, () => {
     });
   });
 
+  // Regression tests for https://github.com/aws/aws-sdk-js-v3/issues/6742
+  describe("precomputed checksum + multipart validation", () => {
+    const MOCK_PART_SIZE = 24;
+    beforeEach(() => {
+      (Upload as any).MIN_PART_SIZE = MOCK_PART_SIZE;
+    });
+
+    afterAll(() => {
+      (Upload as any).MIN_PART_SIZE = 1024 * 1024 * 5;
+    });
+
+    it("rejects multipart Upload when caller supplies a precomputed ChecksumSHA256", async () => {
+      const largeBuffer = Buffer.from("#".repeat(MOCK_PART_SIZE + 10));
+      const actionParams = {
+        ...params,
+        Body: largeBuffer,
+        ChecksumSHA256: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      };
+
+      const upload = new Upload({
+        params: actionParams,
+        partSize: MOCK_PART_SIZE,
+        client: new S3({}),
+      });
+
+      await expect(upload.done()).rejects.toThrow(/ChecksumSHA256/);
+      await expect(
+        new Upload({
+          params: actionParams,
+          partSize: MOCK_PART_SIZE,
+          client: new S3({}),
+        }).done()
+      ).rejects.toThrow(/issues\/6742/);
+
+      // The upload must fail before any S3 multipart side-effects.
+      expect(CreateMultipartUploadCommand).toHaveBeenCalledTimes(0);
+      expect(UploadPartCommand).toHaveBeenCalledTimes(0);
+      expect(CompleteMultipartUploadCommand).toHaveBeenCalledTimes(0);
+    });
+
+    it.each(["ChecksumSHA1", "ChecksumCRC32", "ChecksumCRC32C", "ChecksumCRC64NVME"])(
+      "rejects multipart Upload when caller supplies precomputed %s",
+      async (checksumKey) => {
+        const largeBuffer = Buffer.from("#".repeat(MOCK_PART_SIZE + 10));
+        const actionParams = {
+          ...params,
+          Body: largeBuffer,
+          [checksumKey]: "AAAAAAAA",
+        };
+
+        const upload = new Upload({
+          params: actionParams,
+          partSize: MOCK_PART_SIZE,
+          client: new S3({}),
+        });
+
+        await expect(upload.done()).rejects.toThrow(new RegExp(checksumKey));
+        expect(CreateMultipartUploadCommand).toHaveBeenCalledTimes(0);
+      }
+    );
+
+    it("accepts multipart Upload with ChecksumAlgorithm only (no precomputed value)", async () => {
+      const largeBuffer = Buffer.from("#".repeat(MOCK_PART_SIZE + 10));
+      const actionParams = {
+        ...params,
+        Body: largeBuffer,
+        ChecksumAlgorithm: "SHA256" as const,
+      };
+
+      const upload = new Upload({
+        params: actionParams,
+        partSize: MOCK_PART_SIZE,
+        client: new S3({}),
+      });
+
+      await upload.done();
+
+      expect(CreateMultipartUploadCommand).toHaveBeenCalledTimes(1);
+      expect(CreateMultipartUploadCommand).toHaveBeenCalledWith({
+        ...actionParams,
+        Body: undefined,
+        ChecksumAlgorithm: "SHA256",
+      });
+      expect(UploadPartCommand).toHaveBeenCalledTimes(2);
+      expect(CompleteMultipartUploadCommand).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not reject single-part Upload when caller supplies a precomputed ChecksumSHA256", async () => {
+      // Body smaller than partSize -> __uploadUsingPut path, not multipart.
+      const smallBuffer = Buffer.from("#".repeat(MOCK_PART_SIZE - 1));
+      const actionParams = {
+        ...params,
+        Body: smallBuffer,
+        ChecksumSHA256: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      };
+
+      const upload = new Upload({
+        params: actionParams,
+        partSize: MOCK_PART_SIZE,
+        client: new S3({}),
+      });
+
+      await upload.done();
+
+      // Single PUT path: no multipart commands issued.
+      expect(CreateMultipartUploadCommand).toHaveBeenCalledTimes(0);
+      expect(UploadPartCommand).toHaveBeenCalledTimes(0);
+      expect(CompleteMultipartUploadCommand).toHaveBeenCalledTimes(0);
+      expect(PutObjectCommand).toHaveBeenCalledTimes(1);
+      expect(PutObjectCommand).toHaveBeenCalledWith({
+        ...actionParams,
+        Body: smallBuffer,
+      });
+    });
+  });
+
   it("should add tags to the object if tags have been added PUT", async () => {
     const tags = [
       {

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -222,6 +222,7 @@ export class Upload extends EventEmitter {
   }
 
   private async __createMultipartUpload(): Promise<CreateMultipartUploadCommandOutput> {
+    this.__validateChecksumForMultipart();
     const requestChecksumCalculation = await this.client.config.requestChecksumCalculation();
     if (!this.createMultiPartPromise) {
       const createCommandParams = { ...this.params, Body: undefined };
@@ -496,6 +497,37 @@ to input.params.ContentLength in bytes.
 
     if (this.queueSize < 1) {
       throw new Error(`Queue size: Must have at least one uploading queue.`);
+    }
+  }
+
+  /**
+   * Fail fast when the caller provided a precomputed full-object Checksum* value
+   * but the body is large enough to be uploaded as multipart. S3 computes a
+   * composite (per-part) checksum for multipart uploads, which never matches a
+   * full-object checksum supplied by the caller, so the request would otherwise
+   * fail server-side with a confusing BadDigest error after the full upload.
+   *
+   * See https://github.com/aws/aws-sdk-js-v3/issues/6742
+   */
+  private __validateChecksumForMultipart(): void {
+    const precomputedChecksumKeys = [
+      "ChecksumSHA256",
+      "ChecksumSHA1",
+      "ChecksumCRC32",
+      "ChecksumCRC32C",
+      "ChecksumCRC64NVME",
+    ] as const;
+
+    const providedKey = precomputedChecksumKeys.find(
+      (key) => (this.params as Record<string, unknown>)[key] !== undefined
+    );
+
+    if (providedKey) {
+      throw new Error(
+        `lib-storage Upload does not support a precomputed full-object ${providedKey} parameter when the upload is multipart (body > partSize). ` +
+          `For multipart uploads, drop the precomputed checksum and pass ChecksumAlgorithm instead so per-part checksums are computed; ` +
+          `or call PutObject directly. See https://github.com/aws/aws-sdk-js-v3/issues/6742`
+      );
     }
   }
 }


### PR DESCRIPTION
## Issue

Fixes #6742 — `[lib-storage] Upload fails if application provides checksum for >5 MB file`.

## Description

When a caller passes a precomputed full-object checksum (`ChecksumSHA256`, `ChecksumSHA1`, `ChecksumCRC32`, `ChecksumCRC32C`, `ChecksumCRC64NVME`) into `lib-storage`'s `Upload` for a body that exceeds `partSize`, `Upload` performs a multipart upload. S3 then computes a *composite* per-part checksum and rejects the upload with a confusing `BadDigest` error only after the full network roundtrip — which is especially painful for large objects.

The proper service-side fix needs the new `x-amz-checksum-type` header (tracked upstream by the S3 service team). Until that lands, this PR is a **fail-fast client-side improvement**: it converts the confusing post-upload server error into a clear pre-upload client error.

### What changed

- New private `__validateChecksumForMultipart()` on `Upload` (`lib/lib-storage/src/Upload.ts`) is invoked as the first statement of `__createMultipartUpload()` — so it only fires on the multipart code path. Single-part `PutObject` callers are unaffected.
- When any of the five full-object `Checksum*` params is present, it throws an `Error` that:
  - names the offending param,
  - explains why it cannot work with multipart,
  - lists the two supported workarounds (use `ChecksumAlgorithm` instead, or call `PutObject` directly),
  - links the issue.
- `ChecksumAlgorithm` is intentionally **not** rejected — it is the supported way to use checksums on multipart uploads.

This is purely additive. No currently-working configuration is altered.

> Note: the proper fix is blocked on the S3 service-side `x-amz-checksum-type` header support. This PR is a fail-fast client-side guard until that lands.

## Testing

Added 4 tests in `lib/lib-storage/src/Upload.spec.ts`:

1. **Negative** — multipart upload with `ChecksumSHA256` rejects with a message matching `/ChecksumSHA256/` and `/issues\/6742/`, and the mocked S3 client never receives `CreateMultipartUploadCommand` / `UploadPartCommand` / `CompleteMultipartUploadCommand`.
2. **Negative (parametrized via `it.each`)** — same rejection check for `ChecksumSHA1`, `ChecksumCRC32`, `ChecksumCRC32C`, `ChecksumCRC64NVME`.
3. **Positive** — multipart with `ChecksumAlgorithm: \"SHA256\"` succeeds — happy path unchanged.
4. **Positive** — single-part upload with precomputed `ChecksumSHA256` is unaffected (validation does not fire on the `PutObject` path).

### Local test status (transparency)

- `tsc --noEmit` passed for the changed files; no new TypeScript errors.
- Local Vitest run was blocked by the known Yarn-on-Windows + missing workspace `dist-*/` build outputs (`@aws-sdk/client-s3` cannot be resolved from a fresh clone). CI on this PR will validate test execution.

## Checklist

- [x] Scoped change: only `lib/lib-storage/src/Upload.ts` and `lib/lib-storage/src/Upload.spec.ts` are touched.
- [x] No public API additions or breaking changes — only converts a previously-broken runtime path into a clear client-side error.
- [x] Conventional Commits title with module scope.
- [x] Issue linked (`Fixes #6742`).
- [x] Tests added covering both negative (all five `Checksum*` params) and positive (`ChecksumAlgorithm`, single-part `PutObject`) cases.
- [x] Pre-commit hooks (lint-staged + lint:versions + lint:dependencies + lint:api) ran and passed; hooks were not skipped.

---

_generated by AI tools, and reviewed by Mohanraj Venkatesan_