### PR TITLE
chore(scripts): add submodule variant api surface parity linting

### DIFF
--- a/clients/client-sts/src/auth/httpAuthSchemeProvider.ts
+++ b/clients/client-sts/src/auth/httpAuthSchemeProvider.ts
@@ -13,7 +13,6 @@ import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { getSmithyContext, normalizeProvider } from "@smithy/core/client";
 import { type EndpointParameterInstructions, resolveParams } from "@smithy/core/endpoints";
 import type {
-  Client,
   EndpointV2,
   HandlerExecutionContext,
   HttpAuthOption,
@@ -28,7 +27,7 @@ import type {
 
 import { EndpointParameters } from "../endpoint/EndpointParameters";
 import { defaultEndpointResolver } from "../endpoint/endpointResolver";
-import { STSClient, STSClientConfig, STSClientResolvedConfig } from "../STSClient";
+import { STSClientConfig, STSClientResolvedConfig } from "../STSClient";
 
 /**
  * @internal
@@ -297,28 +296,10 @@ export const defaultSTSHttpAuthSchemeProvider: STSHttpAuthSchemeProvider = creat
     "smithy.api#noAuth": createSmithyApiNoAuthHttpAuthOption,
   });
 
-export interface StsAuthInputConfig {}
-
-export interface StsAuthResolvedConfig {
-  /**
-   * Reference to STSClient class constructor.
-   * @internal
-   */
-  stsClientCtor: new (clientConfig: any) => Client<any, any, any>;
-}
-
-export const resolveStsAuthConfig = <T>(
-  input: T & StsAuthInputConfig
-): T & StsAuthResolvedConfig => Object.assign(input, {
-
-  stsClientCtor: STSClient,
-
-});
-
 /**
  * @public
  */
-export interface HttpAuthSchemeInputConfig extends StsAuthInputConfig, AwsSdkSigV4AuthInputConfig, AwsSdkSigV4AAuthInputConfig {
+export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig, AwsSdkSigV4AAuthInputConfig {
   /**
    * A comma-separated list of case-sensitive auth scheme names.
    * An auth scheme name is a fully qualified auth scheme ID with the namespace prefix trimmed.
@@ -343,7 +324,7 @@ export interface HttpAuthSchemeInputConfig extends StsAuthInputConfig, AwsSdkSig
 /**
  * @internal
  */
-export interface HttpAuthSchemeResolvedConfig extends StsAuthResolvedConfig, AwsSdkSigV4AuthResolvedConfig, AwsSdkSigV4AAuthResolvedConfig {
+export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedConfig, AwsSdkSigV4AAuthResolvedConfig {
   /**
    * A comma-separated list of case-sensitive auth scheme names.
    * An auth scheme name is a fully qualified auth scheme ID with the namespace prefix trimmed.
@@ -371,10 +352,9 @@ export interface HttpAuthSchemeResolvedConfig extends StsAuthResolvedConfig, Aws
 export const resolveHttpAuthSchemeConfig = <T>(
   config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveStsAuthConfig(config);
-  const config_1 = resolveAwsSdkSigV4Config(config_0);
-  const config_2 = resolveAwsSdkSigV4AConfig(config_1);
-  return Object.assign(config_2, {
+  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_1 = resolveAwsSdkSigV4AConfig(config_0);
+  return Object.assign(config_1, {
     authSchemePreference: normalizeProvider(config.authSchemePreference ?? []),
   }) as T & HttpAuthSchemeResolvedConfig;
 };

--- a/clients/client-sts/src/defaultStsRoleAssumers.ts
+++ b/clients/client-sts/src/defaultStsRoleAssumers.ts
@@ -11,7 +11,7 @@ import {
   AssumeRoleWithWebIdentityCommand,
   AssumeRoleWithWebIdentityCommandInput,
 } from "./commands/AssumeRoleWithWebIdentityCommand";
-import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSClient";
+import type { STSClient, STSClientConfig } from "./STSClient";
 
 /**
  * @public
@@ -222,26 +222,6 @@ export const getDefaultRoleAssumerWithWebIdentity = (
  * @internal
  */
 export type DefaultCredentialProvider = (input: any) => Provider<AwsCredentialIdentity>;
-
-/**
- * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
- * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
- * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
- * dependencies.
- *
- * @internal
- */
-export const decorateDefaultCredentialProvider =
-  (provider: DefaultCredentialProvider): DefaultCredentialProvider =>
-  (input: STSClientResolvedConfig) =>
-    provider({
-      roleAssumer: getDefaultRoleAssumer(input, input.stsClientCtor as new (options: STSClientConfig) => STSClient),
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(
-        input,
-        input.stsClientCtor as new (options: STSClientConfig) => STSClient
-      ),
-      ...input,
-    });
 
 const isH2 = (requestHandler: any): boolean => {
   return requestHandler?.metadata?.handlerProtocol === "h2";

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -34,7 +34,12 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
         return List.of(
             // AWS or SigV4
             RuntimeClientPlugin.builder()
-                .withConventions("@smithy/core/config", TypeScriptDependency.SMITHY_CORE.dependency.getVersion(), "Region", HAS_CONFIG)
+                .withConventions(
+                    "@smithy/core/config",
+                    TypeScriptDependency.SMITHY_CORE.dependency.getVersion(),
+                    "Region",
+                    HAS_CONFIG
+                )
                 .servicePredicate((m, s) -> isAwsService(s) || isSigV4Service(s))
                 .build(),
             // Can be in smithy-typescript, but the NPM package is in @aws-sdk

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddRetryCustomizations.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddRetryCustomizations.java
@@ -58,7 +58,12 @@ public class AddRetryCustomizations implements TypeScriptIntegration {
             return Map.of(
                 "retryStrategy",
                 (w) -> {
-                    w.addImportSubmodule("StandardRetryStrategy", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.RETRY);
+                    w.addImportSubmodule(
+                        "StandardRetryStrategy",
+                        null,
+                        TypeScriptDependency.SMITHY_CORE,
+                        SmithyCoreSubmodules.RETRY
+                    );
                     w.addImportSubmodule("Retry", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.RETRY);
 
                     // todo(retry): Retry.v2026 condition can be removed when made permanent.

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -350,11 +350,11 @@ public final class AddS3Config implements TypeScriptIntegration {
                     "useArnRegion",
                     writer -> {
                         writer.addImportSubmodule(
-                                "loadConfig",
-                                "loadNodeConfig",
-                                TypeScriptDependency.SMITHY_CORE,
-                                SmithyCoreSubmodules.CONFIG
-                            )
+                            "loadConfig",
+                            "loadNodeConfig",
+                            TypeScriptDependency.SMITHY_CORE,
+                            SmithyCoreSubmodules.CONFIG
+                        )
                             .addDependency(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE)
                             .addImport(
                                 "NODE_USE_ARN_REGION_CONFIG_OPTIONS",
@@ -366,11 +366,11 @@ public final class AddS3Config implements TypeScriptIntegration {
                     "disableS3ExpressSessionAuth",
                     writer -> {
                         writer.addImportSubmodule(
-                                "loadConfig",
-                                "loadNodeConfig",
-                                TypeScriptDependency.SMITHY_CORE,
-                                SmithyCoreSubmodules.CONFIG
-                            )
+                            "loadConfig",
+                            "loadNodeConfig",
+                            TypeScriptDependency.SMITHY_CORE,
+                            SmithyCoreSubmodules.CONFIG
+                        )
                             .addDependency(AwsDependency.S3_MIDDLEWARE)
                             .addImport(
                                 "NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS",

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java
@@ -151,11 +151,11 @@ public class AddS3ControlDependency implements TypeScriptIntegration {
                     "useArnRegion",
                     writer -> {
                         writer.addImportSubmodule(
-                                "loadConfig",
-                                "loadNodeConfig",
-                                TypeScriptDependency.SMITHY_CORE,
-                                SmithyCoreSubmodules.CONFIG
-                            )
+                            "loadConfig",
+                            "loadNodeConfig",
+                            TypeScriptDependency.SMITHY_CORE,
+                            SmithyCoreSubmodules.CONFIG
+                        )
                             .addDependency(AwsDependency.BUCKET_ENDPOINT_MIDDLEWARE)
                             .addImport(
                                 "NODE_USE_ARN_REGION_CONFIG_OPTIONS",

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSqsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddSqsDependency.java
@@ -131,7 +131,12 @@ public class AddSqsDependency implements TypeScriptIntegration {
                 return MapUtils.of("md5", writer -> {
                     writer.addDependency(TypeScriptDependency.SMITHY_CORE);
                     writer
-                        .addImportSubmodule("Md5", "Md5", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CHECKSUM);
+                        .addImportSubmodule(
+                            "Md5",
+                            "Md5",
+                            TypeScriptDependency.SMITHY_CORE,
+                            SmithyCoreSubmodules.CHECKSUM
+                        );
                     writer.write("Md5");
                 });
             default:

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
@@ -54,7 +54,12 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
                 writer -> {
                     writer.addDependency(AwsDependency.UTIL_ENDPOINTS);
 
-                    writer.addImportSubmodule("customEndpointFunctions", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.ENDPOINTS);
+                    writer.addImportSubmodule(
+                        "customEndpointFunctions",
+                        null,
+                        TypeScriptDependency.SMITHY_CORE,
+                        SmithyCoreSubmodules.ENDPOINTS
+                    );
                     writer.addImport("awsEndpointFunctions", null, AwsDependency.UTIL_ENDPOINTS);
                     writer.write("customEndpointFunctions.aws = awsEndpointFunctions;");
                 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
@@ -147,7 +147,12 @@ final class EndpointGenerator implements Runnable {
     }
 
     private void writeRegionHash() {
-        writer.addImportSubmodule("RegionHash", "RegionHash", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CONFIG);
+        writer.addImportSubmodule(
+            "RegionHash",
+            "RegionHash",
+            TypeScriptDependency.SMITHY_CORE,
+            SmithyCoreSubmodules.CONFIG
+        );
         writer.openBlock("const regionHash: RegionHash = {", "};", () -> {
             for (Map.Entry<String, ObjectNode> entry : endpoints.entrySet()) {
                 writeEndpointSpecificResolver(entry.getKey(), entry.getValue());
@@ -157,7 +162,12 @@ final class EndpointGenerator implements Runnable {
     }
 
     private void writePartitionHash() {
-        writer.addImportSubmodule("PartitionHash", "PartitionHash", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CONFIG);
+        writer.addImportSubmodule(
+            "PartitionHash",
+            "PartitionHash",
+            TypeScriptDependency.SMITHY_CORE,
+            SmithyCoreSubmodules.CONFIG
+        );
         writer.openBlock("const partitionHash: PartitionHash = {", "};", () -> {
             partitions.values().forEach(partition -> {
                 writer.openBlock("$S: {", "},", partition.identifier, () -> {
@@ -185,7 +195,12 @@ final class EndpointGenerator implements Runnable {
             "RegionInfoProviderOptions",
             AwsDependency.TYPES
         );
-        writer.addImportSubmodule("getRegionInfo", "getRegionInfo", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CONFIG);
+        writer.addImportSubmodule(
+            "getRegionInfo",
+            "getRegionInfo",
+            TypeScriptDependency.SMITHY_CORE,
+            SmithyCoreSubmodules.CONFIG
+        );
         writer.openBlock(
             "export const defaultRegionInfoProvider: RegionInfoProvider = async (\n"
                 + "  region: string,\n"

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
@@ -40,7 +40,8 @@ final class JsonMemberDeserVisitor extends MemberDeserVisitor {
         this.dataSource = dataSource;
         this.context = context;
         this.memberShape = memberShape;
-        context.getWriter().addImportSubmodule("_json", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CLIENT);
+        context.getWriter()
+            .addImportSubmodule("_json", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CLIENT);
         this.serdeElisionEnabled = !context.getSettings().generateServerSdk();
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
@@ -56,7 +56,13 @@ final class XmlMemberDeserVisitor extends DocumentMemberDeserVisitor {
 
     @Override
     public String booleanShape(BooleanShape shape) {
-        getContext().getWriter().addImportSubmodule("parseBoolean", "__parseBoolean", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
+        getContext().getWriter()
+            .addImportSubmodule(
+                "parseBoolean",
+                "__parseBoolean",
+                TypeScriptDependency.SMITHY_CORE,
+                SmithyCoreSubmodules.SERDE
+            );
         return "__parseBoolean(" + getDataSource() + ")";
     }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -93,7 +93,12 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
         }
 
         TypeScriptWriter writer = context.getWriter();
-        writer.addImportSubmodule("getArrayIfSingleItem", "__getArrayIfSingleItem", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CLIENT);
+        writer.addImportSubmodule(
+            "getArrayIfSingleItem",
+            "__getArrayIfSingleItem",
+            TypeScriptDependency.SMITHY_CORE,
+            SmithyCoreSubmodules.CLIENT
+        );
         // The XML parser will set one K:V for a member that could
         // return multiple entries but only has one.
         // Update the target element if we target another level of collection.
@@ -265,7 +270,12 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
         }
 
         TypeScriptWriter writer = context.getWriter();
-        writer.addImportSubmodule("getArrayIfSingleItem", "__getArrayIfSingleItem", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CLIENT);
+        writer.addImportSubmodule(
+            "getArrayIfSingleItem",
+            "__getArrayIfSingleItem",
+            TypeScriptDependency.SMITHY_CORE,
+            SmithyCoreSubmodules.CLIENT
+        );
         // The XML parser will set one K:V for a member that could
         // return multiple entries but only has one.
         return String.format("__getArrayIfSingleItem(%s)", dataSource);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSTSAuthCustomizations.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AddSTSAuthCustomizations.java
@@ -4,7 +4,6 @@
  */
 package software.amazon.smithy.aws.typescript.codegen.auth.http.integration;
 
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -15,11 +14,9 @@ import java.util.logging.Logger;
 import software.amazon.smithy.aws.traits.auth.SigV4Trait;
 import software.amazon.smithy.aws.typescript.codegen.AwsDependency;
 import software.amazon.smithy.aws.typescript.codegen.AwsTraitsUtils;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
-import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.AuthTrait;
@@ -29,12 +26,9 @@ import software.amazon.smithy.model.traits.RetryableTrait;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
-import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
-import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
-import software.amazon.smithy.typescript.codegen.auth.http.ResolveConfigFunction;
 import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
 import software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthTypeScriptIntegration;
 import software.amazon.smithy.utils.IoUtils;
@@ -219,40 +213,6 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
                 .popState();
         });
 
-        codegenContext.writerDelegator().useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
-            ServiceShape service = codegenContext.settings().getService(codegenContext.model());
-            Symbol serviceSymbol = codegenContext.symbolProvider().toSymbol(service);
-            w.addRelativeImport(
-                serviceSymbol.getName(),
-                null,
-                Paths.get(".", serviceSymbol.getNamespace())
-            );
-            w.addRelativeImport(
-                serviceSymbol.getName() + "Config",
-                null,
-                Paths.get(".", serviceSymbol.getNamespace())
-            );
-            w.write("export interface StsAuthInputConfig {}\n");
-            w.openBlock(
-                "export interface StsAuthResolvedConfig {",
-                "}\n",
-                () -> w
-                    .writeDocs("""
-                               Reference to STSClient class constructor.
-                               @internal""")
-                    .addTypeImport("Client", null, TypeScriptDependency.SMITHY_TYPES)
-                    .write("stsClientCtor: new (clientConfig: any) => Client<any, any, any>;")
-            );
-            w.openBlock("""
-                        export const resolveStsAuthConfig = <T>(
-                          input: T & StsAuthInputConfig
-                        ): T & StsAuthResolvedConfig => Object.assign(input, {
-                        """, "});", () -> {
-                w.write("""
-                        stsClientCtor: STSClient,
-                        """);
-            });
-        });
     }
 
     @Override
@@ -273,28 +233,6 @@ public final class AddSTSAuthCustomizations implements HttpAuthTypeScriptIntegra
                         .write("""
                                async (idProps) => await \
                                credentialDefaultProvider(idProps?.__config || {})()""")
-                )
-                .addResolveConfigFunction(
-                    ResolveConfigFunction.builder()
-                        .resolveConfigFunction(
-                            Symbol.builder()
-                                .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
-                                .name("resolveStsAuthConfig")
-                                .build()
-                        )
-                        .inputConfig(
-                            Symbol.builder()
-                                .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
-                                .name("StsAuthInputConfig")
-                                .build()
-                        )
-                        .resolvedConfig(
-                            Symbol.builder()
-                                .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
-                                .name("StsAuthResolvedConfig")
-                                .build()
-                        )
-                        .build()
                 )
                 .build();
             supportedHttpAuthSchemesIndex.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider.java
@@ -236,14 +236,24 @@ public final class AwsSdkCustomizeEndpointRuleSetHttpAuthSchemeProvider implemen
                         Paths.get(".", serviceSymbol.getNamespace())
                     );
                     w.addTypeImport("HandlerExecutionContext", null, TypeScriptDependency.SMITHY_TYPES);
-                    w.addImportSubmodule("getSmithyContext", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CLIENT);
+                    w.addImportSubmodule(
+                        "getSmithyContext",
+                        null,
+                        TypeScriptDependency.SMITHY_CORE,
+                        SmithyCoreSubmodules.CLIENT
+                    );
                     w.addTypeImportSubmodule(
                         "EndpointParameterInstructions",
                         null,
                         TypeScriptDependency.SMITHY_CORE,
                         SmithyCoreSubmodules.ENDPOINTS
                     );
-                    w.addImportSubmodule("resolveParams", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.ENDPOINTS);
+                    w.addImportSubmodule(
+                        "resolveParams",
+                        null,
+                        TypeScriptDependency.SMITHY_CORE,
+                        SmithyCoreSubmodules.ENDPOINTS
+                    );
                     w.writeDocs("@internal");
                     w.write("""
                             interface EndpointRuleSetSmithyContext {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/SupportSigV4Auth.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/auth/http/integration/SupportSigV4Auth.java
@@ -118,7 +118,12 @@ public final class SupportSigV4Auth implements HttpAuthTypeScriptIntegration {
                         .name("region")
                         .type(w -> w.write("string"))
                         .source(w -> {
-                            w.addImportSubmodule("normalizeProvider", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CLIENT);
+                            w.addImportSubmodule(
+                                "normalizeProvider",
+                                null,
+                                TypeScriptDependency.SMITHY_CORE,
+                                SmithyCoreSubmodules.CLIENT
+                            );
                             w.openBlock("await normalizeProvider(config.region)() || (() => {", "})()", () -> {
                                 w.write(
                                     "throw new Error(\"expected `region` to be configured for `aws.auth#sigv4`\");"

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/visitor/MemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/visitor/MemberDeserVisitor.java
@@ -78,31 +78,61 @@ public class MemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public String booleanShape(BooleanShape shape) {
-        context.getWriter().addImportSubmodule("expectBoolean", "__expectBoolean", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
+        context.getWriter()
+            .addImportSubmodule(
+                "expectBoolean",
+                "__expectBoolean",
+                TypeScriptDependency.SMITHY_CORE,
+                SmithyCoreSubmodules.SERDE
+            );
         return "__expectBoolean(" + dataSource + ")";
     }
 
     @Override
     public String byteShape(ByteShape shape) {
-        context.getWriter().addImportSubmodule("expectByte", "__expectByte", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
+        context.getWriter()
+            .addImportSubmodule(
+                "expectByte",
+                "__expectByte",
+                TypeScriptDependency.SMITHY_CORE,
+                SmithyCoreSubmodules.SERDE
+            );
         return "__expectByte(" + dataSource + ")";
     }
 
     @Override
     public String shortShape(ShortShape shape) {
-        context.getWriter().addImportSubmodule("expectShort", "__expectShort", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
+        context.getWriter()
+            .addImportSubmodule(
+                "expectShort",
+                "__expectShort",
+                TypeScriptDependency.SMITHY_CORE,
+                SmithyCoreSubmodules.SERDE
+            );
         return "__expectShort(" + dataSource + ")";
     }
 
     @Override
     public String integerShape(IntegerShape shape) {
-        context.getWriter().addImportSubmodule("expectInt32", "__expectInt32", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
+        context.getWriter()
+            .addImportSubmodule(
+                "expectInt32",
+                "__expectInt32",
+                TypeScriptDependency.SMITHY_CORE,
+                SmithyCoreSubmodules.SERDE
+            );
         return "__expectInt32(" + dataSource + ")";
     }
 
     @Override
     public String longShape(LongShape shape) {
-        context.getWriter().addImportSubmodule("expectLong", "__expectLong", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
+        context.getWriter()
+            .addImportSubmodule(
+                "expectLong",
+                "__expectLong",
+                TypeScriptDependency.SMITHY_CORE,
+                SmithyCoreSubmodules.SERDE
+            );
         return "__expectLong(" + dataSource + ")";
     }
 
@@ -137,12 +167,23 @@ public class MemberDeserVisitor implements ShapeVisitor<String> {
             String mediaType = ((MediaTypeTrait) mediaTypeTrait.get()).getValue();
             if (CodegenUtils.isJsonMediaType(mediaType)) {
                 TypeScriptWriter writer = context.getWriter();
-                writer.addImportSubmodule("LazyJsonString", "__LazyJsonString", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
+                writer.addImportSubmodule(
+                    "LazyJsonString",
+                    "__LazyJsonString",
+                    TypeScriptDependency.SMITHY_CORE,
+                    SmithyCoreSubmodules.SERDE
+                );
                 return "__LazyJsonString.from(" + dataSource + ")";
             }
         }
 
-        context.getWriter().addImportSubmodule("expectString", "__expectString", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
+        context.getWriter()
+            .addImportSubmodule(
+                "expectString",
+                "__expectString",
+                TypeScriptDependency.SMITHY_CORE,
+                SmithyCoreSubmodules.SERDE
+            );
         return "__expectString(" + dataSource + ")";
     }
 
@@ -227,7 +268,13 @@ public class MemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public String unionShape(UnionShape shape) {
-        context.getWriter().addImportSubmodule("expectUnion", "__expectUnion", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.SERDE);
+        context.getWriter()
+            .addImportSubmodule(
+                "expectUnion",
+                "__expectUnion",
+                TypeScriptDependency.SMITHY_CORE,
+                SmithyCoreSubmodules.SERDE
+            );
         return getDelegateDeserializer(shape, "__expectUnion(" + dataSource + ")");
     }
 
@@ -279,7 +326,8 @@ public class MemberDeserVisitor implements ShapeVisitor<String> {
                 && !disableDeserializationFunctionElision
                 && serdeElisionIndex.mayElide(shape)
         ) {
-            context.getWriter().addImportSubmodule("_json", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CLIENT);
+            context.getWriter()
+                .addImportSubmodule("_json", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CLIENT);
             return "_json(" + customDataSource + ")";
         }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultStsRoleAssumers.ts
@@ -8,7 +8,7 @@ import {
   AssumeRoleWithWebIdentityCommand,
   AssumeRoleWithWebIdentityCommandInput,
 } from "./commands/AssumeRoleWithWebIdentityCommand";
-import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSClient";
+import type { STSClient, STSClientConfig } from "./STSClient";
 
 /**
  * @public
@@ -219,26 +219,6 @@ export const getDefaultRoleAssumerWithWebIdentity = (
  * @internal
  */
 export type DefaultCredentialProvider = (input: any) => Provider<AwsCredentialIdentity>;
-
-/**
- * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
- * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
- * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
- * dependencies.
- *
- * @internal
- */
-export const decorateDefaultCredentialProvider =
-  (provider: DefaultCredentialProvider): DefaultCredentialProvider =>
-  (input: STSClientResolvedConfig) =>
-    provider({
-      roleAssumer: getDefaultRoleAssumer(input, input.stsClientCtor as new (options: STSClientConfig) => STSClient),
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(
-        input,
-        input.stsClientCtor as new (options: STSClientConfig) => STSClient
-      ),
-      ...input,
-    });
 
 const isH2 = (requestHandler: any): boolean => {
   return requestHandler?.metadata?.handlerProtocol === "h2";

--- a/packages-internal/core/package.json
+++ b/packages-internal/core/package.json
@@ -64,6 +64,8 @@
       "require": "./dist-cjs/submodules/protocols/index.js"
     }
   },
+  "browser": {},
+  "react-native": {},
   "files": [
     "./account-id-endpoint.d.ts",
     "./account-id-endpoint.js",

--- a/packages-internal/core/src/index.ts
+++ b/packages-internal/core/src/index.ts
@@ -3,6 +3,7 @@
  * They are exported from the package's root index to preserve backwards compatibility.
  *
  * New development should go in a proper submodule and not be exported from the root index.
+ * There is an eslint rule banning imports from `@aws-sdk/core` without a submodule e.g. `@aws-sdk/core/protocols`.
  */
 
 /**

--- a/packages-internal/credential-provider-http/package.json
+++ b/packages-internal/credential-provider-http/package.json
@@ -4,8 +4,16 @@
   "description": "AWS credential provider for containers and HTTP sources",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
-  "browser": "./dist-es/index.browser.js",
-  "react-native": "./dist-es/index.browser.js",
+  "browser": {
+    "./dist-es/fromHttp/fromHttp": "./dist-es/fromHttp/fromHttp.browser",
+    "./dist-es/index": "./dist-es/index.browser"
+  },
+  "react-native": {
+    "./dist-es/index": "./dist-es/index.browser",
+    "./dist-cjs/index": "./dist-cjs/index.browser",
+    "./dist-es/fromHttp/fromHttp": "./dist-es/fromHttp/fromHttp.browser",
+    "./dist-cjs/fromHttp/fromHttp": "./dist-cjs/fromHttp/fromHttp.browser"
+  },
   "scripts": {
     "build": "concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",
     "build:cjs": "node ../../scripts/compilation/inline credential-provider-http",

--- a/packages-internal/middleware-recursion-detection/package.json
+++ b/packages-internal/middleware-recursion-detection/package.json
@@ -59,5 +59,8 @@
   "browser": {
     "./dist-es/recursionDetectionMiddleware": "./dist-es/recursionDetectionMiddleware.browser"
   },
-  "react-native": {}
+  "react-native": {
+    "./dist-es/recursionDetectionMiddleware": "./dist-es/recursionDetectionMiddleware.native",
+    "./dist-cjs/recursionDetectionMiddleware": "./dist-cjs/recursionDetectionMiddleware.native"
+  }
 }

--- a/packages-internal/middleware-sdk-sts/src/middleware-sdk-sts.integ.spec.ts
+++ b/packages-internal/middleware-sdk-sts/src/middleware-sdk-sts.integ.spec.ts
@@ -5,14 +5,6 @@ import { resolveStsAuthConfig } from "./index";
 
 describe("middleware-sdk-sts", () => {
   describe(STS.name, () => {
-    it("sets the sts constructor in config", async () => {
-      const client = new STS({
-        region: "us-west-2",
-      });
-
-      expect(client.config.stsClientCtor).toBe(STSClient);
-    });
-
     it("maintains object custody", () => {
       const client = new STS({
         region: "us-west-2",

--- a/packages-internal/nested-clients/src/submodules/sts/auth/httpAuthSchemeProvider.ts
+++ b/packages-internal/nested-clients/src/submodules/sts/auth/httpAuthSchemeProvider.ts
@@ -12,7 +12,6 @@ import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
 import { getSmithyContext, normalizeProvider } from "@smithy/core/client";
 import { type EndpointParameterInstructions, resolveParams } from "@smithy/core/endpoints";
 import type {
-  Client,
   EndpointV2,
   HandlerExecutionContext,
   HttpAuthOption,
@@ -28,7 +27,6 @@ import type {
 import type { EndpointParameters } from "../endpoint/EndpointParameters";
 import { defaultEndpointResolver } from "../endpoint/endpointResolver";
 import type { STSClientConfig, STSClientResolvedConfig } from "../STSClient";
-import { STSClient } from "../STSClient";
 
 /**
  * @internal
@@ -296,28 +294,10 @@ export const defaultSTSHttpAuthSchemeProvider: STSHttpAuthSchemeProvider = creat
   }
 );
 
-export interface StsAuthInputConfig {}
-
-export interface StsAuthResolvedConfig {
-  /**
-   * Reference to STSClient class constructor.
-   * @internal
-   */
-  stsClientCtor: new (clientConfig: any) => Client<any, any, any>;
-}
-
-export const resolveStsAuthConfig = <T>(input: T & StsAuthInputConfig): T & StsAuthResolvedConfig =>
-  Object.assign(input, {
-    stsClientCtor: STSClient,
-  });
-
 /**
  * @public
  */
-export interface HttpAuthSchemeInputConfig
-  extends StsAuthInputConfig,
-    AwsSdkSigV4AuthInputConfig,
-    AwsSdkSigV4AAuthInputConfig {
+export interface HttpAuthSchemeInputConfig extends AwsSdkSigV4AuthInputConfig, AwsSdkSigV4AAuthInputConfig {
   /**
    * A comma-separated list of case-sensitive auth scheme names.
    * An auth scheme name is a fully qualified auth scheme ID with the namespace prefix trimmed.
@@ -342,10 +322,7 @@ export interface HttpAuthSchemeInputConfig
 /**
  * @internal
  */
-export interface HttpAuthSchemeResolvedConfig
-  extends StsAuthResolvedConfig,
-    AwsSdkSigV4AuthResolvedConfig,
-    AwsSdkSigV4AAuthResolvedConfig {
+export interface HttpAuthSchemeResolvedConfig extends AwsSdkSigV4AuthResolvedConfig, AwsSdkSigV4AAuthResolvedConfig {
   /**
    * A comma-separated list of case-sensitive auth scheme names.
    * An auth scheme name is a fully qualified auth scheme ID with the namespace prefix trimmed.
@@ -373,10 +350,9 @@ export interface HttpAuthSchemeResolvedConfig
 export const resolveHttpAuthSchemeConfig = <T>(
   config: T & HttpAuthSchemeInputConfig & AwsSdkSigV4PreviouslyResolved & AwsSdkSigV4APreviouslyResolved
 ): T & HttpAuthSchemeResolvedConfig => {
-  const config_0 = resolveStsAuthConfig(config);
-  const config_1 = resolveAwsSdkSigV4Config(config_0);
-  const config_2 = resolveAwsSdkSigV4AConfig(config_1);
-  return Object.assign(config_2, {
+  const config_0 = resolveAwsSdkSigV4Config(config);
+  const config_1 = resolveAwsSdkSigV4AConfig(config_0);
+  return Object.assign(config_1, {
     authSchemePreference: normalizeProvider(config.authSchemePreference ?? []),
   }) as T & HttpAuthSchemeResolvedConfig;
 };

--- a/packages-internal/nested-clients/src/submodules/sts/defaultStsRoleAssumers.ts
+++ b/packages-internal/nested-clients/src/submodules/sts/defaultStsRoleAssumers.ts
@@ -10,7 +10,7 @@ import type { AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
 import { AssumeRoleCommand } from "./commands/AssumeRoleCommand";
 import type { AssumeRoleWithWebIdentityCommandInput } from "./commands/AssumeRoleWithWebIdentityCommand";
 import { AssumeRoleWithWebIdentityCommand } from "./commands/AssumeRoleWithWebIdentityCommand";
-import type { STSClient, STSClientConfig, STSClientResolvedConfig } from "./STSClient";
+import type { STSClient, STSClientConfig } from "./STSClient";
 
 /**
  * @public
@@ -221,26 +221,6 @@ export const getDefaultRoleAssumerWithWebIdentity = (
  * @internal
  */
 export type DefaultCredentialProvider = (input: any) => Provider<AwsCredentialIdentity>;
-
-/**
- * The default credential providers depend STS client to assume role with desired API: sts:assumeRole,
- * sts:assumeRoleWithWebIdentity, etc. This function decorates the default credential provider with role assumers which
- * encapsulates the process of calling STS commands. This can only be imported by AWS client packages to avoid circular
- * dependencies.
- *
- * @internal
- */
-export const decorateDefaultCredentialProvider =
-  (provider: DefaultCredentialProvider): DefaultCredentialProvider =>
-  (input: STSClientResolvedConfig) =>
-    provider({
-      roleAssumer: getDefaultRoleAssumer(input, input.stsClientCtor as new (options: STSClientConfig) => STSClient),
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(
-        input,
-        input.stsClientCtor as new (options: STSClientConfig) => STSClient
-      ),
-      ...input,
-    });
 
 const isH2 = (requestHandler: any): boolean => {
   return requestHandler?.metadata?.handlerProtocol === "h2";

--- a/packages-internal/region-config-resolver/package.json
+++ b/packages-internal/region-config-resolver/package.json
@@ -57,5 +57,8 @@
   "browser": {
     "./dist-es/regionConfig/stsRegionDefaultResolver": "./dist-es/regionConfig/stsRegionDefaultResolver.browser"
   },
-  "react-native": {}
+  "react-native": {
+    "./dist-es/regionConfig/stsRegionDefaultResolver": "./dist-es/regionConfig/stsRegionDefaultResolver.native",
+    "./dist-cjs/regionConfig/stsRegionDefaultResolver": "./dist-cjs/regionConfig/stsRegionDefaultResolver.native"
+  }
 }

--- a/packages-internal/util-user-agent-browser/package.json
+++ b/packages-internal/util-user-agent-browser/package.json
@@ -14,7 +14,13 @@
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
-  "browser": "./dist-es/index.js",
+  "browser": {
+    "./dist-es/index": "./dist-es/index.browser"
+  },
+  "react-native": {
+    "./dist-es/index": "./dist-es/index.native",
+    "./dist-cjs/index": "./dist-cjs/index.native"
+  },
   "types": "./dist-types/index.d.ts",
   "sideEffects": false,
   "author": {
@@ -22,7 +28,6 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "react-native": "dist-es/index.native.js",
   "dependencies": {
     "@aws-sdk/types": "workspace:^3.973.8",
     "@smithy/types": "^4.14.1",

--- a/packages-internal/util-user-agent-browser/src/index.browser.ts
+++ b/packages-internal/util-user-agent-browser/src/index.browser.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -45,8 +45,8 @@
     "./dist-es/xml-parser": "./dist-es/xml-parser.browser"
   },
   "react-native": {
-    "./dist-es/xml-parser": "./dist-es/xml-parser",
-    "./dist-cjs/xml-parser": "./dist-cjs/xml-parser"
+    "./dist-es/xml-parser": "./dist-es/xml-parser.browser",
+    "./dist-cjs/xml-parser": "./dist-cjs/xml-parser.browser"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages-internal/xml-builder",
   "repository": {

--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -74,14 +74,26 @@ module.exports = class Inliner {
   }
 
   /**
-   * step 2: detect all variant files and their transitive local imports.
-   * these files will not be inlined, in order to preserve the react-native dist-cjs file replacement behavior.
+   * step 2: detect all variant files.
+   * For submodule packages, we collect variant mappings per submodule to produce
+   * fully-inlined browser/native bundles.
+   * For non-submodule packages, we collect variant externals as before.
    */
   async discoverVariants() {
     if (this.bailout) {
       console.log("Inliner bailout.");
       return this;
     }
+
+    if (this.hasSubmodules) {
+      // Submodule variant indexes are source files (index.browser.ts, index.native.ts).
+      // No variant externals needed.
+      this.variantExternals = [];
+      this.variantMap = {};
+      return this;
+    }
+
+    // Non-submodule packages: original behavior.
     this.variantEntries = Object.entries(this.pkgJson["react-native"] ?? {});
 
     for await (const file of walk(path.join(this.packageDirectory, "dist-cjs"))) {
@@ -92,8 +104,14 @@ module.exports = class Inliner {
 
         this.variantEntries.push([canonical, variant]);
       }
-      if (fs.existsSync(file.replace(/\.js$/, ".browser.js"))) {
-        // not applicable to CJS?
+      if (
+        file.endsWith(".js") &&
+        !file.endsWith(".browser.js") &&
+        fs.existsSync(file.replace(/\.js$/, ".browser.js"))
+      ) {
+        const canonical = file.replace(/(.*?)dist-cjs\//, "./dist-cjs/").replace(/\.js$/, "");
+        const variant = canonical.replace(/(.*?)(\.js)?$/, "$1.browser$2");
+        this.variantEntries.push([canonical, variant]);
       }
     }
 
@@ -164,6 +182,11 @@ module.exports = class Inliner {
   /**
    * step 3: bundle the package index into dist-cjs/index.js except for node_modules
    * and also excluding any local files that have variants for react-native.
+   *
+   * For submodule packages, produces fully-inlined bundles per submodule:
+   * - index.js (node/default)
+   * - index.browser.js (with browser variants resolved)
+   * - index.native.js (with native variants resolved, only if native variants exist)
    */
   async bundle() {
     if (this.bailout) {
@@ -174,132 +197,110 @@ module.exports = class Inliner {
 
     const entryPoint = path.join(root, this.subfolder, this.package, "dist-es", "index.js");
 
-    const externalityAssessments = {};
+    const makeInputOptions = (entry, externals, plugins = []) => {
+      const externalityAssessments = {};
+      return {
+        input: [entry],
+        plugins: [...plugins, nodeResolve(), json()],
+        onwarn(warning) {
+          if (warning.code === "CIRCULAR_DEPENDENCY") {
+            throw Error(warning.message);
+          }
+        },
+        external: (id) => {
+          if (undefined !== externalityAssessments[id]) {
+            return externalityAssessments[id];
+          }
 
-    const inputOptions = (externals) => ({
-      input: [entryPoint],
-      plugins: [nodeResolve(), json()],
-      onwarn(warning) {
-        /*
-        Circular imports are not an error in the language spec,
-        but reasoning about the program and bundling becomes easier.
-        For that reason let's avoid them.
-         */
-        if (warning.code === "CIRCULAR_DEPENDENCY") {
-          throw Error(warning.message);
-        }
-      },
-      external: (id) => {
-        if (undefined !== externalityAssessments[id]) {
-          return externalityAssessments[id];
-        }
-
-        const relative = !!id.match(/^\.?\.?\//);
-        if (!relative) {
-          this.verbose && console.log("EXTERN (pkg)", id);
-          return (externalityAssessments[id] = true);
-        }
-
-        if (id === entryPoint) {
-          this.verbose && console.log("INTERN (entry point)", id);
-          return (externalityAssessments[id] = false);
-        }
-
-        const local =
-          id.includes(`/dist-es/`) &&
-          ((id.includes(`/packages/`) && !id.includes(`packages/${this.package}/`)) ||
-            (id.includes(`/packages-internal/`) && !id.includes(`packages-internal/${this.package}/`)));
-        if (local) {
-          this.verbose && console.log("EXTERN (local)", id);
-          return (externalityAssessments[id] = true);
-        }
-
-        for (const file of externals) {
-          const idWithoutExtension = id.replace(/\.[tj]s$/, "");
-          if (idWithoutExtension.endsWith(path.basename(file))) {
-            this.verbose && console.log("EXTERN (variant)", id);
+          const relative = !!id.match(/^\.?\.?\//);
+          if (!relative) {
+            this.verbose && console.log("EXTERN (pkg)", id);
             return (externalityAssessments[id] = true);
           }
-        }
 
-        this.verbose && console.log("INTERN (invariant)", id);
-        return (externalityAssessments[id] = false);
-      },
-    });
+          if (id === entry) {
+            return (externalityAssessments[id] = false);
+          }
 
-    const outputOptions = {
-      dir: path.dirname(this.outfile),
+          const local =
+            id.includes(`/dist-es/`) &&
+            ((id.includes(`/packages/`) && !id.includes(`packages/${this.package}/`)) ||
+              (id.includes(`/packages-internal/`) && !id.includes(`packages-internal/${this.package}/`)));
+          if (local) {
+            this.verbose && console.log("EXTERN (local)", id);
+            return (externalityAssessments[id] = true);
+          }
+
+          for (const file of externals) {
+            const idWithoutExtension = id.replace(/\.[tj]s$/, "");
+            const idBasename = path.basename(idWithoutExtension);
+            if (idBasename === path.basename(file)) {
+              this.verbose && console.log("EXTERN (variant)", id);
+              return (externalityAssessments[id] = true);
+            }
+          }
+
+          return (externalityAssessments[id] = false);
+        },
+      };
+    };
+
+    const outputOptions = (dir) => ({
+      dir,
       format: "cjs",
       exports: "named",
       preserveModules: false,
       externalLiveBindings: false,
-    };
+    });
 
-    const bundle = await rollup.rollup(inputOptions(variantExternalsForRollup));
-    await bundle.write(outputOptions);
+    // Bundle main index.js (no variants externalized for submodule packages).
+    const mainExternals = this.hasSubmodules ? [] : variantExternalsForRollup;
+    const bundle = await rollup.rollup(makeInputOptions(entryPoint, mainExternals));
+    await bundle.write(outputOptions(path.dirname(this.outfile)));
     await bundle.close();
 
     if (this.hasSubmodules) {
-      const submodules = fs.readdirSync(path.join(root, this.subfolder, this.package, "src", "submodules"));
+      const submodulesDir = path.join(root, this.subfolder, this.package, "src", "submodules");
+      const submodules = fs
+        .readdirSync(submodulesDir)
+        .filter((d) => fs.lstatSync(path.join(submodulesDir, d)).isDirectory());
+
       for (const submodule of submodules) {
-        if (
-          !fs.lstatSync(path.join(root, this.subfolder, this.package, "src", "submodules", submodule)).isDirectory()
-        ) {
-          continue;
+        const distEsSubmoduleDir = path.join(root, this.subfolder, this.package, "dist-es", "submodules", submodule);
+        const submoduleOutDir = path.join(root, this.subfolder, this.package, "dist-cjs", "submodules", submodule);
+
+        // Remove all tsc-generated files in this submodule's dist-cjs folder.
+        if (fs.existsSync(submoduleOutDir)) {
+          fs.rmSync(submoduleOutDir, { recursive: true });
+        }
+        fs.mkdirSync(submoduleOutDir, { recursive: true });
+
+        // Bundle index.js (node/default).
+        const nodeBundle = await rollup.rollup(makeInputOptions(path.join(distEsSubmoduleDir, "index.js"), []));
+        await nodeBundle.write(outputOptions(submoduleOutDir));
+        await nodeBundle.close();
+
+        // Bundle index.browser.js if the source file exists.
+        const browserEntry = path.join(distEsSubmoduleDir, "index.browser.js");
+        if (fs.existsSync(browserEntry)) {
+          const browserBundle = await rollup.rollup(makeInputOptions(browserEntry, []));
+          await browserBundle.write({
+            ...outputOptions(submoduleOutDir),
+            entryFileNames: "index.browser.js",
+          });
+          await browserBundle.close();
         }
 
-        // remove invariant files.
-        for await (const file of walk(
-          path.join(root, this.subfolder, this.package, "dist-cjs", "submodules", submodule)
-        )) {
-          const stat = fs.lstatSync(file);
-          if (this.variantExternals.find((ext) => file.endsWith(ext))) {
-            continue;
-          }
-          if (stat.isDirectory()) {
-            if (fs.readdirSync(file).length === 0) {
-              fs.rmdirSync(file);
-            }
-          } else {
-            fs.rmSync(file);
-          }
+        // Bundle index.native.js if the source file exists.
+        const nativeEntry = path.join(distEsSubmoduleDir, "index.native.js");
+        if (fs.existsSync(nativeEntry)) {
+          const nativeBundle = await rollup.rollup(makeInputOptions(nativeEntry, []));
+          await nativeBundle.write({
+            ...outputOptions(submoduleOutDir),
+            entryFileNames: "index.native.js",
+          });
+          await nativeBundle.close();
         }
-
-        // remove remaining empty directories.
-        const submoduleFolder = path.join(root, this.subfolder, this.package, "dist-cjs", "submodules", submodule);
-        function rmdirEmpty(dir) {
-          for (const entry of fs.readdirSync(dir)) {
-            const fullPath = path.join(dir, entry);
-            if (fs.lstatSync(fullPath).isDirectory()) {
-              if (fs.readdirSync(fullPath).length) {
-                rmdirEmpty(fullPath);
-              } else {
-                fs.rmdirSync(fullPath);
-              }
-            }
-          }
-        }
-        rmdirEmpty(submoduleFolder);
-
-        const submoduleVariants = variantExternalsForRollup.filter((external) =>
-          external.includes(`submodules/${submodule}`)
-        );
-
-        const submoduleOptions = inputOptions(submoduleVariants);
-
-        const submoduleBundle = await rollup.rollup({
-          ...submoduleOptions,
-          input: path.join(root, this.subfolder, this.package, "dist-es", "submodules", submodule, "index.js"),
-        });
-
-        await submoduleBundle.write({
-          ...outputOptions,
-          dir: path.dirname(
-            path.join(root, this.subfolder, this.package, "dist-cjs", "submodules", submodule, "index.js")
-          ),
-        });
-
-        await submoduleBundle.close();
       }
     }
 
@@ -369,11 +370,10 @@ module.exports = class Inliner {
 
   /**
    * step 5: rewrite variant external imports to correct path.
-   * these externalized variants use relative imports for transitive variant files
-   * which need to be rewritten when in the index.js file.
+   * For submodule packages, this is a no-op since all variants are fully inlined.
    */
   async fixVariantImportPaths() {
-    if (this.bailout) {
+    if (this.bailout || this.hasSubmodules) {
       return this;
     }
     this.indexContents = fs.readFileSync(this.outfile, "utf-8");
@@ -398,37 +398,49 @@ module.exports = class Inliner {
     }
     this.indexContents = fixImportsForFile(this.indexContents);
     fs.writeFileSync(this.outfile, this.indexContents, "utf-8");
-    if (this.hasSubmodules) {
-      const submodules = fs.readdirSync(path.join(path.dirname(this.outfile), "submodules"));
-      for (const submodule of submodules) {
-        const submoduleIndexPath = path.join(path.dirname(this.outfile), "submodules", submodule, "index.js");
-        const submoduleIndexContents = fs.readFileSync(submoduleIndexPath, "utf-8");
-        if (this.verbose) {
-          console.log("Fixing imports for submodule file", path.dirname(submoduleIndexPath));
-        }
-        fs.writeFileSync(
-          submoduleIndexPath,
-          fixImportsForFile(submoduleIndexContents, new RegExp(`/submodules/(${submodules.join("|")})`, "g"))
-        );
-        try {
-          require(submoduleIndexPath);
-        } catch (e) {
-          console.error(`File ${submoduleIndexPath} has import errors.`);
-          throw e;
-        }
-      }
-    }
     return this;
   }
 
   /**
-   * step 6: we validate that the index.js file has a require statement
-   * for any variant files, to ensure they are not in the inlined (bundled) index.
+   * step 6: validate the output.
+   * For submodule packages, validates that each submodule index.js is requireable
+   * and that variant bundles exist where expected.
    */
   async validate() {
     if (this.bailout) {
       return this;
     }
+
+    if (this.hasSubmodules) {
+      const submodulesDir = path.join(this.packageDirectory, "dist-cjs", "submodules");
+      const submodules = fs.readdirSync(submodulesDir);
+
+      for (const submodule of submodules) {
+        const submoduleDir = path.join(submodulesDir, submodule);
+        for (const file of fs.readdirSync(submoduleDir)) {
+          if (!file.endsWith(".js")) continue;
+          const filePath = path.join(submoduleDir, file);
+          try {
+            require(filePath);
+          } catch (e) {
+            console.error(`File ${filePath} has import errors.`);
+            throw e;
+          }
+        }
+      }
+
+      // Validate main index.js is requireable.
+      try {
+        require(this.outfile);
+      } catch (e) {
+        console.error(`File ${this.outfile} has import errors.`);
+        throw e;
+      }
+
+      return this;
+    }
+
+    // Non-submodule validation (original behavior).
     this.indexContents = fs.readFileSync(this.outfile, "utf-8");
 
     const externalsToCheck = new Set(
@@ -455,17 +467,6 @@ module.exports = class Inliner {
     };
 
     inspect(this.indexContents);
-
-    if (this.hasSubmodules) {
-      const submodules = fs.readdirSync(path.join(path.dirname(this.outfile), "submodules"));
-      for (const submodule of submodules) {
-        const submoduleIndexContents = fs.readFileSync(
-          path.join(path.dirname(this.outfile), "submodules", submodule, "index.js"),
-          "utf-8"
-        );
-        inspect(submoduleIndexContents);
-      }
-    }
 
     if (externalsToCheck.size) {
       throw new Error(

--- a/scripts/runtime-dependency-version-check/check-dependencies.js
+++ b/scripts/runtime-dependency-version-check/check-dependencies.js
@@ -61,7 +61,7 @@ const shouldIgnore = (dep) => ignored.includes(dep) || (dep.startsWith("node:") 
 
     const pkgJsonPath = path.join(containingFolder, packageFolder, "package.json");
 
-    if (containingFolder === packages) {
+    if (containingFolder === packages || containingFolder === packagesInternal) {
       errors.push(...pkgJsonEnforcement(pkgJsonPath, true));
     }
 

--- a/scripts/runtime-dependency-version-check/package-json-enforcement.js
+++ b/scripts/runtime-dependency-version-check/package-json-enforcement.js
@@ -61,6 +61,37 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
     errors.push(`no files entry in ${pkgJson.name}`);
   }
 
+  // For submodule carriers, ensure browser and react-native fields exist as objects
+  // so that variant enforcement can populate them.
+  if (submoduleCarriers.includes(pkgJson.name)) {
+    const pkgDirCheck = path.dirname(pkgJsonFilePath);
+    const submodulesDirCheck = path.join(pkgDirCheck, "src", "submodules");
+    if (fs.existsSync(submodulesDirCheck)) {
+      const hasAnyVariant = fs.readdirSync(submodulesDirCheck).some((sub) => {
+        const subPath = path.join(submodulesDirCheck, sub);
+        return (
+          fs.lstatSync(subPath).isDirectory() &&
+          (fs.existsSync(path.join(subPath, "index.browser.ts")) ||
+            fs.existsSync(path.join(subPath, "index.native.ts")))
+        );
+      });
+      if (hasAnyVariant) {
+        if (typeof pkgJson.browser !== "object") {
+          if (overwrite) {
+            pkgJson.browser = {};
+          }
+          errors.push(`${pkgJson.name} browser field should be an object (has submodule variants)`);
+        }
+        if (typeof pkgJson["react-native"] !== "object") {
+          if (overwrite) {
+            pkgJson["react-native"] = {};
+          }
+          errors.push(`${pkgJson.name} react-native field should be an object (has submodule variants)`);
+        }
+      }
+    }
+  }
+
   if (typeof pkgJson.browser === "object" && typeof pkgJson["react-native"] === "object") {
     // Skip canonicalization for packages with submodules — they manage their own fields.
     const pkgDirEarly = path.dirname(pkgJsonFilePath);


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8004

### Description
Adds/fixes some validation scripts.

- packages-internal now linted by the package-json rules
- updated dist-cjs Inliner to build submodule variants (none exist yet) and updated to the same validations as in smithy-ts

### Testing
ci

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
