### PR TITLE
chore(scripts): optimize codegen build speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This is the public Makefile containing some build commands.
 # You can implement some additional personal commands such as login and sync in Makefile.private.mk (unversioned).
 
-.PHONY: login sync bundles test-unit test-types test-indices test-protocols test-schema test-integration test-endpoints test-e2e build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle clean-nested link-smithy unlink-smithy copy-smithy gen-auth b-auth tpk unbuilt turbo-clean server-protocols
+.PHONY: login sync bundles test-unit test-types test-indices test-protocols test-schema test-integration test-endpoints test-e2e build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle clean-nested link-smithy unlink-smithy copy-smithy gen-auth b-auth tpk unbuilt turbo-clean server-protocols nested-clients clients
 
 # fetch AWS testing credentials
 login:
@@ -142,3 +142,9 @@ turbo-clean:
 server-protocols:
 	yarn generate-clients -s
 	yarn test:server-protocols
+
+clients:
+	yarn generate-clients -x
+
+nested-clients:
+	node scripts/generate-clients/nested-clients/generate-nested-clients.js --exec

--- a/scripts/generate-clients/code-gen.js
+++ b/scripts/generate-clients/code-gen.js
@@ -1,6 +1,6 @@
 // @ts-check
 const { basename, join, relative, normalize } = require("node:path");
-const { copySync, emptyDirSync, rmSync, copyFileSync } = require("fs-extra");
+const { copySync, emptyDirSync, rmSync, copyFileSync, existsSync } = require("fs-extra");
 const { spawnProcess } = require("../utils/spawn-process");
 const {
   CODE_GEN_ROOT,
@@ -12,16 +12,35 @@ const {
 } = require("./code-gen-dir");
 const { getModelFilepaths } = require("./get-model-filepaths");
 
+/**
+ * Remove only the smithyprojections output dir for sdk-codegen.
+ * This avoids a full `:sdk-codegen:clean` which would also force
+ * a rebuild of the smithy-aws-typescript-codegen dependency.
+ */
+const cleanSdkCodegenOutput = () => {
+  const outputDir = join(CODE_GEN_ROOT, "sdk-codegen", "build", "smithyprojections");
+  if (existsSync(outputDir)) {
+    emptyDirSync(outputDir);
+  }
+};
+
 const generateClient = async (clientName) => {
   const TEMP_CODE_GEN_INPUT_DIR_SERVICE = join(TEMP_CODE_GEN_INPUT_DIR, clientName);
 
   emptyDirSync(normalize(join(__dirname, "..", "..", "codegen", "sdk-codegen", "build-single", clientName)));
 
+  cleanSdkCodegenOutput();
+
+  // Ensure the dependency is built before using --no-rebuild.
+  const depJar = join(CODE_GEN_ROOT, "smithy-aws-typescript-codegen", "build", "libs");
+  if (!existsSync(depJar)) {
+    await spawnProcess("./gradlew", [":smithy-aws-typescript-codegen:build"], { cwd: CODE_GEN_ROOT });
+  }
+
   const options = [
-    ":sdk-codegen:clean",
     ":sdk-codegen:build",
+    "--no-rebuild",
     "--stacktrace",
-    // "--no-rebuild", // prevent dependency smithy-aws-typescript-codegen files from being rebuilt and possibly missing during multi-process
     `-PmodelsDirProp=${relative(CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR_SERVICE)}`,
     `-PclientNameProp=${clientName}`,
   ];
@@ -37,12 +56,10 @@ const generateClient = async (clientName) => {
 
 const generateClients = async (models, batchSize) => {
   const filepaths = getModelFilepaths(models);
-  const options = [
-    ":sdk-codegen:clean",
-    ":sdk-codegen:build",
-    "--stacktrace",
-    `-PmodelsDirProp=${relative(CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR)}`,
-  ];
+
+  // Build the smithy-aws-typescript-codegen dependency once upfront.
+  // Subsequent batches use --no-rebuild to skip recompiling it.
+  await spawnProcess("./gradlew", [":smithy-aws-typescript-codegen:build"], { cwd: CODE_GEN_ROOT });
 
   while (filepaths.length > 0) {
     emptyDirSync(TEMP_CODE_GEN_INPUT_DIR);
@@ -51,9 +68,21 @@ const generateClients = async (models, batchSize) => {
       const filename = basename(filepath);
       copyFileSync(filepath, join(TEMP_CODE_GEN_INPUT_DIR, filename));
     }
+
+    // Remove only the smithyprojections output (not the full clean which
+    // would force smithy-aws-typescript-codegen to recompile).
+    cleanSdkCodegenOutput();
+
+    const options = [
+      ":sdk-codegen:build",
+      "--no-rebuild",
+      "--stacktrace",
+      `-PmodelsDirProp=${relative(CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR)}`,
+    ];
+
     await spawnProcess("./gradlew", options, { cwd: CODE_GEN_ROOT });
-    // We're copying generated code to temporary directory as it's cleans
-    // codegen directory in every run.
+    // Copy generated code to temporary directory since the output dir
+    // is overwritten on each batch run.
     // Refs: https://github.com/aws/aws-sdk-js-v3/issues/3321
     copySync(CODE_GEN_SDK_OUTPUT_DIR, TEMP_CODE_GEN_SDK_OUTPUT_DIR);
   }
@@ -62,15 +91,19 @@ const generateClients = async (models, batchSize) => {
 };
 
 const generateProtocolTests = async () => {
-  await spawnProcess("./gradlew", [":protocol-test-codegen:clean", ":protocol-test-codegen:build"], {
+  await spawnProcess("./gradlew", [":protocol-test-codegen:clean", ":protocol-test-codegen:build", "--no-rebuild"], {
     cwd: CODE_GEN_ROOT,
   });
 };
 
 const generateGenericClient = async () => {
-  await spawnProcess("./gradlew", [":smithy-aws-typescript-codegen:clean", ":generic-client-test-codegen:build"], {
-    cwd: CODE_GEN_ROOT,
-  });
+  await spawnProcess(
+    "./gradlew",
+    [":generic-client-test-codegen:clean", ":generic-client-test-codegen:build", "--no-rebuild"],
+    {
+      cwd: CODE_GEN_ROOT,
+    }
+  );
 };
 
 module.exports = {

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -68,7 +68,7 @@ const {
   .describe("b", "Batchsize for generating clients")
   .number("b")
   .alias("b", "batch-size")
-  .default("b", 50)
+  .default("b", 200)
   .describe("r", "The location where smithy-typescript is cloned.")
   .string("r")
   .alias("r", "repo")

--- a/scripts/generate-clients/nested-clients/generate-nested-clients.js
+++ b/scripts/generate-clients/nested-clients/generate-nested-clients.js
@@ -22,12 +22,21 @@ const clients = [
 ];
 
 const { join, relative, normalize } = require("node:path");
-const { emptyDirSync, rmSync, copyFileSync, copySync, rmdirSync, writeFileSync, readFileSync } = require("fs-extra");
+const {
+  emptyDirSync,
+  copyFileSync,
+  copySync,
+  rmdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} = require("fs-extra");
 const { copyToClients } = require("../copy-to-clients");
 const { spawnProcess } = require("../../utils/spawn-process");
 const {
   CODE_GEN_ROOT,
   CODE_GEN_SDK_ROOT,
+  CODE_GEN_SDK_OUTPUT_DIR,
   DEFAULT_CODE_GEN_INPUT_DIR,
   TEMP_CODE_GEN_INPUT_DIR,
 } = require("../code-gen-dir");
@@ -42,13 +51,17 @@ const NESTED_SDK_CLIENTS_DIR = normalize(
  *
  */
 async function generateNestedClients() {
+  // Prepare all nested client models into a single temp directory.
+  emptyDirSync(TEMP_CODE_GEN_INPUT_DIR);
   for (const { name, operations } of clients) {
-    await generateNestedClient(name, operations);
-    await copyToClients(
-      normalize(join(__dirname, "..", "..", "..", "codegen", "sdk-codegen", "build-single", name)),
-      NESTED_SDK_CLIENTS_DIR,
-      name
-    );
+    prepareNestedClientModel(name, operations);
+  }
+
+  // Single Gradle invocation generates all nested clients at once.
+  await generateAllNestedClientsBatch();
+
+  for (const { name } of clients) {
+    await copyToClients(CODE_GEN_SDK_OUTPUT_DIR, NESTED_SDK_CLIENTS_DIR, name);
 
     const srcFolder = join(NESTED_SDK_CLIENTS_DIR, `client-${name}`, "src");
     const srcContainer = join(NESTED_SDK_CLIENTS_DIR, `client-${name}`);
@@ -70,43 +83,45 @@ async function generateNestedClients() {
 module.exports = generateNestedClients;
 
 /**
- * @param clientName - client to generate.
- * @param operations - operations to include.
+ * Prepares the trimmed model file for a nested client in the shared temp directory.
  */
-async function generateNestedClient(clientName, operations) {
-  const TEMP_CODE_GEN_INPUT_DIR_SERVICE = join(TEMP_CODE_GEN_INPUT_DIR, clientName);
-
-  emptyDirSync(normalize(join(__dirname, "..", "..", "..", "codegen", "sdk-codegen", "build-single", clientName)));
-
-  const options = [
-    ":sdk-codegen:clean",
-    ":sdk-codegen:build",
-    "--stacktrace",
-    `-PmodelsDirProp=${relative(CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR_SERVICE)}`,
-    `-PclientNameProp=${clientName}`,
-  ];
-
-  emptyDirSync(TEMP_CODE_GEN_INPUT_DIR_SERVICE);
-
+function prepareNestedClientModel(clientName, operations) {
   const filename = `${clientName}.json`;
-  const targetModelPath = join(TEMP_CODE_GEN_INPUT_DIR_SERVICE, filename);
+  const targetModelPath = join(TEMP_CODE_GEN_INPUT_DIR, filename);
   copyFileSync(join(DEFAULT_CODE_GEN_INPUT_DIR, filename), targetModelPath);
 
-  const model = require(targetModelPath);
+  const model = JSON.parse(readFileSync(targetModelPath, "utf-8"));
   Object.entries(model.shapes).forEach(([key, value]) => {
     if (value.type === "service") {
-      // remove operations not in list.
       value.operations = value.operations.filter((operationObj) => {
         return !!operations.find((opName) => operationObj.target.endsWith(`#${opName}`));
       });
-      // prevent validation from complaining about unused operations.
       delete value.traits["smithy.rules#endpointTests"];
     }
   });
   writeFileSync(targetModelPath, JSON.stringify(model, null, 2) + "\n");
+}
+
+/**
+ * Generates all nested clients in a single Smithy CLI / Gradle invocation.
+ * All trimmed models are in TEMP_CODE_GEN_INPUT_DIR; Gradle generates
+ * projections for all of them at once.
+ */
+async function generateAllNestedClientsBatch() {
+  // Clean only the smithyprojections output.
+  const outputDir = join(CODE_GEN_ROOT, "sdk-codegen", "build", "smithyprojections");
+  if (existsSync(outputDir)) {
+    emptyDirSync(outputDir);
+  }
+
+  const options = [
+    ":sdk-codegen:build",
+    "--no-rebuild",
+    "--stacktrace",
+    `-PmodelsDirProp=${relative(CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR)}`,
+  ];
 
   await spawnProcess("./gradlew", options, { cwd: CODE_GEN_ROOT });
-  rmSync(join(__dirname, "..", "..", "..", "codegen", "sdk-codegen", `smithy-build-${clientName}.json`));
 }
 
 /**


### PR DESCRIPTION
### Issue
n/a

### Description
Speed up codegen a bit by batching nested-client codegen and running fewer gradle builds in the overall process.

With this, it's about 3 minutes on my remote. Maybe 8 minutes if fully cold, no Gradle caches at all.

### Testing
ran codegen

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
