### PR TITLE
fix(credential-provider-http): close sockets after connection attempts

### DIFF
--- a/packages-internal/credential-provider-http/package.json
+++ b/packages-internal/credential-provider-http/package.json
@@ -23,6 +23,7 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
     "test": "yarn g:vitest run",
+    "test:integration": "yarn g:vitest run -c vitest.config.integ.mts",
     "test:watch": "yarn g:vitest watch"
   },
   "keywords": [

--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.integ.spec.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.integ.spec.ts
@@ -1,0 +1,92 @@
+import http from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { fromHttp } from "./fromHttp";
+
+describe("fromHttp socket cleanup", () => {
+  let server: http.Server;
+  let port: number;
+  let activeConnections: Set<Socket>;
+
+  beforeAll(async () => {
+    activeConnections = new Set();
+
+    server = http.createServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          AccessKeyId: "AKID",
+          SecretAccessKey: "SECRET",
+          Token: "TOKEN",
+          Expiration: new Date(Date.now() + 3600_000).toISOString(),
+        })
+      );
+    });
+
+    server.on("connection", (socket) => {
+      activeConnections.add(socket);
+      socket.on("close", () => activeConnections.delete(socket));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    for (const socket of activeConnections) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("destroys sockets after each credential fetch", async () => {
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: `http://127.0.0.1:${port}/creds`,
+    });
+
+    // Call the provider multiple times to simulate repeated credential refreshes.
+    for (let i = 0; i < 10; i++) {
+      await provider();
+    }
+
+    // Allow time for socket close events to propagate.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(activeConnections.size).toBe(0);
+  });
+
+  it("destroys sockets even when requests fail", async () => {
+    // Use a server that always returns 500 to trigger retries and failure.
+    const failServer = http.createServer((_, res) => {
+      res.writeHead(500, { "content-type": "text/plain" });
+      res.end("Internal Server Error");
+    });
+    const failConnections = new Set<Socket>();
+    failServer.on("connection", (socket) => {
+      failConnections.add(socket);
+      socket.on("close", () => failConnections.delete(socket));
+    });
+    await new Promise<void>((resolve) => failServer.listen(0, "127.0.0.1", resolve));
+    const failPort = (failServer.address() as AddressInfo).port;
+
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: `http://127.0.0.1:${failPort}/creds`,
+      maxRetries: 1,
+      timeout: 500,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await provider().catch(() => {});
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(failConnections.size).toBe(0);
+
+    for (const socket of failConnections) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => failServer.close(() => resolve()));
+  });
+});

--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.spec.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.spec.ts
@@ -24,6 +24,8 @@ const mockHandle = vi.fn().mockResolvedValue({
   }),
 });
 
+let createCallCount = 0;
+
 vi.mock("@smithy/node-http-handler", () => ({
   NodeHttpHandler: (() => {
     const getImpl = () => ({
@@ -31,7 +33,10 @@ vi.mock("@smithy/node-http-handler", () => ({
       handle: mockHandle,
     });
     const impl = Object.assign(vi.fn().mockImplementation(getImpl), {
-      create: () => getImpl(),
+      create: () => {
+        createCallCount++;
+        return getImpl();
+      },
     });
     return impl;
   })(),
@@ -61,7 +66,9 @@ describe(fromHttp.name, () => {
 
     await provider();
 
-    expect(mockHandle).toHaveBeenCalledWith(helpers.createGetRequest(new URL("https://u1.aws")));
+    expect(mockHandle).toHaveBeenCalledWith(helpers.createGetRequest(new URL("https://u1.aws")), {
+      requestTimeout: 1000,
+    });
   });
 
   it("uses the relative uri", async () => {
@@ -72,7 +79,9 @@ describe(fromHttp.name, () => {
 
     await provider();
 
-    expect(mockHandle).toHaveBeenCalledWith(helpers.createGetRequest(new URL("http://169.254.170.2/some-path")));
+    expect(mockHandle).toHaveBeenCalledWith(helpers.createGetRequest(new URL("http://169.254.170.2/some-path")), {
+      requestTimeout: 1000,
+    });
   });
 
   it("can use the token", async () => {
@@ -86,7 +95,7 @@ describe(fromHttp.name, () => {
 
     await provider();
 
-    expect(mockHandle).toHaveBeenCalledWith(request);
+    expect(mockHandle).toHaveBeenCalledWith(request, { requestTimeout: 1000 });
   });
 
   it("can use the token file", async () => {
@@ -100,6 +109,31 @@ describe(fromHttp.name, () => {
 
     await provider();
 
-    expect(mockHandle).toHaveBeenCalledWith(request);
+    expect(mockHandle).toHaveBeenCalledWith(request, { requestTimeout: 1000 });
+  });
+
+  it("passes custom timeout as requestTimeout to handle()", async () => {
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: "https://u1.aws",
+      timeout: 5000,
+    });
+
+    await provider();
+
+    expect(mockHandle).toHaveBeenCalledWith(expect.anything(), { requestTimeout: 5000 });
+  });
+
+  it("reuses a single NodeHttpHandler instance across multiple calls", async () => {
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: "https://u1.aws",
+    });
+
+    await provider();
+    await provider();
+    await provider();
+
+    // NodeHttpHandler.create() should only be called once (cached at module level)
+    // across all tests in this file
+    expect(createCallCount).toBe(1);
   });
 });

--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.spec.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.spec.ts
@@ -24,19 +24,16 @@ const mockHandle = vi.fn().mockResolvedValue({
   }),
 });
 
-let createCallCount = 0;
+const mockDestroy = vi.fn();
 
 vi.mock("@smithy/node-http-handler", () => ({
   NodeHttpHandler: (() => {
     const getImpl = () => ({
-      destroy: () => {},
+      destroy: mockDestroy,
       handle: mockHandle,
     });
     const impl = Object.assign(vi.fn().mockImplementation(getImpl), {
-      create: () => {
-        createCallCount++;
-        return getImpl();
-      },
+      create: () => getImpl(),
     });
     return impl;
   })(),
@@ -123,17 +120,31 @@ describe(fromHttp.name, () => {
     expect(mockHandle).toHaveBeenCalledWith(expect.anything(), { requestTimeout: 5000 });
   });
 
-  it("reuses a single NodeHttpHandler instance across multiple calls", async () => {
+  it("destroys the request handler after the provider resolves", async () => {
+    mockDestroy.mockClear();
+
     const provider = fromHttp({
       awsContainerCredentialsFullUri: "https://u1.aws",
     });
 
     await provider();
-    await provider();
-    await provider();
 
-    // NodeHttpHandler.create() should only be called once (cached at module level)
-    // across all tests in this file
-    expect(createCallCount).toBe(1);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroys the request handler even when the request fails", async () => {
+    mockDestroy.mockClear();
+    mockHandle.mockRejectedValueOnce(new Error("network error"));
+    mockHandle.mockRejectedValueOnce(new Error("network error"));
+    mockHandle.mockRejectedValueOnce(new Error("network error"));
+    mockHandle.mockRejectedValueOnce(new Error("network error"));
+
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: "https://u1.aws",
+    });
+
+    await expect(provider()).rejects.toThrow();
+
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts
@@ -16,12 +16,6 @@ const AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE = "AWS_CONTAINER_AUTHORIZATION_TOKE
 const AWS_CONTAINER_AUTHORIZATION_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
 
 /**
- * Cached request handler shared across all fromHttp provider instances.
- * This prevents socket leaks from creating a new NodeHttpHandler (and http.Agent) per credential refresh.
- */
-let cachedHandler: InstanceType<typeof NodeHttpHandler> | undefined;
-
-/**
  * Creates a provider that gets credentials via HTTP request.
  */
 export const fromHttp = (options: FromHttpOptions = {}): AwsCredentialIdentityProvider => {
@@ -72,15 +66,12 @@ Set AWS_CONTAINER_CREDENTIALS_FULL_URI or AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
   // throws if not to spec for provider.
   checkUrl(url, options.logger);
 
-  if (!cachedHandler) {
-    cachedHandler = NodeHttpHandler.create({ connectionTimeout: options.timeout ?? 1000 }) as InstanceType<
-      typeof NodeHttpHandler
-    >;
-  }
-  const requestHandler = cachedHandler;
+  const requestHandler = NodeHttpHandler.create({ connectionTimeout: options.timeout ?? 1000 }) as InstanceType<
+    typeof NodeHttpHandler
+  >;
   const requestTimeout = options.timeout ?? 1000;
 
-  return retryWrapper(
+  const provider = retryWrapper(
     async (): Promise<AwsCredentialIdentity> => {
       const request = createGetRequest(url);
 
@@ -101,4 +92,12 @@ Set AWS_CONTAINER_CREDENTIALS_FULL_URI or AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
     options.maxRetries ?? 3,
     options.timeout ?? 1000
   );
+
+  return async () => {
+    try {
+      return await provider();
+    } finally {
+      requestHandler.destroy?.();
+    }
+  };
 };

--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts
@@ -66,9 +66,7 @@ Set AWS_CONTAINER_CREDENTIALS_FULL_URI or AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
   // throws if not to spec for provider.
   checkUrl(url, options.logger);
 
-  const requestHandler = NodeHttpHandler.create({ connectionTimeout: options.timeout ?? 1000 }) as InstanceType<
-    typeof NodeHttpHandler
-  >;
+  const requestHandler = NodeHttpHandler.create({ connectionTimeout: options.timeout ?? 1000 }) as NodeHttpHandler;
   const requestTimeout = options.timeout ?? 1000;
 
   const provider = retryWrapper(

--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts
@@ -16,6 +16,12 @@ const AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE = "AWS_CONTAINER_AUTHORIZATION_TOKE
 const AWS_CONTAINER_AUTHORIZATION_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
 
 /**
+ * Cached request handler shared across all fromHttp provider instances.
+ * This prevents socket leaks from creating a new NodeHttpHandler (and http.Agent) per credential refresh.
+ */
+let cachedHandler: InstanceType<typeof NodeHttpHandler> | undefined;
+
+/**
  * Creates a provider that gets credentials via HTTP request.
  */
 export const fromHttp = (options: FromHttpOptions = {}): AwsCredentialIdentityProvider => {
@@ -66,10 +72,13 @@ Set AWS_CONTAINER_CREDENTIALS_FULL_URI or AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
   // throws if not to spec for provider.
   checkUrl(url, options.logger);
 
-  const requestHandler = NodeHttpHandler.create({
-    requestTimeout: options.timeout ?? 1000,
-    connectionTimeout: options.timeout ?? 1000,
-  });
+  if (!cachedHandler) {
+    cachedHandler = NodeHttpHandler.create({ connectionTimeout: options.timeout ?? 1000 }) as InstanceType<
+      typeof NodeHttpHandler
+    >;
+  }
+  const requestHandler = cachedHandler;
+  const requestTimeout = options.timeout ?? 1000;
 
   return retryWrapper(
     async (): Promise<AwsCredentialIdentity> => {
@@ -83,7 +92,7 @@ Set AWS_CONTAINER_CREDENTIALS_FULL_URI or AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
         request.headers.Authorization = (await fs.readFile(tokenFile)).toString();
       }
       try {
-        const result = await requestHandler.handle(request);
+        const result = await requestHandler.handle(request, { requestTimeout });
         return getCredentials(result.response).then((creds) => setCredentialFeature(creds, "CREDENTIALS_HTTP", "z"));
       } catch (e: unknown) {
         throw new CredentialsProviderError(String(e), { logger: options.logger });

--- a/packages-internal/credential-provider-http/vitest.config.integ.mts
+++ b/packages-internal/credential-provider-http/vitest.config.integ.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.integ.spec.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
### Issue
#7913 

### Description
Ensures the `NodeHttpHandler` created by `fromHttp()` is destroyed after each credential fetch (success or failure), preventing socket accumulation when credential refresh fails repeatedly.

### Testing
new unit test
 ```console
 RUN  v4.0.17 /../aws-sdk-js-v3/packages-internal/credential-provider-http

 ✓ src/fromHttp/checkUrl.spec.ts (8 tests) 4ms
 ✓ src/fromHttp/requestHelpers.spec.ts (4 tests) 7ms
 ✓ src/fromHttp/fromHttp.spec.ts (7 tests) 3012ms
     ✓ destroys the request handler even when the request fails  3005ms

 Test Files  3 passed (3)
      Tests  19 passed (19)
```

new integ test:
```console
 RUN  v4.0.17 /../aws-sdk-js-v3/packages-internal/credential-provider-http

 ✓ src/fromHttp/fromHttp.integ.spec.ts (2 tests) 2644ms
   ✓ fromHttp socket cleanup (2)
     ✓ destroys sockets after each credential fetch 75ms
     ✓ destroys sockets even when requests fail  2563ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
