### PR TITLE
chore(build): set compilation config module type to nodenext

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,8 @@ turbo-clean:
 	@read -p "Are you sure you want to delete your local cache? [y/N]: " ans && [ $${ans:-N} = y ]
 	@echo "\nDeleted cache folders: \n--------"
 	@find . -name '.turbo' -type d -prune -print -exec rm -rf '{}' + && echo '\n'
+	@echo "Deleted tsbuildinfo files: \n--------"
+	@find . -name '*.tsbuildinfo' -type f -print -delete && echo '\n'
 
 server-protocols:
 	yarn generate-clients -s

--- a/packages-internal/core/package.json
+++ b/packages-internal/core/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "node ../../scripts/compilation/inline core && premove ./dist-cjs/api-extractor-type-index.js",
     "build:es": "tsc -p tsconfig.es.json && premove ./dist-es/api-extractor-type-index.js",
     "build:include:deps": "yarn g:turbo run build -F=\"$npm_package_name\"",
-    "build:types": "premove dist-types && tsc -p tsconfig.types.json",
+    "build:types": "premove dist-types tsconfig.types.tsbuildinfo && tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "lint": "node ../../scripts/validation/submodules-linter.js --pkg core",
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",

--- a/packages-internal/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages-internal/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -31,7 +31,7 @@ export type CognitoIdentityCredentialProvider = RuntimeConfigIdentityProvider<Co
 export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): CognitoIdentityCredentialProvider {
   return async (awsIdentityProperties?: AwsIdentityProperties): Promise<CognitoIdentityCredentials> => {
     parameters.logger?.debug("@aws-sdk/credential-provider-cognito-identity - fromCognitoIdentity");
-    const { GetCredentialsForIdentityCommand, CognitoIdentityClient } = await import("./loadCognitoIdentity");
+    const { GetCredentialsForIdentityCommand, CognitoIdentityClient } = await import("./loadCognitoIdentity.js");
 
     const fromConfigs = (property: "region" | "profile" | "userAgentAppId"): any =>
       parameters.clientConfig?.[property] ??

--- a/packages-internal/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
+++ b/packages-internal/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts
@@ -37,7 +37,7 @@ export function fromCognitoIdentityPool({
     : undefined;
 
   let provider: CognitoIdentityCredentialProvider = async (awsIdentityProperties?: AwsIdentityProperties) => {
-    const { GetIdCommand, CognitoIdentityClient } = await import("./loadCognitoIdentity");
+    const { GetIdCommand, CognitoIdentityClient } = await import("./loadCognitoIdentity.js");
 
     const fromConfigs = (property: "region" | "profile" | "userAgentAppId"): any =>
       clientConfig?.[property] ??

--- a/packages-internal/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages-internal/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -69,7 +69,7 @@ export const resolveSSOCredentials = async ({
 
   const { accessToken } = token;
 
-  const { SSOClient, GetRoleCredentialsCommand } = await import("./loadSso");
+  const { SSOClient, GetRoleCredentialsCommand } = await import("./loadSso.js");
 
   const sso =
     ssoClient ||

--- a/packages/credential-providers/src/fromTemporaryCredentials.base.ts
+++ b/packages/credential-providers/src/fromTemporaryCredentials.base.ts
@@ -52,7 +52,7 @@ export const fromTemporaryCredentials = (
       params.TokenCode = await options.mfaCodeProvider(params?.SerialNumber);
     }
 
-    const { AssumeRoleCommand, STSClient } = await import("./loadSts");
+    const { AssumeRoleCommand, STSClient } = await import("./loadSts.js");
 
     if (!stsClient) {
       const defaultCredentialsOrError =

--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -316,6 +316,19 @@ module.exports = class Inliner {
       return this;
     }
 
+    // Collect files that are targets of dynamic import() from variant externals.
+    const dynamicImportTargets = new Set();
+    for (const external of this.variantExternals) {
+      const externalFile = path.join(this.packageDirectory, "dist-cjs", external);
+      if (fs.existsSync(externalFile)) {
+        const contents = fs.readFileSync(externalFile, "utf-8");
+        for (const match of contents.matchAll(/import\("(\.[^"]*?)"\)/g)) {
+          const resolved = path.normalize(path.join(path.dirname(external), match[1]));
+          dynamicImportTargets.add(resolved.endsWith(".js") ? resolved : resolved + ".js");
+        }
+      }
+    }
+
     for await (const file of walk(path.join(this.packageDirectory, "dist-cjs"))) {
       const relativePath = file.replace(path.join(this.packageDirectory, "dist-cjs"), "").slice(1);
 
@@ -340,6 +353,13 @@ module.exports = class Inliner {
       if (this.variantExternals.find((external) => relativePath.endsWith(external))) {
         if (this.verbose) {
           console.log("Not rewriting.", relativePath, "is variant.");
+        }
+        continue;
+      }
+
+      if (dynamicImportTargets.has(relativePath)) {
+        if (this.verbose) {
+          console.log("Not rewriting.", relativePath, "is a dynamic import target.");
         }
         continue;
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     "downlevelIteration": true,
     "incremental": true,
     "importHelpers": true,
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmitHelpers": false,
     "noFallthroughCasesInSwitch": true,
     "paths": {


### PR DESCRIPTION
### Issue
Internal P432964761

### Description
Update TypeScript compilation settings from common to nodenext.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
