### PR TITLE
fix(lib-storage): strip file-level ContentMD5 from per-part UploadPart commands (#4321)

### DIFF
--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -1066,4 +1066,99 @@ describe(Upload.name, () => {
       }).not.toThrow();
     });
   });
+
+  // Regression tests for https://github.com/aws/aws-sdk-js-v3/issues/4321:
+  // a user-supplied file-level ContentMD5 must not be forwarded to per-part
+  // UploadPart commands or to CompleteMultipartUpload, since S3 would reject
+  // the upload (e.g. with MalformedXML) when those commands carry the
+  // whole-object MD5.
+  describe("ContentMD5 handling on multipart uploads (issue #4321)", () => {
+    const MOCK_PART_SIZE = 24;
+
+    beforeEach(() => {
+      (Upload as any).MIN_PART_SIZE = MOCK_PART_SIZE;
+    });
+
+    afterAll(() => {
+      (Upload as any).MIN_PART_SIZE = 1024 * 1024 * 5;
+    });
+
+    it("should strip file-level ContentMD5 from UploadPartCommand on multipart uploads", async () => {
+      const largeBuffer = Buffer.from("#".repeat(MOCK_PART_SIZE + 10));
+      const fileLevelContentMD5 = "Q2hlY2sgSW50ZWdyaXR5IQ==";
+      const actionParams = { ...params, Body: largeBuffer, ContentMD5: fileLevelContentMD5 };
+
+      const upload = new Upload({
+        params: actionParams,
+        partSize: MOCK_PART_SIZE,
+        client: new S3({}),
+      });
+
+      await upload.done();
+
+      // Two parts must be uploaded.
+      expect(UploadPartCommand).toHaveBeenCalledTimes(2);
+
+      // Neither UploadPart call may carry the file-level ContentMD5.
+      const firstPartInput = vi.mocked(UploadPartCommand).mock.calls[0][0];
+      const secondPartInput = vi.mocked(UploadPartCommand).mock.calls[1][0];
+      expect(firstPartInput).not.toHaveProperty("ContentMD5");
+      expect(secondPartInput).not.toHaveProperty("ContentMD5");
+
+      // CompleteMultipartUpload must also not carry the file-level ContentMD5.
+      expect(CompleteMultipartUploadCommand).toHaveBeenCalledTimes(1);
+      const completeInput = vi.mocked(CompleteMultipartUploadCommand).mock.calls[0][0];
+      expect(completeInput).not.toHaveProperty("ContentMD5");
+
+      // The single-part PUT path is not exercised here.
+      expect(PutObjectCommand).toHaveBeenCalledTimes(0);
+    });
+
+    it("should preserve other user params (e.g. Bucket, Key, Metadata) on UploadPartCommand", async () => {
+      const largeBuffer = Buffer.from("#".repeat(MOCK_PART_SIZE + 10));
+      const actionParams = {
+        ...params,
+        Body: largeBuffer,
+        ContentMD5: "Q2hlY2sgSW50ZWdyaXR5IQ==",
+        Metadata: { foo: "bar" },
+      };
+
+      const upload = new Upload({
+        params: actionParams,
+        partSize: MOCK_PART_SIZE,
+        client: new S3({}),
+      });
+
+      await upload.done();
+
+      expect(UploadPartCommand).toHaveBeenCalledTimes(2);
+      const firstPartInput = vi.mocked(UploadPartCommand).mock.calls[0][0] as any;
+      expect(firstPartInput.Bucket).toEqual("example-bucket");
+      expect(firstPartInput.Key).toEqual("example-key");
+      expect(firstPartInput.Metadata).toEqual({ foo: "bar" });
+      expect(firstPartInput.PartNumber).toEqual(1);
+      expect(firstPartInput.UploadId).toEqual("mockuploadId");
+    });
+  });
+
+  it("should preserve ContentMD5 on single-part PutObjectCommand uploads (issue #4321)", async () => {
+    const fileLevelContentMD5 = "Q2hlY2sgSW50ZWdyaXR5IQ==";
+    const actionParams = { ...params, ContentMD5: fileLevelContentMD5 };
+
+    const upload = new Upload({
+      params: actionParams,
+      client: new S3({}),
+    });
+
+    await upload.done();
+
+    // Single-part path is unaffected by the multipart ContentMD5 fix.
+    expect(PutObjectCommand).toHaveBeenCalledTimes(1);
+    expect(PutObjectCommand).toHaveBeenCalledWith({
+      ...actionParams,
+      Body: Buffer.from(params.Body),
+    });
+    expect(UploadPartCommand).toHaveBeenCalledTimes(0);
+    expect(CompleteMultipartUploadCommand).toHaveBeenCalledTimes(0);
+  });
 });

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -306,9 +306,15 @@ export class Upload extends EventEmitter {
 
       this.__validateUploadPart(dataPart);
 
+      // The user-supplied file-level ContentMD5 represents the MD5 of the entire
+      // object and must not be propagated to per-part UploadPart commands; doing
+      // so causes S3 to reject the upload (e.g. with MalformedXML). See issue
+      // aws/aws-sdk-js-v3#4321.
+      const { ContentMD5: _fileLevelContentMD5, ...partParams } = this.params;
+
       const partResult = await this.client.send(
         new UploadPartCommand({
-          ...this.params,
+          ...partParams,
           // dataPart.data is chunked into a non-streaming buffer
           // so the ContentLength from the input should not be used for MPU.
           ContentLength: undefined,
@@ -400,8 +406,14 @@ to input.params.ContentLength in bytes.
 
       this.uploadedParts.sort((a, b) => a.PartNumber! - b.PartNumber!);
 
+      // The user-supplied file-level ContentMD5 is the legacy MD5 of the entire
+      // object and is not valid for CompleteMultipartUpload, which derives the
+      // ETag from the assembled part list. Strip it so multipart uploads with
+      // a user-provided ContentMD5 succeed. See issue aws/aws-sdk-js-v3#4321.
+      const { ContentMD5: _fileLevelContentMD5, ...completeParams } = this.params;
+
       const uploadCompleteParams = {
-        ...this.params,
+        ...completeParams,
         Body: undefined,
         UploadId: this.uploadId,
         MultipartUpload: {


### PR DESCRIPTION
### Issue

Fixes #4321 — `lib-storage` `Upload` with a user-supplied `ContentMD5` and a body larger than 5 MB fails with `MalformedXML` from S3.

### Description

When `Upload` enters the multipart path, it spreads `...this.params` into both `UploadPartCommand` (around line 311 of `Upload.ts`) and `CompleteMultipartUploadCommand` (around line 410). That leaks the file-level `ContentMD5` — a single-object MD5 of the entire body — into every per-part command, and S3 rejects the multipart upload with `MalformedXML`. Maintainer **@yenfryherrerafeliz** identified the offending location in the issue thread.

This change destructures `ContentMD5` out of the spread before constructing the per-part and completion commands:

```ts
const { ContentMD5: _fileLevelContentMD5, ...partParams } = this.params;
new UploadPartCommand({ ...partParams, /* per-part fields */ });
```

The same treatment is applied to `CompleteMultipartUploadCommand`. The single-part `PutObjectCommand` path is intentionally unchanged — `ContentMD5` is still passed through there because it is valid for a single-object PUT.

**Relationship with #7990:** This fix is complementary to (and does not conflict with) PR #7990, which fail-fasts on flexible-checksum fields (`ChecksumSHA256`, `ChecksumSHA1`, `ChecksumCRC32`, `ChecksumCRC32C`, `ChecksumCRC64NVME`) for multipart uploads. `ContentMD5` is the legacy MD5 header — different field, different semantics — so this PR transparently strips it from per-part commands while #7990's strict validation continues to surface clear errors for the flexible-checksum case. Both can land in either order without merge conflicts.

**Files changed**
- `lib/lib-storage/src/Upload.ts` — destructure-and-spread in two command constructions
- `lib/lib-storage/src/Upload.spec.ts` — three regression tests

### Testing

Added a new `describe(\"ContentMD5 handling on multipart uploads (issue #4321)\")` block in `lib/lib-storage/src/Upload.spec.ts` with three tests:

1. **`should strip file-level ContentMD5 from UploadPartCommand on multipart uploads`** — multipart upload with a 34-byte body and mocked `MIN_PART_SIZE` of 24 bytes; asserts `UploadPartCommand` is called twice and **neither** call carries a `ContentMD5` property; `CompleteMultipartUploadCommand` also has none.
2. **`should preserve other user params (e.g. Bucket, Key, Metadata) on UploadPartCommand`** — verifies the destructure only strips `ContentMD5`, not other fields like `Bucket` / `Key` / `Metadata` / `PartNumber` / `UploadId`.
3. **`should preserve ContentMD5 on single-part PutObjectCommand uploads (issue #4321)`** — small body, single-part path; asserts `PutObjectCommand` IS called with `ContentMD5` (single-part path is unaffected).

**Local test status (transparency):** local Vitest execution is currently blocked on this Windows workstation by a pre-existing workspace-build issue (`@aws-sdk/client-s3` `dist-*/` outputs not present from Yarn install). `tsc --noEmit` filtered to `lib/lib-storage/` shows only the same pre-existing baseline errors caused by those missing workspace deps — **no new errors on the changed lines**. CI will validate full test execution end-to-end.

### Checklist

- [x] Linked to issue (#4321)
- [x] Added regression tests covering both the multipart fix and the unchanged single-part behavior
- [x] Followed Conventional Commits with module scope in the commit title
- [x] No skipped husky hooks (lint-staged + lint:versions + lint:dependencies + lint:api ran on commit)
- [x] No public API changes
- [x] Documented relationship with related PR #7990

---

_generated by AI tools, and reviewed by Mohanraj Venkatesan_