### PR TITLE
chore(core/util): update tsconfig.types.json

### DIFF
--- a/packages-internal/util-arn-parser/tsconfig.types.json
+++ b/packages-internal/util-arn-parser/tsconfig.types.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "baseUrl": ".",
     "declarationDir": "dist-types",
-    "rootDir": "src"
+    "rootDir": "src",
+    "paths": {
+      "@aws-sdk/core/*": ["../core/dist-types/submodules/*/index.d.ts"]
+    }
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages-internal/util-format-url/tsconfig.types.json
+++ b/packages-internal/util-format-url/tsconfig.types.json
@@ -4,7 +4,8 @@
     "declarationDir": "dist-types",
     "rootDir": "src",
     "paths": {
-      "@smithy/core/*": ["../../node_modules/@smithy/core/dist-types/submodules/*/index.d.ts"]
+      "@smithy/core/*": ["../../node_modules/@smithy/core/dist-types/submodules/*/index.d.ts"],
+      "@aws-sdk/core/*": ["../core/dist-types/submodules/*/index.d.ts"]
     }
   },
   "extends": "../../tsconfig.types.json",


### PR DESCRIPTION
### Issue
P432964761

### Description
I suspect that because tsconfig.types.json for these two util packages uses a deprecated `node` moduleresolution we need to add explicit paths for new conditional exports (submodules).

Later on, I believe we can remove these explicit paths and update the module resolution to a modern mode.

### Testing
inconclusive

