### PR TITLE
fix(credential-provider-http): reuse default requestHandler across calls (#7913)

### DIFF
--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.spec.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.spec.ts
@@ -24,14 +24,15 @@ const mockHandle = vi.fn().mockResolvedValue({
   }),
 });
 
+const mockHandlerCreate = vi.fn(() => ({
+  destroy: () => {},
+  handle: mockHandle,
+}));
+
 vi.mock("@smithy/node-http-handler", () => ({
   NodeHttpHandler: (() => {
-    const getImpl = () => ({
-      destroy: () => {},
-      handle: mockHandle,
-    });
-    const impl = Object.assign(vi.fn().mockImplementation(getImpl), {
-      create: () => getImpl(),
+    const impl = Object.assign(vi.fn().mockImplementation(mockHandlerCreate), {
+      create: mockHandlerCreate,
     });
     return impl;
   })(),
@@ -101,5 +102,68 @@ describe(fromHttp.name, () => {
     await provider();
 
     expect(mockHandle).toHaveBeenCalledWith(request);
+  });
+
+  describe("requestHandler reuse (issue #7913)", () => {
+    it("reuses the default NodeHttpHandler across multiple fromHttp calls and credential refreshes", async () => {
+      // Snapshot the call count up to this point — earlier tests in this file
+      // already exercised the default handler and primed the module-level cache.
+      const baseline = mockHandlerCreate.mock.calls.length;
+
+      // Build many providers sharing the same default timeout. They should
+      // all share a single underlying handler.
+      const providerA = fromHttp({ awsContainerCredentialsFullUri: "https://leak-test-a.aws" });
+      const providerB = fromHttp({ awsContainerCredentialsFullUri: "https://leak-test-b.aws" });
+      const providerC = fromHttp({ awsContainerCredentialsFullUri: "https://leak-test-c.aws" });
+
+      await providerA();
+      await providerA();
+      await providerB();
+      await providerC();
+
+      // No new handler instances should have been created — the SDK-default
+      // handler is memoized across fromHttp invocations.
+      expect(mockHandlerCreate.mock.calls.length - baseline).toBe(0);
+    });
+
+    it("creates a new default handler only for a previously-unseen timeout value", async () => {
+      const baseline = mockHandlerCreate.mock.calls.length;
+
+      // First use of timeout=2500 should construct a new handler.
+      const provider1 = fromHttp({ awsContainerCredentialsFullUri: "https://t-2500.aws", timeout: 2500 });
+      await provider1();
+      expect(mockHandlerCreate.mock.calls.length - baseline).toBe(1);
+
+      // Second use of the same timeout should reuse it.
+      const provider2 = fromHttp({ awsContainerCredentialsFullUri: "https://t-2500-b.aws", timeout: 2500 });
+      await provider2();
+      expect(mockHandlerCreate.mock.calls.length - baseline).toBe(1);
+    });
+
+    it("respects a caller-supplied requestHandler and does not construct a default one", async () => {
+      const baseline = mockHandlerCreate.mock.calls.length;
+
+      const customHandle = vi.fn().mockResolvedValue({
+        response: new HttpResponse({
+          statusCode: 200,
+          headers: { "content-type": "application/json" },
+          body: Readable.from([""]),
+        }),
+      });
+      const customHandler = { handle: customHandle, destroy: () => {} } as any;
+
+      const provider = fromHttp({
+        awsContainerCredentialsFullUri: "https://custom-handler.aws",
+        requestHandler: customHandler,
+      });
+
+      await provider();
+      await provider();
+
+      // Caller-supplied handler should be used directly...
+      expect(customHandle).toHaveBeenCalled();
+      // ...and no SDK-default handler should be constructed for this provider.
+      expect(mockHandlerCreate.mock.calls.length - baseline).toBe(0);
+    });
   });
 });

--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts
@@ -1,6 +1,7 @@
 import { setCredentialFeature } from "@aws-sdk/core/client";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import { CredentialsProviderError } from "@smithy/property-provider";
+import type { HttpHandler } from "@smithy/protocol-http";
 import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types";
 import fs from "node:fs/promises";
 
@@ -14,6 +15,20 @@ const DEFAULT_LINK_LOCAL_HOST = "http://169.254.170.2";
 const AWS_CONTAINER_CREDENTIALS_FULL_URI = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
 const AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
 const AWS_CONTAINER_AUTHORIZATION_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
+
+/**
+ * Module-level cache of the default {@link NodeHttpHandler}, keyed by
+ * timeout. Callers (e.g. EKS Pod Identity) may invoke `fromHttp` repeatedly
+ * across credential refreshes; constructing a new handler each time leaks
+ * sockets/file descriptors because the previous handler is never destroyed.
+ *
+ * Memoizing on first use keeps a single shared handler/socket pool for the
+ * lifetime of the process. Caller-supplied handlers are respected and never
+ * cached here.
+ *
+ * @internal
+ */
+const defaultRequestHandlerCache = new Map<number, HttpHandler<any>>();
 
 /**
  * Creates a provider that gets credentials via HTTP request.
@@ -66,10 +81,23 @@ Set AWS_CONTAINER_CREDENTIALS_FULL_URI or AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
   // throws if not to spec for provider.
   checkUrl(url, options.logger);
 
-  const requestHandler = NodeHttpHandler.create({
-    requestTimeout: options.timeout ?? 1000,
-    connectionTimeout: options.timeout ?? 1000,
-  });
+  // Respect a caller-supplied handler; otherwise reuse a single SDK-default
+  // handler across calls to avoid leaking sockets on credential refresh.
+  let requestHandler: HttpHandler<any>;
+  if (options.requestHandler) {
+    requestHandler = options.requestHandler;
+  } else {
+    const timeout = options.timeout ?? 1000;
+    let cached = defaultRequestHandlerCache.get(timeout);
+    if (!cached) {
+      cached = NodeHttpHandler.create({
+        requestTimeout: timeout,
+        connectionTimeout: timeout,
+      });
+      defaultRequestHandlerCache.set(timeout, cached);
+    }
+    requestHandler = cached;
+  }
 
   return retryWrapper(
     async (): Promise<AwsCredentialIdentity> => {

--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttpTypes.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttpTypes.ts
@@ -1,4 +1,5 @@
 import type { CredentialProviderOptions } from "@aws-sdk/types";
+import type { HttpHandler } from "@smithy/protocol-http";
 
 /**
  * @public
@@ -64,6 +65,17 @@ export interface FromHttpOptions extends CredentialProviderOptions {
    * Default is 1000ms. Time in milliseconds to spend waiting between retry attempts.
    */
   timeout?: number;
+
+  /**
+   * Optional HTTP handler to use for credential requests.
+   *
+   * When omitted (the typical case), a single SDK-default handler is created
+   * and reused across calls to avoid leaking sockets in long-running processes
+   * that refresh credentials (e.g., EKS Pod Identity token rotation).
+   *
+   * When supplied, the caller takes ownership of the handler's lifecycle.
+   */
+  requestHandler?: HttpHandler<any>;
 }
 
 /**


### PR DESCRIPTION
## Issue

Fixes #7913 — `fromHttp` credential provider leaks sockets when EKS Pod Identity token expires.

## Description

`fromHttp` (`packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts`) constructed a fresh `NodeHttpHandler` on every invocation. In long-lived processes — most visibly EKS Pod Identity, where `defaultProvider.ts` re-calls `fromHttp(init)` on each credential refresh — every refresh created a brand-new socket pool that the previous handler never returned. Over time this leaks file descriptors / sockets.

**Fix:** a module-scoped `Map<number, HttpHandler>` (keyed by effective timeout) lazily memoizes the SDK-default handler. Subsequent `fromHttp(...)` calls with the same timeout reuse the same handler and its underlying socket pool. If the caller supplies their own `requestHandler` via the new optional `FromHttpOptions.requestHandler`, it is used as-is and never cached (caller owns lifecycle).

The browser variant (`fromHttp.browser.ts`) is unchanged because `FetchHttpHandler` does not hold native socket pools.

The public `fromHttp` function signature is unchanged. The `requestHandler` field added to `FromHttpOptions` is optional and additive — fully backward compatible.

### Files changed
- `packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts` — module-scoped handler cache; honor caller-supplied handler when provided.
- `packages-internal/credential-provider-http/src/fromHttp/fromHttpTypes.ts` — added optional `requestHandler` to `FromHttpOptions`.
- `packages-internal/credential-provider-http/src/fromHttp/fromHttp.spec.ts` — regression tests (see Testing).

## Testing

Added a new `describe("requestHandler reuse (issue #7913)")` block in `fromHttp.spec.ts` with three regression tests:

1. Resolving credentials across multiple providers / refreshes does not call `NodeHttpHandler.create` again after the cache is primed (the production scenario from the issue).
2. Per-timeout caching: a previously-unseen `timeout` constructs the handler once; a second use with the same timeout reuses it.
3. Caller-supplied `requestHandler` is used directly; no default handler is constructed.

The mock for `NodeHttpHandler` was tightened so `new NodeHttpHandler(...)` and `NodeHttpHandler.create(...)` route through the same spy, enabling reliable call-count assertions. Existing tests are unchanged in behavior.

**Local validation:** `tsc --noEmit -p tsconfig.types.json` produces zero new errors versus the baseline on `main`. Local Vitest execution is currently blocked by a Yarn-on-Windows + missing workspace `dist-*/` outputs issue (`@aws-sdk/core/client` cannot be resolved without a full workspace build); CI on this PR will validate test execution end-to-end.

## Checklist

- [x] Code change follows the existing style and conventions.
- [x] Public API change is backward compatible (new field is optional).
- [x] Regression tests added covering the reported failure mode.
- [x] No `--no-verify` used; pre-commit hooks (lint-staged, lint:versions, lint:dependencies, lint:api) ran successfully.
- [x] Linked to the issue with `Fixes #7913`.

---

_generated by AI tools, and reviewed by Mohanraj Venkatesan_