### PR TITLE
test(lib-storage): speed up lib-storage e2e tests by reducing permutations

### DIFF
--- a/lib/lib-storage/src/lib-storage.e2e.spec.ts
+++ b/lib/lib-storage/src/lib-storage.e2e.spec.ts
@@ -1,5 +1,5 @@
 import { getE2eTestResources } from "@aws-sdk/aws-util-test/src";
-import { ChecksumAlgorithm, S3 } from "@aws-sdk/client-s3";
+import { type S3ClientConfig, ChecksumAlgorithm, S3 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
@@ -7,190 +7,224 @@ import { Readable } from "node:stream";
 import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
 
 describe("@aws-sdk/lib-storage", () => {
-  describe.each([undefined, "WHEN_REQUIRED", "WHEN_SUPPORTED"])(
-    "requestChecksumCalculation: %s",
-    (requestChecksumCalculation) => {
-      describe.each([
-        undefined,
-        ChecksumAlgorithm.SHA1,
-        ChecksumAlgorithm.SHA256,
-        ChecksumAlgorithm.CRC32,
-        ChecksumAlgorithm.CRC32C,
-      ])("ChecksumAlgorithm: %s", (ChecksumAlgorithm) => {
-        let Key: string;
-        let client: S3;
-        let data: Uint8Array;
-        let dataString: string;
-        let Bucket: string;
-        let region: string;
+  let Bucket: string;
+  let region: string;
+  let data: Uint8Array;
+  let dataString: string;
 
-        beforeAll(async () => {
+  beforeAll(async () => {
+    const e2eTestResourcesEnv = await getE2eTestResources();
+    Object.assign(process.env, e2eTestResourcesEnv);
+    region = process.env.AWS_SMOKE_TEST_REGION as string;
+    Bucket = process.env.AWS_SMOKE_TEST_BUCKET as string;
+    data = randomBytes(20_240_000);
+    dataString = data.toString();
+  }, 45_000);
+
+  // Test body types with a single checksum config (CRC32).
+  // Body serialization is independent of checksum algorithm.
+  describe("body types", () => {
+    let client: S3;
+    let Key: string;
+
+    beforeAll(() => {
+      client = new S3({ region });
+      Key = `multi-part-body-types-${Date.now()}`;
+    });
+
+    afterAll(async () => {
+      if (client && Bucket && Key) {
+        try {
+          await client.deleteObject({ Bucket, Key });
+        } catch (error) {
+          console.warn("Failed to clean up test object:", error);
+        }
+      }
+    }, 10_000);
+
+    it("should upload in parts for input type bytes", async () => {
+      const s3Upload = new Upload({
+        client,
+        params: { Bucket, Key, Body: data, ChecksumAlgorithm: ChecksumAlgorithm.CRC32 },
+      });
+      await s3Upload.done();
+
+      const object = await client.getObject({ Bucket, Key });
+      expect(await object.Body?.transformToString()).toEqual(dataString);
+    });
+
+    it("should upload in parts for input type string", async () => {
+      const s3Upload = new Upload({
+        client,
+        params: { Bucket, Key, Body: dataString, ChecksumAlgorithm: ChecksumAlgorithm.CRC32 },
+      });
+      await s3Upload.done();
+
+      const object = await client.getObject({ Bucket, Key });
+      expect(await object.Body?.transformToString()).toEqual(dataString);
+    });
+
+    it("should upload in parts for input type Readable", async () => {
+      const s3Upload = new Upload({
+        client,
+        params: { Bucket, Key, Body: Readable.from(data), ChecksumAlgorithm: ChecksumAlgorithm.CRC32 },
+      });
+      await s3Upload.done();
+
+      const object = await client.getObject({ Bucket, Key });
+      expect(await object.Body?.transformToString()).toEqual(dataString);
+    });
+  });
+
+  // Test checksum algorithm variations with a single body type (bytes).
+  // Each meaningful combination of requestChecksumCalculation × ChecksumAlgorithm.
+  describe.each([
+    { requestChecksumCalculation: undefined, checksumAlgorithm: undefined },
+    { requestChecksumCalculation: undefined, checksumAlgorithm: ChecksumAlgorithm.SHA1 },
+    { requestChecksumCalculation: undefined, checksumAlgorithm: ChecksumAlgorithm.SHA256 },
+    { requestChecksumCalculation: undefined, checksumAlgorithm: ChecksumAlgorithm.CRC32C },
+    { requestChecksumCalculation: "WHEN_REQUIRED", checksumAlgorithm: undefined },
+    { requestChecksumCalculation: "WHEN_SUPPORTED", checksumAlgorithm: ChecksumAlgorithm.CRC32 },
+  ] as Array<{
+    requestChecksumCalculation?: S3ClientConfig["requestChecksumCalculation"];
+    checksumAlgorithm?: ChecksumAlgorithm;
+  }>)(
+    "checksum: requestChecksumCalculation=$requestChecksumCalculation, algorithm=$checksumAlgorithm",
+    ({ requestChecksumCalculation, checksumAlgorithm }) => {
+      let client: S3;
+      let Key: string;
+
+      beforeAll(() => {
+        client = new S3({ region, requestChecksumCalculation });
+        Key = `multi-part-checksum-${requestChecksumCalculation}-${checksumAlgorithm}-${Date.now()}`;
+      });
+
+      afterAll(async () => {
+        if (client && Bucket && Key) {
           try {
-            const e2eTestResourcesEnv = await getE2eTestResources();
-            Object.assign(process.env, e2eTestResourcesEnv);
-
-            region = process?.env?.AWS_SMOKE_TEST_REGION as string;
-            Bucket = process?.env?.AWS_SMOKE_TEST_BUCKET as string;
-
-            Key = ``;
-            data = randomBytes(20_240_000);
-            dataString = data.toString();
-
-            // @ts-expect-error: Types of property 'requestChecksumCalculation' are incompatible
-            client = new S3({
-              region,
-              requestChecksumCalculation,
-            });
-            Key = `multi-part-file-${requestChecksumCalculation}-${ChecksumAlgorithm}-${Date.now()}`;
+            await client.deleteObject({ Bucket, Key });
           } catch (error) {
-            console.warn("Failed to set up test resources:", error);
+            console.warn("Failed to clean up test object:", error);
           }
-        }, 45_000);
+        }
+      }, 10_000);
 
-        afterAll(async () => {
-          if (client && Bucket && Key) {
-            try {
-              await client.deleteObject({ Bucket, Key });
-            } catch (error) {
-              console.warn("Failed to clean up test object:", error);
-            }
-          }
-        }, 10_000);
-
-        it("should upload in parts for input type bytes", async () => {
-          const s3Upload = new Upload({
-            client,
-            params: { Bucket, Key, Body: data, ChecksumAlgorithm },
-          });
-          await s3Upload.done();
-
-          const object = await client.getObject({ Bucket, Key });
-          expect(await object.Body?.transformToString()).toEqual(dataString);
+      it("should upload in parts", async () => {
+        const s3Upload = new Upload({
+          client,
+          params: { Bucket, Key, Body: data, ChecksumAlgorithm: checksumAlgorithm },
         });
+        await s3Upload.done();
 
-        it("should upload in parts for input type string", async () => {
-          const s3Upload = new Upload({
-            client,
-            params: { Bucket, Key, Body: dataString, ChecksumAlgorithm },
-          });
-          await s3Upload.done();
-
-          const object = await client.getObject({ Bucket, Key });
-          expect(await object.Body?.transformToString()).toEqual(dataString);
-        });
-
-        it("should upload in parts for input type Readable", async () => {
-          const s3Upload = new Upload({
-            client,
-            params: { Bucket, Key, Body: Readable.from(data), ChecksumAlgorithm },
-          });
-          await s3Upload.done();
-
-          const object = await client.getObject({ Bucket, Key });
-          expect(await object.Body?.transformToString()).toEqual(dataString);
-        });
-
-        it("should call AbortMultipartUpload if unable to complete a multipart upload.", async () => {
-          class MockFailureS3 extends S3 {
-            public counter = 0;
-            async send(command: any, ...rest: any[]) {
-              if (command?.constructor?.name === "UploadPartCommand" && this.counter++ % 3 === 0) {
-                throw new Error("simulated upload part error");
-              }
-              return super.send(command, ...rest);
-            }
-          }
-
-          const client = new MockFailureS3({ region });
-
-          const requestLog = [] as string[];
-
-          client.middlewareStack.add(
-            (next, context) => async (args) => {
-              const result = await next(args);
-              requestLog.push(
-                [context.clientName, context.commandName, result.output.$metadata.httpStatusCode].join(" ")
-              );
-              return result;
-            },
-            {
-              name: "E2eRequestLog",
-              step: "build",
-              override: true,
-            }
-          );
-
-          const s3Upload = new Upload({
-            client,
-            params: { Bucket, Key, Body: data, ChecksumAlgorithm },
-          });
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          await s3Upload.done().catch((ignored) => {});
-
-          const uploadStatus = await client
-            .listParts({ Bucket, Key, UploadId: s3Upload.uploadId })
-            .then((listParts) => listParts.$metadata.httpStatusCode)
-            .catch((err) => err.toString());
-
-          expect(uploadStatus).toMatch(/NoSuchUpload:(.*?)aborted or completed\./);
-          expect(requestLog).toEqual([
-            "S3Client CreateMultipartUploadCommand 200",
-            "S3Client UploadPartCommand 200",
-            "S3Client UploadPartCommand 200",
-            "S3Client AbortMultipartUploadCommand 204",
-          ]);
-        });
-
-        it("should validate part size constraints", () => {
-          const upload = new Upload({
-            client,
-            params: {
-              Bucket,
-              Key: `validation-test-${Date.now()}`,
-              Body: Buffer.alloc(1024 * 1024 * 10),
-            },
-          });
-
-          const invalidPart = {
-            partNumber: 2,
-            data: Buffer.alloc(1024 * 1024 * 3), // 3MB - too small for non-final part
-            lastPart: false,
-          };
-
-          expect(() => {
-            (upload as any).__validateUploadPart(invalidPart);
-          }).toThrow(/The byte size for part number 2, size \d+ does not match expected size \d+/);
-        });
-
-        it("should validate part count constraints", async () => {
-          const upload = new Upload({
-            client,
-            params: {
-              Bucket,
-              Key: `validation-test-${Date.now()}`,
-              Body: Buffer.alloc(1024 * 1024 * 10),
-            },
-          });
-
-          (upload as any).uploadedParts = [{ PartNumber: 1, ETag: "etag1" }];
-          (upload as any).isMultiPart = true;
-
-          await expect(upload.done()).rejects.toThrow(/Expected \d+ part\(s\) but uploaded \d+ part\(s\)\./);
-        });
+        const object = await client.getObject({ Bucket, Key });
+        expect(await object.Body?.transformToString()).toEqual(dataString);
       });
     }
   );
 
-  describe("inferring the byte length of the input", () => {
-    beforeAll(async () => {
-      const e2eTestResourcesEnv = await getE2eTestResources();
-      Object.assign(process.env, e2eTestResourcesEnv);
+  // Abort test — independent of checksum config, run once.
+  describe("abort handling", () => {
+    it("should call AbortMultipartUpload if unable to complete a multipart upload.", async () => {
+      const Key = `multi-part-abort-${Date.now()}`;
+
+      class MockFailureS3 extends S3 {
+        public counter = 0;
+        async send(command: any, ...rest: any[]) {
+          if (command?.constructor?.name === "UploadPartCommand" && this.counter++ % 3 === 0) {
+            throw new Error("simulated upload part error");
+          }
+          return super.send(command, ...rest);
+        }
+      }
+
+      const mockClient = new MockFailureS3({ region });
+
+      const requestLog = [] as string[];
+
+      mockClient.middlewareStack.add(
+        (next, context) => async (args) => {
+          const result = await next(args);
+          requestLog.push([context.clientName, context.commandName, result.output.$metadata.httpStatusCode].join(" "));
+          return result;
+        },
+        {
+          name: "E2eRequestLog",
+          step: "build",
+          override: true,
+        }
+      );
+
+      const s3Upload = new Upload({
+        client: mockClient,
+        params: { Bucket, Key, Body: data },
+      });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      await s3Upload.done().catch((ignored) => {});
+
+      const uploadStatus = await mockClient
+        .listParts({ Bucket, Key, UploadId: s3Upload.uploadId })
+        .then((listParts) => listParts.$metadata.httpStatusCode)
+        .catch((err) => err.toString());
+
+      expect(uploadStatus).toMatch(/NoSuchUpload:(.*?)aborted or completed\./);
+      expect(requestLog).toEqual([
+        "S3Client CreateMultipartUploadCommand 200",
+        "S3Client UploadPartCommand 200",
+        "S3Client UploadPartCommand 200",
+        "S3Client AbortMultipartUploadCommand 204",
+      ]);
+    });
+  });
+
+  // Validation tests — run once, independent of checksum/body-type permutations.
+  describe("validation", () => {
+    let client: S3;
+
+    beforeAll(() => {
+      client = new S3({ region });
     });
 
-    it("should throw an informative error about the correct override if the SDK infers the byte count incorrectly", async () => {
-      const s3 = new S3({
-        region: process.env.AWS_SMOKE_TEST_REGION,
+    it("should validate part size constraints", () => {
+      const upload = new Upload({
+        client,
+        params: {
+          Bucket,
+          Key: `validation-test-${Date.now()}`,
+          Body: Buffer.alloc(1024 * 1024 * 10),
+        },
       });
+
+      const invalidPart = {
+        partNumber: 2,
+        data: Buffer.alloc(1024 * 1024 * 3), // 3MB - too small for non-final part
+        lastPart: false,
+      };
+
+      expect(() => {
+        (upload as any).__validateUploadPart(invalidPart);
+      }).toThrow(/The byte size for part number 2, size \d+ does not match expected size \d+/);
+    });
+
+    it("should validate part count constraints", async () => {
+      const upload = new Upload({
+        client,
+        params: {
+          Bucket,
+          Key: `validation-test-${Date.now()}`,
+          Body: Buffer.alloc(1024 * 1024 * 10),
+        },
+      });
+
+      (upload as any).uploadedParts = [{ PartNumber: 1, ETag: "etag1" }];
+      (upload as any).isMultiPart = true;
+
+      await expect(upload.done()).rejects.toThrow(/Expected \d+ part\(s\) but uploaded \d+ part\(s\)\./);
+    });
+  });
+
+  describe("inferring the byte length of the input", () => {
+    it("should throw an informative error about the correct override if the SDK infers the byte count incorrectly", async () => {
+      const s3 = new S3({ region });
 
       const pseudoFileReadStream = fs.createReadStream("/dev/urandom", { end: 6 * 1024 * 1024 });
 
@@ -198,7 +232,7 @@ describe("@aws-sdk/lib-storage", () => {
         client: s3,
         params: {
           Key: `/dev/urandom`,
-          Bucket: process.env.AWS_SMOKE_TEST_BUCKET,
+          Bucket,
           Body: pseudoFileReadStream,
         },
       });
@@ -215,9 +249,7 @@ to input.params.ContentLength in bytes.
     });
 
     it("should use the input ContentLength as the total byte count if supplied by the caller", async () => {
-      const s3 = new S3({
-        region: process.env.AWS_SMOKE_TEST_REGION,
-      });
+      const s3 = new S3({ region });
 
       const pseudoFileReadStream = fs.createReadStream("/dev/urandom", { end: 6 * 1024 * 1024 });
 
@@ -225,7 +257,7 @@ to input.params.ContentLength in bytes.
         client: s3,
         params: {
           Key: `/dev/urandom`,
-          Bucket: process.env.AWS_SMOKE_TEST_BUCKET,
+          Bucket,
           Body: pseudoFileReadStream,
           ContentLength: 6 * 1024 * 1024,
         },


### PR DESCRIPTION
### Issue
n/a

### Description
Reduces the number of permutations in the lib-storage e2e test to allow it to complete faster.

### Testing
modified e2e test

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.