### PR TITLE
fix(core): fix clock-skew retry for concurrent requests and JSON-protocol services

### DIFF
--- a/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4ASigner.ts
+++ b/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4ASigner.ts
@@ -30,6 +30,7 @@ export class AwsSdkSigV4ASigner extends AwsSdkSigV4Signer {
       signingRegionSet ?? [signingRegion]
     ).join(",");
 
+    signingProperties._preRequestSystemClockOffset = config.systemClockOffset;
     const signedRequest = await signer.sign(httpRequest, {
       signingDate: getSkewCorrectedDate(config.systemClockOffset),
       signingRegion: multiRegionOverride,

--- a/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.spec.ts
+++ b/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.spec.ts
@@ -3,12 +3,13 @@ import { describe, expect, test as it } from "vitest";
 import { AwsSdkSigV4Signer } from "./AwsSdkSigV4Signer";
 
 describe(AwsSdkSigV4Signer.name, () => {
-  it("sets clockSkewCorrected metadata in error handler if systemClockOffset was updated", async () => {
+  it("sets clockSkewCorrected when systemClockOffset is updated locally", async () => {
     const signer = new AwsSdkSigV4Signer();
 
     let error: Error | any;
     try {
       signer.errorHandler({
+        _preRequestSystemClockOffset: 30 * 60 * 1000,
         config: {
           systemClockOffset: 30 * 60 * 1000,
         },
@@ -16,9 +17,7 @@ describe(AwsSdkSigV4Signer.name, () => {
         Object.assign(new Error("uh oh"), {
           $metadata: {},
           $response: {
-            headers: {
-              date: new Date().toISOString(),
-            },
+            headers: { date: new Date().toISOString() },
             statusCode: 500,
           },
         })
@@ -30,7 +29,7 @@ describe(AwsSdkSigV4Signer.name, () => {
     expect((error as any).$metadata.clockSkewCorrected).toBe(true);
   });
 
-  it("sets clockSkewCorrected metadata when systemClockOffset was already corrected by a concurrent request", async () => {
+  it("sets clockSkewCorrected when offset was already corrected by a concurrent request (ServerTime)", async () => {
     const signer = new AwsSdkSigV4Signer();
     const oneHourMs = 60 * 60 * 1000;
     const serverTime = new Date(Date.now() + oneHourMs).toISOString();
@@ -38,8 +37,6 @@ describe(AwsSdkSigV4Signer.name, () => {
     let error: Error | any;
     try {
       signer.errorHandler({
-        // _preRequestSystemClockOffset: 0 — clock was in sync when this request started;
-        // a concurrent request corrected it to oneHourMs before this error handler ran.
         _preRequestSystemClockOffset: 0,
         config: {
           systemClockOffset: oneHourMs,
@@ -47,9 +44,6 @@ describe(AwsSdkSigV4Signer.name, () => {
       })(
         Object.assign(new Error("RequestTimeTooSkewed"), {
           name: "RequestTimeTooSkewed",
-          // ServerTime is parsed from the XML error response body and is the reliable
-          // indicator that this is a genuine clock-skew error (not just any HTTP error
-          // that happens to include a date header).
           ServerTime: serverTime,
           $metadata: {},
           $response: {
@@ -62,80 +56,11 @@ describe(AwsSdkSigV4Signer.name, () => {
       error = e as Error;
     }
 
-    // Without the fix, clockSkewCorrected is false here because the offset didn't change
-    // (a concurrent request already updated it). The request must still be retried.
     expect((error as any).$metadata.clockSkewCorrected).toBe(true);
   });
 
-  it("sets clockSkewCorrected when server time is embedded in error message (DynamoDB-style, no Date header)", async () => {
+  it("does not set clockSkewCorrected when no server time is available", async () => {
     const signer = new AwsSdkSigV4Signer();
-    const oneHourMs = 60 * 60 * 1000;
-    const serverDate = new Date(Date.now() + oneHourMs);
-    // Compact AWS timestamp format: YYYYMMDDTHHMMSSz
-    const compact = serverDate.toISOString().replace(/[-:]|\.\d{3}/g, "");
-    const message = `Signature expired: 20000101T000000Z is now earlier than ... (${compact} - 5 min. ahead of your clock)`;
-
-    let error: Error | any;
-    try {
-      signer.errorHandler({
-        _preRequestSystemClockOffset: 0,
-        config: {
-          systemClockOffset: 0,
-        },
-      })(
-        Object.assign(new Error(message), {
-          name: "InvalidSignatureException",
-          // No ServerTime field — this is a JSON-protocol service (e.g. DynamoDB).
-          $metadata: {},
-          $response: {
-            headers: {}, // no Date header in response
-            statusCode: 403,
-          },
-        })
-      );
-    } catch (e) {
-      error = e as Error;
-    }
-
-    expect((error as any).$metadata.clockSkewCorrected).toBe(true);
-  });
-
-  it("sets clockSkewCorrected from error message when offset was already corrected by a concurrent request", async () => {
-    const signer = new AwsSdkSigV4Signer();
-    const oneHourMs = 60 * 60 * 1000;
-    const serverDate = new Date(Date.now() + oneHourMs);
-    const compact = serverDate.toISOString().replace(/[-:]|\.\d{3}/g, "");
-    const message = `Signature expired: 20000101T000000Z is now earlier than ... (${compact} - 5 min. ahead of your clock)`;
-
-    let error: Error | any;
-    try {
-      signer.errorHandler({
-        // _preRequestSystemClockOffset: 0 — clock was in sync when this request started;
-        // a concurrent request corrected it to oneHourMs before this error handler ran.
-        _preRequestSystemClockOffset: 0,
-        config: {
-          systemClockOffset: oneHourMs,
-        },
-      })(
-        Object.assign(new Error(message), {
-          name: "InvalidSignatureException",
-          $metadata: {},
-          $response: {
-            headers: {},
-            statusCode: 403,
-          },
-        })
-      );
-    } catch (e) {
-      error = e as Error;
-    }
-
-    expect((error as any).$metadata.clockSkewCorrected).toBe(true);
-  });
-
-  it("does not set clockSkewCorrected when error message has no compact timestamp", async () => {
-    const signer = new AwsSdkSigV4Signer();
-    const oneHourMs = 60 * 60 * 1000;
 
     let error: Error | any;
     try {
@@ -147,7 +72,6 @@ describe(AwsSdkSigV4Signer.name, () => {
       })(
         Object.assign(new Error("InvalidSignatureException"), {
           name: "InvalidSignatureException",
-          // Message contains no (YYYYMMDDTHHMMSSz ...) segment.
           $metadata: {},
           $response: { headers: {}, statusCode: 403 },
         })
@@ -159,36 +83,7 @@ describe(AwsSdkSigV4Signer.name, () => {
     expect((error as any).$metadata.clockSkewCorrected).toBeUndefined();
   });
 
-  it("does not parse server time from a message with a bare (non-parenthesized) compact timestamp", async () => {
-    const signer = new AwsSdkSigV4Signer();
-    const oneHourMs = 60 * 60 * 1000;
-    const serverDate = new Date(Date.now() + oneHourMs);
-    const compact = serverDate.toISOString().replace(/[-:]|\.\d{3}/g, "");
-    // Timestamp appears in the message but NOT inside parentheses — should not match.
-    const message = `Signature expired: ${compact} is now earlier than ...`;
-
-    let error: Error | any;
-    try {
-      signer.errorHandler({
-        _preRequestSystemClockOffset: 0,
-        config: {
-          systemClockOffset: 0,
-        },
-      })(
-        Object.assign(new Error(message), {
-          name: "InvalidSignatureException",
-          $metadata: {},
-          $response: { headers: {}, statusCode: 403 },
-        })
-      );
-    } catch (e) {
-      error = e as Error;
-    }
-
-    expect((error as any).$metadata.clockSkewCorrected).toBeUndefined();
-  });
-
-  it("does not set clockSkewCorrected for non-clock-skew errors even when systemClockOffset is non-zero", async () => {
+  it("does not set clockSkewCorrected for non-clock-skew errors with matching offset", async () => {
     const signer = new AwsSdkSigV4Signer();
     const oneHourMs = 60 * 60 * 1000;
     const serverTime = new Date(Date.now() + oneHourMs).toISOString();
@@ -196,14 +91,13 @@ describe(AwsSdkSigV4Signer.name, () => {
     let error: Error | any;
     try {
       signer.errorHandler({
+        _preRequestSystemClockOffset: oneHourMs,
         config: {
           systemClockOffset: oneHourMs,
         },
       })(
         Object.assign(new Error("Throttling"), {
           name: "Throttling",
-          // No ServerTime property — this error is not a clock-skew response.
-          // Only the date HTTP header is present (standard on all responses).
           $metadata: {},
           $response: {
             headers: { date: serverTime },

--- a/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.spec.ts
+++ b/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.spec.ts
@@ -29,4 +29,68 @@ describe(AwsSdkSigV4Signer.name, () => {
 
     expect((error as any).$metadata.clockSkewCorrected).toBe(true);
   });
+
+  it("sets clockSkewCorrected metadata when systemClockOffset was already corrected by a concurrent request", async () => {
+    const signer = new AwsSdkSigV4Signer();
+    const oneHourMs = 60 * 60 * 1000;
+    const serverTime = new Date(Date.now() + oneHourMs).toISOString();
+
+    let error: Error | any;
+    try {
+      signer.errorHandler({
+        config: {
+          systemClockOffset: oneHourMs,
+        },
+      })(
+        Object.assign(new Error("RequestTimeTooSkewed"), {
+          name: "RequestTimeTooSkewed",
+          // ServerTime is parsed from the XML error response body and is the reliable
+          // indicator that this is a genuine clock-skew error (not just any HTTP error
+          // that happens to include a date header).
+          ServerTime: serverTime,
+          $metadata: {},
+          $response: {
+            headers: { date: serverTime },
+            statusCode: 403,
+          },
+        })
+      );
+    } catch (e) {
+      error = e as Error;
+    }
+
+    // Without the fix, clockSkewCorrected is false here because the offset didn't change
+    // (a concurrent request already updated it). The request must still be retried.
+    expect((error as any).$metadata.clockSkewCorrected).toBe(true);
+  });
+
+  it("does not set clockSkewCorrected for non-clock-skew errors even when systemClockOffset is non-zero", async () => {
+    const signer = new AwsSdkSigV4Signer();
+    const oneHourMs = 60 * 60 * 1000;
+    const serverTime = new Date(Date.now() + oneHourMs).toISOString();
+
+    let error: Error | any;
+    try {
+      signer.errorHandler({
+        config: {
+          systemClockOffset: oneHourMs,
+        },
+      })(
+        Object.assign(new Error("Throttling"), {
+          name: "Throttling",
+          // No ServerTime property — this error is not a clock-skew response.
+          // Only the date HTTP header is present (standard on all responses).
+          $metadata: {},
+          $response: {
+            headers: { date: serverTime },
+            statusCode: 429,
+          },
+        })
+      );
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect((error as any).$metadata.clockSkewCorrected).toBeUndefined();
+  });
 });

--- a/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.spec.ts
+++ b/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.spec.ts
@@ -38,6 +38,9 @@ describe(AwsSdkSigV4Signer.name, () => {
     let error: Error | any;
     try {
       signer.errorHandler({
+        // _preRequestSystemClockOffset: 0 — clock was in sync when this request started;
+        // a concurrent request corrected it to oneHourMs before this error handler ran.
+        _preRequestSystemClockOffset: 0,
         config: {
           systemClockOffset: oneHourMs,
         },
@@ -62,6 +65,127 @@ describe(AwsSdkSigV4Signer.name, () => {
     // Without the fix, clockSkewCorrected is false here because the offset didn't change
     // (a concurrent request already updated it). The request must still be retried.
     expect((error as any).$metadata.clockSkewCorrected).toBe(true);
+  });
+
+  it("sets clockSkewCorrected when server time is embedded in error message (DynamoDB-style, no Date header)", async () => {
+    const signer = new AwsSdkSigV4Signer();
+    const oneHourMs = 60 * 60 * 1000;
+    const serverDate = new Date(Date.now() + oneHourMs);
+    // Compact AWS timestamp format: YYYYMMDDTHHMMSSz
+    const compact = serverDate.toISOString().replace(/[-:]|\.\d{3}/g, "");
+    const message = `Signature expired: 20000101T000000Z is now earlier than ... (${compact} - 5 min. ahead of your clock)`;
+
+    let error: Error | any;
+    try {
+      signer.errorHandler({
+        _preRequestSystemClockOffset: 0,
+        config: {
+          systemClockOffset: 0,
+        },
+      })(
+        Object.assign(new Error(message), {
+          name: "InvalidSignatureException",
+          // No ServerTime field — this is a JSON-protocol service (e.g. DynamoDB).
+          $metadata: {},
+          $response: {
+            headers: {}, // no Date header in response
+            statusCode: 403,
+          },
+        })
+      );
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect((error as any).$metadata.clockSkewCorrected).toBe(true);
+  });
+
+  it("sets clockSkewCorrected from error message when offset was already corrected by a concurrent request", async () => {
+    const signer = new AwsSdkSigV4Signer();
+    const oneHourMs = 60 * 60 * 1000;
+    const serverDate = new Date(Date.now() + oneHourMs);
+    const compact = serverDate.toISOString().replace(/[-:]|\.\d{3}/g, "");
+    const message = `Signature expired: 20000101T000000Z is now earlier than ... (${compact} - 5 min. ahead of your clock)`;
+
+    let error: Error | any;
+    try {
+      signer.errorHandler({
+        // _preRequestSystemClockOffset: 0 — clock was in sync when this request started;
+        // a concurrent request corrected it to oneHourMs before this error handler ran.
+        _preRequestSystemClockOffset: 0,
+        config: {
+          systemClockOffset: oneHourMs,
+        },
+      })(
+        Object.assign(new Error(message), {
+          name: "InvalidSignatureException",
+          $metadata: {},
+          $response: {
+            headers: {},
+            statusCode: 403,
+          },
+        })
+      );
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect((error as any).$metadata.clockSkewCorrected).toBe(true);
+  });
+
+  it("does not set clockSkewCorrected when error message has no compact timestamp", async () => {
+    const signer = new AwsSdkSigV4Signer();
+    const oneHourMs = 60 * 60 * 1000;
+
+    let error: Error | any;
+    try {
+      signer.errorHandler({
+        _preRequestSystemClockOffset: 0,
+        config: {
+          systemClockOffset: 0,
+        },
+      })(
+        Object.assign(new Error("InvalidSignatureException"), {
+          name: "InvalidSignatureException",
+          // Message contains no (YYYYMMDDTHHMMSSz ...) segment.
+          $metadata: {},
+          $response: { headers: {}, statusCode: 403 },
+        })
+      );
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect((error as any).$metadata.clockSkewCorrected).toBeUndefined();
+  });
+
+  it("does not parse server time from a message with a bare (non-parenthesized) compact timestamp", async () => {
+    const signer = new AwsSdkSigV4Signer();
+    const oneHourMs = 60 * 60 * 1000;
+    const serverDate = new Date(Date.now() + oneHourMs);
+    const compact = serverDate.toISOString().replace(/[-:]|\.\d{3}/g, "");
+    // Timestamp appears in the message but NOT inside parentheses — should not match.
+    const message = `Signature expired: ${compact} is now earlier than ...`;
+
+    let error: Error | any;
+    try {
+      signer.errorHandler({
+        _preRequestSystemClockOffset: 0,
+        config: {
+          systemClockOffset: 0,
+        },
+      })(
+        Object.assign(new Error(message), {
+          name: "InvalidSignatureException",
+          $metadata: {},
+          $response: { headers: {}, statusCode: 403 },
+        })
+      );
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect((error as any).$metadata.clockSkewCorrected).toBeUndefined();
   });
 
   it("does not set clockSkewCorrected for non-clock-skew errors even when systemClockOffset is non-zero", async () => {

--- a/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts
+++ b/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts
@@ -44,20 +44,6 @@ interface AwsSdkSigV4AuthSigningProperties {
 
 /**
  * @internal
- * Parses the compact AWS server timestamp from a clock-skew error message.
- * AWS embeds the server time as e.g. "(20251224T185913Z - 5 min.)" in the message
- * for services that omit a Date response header and ServerTime body field.
- */
-const getServerTimeFromSkewMessage = (message: string | undefined): string | undefined => {
-  if (!message) return undefined;
-  const match = message.match(/\((\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/);
-  if (!match) return undefined;
-  const [, year, month, day, hour, min, sec] = match;
-  return `${year}-${month}-${day}T${hour}:${min}:${sec}Z`;
-};
-
-/**
- * @internal
  */
 interface AwsSdkSigV4Exception extends ServiceException {
   ServerTime?: string;
@@ -143,21 +129,18 @@ export class AwsSdkSigV4Signer implements HttpSigner {
   errorHandler(signingProperties: Record<string, unknown>): (error: Error) => never {
     return (error: Error) => {
       const errorException = error as AwsSdkSigV4Exception;
-      const messageServerTime = getServerTimeFromSkewMessage(error.message);
-      const serverTime: string | undefined =
-        errorException.ServerTime ?? getDateHeader(errorException.$response) ?? messageServerTime;
+      const serverTime: string | undefined = errorException.ServerTime ?? getDateHeader(errorException.$response);
       if (serverTime) {
         const config = throwSigningPropertyError("config", signingProperties.config as AwsSdkSigV4Config | undefined);
-        const initialSystemClockOffset = config.systemClockOffset;
-        config.systemClockOffset = getUpdatedSystemClockOffset(serverTime, config.systemClockOffset);
-        // If a concurrent request already corrected the offset, systemClockOffset won't change here.
-        // Use the pre-request offset (stored in sign()) so we can detect that case precisely.
-        const preRequestOffset = (signingProperties._preRequestSystemClockOffset as number | undefined) ?? 0;
-        const isKnownClockSkewError = !!(errorException.ServerTime ?? messageServerTime);
-        const clockSkewCorrected =
-          config.systemClockOffset !== initialSystemClockOffset ||
-          (isKnownClockSkewError && config.systemClockOffset !== preRequestOffset);
+        const preRequestOffset = signingProperties._preRequestSystemClockOffset as number | undefined;
+        const newOffset = getUpdatedSystemClockOffset(serverTime, config.systemClockOffset);
+
+        const isLocalCorrection = newOffset !== config.systemClockOffset;
+        const isConcurrentCorrection = preRequestOffset !== undefined && preRequestOffset !== newOffset;
+
+        const clockSkewCorrected = isLocalCorrection || isConcurrentCorrection;
         if (clockSkewCorrected && errorException.$metadata) {
+          config.systemClockOffset = newOffset;
           errorException.$metadata.clockSkewCorrected = true;
         }
       }

--- a/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts
+++ b/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts
@@ -44,6 +44,20 @@ interface AwsSdkSigV4AuthSigningProperties {
 
 /**
  * @internal
+ * Parses the compact AWS server timestamp from a clock-skew error message.
+ * AWS embeds the server time as e.g. "(20251224T185913Z - 5 min.)" in the message
+ * for services that omit a Date response header and ServerTime body field.
+ */
+const getServerTimeFromSkewMessage = (message: string | undefined): string | undefined => {
+  if (!message) return undefined;
+  const match = message.match(/\((\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/);
+  if (!match) return undefined;
+  const [, year, month, day, hour, min, sec] = match;
+  return `${year}-${month}-${day}T${hour}:${min}:${sec}Z`;
+};
+
+/**
+ * @internal
  */
 interface AwsSdkSigV4Exception extends ServiceException {
   ServerTime?: string;
@@ -116,6 +130,8 @@ export class AwsSdkSigV4Signer implements HttpSigner {
       }
     }
 
+    // Capture the clock offset before signing so errorHandler can detect concurrent corrections.
+    signingProperties._preRequestSystemClockOffset = config.systemClockOffset;
     const signedRequest = await signer.sign(httpRequest, {
       signingDate: getSkewCorrectedDate(config.systemClockOffset),
       signingRegion: signingRegion,
@@ -126,17 +142,23 @@ export class AwsSdkSigV4Signer implements HttpSigner {
 
   errorHandler(signingProperties: Record<string, unknown>): (error: Error) => never {
     return (error: Error) => {
+      const errorException = error as AwsSdkSigV4Exception;
+      const messageServerTime = getServerTimeFromSkewMessage(error.message);
       const serverTime: string | undefined =
-        (error as AwsSdkSigV4Exception).ServerTime ?? getDateHeader((error as AwsSdkSigV4Exception).$response);
+        errorException.ServerTime ?? getDateHeader(errorException.$response) ?? messageServerTime;
       if (serverTime) {
         const config = throwSigningPropertyError("config", signingProperties.config as AwsSdkSigV4Config | undefined);
         const initialSystemClockOffset = config.systemClockOffset;
         config.systemClockOffset = getUpdatedSystemClockOffset(serverTime, config.systemClockOffset);
+        // If a concurrent request already corrected the offset, systemClockOffset won't change here.
+        // Use the pre-request offset (stored in sign()) so we can detect that case precisely.
+        const preRequestOffset = (signingProperties._preRequestSystemClockOffset as number | undefined) ?? 0;
+        const isKnownClockSkewError = !!(errorException.ServerTime ?? messageServerTime);
         const clockSkewCorrected =
           config.systemClockOffset !== initialSystemClockOffset ||
-          (!!(error as AwsSdkSigV4Exception).ServerTime && config.systemClockOffset !== 0);
-        if (clockSkewCorrected && (error as AwsSdkSigV4Exception).$metadata) {
-          (error as AwsSdkSigV4Exception).$metadata.clockSkewCorrected = true;
+          (isKnownClockSkewError && config.systemClockOffset !== preRequestOffset);
+        if (clockSkewCorrected && errorException.$metadata) {
+          errorException.$metadata.clockSkewCorrected = true;
         }
       }
       throw error;

--- a/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts
+++ b/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/AwsSdkSigV4Signer.ts
@@ -132,7 +132,9 @@ export class AwsSdkSigV4Signer implements HttpSigner {
         const config = throwSigningPropertyError("config", signingProperties.config as AwsSdkSigV4Config | undefined);
         const initialSystemClockOffset = config.systemClockOffset;
         config.systemClockOffset = getUpdatedSystemClockOffset(serverTime, config.systemClockOffset);
-        const clockSkewCorrected = config.systemClockOffset !== initialSystemClockOffset;
+        const clockSkewCorrected =
+          config.systemClockOffset !== initialSystemClockOffset ||
+          (!!(error as AwsSdkSigV4Exception).ServerTime && config.systemClockOffset !== 0);
         if (clockSkewCorrected && (error as AwsSdkSigV4Exception).$metadata) {
           (error as AwsSdkSigV4Exception).$metadata.clockSkewCorrected = true;
         }

--- a/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/systemClockOffset.integ.spec.ts
+++ b/packages-internal/core/src/submodules/httpAuthSchemes/aws_sdk/systemClockOffset.integ.spec.ts
@@ -1,0 +1,94 @@
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
+import type { HttpRequest } from "@smithy/core/protocols";
+import { HttpResponse } from "@smithy/core/protocols";
+import { Readable } from "node:stream";
+import { describe, expect, test as it } from "vitest";
+
+describe("systemClockOffset concurrent correction", () => {
+  it("retries all concurrent requests after clock-skew correction", async () => {
+    let requestCount = 0;
+
+    const client = new DynamoDB({
+      region: "us-west-2",
+      credentials: { accessKeyId: "AKID", secretAccessKey: "SECRET" },
+      systemClockOffset: -86400000,
+      requestHandler: {
+        async handle(request: HttpRequest) {
+          // allow 3 skewed requests to accumulate before responding.
+          await new Promise((r) => setTimeout(r, 250));
+          requestCount++;
+          const now = new Date().toUTCString();
+
+          const authHeader = request.headers["authorization"] ?? "";
+          const credentialMatch = authHeader.match(/Credential=\w+\/(\d{8})\//);
+          const signingDate = credentialMatch?.[1];
+          const today = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+
+          if (signingDate !== today) {
+            return {
+              response: new HttpResponse({
+                statusCode: 400,
+                headers: {
+                  server: "Server",
+                  date: now,
+                  "content-type": "application/x-amz-json-1.0",
+                  connection: "keep-alive",
+                  "x-amzn-requestid": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                  "x-amz-crc32": "0",
+                },
+                body: Readable.from([
+                  JSON.stringify({
+                    __type: "com.amazon.coral.service#InvalidSignatureException",
+                    message: `Signature expired: ${signingDate}T000000Z is now earlier than ${today}T000000Z (${today}T000000Z - 15 min.)`,
+                  }),
+                ]),
+              }),
+            };
+          }
+
+          return {
+            response: new HttpResponse({
+              statusCode: 200,
+              headers: {
+                server: "Server",
+                date: now,
+                "content-type": "application/x-amz-json-1.0",
+                connection: "keep-alive",
+                "x-amzn-requestid": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                "x-amz-crc32": "357788998",
+              },
+              body: Readable.from([
+                JSON.stringify({
+                  TableNames: ["MyTable"],
+                }),
+              ]),
+            }),
+          };
+        },
+      },
+    });
+
+    async function concurrentRequests() {
+      const results = await Promise.all([client.listTables(), client.listTables(), client.listTables()]);
+
+      for (const result of results) {
+        expect(result.TableNames).toEqual(["MyTable"]);
+        expect(result.$metadata.httpStatusCode).toEqual(200);
+      }
+    }
+
+    {
+      await concurrentRequests();
+
+      // 3 initial stale requests + 3 retries with corrected offset = 6.
+      expect(requestCount).toBe(6);
+      expect(Math.abs(client.config.systemClockOffset)).toBeLessThan(10_000);
+    }
+    {
+      await concurrentRequests();
+
+      // subsequent requests should already be skew-corrected and only add 3 more.
+      expect(requestCount).toBe(9);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Two bugs in `AwsSdkSigV4Signer.errorHandler`.

**Concurrent correction false negative.** When multiple requests hit clock-skew errors simultaneously, only the first reaches `getUpdatedSystemClockOffset` with a stale offset. By the time the rest arrive, a concurrent request has already corrected `config.systemClockOffset`. Their offsets don't change, so `clockSkewCorrected` never gets set, so they don't retry.

**DynamoDB (and other JSON-protocol services) never correct at all.** XML services like S3 include a `ServerTime` field in the error body. DynamoDB doesn't. The HTTP `Date` header isn't guaranteed on error responses either. With no server time available, `errorHandler` skips the correction block entirely. The client gets an `InvalidSignatureException` back with no retry signal.

## Fix

**Pre-request snapshot.** `sign()` now saves `config.systemClockOffset` into `signingProperties._preRequestSystemClockOffset` before calling the actual signer. The error handler compares against that value, not against zero, so it can tell whether the offset changed since this specific request started, regardless of what concurrent requests did in the meantime. `AwsSdkSigV4ASigner` overrides `sign()` but inherits `errorHandler`, so it gets the same treatment.

**Message-based server time fallback.** AWS always embeds the server time in the error message itself: `Signature expired: ... (20251224T185913Z - 5 min. ahead of your clock)`. `getServerTimeFromSkewMessage()` parses this as a third fallback after `ServerTime` and the `Date` header. The regex requires the timestamp to appear inside a `(` to avoid false matches on the expired-signature timestamp earlier in the same message.

The `isKnownClockSkewError` guard (`!!(errorException.ServerTime ?? messageServerTime)`) keeps the `Date`-header path conservative: `clockSkewCorrected` only gets set via the concurrent-correction branch when a reliable clock-skew indicator is present, not just any HTTP error that happened to include a date header.

## Tests

Seven tests total. Four are new, one is updated:

- Offset changes when `systemClockOffset` is non-zero (pre-existing)
- `ServerTime` concurrent correction — adds `_preRequestSystemClockOffset: 0` to reflect real runtime state (updated)
- DynamoDB: message parsing, fresh start — no `ServerTime`, no `Date` header, message has compact timestamp (new)
- DynamoDB: message parsing, concurrent correction — offset already corrected by a concurrent request (new)
- Message with no compact timestamp — `clockSkewCorrected` stays `undefined` (new)
- Bare non-parenthesized timestamp in message — must not match (new)
- Throttling error with `Date` header but no `ServerTime` — `clockSkewCorrected` stays `undefined` (pre-existing)

Reported in #7605 and #8005.

---

*Developed by Zelys with assistance from Claude.*