### PR TITLE
fix(core/protocols): make error namespace removal unconditional in JSON RPC

### DIFF
--- a/packages-internal/core/integ/dynamodb.rpc1_0.error-lookup.integ.spec.ts
+++ b/packages-internal/core/integ/dynamodb.rpc1_0.error-lookup.integ.spec.ts
@@ -1,0 +1,66 @@
+import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
+import { ConditionalCheckFailedException, ConditionalCheckFailedException$, DynamoDB } from "@aws-sdk/client-dynamodb";
+import { HttpResponse } from "@smithy/core/protocols";
+import { TypeRegistry } from "@smithy/core/schema";
+import { Readable } from "node:stream";
+import { describe, expect, test as it } from "vitest";
+
+describe("error lookup using DynamoDB as an example", () => {
+  it("should look up errors using the shape name rather than the apparent shape ID", async () => {
+    // because the specification says to remove the namespace:
+    // https://smithy.io/2.0/aws/protocols/aws-json-1_0-protocol.html#operation-error-serialization
+    // and because the server may return an error with a namespace different from the modeled one.
+    const ddb = new DynamoDB({
+      region: "us-west-2",
+      credentials: {
+        accessKeyId: "INTEG",
+        secretAccessKey: "INTEG",
+      },
+    });
+
+    requireRequestsFrom(ddb)
+      .toMatch({
+        hostname: "dynamodb.us-west-2.amazonaws.com",
+      })
+      .respondWith(
+        new HttpResponse({
+          statusCode: 400,
+          headers: {},
+          body: Readable.from(
+            Buffer.from(
+              JSON.stringify({
+                __type: "com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException",
+                message: "integration test error",
+              })
+            )
+          ),
+        })
+      );
+
+    const error = await ddb
+      .getItem({
+        TableName: "table",
+        Key: {
+          id: {
+            S: "1",
+          },
+        },
+      })
+      .catch((e) => e);
+
+    const privateAccessTypeRegistry = (ddb.config.protocol as any).compositeErrorRegistry;
+    expect(privateAccessTypeRegistry).toBeInstanceOf(TypeRegistry);
+
+    const serverId = `com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException`;
+    const modeledId = `com.amazonaws.dynamodb#ConditionalCheckFailedException`;
+    const shapeName = `ConditionalCheckFailedException`;
+
+    expect(() => {
+      privateAccessTypeRegistry.getSchema(serverId);
+    }).toThrow(`@smithy/core/schema - schema not found for ${serverId}`);
+    expect(error).toBeInstanceOf(ConditionalCheckFailedException);
+
+    expect(privateAccessTypeRegistry.getSchema(modeledId)).toBe(ConditionalCheckFailedException$);
+    expect(privateAccessTypeRegistry.getSchema(shapeName)).toBe(ConditionalCheckFailedException$);
+  });
+});

--- a/packages-internal/core/src/submodules/protocols/json/AwsJsonRpcProtocol.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsJsonRpcProtocol.ts
@@ -105,8 +105,7 @@ export abstract class AwsJsonRpcProtocol extends RpcProtocol {
     if (awsQueryCompatible) {
       this.mixin.setQueryCompatError(dataObject, response);
     }
-    const errorIdentifier =
-      loadJsonRpcErrorCode(response, dataObject, this.getJsonRpcVersion() === "1.1", awsQueryCompatible) ?? "Unknown";
+    const errorIdentifier = loadJsonRpcErrorCode(response, dataObject, awsQueryCompatible) ?? "Unknown";
     this.mixin.compose(this.compositeErrorRegistry, errorIdentifier, this.options.defaultNamespace);
 
     const { errorSchema, errorMetadata } = await this.mixin.getErrorSchemaOrThrowBaseException(

--- a/packages-internal/core/src/submodules/protocols/json/parseJsonBody.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/parseJsonBody.spec.ts
@@ -48,7 +48,7 @@ describe(loadJsonRpcErrorCode.name, () => {
     expect(code).toEqual("FooError");
   });
 
-  it("strips namespace when removeNamespace is true (awsJson1_1)", () => {
+  it("strips namespace", () => {
     const code = loadJsonRpcErrorCode(
       { statusCode: 400, headers: {} },
       { __type: "com.amazonaws.example#FooError" },
@@ -57,25 +57,7 @@ describe(loadJsonRpcErrorCode.name, () => {
     expect(code).toEqual("FooError");
   });
 
-  it("preserves namespace when removeNamespace is false (awsJson1_0)", () => {
-    const code = loadJsonRpcErrorCode(
-      { statusCode: 400, headers: {} },
-      { __type: "com.amazonaws.example#FooError" },
-      false
-    );
-    expect(code).toEqual("com.amazonaws.example#FooError");
-  });
-
-  it("strips colon suffix regardless of removeNamespace", () => {
-    const code = loadJsonRpcErrorCode(
-      { statusCode: 400, headers: {} },
-      { __type: "com.amazonaws.example#FooError:http://internal.amazon.com/coral" },
-      false
-    );
-    expect(code).toEqual("com.amazonaws.example#FooError");
-  });
-
-  it("strips colon then namespace when removeNamespace is true", () => {
+  it("strips colon and namespace", () => {
     const code = loadJsonRpcErrorCode(
       { statusCode: 400, headers: {} },
       { __type: "com.amazonaws.example#FooError:http://internal.amazon.com/coral" },
@@ -89,7 +71,7 @@ describe(loadJsonRpcErrorCode.name, () => {
       const code = loadJsonRpcErrorCode(
         { statusCode: 400, headers: { "x-amzn-errortype": "HeaderError" } },
         { __type: "TypeErr", code: "CodeError" },
-        true
+        false
       );
       expect(code).toEqual("TypeErr");
     });
@@ -124,7 +106,6 @@ describe(loadJsonRpcErrorCode.name, () => {
       const code = loadJsonRpcErrorCode(
         { statusCode: 400, headers: { "x-amzn-errortype": "HeaderError" } },
         { code: "CodeError", __type: "TypeErr" },
-        true,
         true
       );
       expect(code).toEqual("CodeError");
@@ -134,30 +115,19 @@ describe(loadJsonRpcErrorCode.name, () => {
       const code = loadJsonRpcErrorCode(
         { statusCode: 400, headers: { "x-amzn-errortype": "HeaderError" } },
         { __type: "TypeErr" },
-        true,
         true
       );
       expect(code).toEqual("HeaderError");
     });
 
     it("falls back to __type when code and header are absent", () => {
-      const code = loadJsonRpcErrorCode({ statusCode: 400, headers: {} }, { __type: "TypeErr" }, true, true);
+      const code = loadJsonRpcErrorCode({ statusCode: 400, headers: {} }, { __type: "TypeErr" }, true);
       expect(code).toEqual("TypeErr");
     });
 
-    it("still strips namespace when removeNamespace is true", () => {
-      const code = loadJsonRpcErrorCode({ statusCode: 400, headers: {} }, { code: "com.example#BarError" }, true, true);
+    it("still strips namespace", () => {
+      const code = loadJsonRpcErrorCode({ statusCode: 400, headers: {} }, { code: "com.example#BarError" }, true);
       expect(code).toEqual("BarError");
-    });
-
-    it("preserves namespace when removeNamespace is false", () => {
-      const code = loadJsonRpcErrorCode(
-        { statusCode: 400, headers: {} },
-        { code: "com.example#BarError" },
-        false,
-        true
-      );
-      expect(code).toEqual("com.example#BarError");
     });
   });
 });

--- a/packages-internal/core/src/submodules/protocols/json/parseJsonBody.ts
+++ b/packages-internal/core/src/submodules/protocols/json/parseJsonBody.ts
@@ -39,7 +39,7 @@ const findKey = (object: any, key: string) => Object.keys(object).find((k) => k.
 /**
  * @internal
  */
-const sanitizeErrorCode = (rawValue: string | number, removeNamespace = true): string => {
+const sanitizeErrorCode = (rawValue: string | number): string => {
   let cleanValue = rawValue;
   if (typeof cleanValue === "number") {
     cleanValue = cleanValue.toString();
@@ -50,7 +50,7 @@ const sanitizeErrorCode = (rawValue: string | number, removeNamespace = true): s
   if (cleanValue.indexOf(":") >= 0) {
     cleanValue = cleanValue.split(":")[0];
   }
-  if (removeNamespace && cleanValue.indexOf("#") >= 0) {
+  if (cleanValue.indexOf("#") >= 0) {
     cleanValue = cleanValue.split("#")[1];
   }
   return cleanValue;
@@ -60,24 +60,14 @@ const sanitizeErrorCode = (rawValue: string | number, removeNamespace = true): s
  * @internal
  */
 export const loadRestJsonErrorCode = (output: HttpResponse, data: any): string | undefined => {
-  return loadErrorCode(output, data, true, ["header", "code", "type"]);
+  return loadErrorCode(output, data, ["header", "code", "type"]);
 };
 
 /**
  * @internal
  */
-export const loadJsonRpcErrorCode = (
-  output: HttpResponse,
-  data: any,
-  removeNamespace: boolean,
-  queryCompat = false
-): string | undefined => {
-  return loadErrorCode(
-    output,
-    data,
-    removeNamespace,
-    queryCompat ? ["code", "header", "type"] : ["type", "code", "header"]
-  );
+export const loadJsonRpcErrorCode = (output: HttpResponse, data: any, queryCompat = false): string | undefined => {
+  return loadErrorCode(output, data, queryCompat ? ["code", "header", "type"] : ["type", "code", "header"]);
 };
 
 /**
@@ -86,7 +76,6 @@ export const loadJsonRpcErrorCode = (
 const loadErrorCode = (
   { headers }: HttpResponse,
   data: any,
-  removeNamespace: boolean,
   order: ("header" | "code" | "type")[]
 ): string | undefined => {
   while (order.length > 0) {
@@ -95,18 +84,18 @@ const loadErrorCode = (
       case "header":
         const headerKey = findKey(headers ?? {}, "x-amzn-errortype");
         if (headerKey !== undefined) {
-          return sanitizeErrorCode(headers[headerKey], removeNamespace);
+          return sanitizeErrorCode(headers[headerKey]);
         }
         break;
       case "code":
         const codeKey = findKey(data ?? {}, "code");
         if (codeKey && data[codeKey] !== undefined) {
-          return sanitizeErrorCode(data[codeKey], removeNamespace);
+          return sanitizeErrorCode(data[codeKey]);
         }
         break;
       case "type":
         if (data?.__type !== undefined) {
-          return sanitizeErrorCode(data.__type, removeNamespace);
+          return sanitizeErrorCode(data.__type);
         }
         break;
     }

--- a/private/aws-client-api-test/package.json
+++ b/private/aws-client-api-test/package.json
@@ -18,6 +18,7 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
+    "@aws-sdk/aws-protocoltests-ec2-schema": "workspace:3.1048.0",
     "@aws-sdk/client-dynamodb": "workspace:3.1048.0",
     "@aws-sdk/client-ec2": "workspace:3.1048.0",
     "@aws-sdk/client-glacier": "workspace:3.1048.0",

--- a/private/aws-client-api-test/src/client-interface-tests/endpoint-requiredness-variations.spec.ts
+++ b/private/aws-client-api-test/src/client-interface-tests/endpoint-requiredness-variations.spec.ts
@@ -1,5 +1,5 @@
-import type { EC2ProtocolClientConfig } from "@aws-sdk/aws-protocoltests-ec2";
-import { EC2ProtocolClient } from "@aws-sdk/aws-protocoltests-ec2";
+import type { EC2ProtocolClientConfig } from "@aws-sdk/aws-protocoltests-ec2-schema";
+import { EC2ProtocolClient } from "@aws-sdk/aws-protocoltests-ec2-schema";
 import type { S3ClientConfig } from "@aws-sdk/client-s3";
 import { S3Client } from "@aws-sdk/client-s3";
 import type { WeatherClientConfig } from "@aws-sdk/weather";

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk/aws-client-api-test@workspace:private/aws-client-api-test"
   dependencies:
+    "@aws-sdk/aws-protocoltests-ec2-schema": "workspace:3.1048.0"
     "@aws-sdk/client-dynamodb": "workspace:3.1048.0"
     "@aws-sdk/client-ec2": "workspace:3.1048.0"
     "@aws-sdk/client-glacier": "workspace:3.1048.0"
@@ -181,7 +182,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/aws-protocoltests-ec2-schema@workspace:private/aws-protocoltests-ec2-schema":
+"@aws-sdk/aws-protocoltests-ec2-schema@workspace:3.1048.0, @aws-sdk/aws-protocoltests-ec2-schema@workspace:private/aws-protocoltests-ec2-schema":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/aws-protocoltests-ec2-schema@workspace:private/aws-protocoltests-ec2-schema"
   dependencies:


### PR DESCRIPTION
### Issue
V2218690158

### Description
This updates the error identification logic in AWS JSON RPC 1.0 to discard the namespace, which is required when services return errors that have different ids than the service model.

See https://smithy.io/2.0/aws/protocols/aws-json-1_0-protocol.html#operation-error-serialization

For example, DynamoDB has one error which appears as:
- server: `com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException`
- modeled: `com.amazonaws.dynamodb#ConditionalCheckFailedException`

Without this fix, a bug introduced in https://www.npmjs.com/package/@aws-sdk/core/v/3.974.9 through https://www.npmjs.com/package/@aws-sdk/core/v/3.974.11 causes `error instanceof ConditionalCheckFailedException` and similar patterned `instanceof` checks to fail to return `true` when they are supposed to.

AWS JSON 1.0 is an RPC protocol used by the following services:

```
  @aws-sdk/client-apprunner
  @aws-sdk/client-arc-region-switch
  @aws-sdk/client-b2bi
  @aws-sdk/client-backup-gateway
  @aws-sdk/client-bcm-dashboards
  @aws-sdk/client-bcm-pricing-calculator
  @aws-sdk/client-bcm-recommended-actions
  @aws-sdk/client-billing
  @aws-sdk/client-cloudcontrol
  @aws-sdk/client-cloudwatch
  @aws-sdk/client-codeconnections
  @aws-sdk/client-codestar-connections
  @aws-sdk/client-compute-optimizer
  @aws-sdk/client-compute-optimizer-automation
  @aws-sdk/client-cost-optimization-hub
  @aws-sdk/client-dynamodb
  @aws-sdk/client-dynamodb-streams
  @aws-sdk/client-evs
  @aws-sdk/client-freetier
  @aws-sdk/client-healthlake
  @aws-sdk/client-interconnect
  @aws-sdk/client-invoicing
  @aws-sdk/client-iotfleetwise
  @aws-sdk/client-kendra-ranking
  @aws-sdk/client-keyspaces
  @aws-sdk/client-keyspacesstreams
  @aws-sdk/client-lookoutequipment
  @aws-sdk/client-mailmanager
  @aws-sdk/client-marketplace-agreement
  @aws-sdk/client-mwaa-serverless
  @aws-sdk/client-network-firewall
  @aws-sdk/client-odb
  @aws-sdk/client-opensearchserverless
  @aws-sdk/client-partnercentral-account
  @aws-sdk/client-partnercentral-benefits
  @aws-sdk/client-partnercentral-channel
  @aws-sdk/client-partnercentral-selling
  @aws-sdk/client-payment-cryptography
  @aws-sdk/client-pcs
  @aws-sdk/client-pinpoint-sms-voice-v2
  @aws-sdk/client-proton
  @aws-sdk/client-route53-recovery-cluster
  @aws-sdk/client-sfn
  @aws-sdk/client-sqs
  @aws-sdk/client-swf
  @aws-sdk/client-timestream-influxdb
  @aws-sdk/client-timestream-query
  @aws-sdk/client-timestream-write
  @aws-sdk/client-verifiedpermissions
  @aws-sdk/client-voice-id
  @aws-sdk/client-workspaces-instances
```

### Testing
added integration test

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
