### PR TITLE
Pin contents: read on the three read-only CI workflows

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/codegen-ci.yml'
       - 'codegen/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/commit-message-lint.yml
+++ b/.github/workflows/commit-message-lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   run-pre-commit-hooks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Three CI workflows in this repo don't declare a top-level `permissions:` block today, so they run with the repo-wide default `GITHUB_TOKEN` scope. None of them needs that scope — they only check out and build/lint.

| Workflow | What it does | Scope used here |
|---|---|---|
| `codegen-ci.yml` | gradle build of `codegen/`, then `yarn install` + `make test-codegen` on PRs touching `codegen/**` | `contents: read` |
| `commit-message-lint.yml` | `wagoid/commitlint-github-action` against the PR commit history | `contents: read` |
| `pre-commit-hooks.yml` | `yarn lint-staged`, `yarn lint:versions`, `yarn lint:dependencies` | `contents: read` |

Style follows the existing `git-sync.yml`, which already pins a top-level `permissions:` block. Workflows that need broader access (e.g. `pull-request-build.yml` keeps `id-token: write`, `issues: write`, etc. at the job level) are left alone.

YAML re-parsed locally with `yaml.safe_load` for each touched file. No behavior change.