### PR TITLE
fix(middleware-flexible-checksums): exclude Blob/File from isStreaming detection (#6834)

### DIFF
--- a/packages-internal/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages-internal/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -149,7 +149,14 @@ export const flexibleChecksumsMiddleware =
         };
         delete updatedHeaders["content-length"];
       } else if (!hasHeader(checksumLocationName, headers)) {
-        const rawChecksum = await stringHasher(checksumAlgorithmFn, requestBody);
+        // Blob/File are bounded but cannot be passed directly to stringHasher.
+        // Read them into a Uint8Array first.
+        // See: https://github.com/aws/aws-sdk-js-v3/issues/6834
+        const hashableBody =
+          typeof Blob !== "undefined" && requestBody instanceof Blob
+            ? new Uint8Array(await requestBody.arrayBuffer())
+            : requestBody;
+        const rawChecksum = await stringHasher(checksumAlgorithmFn, hashableBody);
         updatedHeaders = {
           ...headers,
           [checksumLocationName]: base64Encoder(rawChecksum),

--- a/packages-internal/middleware-flexible-checksums/src/isStreaming.spec.ts
+++ b/packages-internal/middleware-flexible-checksums/src/isStreaming.spec.ts
@@ -1,38 +1,63 @@
-import { isArrayBuffer } from "@smithy/is-array-buffer";
-import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
+import { Readable } from "stream";
+import { describe, expect, test as it } from "vitest";
 
 import { isStreaming } from "./isStreaming";
 
-vi.mock("@smithy/is-array-buffer");
-
 describe(isStreaming.name, () => {
-  beforeEach(() => {
-    (isArrayBuffer as unknown as any).mockReturnValue(true);
-  });
+  describe("returns true when body is", () => {
+    it("a Node.js Readable stream", () => {
+      const readable = Readable.from([Buffer.from("x")]);
+      expect(isStreaming(readable)).toBe(true);
+    });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
+    it("a web ReadableStream", () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+      expect(isStreaming(stream)).toBe(true);
+    });
 
-  it("returns true when body is a stream", () => {
-    (isArrayBuffer as unknown as any).mockReturnValue(false);
-    // Mocking {} as a stream
-    const mockStream = {};
-    expect(isStreaming(mockStream)).toBe(true);
-    expect(isArrayBuffer).toHaveBeenCalledTimes(1);
-    expect(isArrayBuffer).toHaveBeenCalledWith(mockStream);
+    it("an AsyncIterable", () => {
+      const asyncIterable = (async function* () {
+        yield 1;
+      })();
+      expect(isStreaming(asyncIterable)).toBe(true);
+    });
+
+    it("an object with a pipe() method", () => {
+      const fakeReadable = { pipe: () => {} };
+      expect(isStreaming(fakeReadable)).toBe(true);
+    });
+
+    it("an object with a getReader() method", () => {
+      const fakeReadableStream = { getReader: () => {} };
+      expect(isStreaming(fakeReadableStream)).toBe(true);
+    });
   });
 
   describe("returns false when body is", () => {
-    it.each([undefined, "str"])("special case: %s", (val) => {
+    it.each([undefined, null])("special case: %s", (val) => {
       expect(isStreaming(val)).toBe(false);
-      expect(isArrayBuffer).not.toHaveBeenCalled();
     });
 
-    it.each([null, true, 1])("primitive data type: %s", (val) => {
+    it.each([true, 1, "str"])("primitive data type: %s", (val) => {
       expect(isStreaming(val)).toBe(false);
-      expect(isArrayBuffer).toHaveBeenCalledTimes(1);
-      expect(isArrayBuffer).toHaveBeenCalledWith(val);
+    });
+
+    it("a Blob (regression for #6834)", () => {
+      const blob = new Blob(["hello"], { type: "text/plain" });
+      expect(isStreaming(blob)).toBe(false);
+    });
+
+    it("a File (regression for #6834)", () => {
+      const file = new File(["hello"], "x.txt", { type: "text/plain" });
+      expect(isStreaming(file)).toBe(false);
+    });
+
+    it("a plain object", () => {
+      expect(isStreaming({})).toBe(false);
     });
 
     const buffer = new ArrayBuffer(4);
@@ -54,7 +79,10 @@ describe(isStreaming.name, () => {
       new BigUint64Array(arr.map(BigInt)),
     ])("ArrayBuffer View: %s", (arrayBufferView) => {
       expect(isStreaming(arrayBufferView)).toBe(false);
-      expect(isArrayBuffer).not.toHaveBeenCalled();
+    });
+
+    it("an ArrayBuffer", () => {
+      expect(isStreaming(new ArrayBuffer(4))).toBe(false);
     });
   });
 });

--- a/packages-internal/middleware-flexible-checksums/src/isStreaming.ts
+++ b/packages-internal/middleware-flexible-checksums/src/isStreaming.ts
@@ -1,7 +1,38 @@
-import { isArrayBuffer } from "@smithy/is-array-buffer";
-
 /**
- * Returns true if the given value is a streaming response.
+ * Returns true if the given value is a streaming body.
+ *
+ * Streaming bodies are unbounded byte sources that must be consumed
+ * incrementally:
+ *   - Node.js Readable stream (has `.pipe()`)
+ *   - Web ReadableStream (has `.getReader()`)
+ *   - AsyncIterable (has `Symbol.asyncIterator`)
+ *
+ * Bounded byte-collection types (string, ArrayBuffer, ArrayBufferView,
+ * Blob, File, etc.) are NOT streaming. They can be hashed directly
+ * without being routed through aws-chunked encoding.
+ *
+ * See: https://github.com/aws/aws-sdk-js-v3/issues/6834
  */
-export const isStreaming = (body: unknown) =>
-  body !== undefined && typeof body !== "string" && !ArrayBuffer.isView(body) && !isArrayBuffer(body);
+export const isStreaming = (body: unknown): boolean => {
+  if (body === undefined || body === null) {
+    return false;
+  }
+  if (typeof body !== "object") {
+    return false;
+  }
+  const candidate = body as {
+    pipe?: unknown;
+    getReader?: unknown;
+    [Symbol.asyncIterator]?: unknown;
+  };
+  if (typeof candidate.pipe === "function") {
+    return true;
+  }
+  if (typeof candidate.getReader === "function") {
+    return true;
+  }
+  if (typeof candidate[Symbol.asyncIterator] === "function") {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
## Issue

Fixes #6834 — Angular 19 / browser `PutObject` fails with `readableStream.getReader is not a function` when `Body` is a `Blob` or `File`.

## Description

The previous `isStreaming` predicate in `packages-internal/middleware-flexible-checksums/src/isStreaming.ts` returned `true` for any object that wasn't a string, `ArrayBuffer`, or `ArrayBufferView`. As a result, `Blob`/`File` bodies were misclassified as streams and routed into `getAwsChunkedEncodingStream` (called at `flexibleChecksumsMiddleware.ts:128`), which invokes `.getReader()` directly on the body. Since `Blob`/`File` are not themselves `ReadableStream`s (they expose `.stream()` to obtain one), the call crashed. Maintainer @trivikr identified the offending location in the issue thread.

This PR rewrites the predicate to duck-type true streaming bodies only:

- `true` if the body has `typeof body.pipe === "function"` (Node `Readable`),
- `true` if the body has `typeof body.getReader === "function"` (web `ReadableStream`),
- `true` if the body has `Symbol.asyncIterator` (any `AsyncIterable`, including async generators),
- `false` for everything else — primitives, strings, plain objects, `ArrayBuffer`, all `ArrayBufferView` types, and crucially `Blob`/`File`.

Once `Blob`/`File` are recognized as non-streaming, they flow into the in-memory `stringHasher` path. To make that path actually work for `Blob`, a one-line conversion was added in `flexibleChecksumsMiddleware.ts`: if the body `instanceof Blob` (with `typeof Blob !== "undefined"` guard for non-browser environments), it is read into a `Uint8Array` via `await blob.arrayBuffer()` before hashing. `File` inherits from `Blob`, so the same branch covers both. The public `isStreaming` signature is unchanged.

### Files Changed

- `packages-internal/middleware-flexible-checksums/src/isStreaming.ts` — predicate rewrite
- `packages-internal/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts` — one-line `Blob` → `Uint8Array` conversion in the non-streaming path
- `packages-internal/middleware-flexible-checksums/src/isStreaming.spec.ts` — 27 regression tests

## Testing

Added 27 test cases in `isStreaming.spec.ts`, including:

- `isStreaming(new Blob([...]))` → `false` (regression for #6834)
- `isStreaming(new File([...], "x.txt"))` → `false` (regression for #6834)
- `isStreaming(Readable.from([Buffer.from("x")]))` → `true` (Node `Readable`)
- `isStreaming(new ReadableStream({ start(c) { c.close(); } }))` → `true` (web `ReadableStream`)
- `isStreaming((async function*() { yield 1; })())` → `true` (`AsyncIterable`)
- All `ArrayBufferView` types, `Buffer`, raw `ArrayBuffer`, primitives, plain object, `null`, `undefined` → `false`
- Object with `pipe` function → `true`; object with `getReader` function → `true`

The pre-existing assertion that `isStreaming({}) === true` (treating bare objects as streams) was the source of the bug and has been corrected — bare objects are now non-streaming.

### Local test status (transparency)

- `npx vitest run isStreaming.spec.ts` → **27/27 pass**.
- Full package vitest has 5 pre-existing test-file import failures (workspace deps `@aws-sdk/core`, `@aws-sdk/crc64-nvme` not built locally — known Yarn-on-Windows + missing `dist-*/` issue). Verified by stash + rerun on `main`: same failures pre-exist. This change introduces zero new failures.
- `tsc --noEmit -p tsconfig.types.json` introduces zero new errors versus baseline.
- Local Vitest is partially blocked by the workspace-build issue described above; CI on this PR will validate end-to-end.

## Checklist

- [x] Scoped commit message using Conventional Commits with module scope
- [x] Added regression tests covering the bug (`Blob`/`File` → `false`)
- [x] Public `isStreaming` signature unchanged
- [x] Pre-commit hooks (lint-staged, lint:versions, lint:dependencies, lint:api) passed without `--no-verify`
- [x] Linked issue: Fixes #6834

---

_generated by AI tools, and reviewed by Mohanraj Venkatesan_