### PR TITLE
fix(sesv2): mark EmailTemplateContent.Subject as required

### DIFF
--- a/clients/client-sesv2/src/models/models_0.ts
+++ b/clients/client-sesv2/src/models/models_0.ts
@@ -570,7 +570,7 @@ export interface EmailTemplateContent {
    * <p>The subject line of the email.</p>
    * @public
    */
-  Subject?: string | undefined;
+  Subject: string | undefined;
 
   /**
    * <p>The email body that will be visible to recipients whose email clients do not display

--- a/codegen/sdk-codegen/aws-models/sesv2.json
+++ b/codegen/sdk-codegen/aws-models/sesv2.json
@@ -4231,7 +4231,8 @@
         "Subject": {
           "target": "com.amazonaws.sesv2#EmailTemplateSubject",
           "traits": {
-            "smithy.api#documentation": "<p>The subject line of the email.</p>"
+            "smithy.api#documentation": "<p>The subject line of the email.</p>",
+            "smithy.api#required": {}
           }
         },
         "Text": {


### PR DESCRIPTION
### Issue
#7578

### Description

`EmailTemplateContent.Subject` is typed as `Subject?: string | undefined` (optional) in the generated TypeScript, but the SES v2 API always rejects `CreateEmailTemplate` requests without it:

```
BadRequestException: The subject must be specified.
```

The reporter in #7578 confirmed this, and maintainer @aBurmeseDev verified it as well. The mismatch tells TypeScript users the field is optional when the API won't accept that.

### Fix

Two-file change:

1. `codegen/sdk-codegen/aws-models/sesv2.json`: adds `smithy.api#required` to the `Subject` member of `com.amazonaws.sesv2#EmailTemplateContent`
2. `clients/client-sesv2/src/models/models_0.ts`: removes the `?` optional marker from `Subject` (the generated output of that model change)

The diff is 3 lines across 2 files.

### Testing

No runtime logic changes. The generated TypeScript now correctly reflects the API contract that has always been enforced server-side. Existing callers that already pass `Subject` are unaffected; callers that omit it will get a compile-time error instead of a runtime rejection.

### Checklist
- [x] It's not a feature.
- [x] I didn't write any E2E tests.
- [x] I didn't add any public functions.
- [x] No streams here.

Developed by Zelys with assistance from Claude.