### PR TITLE
chore: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -8,7 +8,7 @@ jobs:
         permissions:
           issues: write
         steps:
-        - uses: aws-actions/closed-issue-message@v1
+        - uses: aws-actions/closed-issue-message@cf797c2463fa6b95a23b2957fe075a3fa9aa8138 # v1
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -15,22 +15,26 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: Java ${{ matrix.java }}
     strategy: 
       matrix:
         java: [17]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'corretto'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 

--- a/.github/workflows/commit-message-lint.yml
+++ b/.github/workflows/commit-message-lint.yml
@@ -9,10 +9,12 @@ on:
 jobs:
   commitlint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+          persist-credentials: false
+      - uses: wagoid/commitlint-github-action@416045160973f9fff174ac6698412cfe7181c3f3 # v4
             
-

--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::231016596583:role/github-actions-git-sync-role
           aws-region: us-west-2
@@ -43,7 +43,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: git-sync
-        uses: wei/git-sync@v3
+        uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83 # v3
         with:
           source_repo: "git@github.com:aws/aws-sdk-js-v3.git"
           source_branch: "main"

--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -13,6 +13,6 @@ jobs:
       discussions: write
     steps:
       - name: Stale discussions action
-        uses: aws-github-ops/handle-stale-discussions@v1
+        uses: aws-github-ops/handle-stale-discussions@711a9813957be17629fc6933afcd8bd132c57254 # v1
         env:
           GITHUB_TOKEN:  ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: Fetch template body
       id: check_regression
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env: 
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TEMPLATE_BODY: ${{ github.event.issue.body }}
@@ -24,8 +24,9 @@ jobs:
     - name: Manage regression label
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        STEPS_CHECK_REGRESSION_OUTPUTS_IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
       run: |
-        if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
+        if [ "${STEPS_CHECK_REGRESSION_OUTPUTS_IS_REGRESSION}" == "true" ]; then
           gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
         else
           gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@f1a42f0f44eb83361d617a014663e1a76cf282d2 # v2
         if: github.repository == 'aws/aws-sdk-js-v3'
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -9,10 +9,14 @@ on:
 jobs:
   run-pre-commit-hooks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '20'
           cache: 'yarn'

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{secrets.PR_WORKFLOW_IAM_ROLE_ARN}}
           role-session-name: PullRequestBuildGitHubAction

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v6
+    - uses: aws-actions/stale-issue-cleanup@7de35968489e4142233d2a6812519a82e68b5c38 # v6
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category


### PR DESCRIPTION
> [!NOTE]
> Some actions may be pinned to versions that are not the latest available. This PR intentionally preserves the currently used compatible versions where possible. The scope is to make action references immutable and address the zizmor findings, not to upgrade actions to their latest releases.

## Overview

This PR hardens several GitHub Actions workflows to resolve [zizmor](https://docs.zizmor.sh/) findings around action pinning, token scope, credential persistence, and shell template expansion.

## Summary

- Pins GitHub Actions `uses:` references to full commit SHAs while retaining version comments for readability.
- Adds explicit least-privilege `permissions: contents: read` blocks to read-only CI jobs.
- Sets `persist-credentials: false` for checkout steps that do not need persisted Git credentials.
- Moves the `issue-regression-labeler` step output into an environment variable before using it in shell, avoiding inline `${{ ... }}` expansion inside the `run:` block.

These changes address the relevant zizmor audit guidance for [`unpinned-uses`](https://docs.zizmor.sh/audits/#unpinned-uses), [`artipacked`](https://docs.zizmor.sh/audits/#artipacked), [`excessive-permissions`](https://docs.zizmor.sh/audits/#excessive-permissions), and [`template-injection`](https://docs.zizmor.sh/audits/#template-injection).

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
