### PR TITLE
fix(cloudfront-signer): encode URL path before signing

### DIFF
--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -423,6 +423,111 @@ describe("getSignedUrl", () => {
     expect(result).toContain("private%20content/My%20File.pdf");
     expect(result).not.toContain("%2520");
   });
+
+  // CloudFront verifies the signature against the URL on the wire (the encoded
+  // form). The signed policy Resource must therefore reference the encoded URL,
+  // otherwise CloudFront returns 403 AccessDenied. Regression introduced in
+  // v3.1046.0; see https://github.com/aws/aws-sdk-js-v3/issues/8033.
+  it("should sign the encoded URL when the path contains special characters", () => {
+    const urlWithSpecialChars =
+      "https://d111111abcdef8.cloudfront.net/i/foo/bar.png/format=webp,height=2000,width=2000";
+    const encodedUrl =
+      "https://d111111abcdef8.cloudfront.net/i/foo/bar.png/format%3Dwebp%2Cheight%3D2000%2Cwidth%3D2000";
+    const result = getSignedUrl({
+      url: urlWithSpecialChars,
+      keyPairId,
+      dateLessThan,
+      privateKey,
+      passphrase,
+    });
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: encodedUrl,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": epochDateLessThan,
+            },
+          },
+        },
+      ],
+    });
+    const expectedSignature = createSignature(policyStr);
+    expect(result).toBe(
+      `${encodedUrl}?Expires=${epochDateLessThan}&Key-Pair-Id=${keyPairId}&Signature=${expectedSignature}`
+    );
+    const parsedUrl = parseUrl(result);
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
+  });
+
+  it("should sign the encoded URL when the path contains spaces", () => {
+    const urlWithSpaces = "https://d111111abcdef8.cloudfront.net/private content/My File.pdf";
+    const encodedUrl = "https://d111111abcdef8.cloudfront.net/private%20content/My%20File.pdf";
+    const result = getSignedUrl({
+      url: urlWithSpaces,
+      keyPairId,
+      dateLessThan,
+      privateKey,
+      passphrase,
+    });
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: encodedUrl,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": epochDateLessThan,
+            },
+          },
+        },
+      ],
+    });
+    const expectedSignature = createSignature(policyStr);
+    expect(result).toBe(
+      `${encodedUrl}?Expires=${epochDateLessThan}&Key-Pair-Id=${keyPairId}&Signature=${expectedSignature}`
+    );
+    const parsedUrl = parseUrl(result);
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
+  });
+
+  it("should sign the encoded URL for a custom policy with special characters in the path", () => {
+    const urlWithSpecialChars =
+      "https://d111111abcdef8.cloudfront.net/i/foo/bar.png/format=webp,height=2000,width=2000";
+    const encodedUrl =
+      "https://d111111abcdef8.cloudfront.net/i/foo/bar.png/format%3Dwebp%2Cheight%3D2000%2Cwidth%3D2000";
+    const result = getSignedUrl({
+      url: urlWithSpecialChars,
+      keyPairId,
+      dateLessThan,
+      ipAddress,
+      privateKey,
+      passphrase,
+    });
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: encodedUrl,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": epochDateLessThan,
+            },
+            IpAddress: {
+              "AWS:SourceIp": `${ipAddress}/32`,
+            },
+          },
+        },
+      ],
+    });
+    const expectedSignature = createSignature(policyStr);
+    expect(result).toBe(
+      `${encodedUrl}?Policy=${encodeToBase64(policyStr)}&Key-Pair-Id=${keyPairId}&Signature=${expectedSignature}`
+    );
+    const parsedUrl = parseUrl(result);
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
+  });
 });
 
 describe("getSignedCookies", () => {

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -113,20 +113,13 @@ export function getSignedUrl({
     throw new Error("@aws-sdk/cloudfront-signer: Please provide 'url' or 'policy'.");
   }
 
-  if (policy) {
-    cloudfrontSignBuilder.setCustomPolicy(policy);
-  } else {
-    cloudfrontSignBuilder.setPolicyParameters({
-      url,
-      dateLessThan,
-      dateGreaterThan,
-      ipAddress,
-    });
-  }
-
   let baseUrl: string | undefined;
   if (url) {
-    baseUrl = url;
+    // Encode the URL up front so the policy Resource matches the URL on the
+    // wire. CloudFront verifies the signature against the encoded URL, so
+    // signing the unencoded form would produce 403 AccessDenied whenever the
+    // path contains characters like '=', ',', or spaces.
+    baseUrl = encodeUrlPath(url);
   } else if (policy) {
     const resources = getPolicyResources(policy!);
     if (!resources[0]) {
@@ -137,13 +130,24 @@ export function getSignedUrl({
     baseUrl = resources[0].replace("*://", "https://");
   }
 
+  if (policy) {
+    cloudfrontSignBuilder.setCustomPolicy(policy);
+  } else {
+    cloudfrontSignBuilder.setPolicyParameters({
+      url: baseUrl,
+      dateLessThan,
+      dateGreaterThan,
+      ipAddress,
+    });
+  }
+
   const startFlag = baseUrl!.includes("?") ? "&" : "?";
   const params = Object.entries(cloudfrontSignBuilder.createCloudfrontAttribute())
     .filter(([, value]) => value !== undefined)
     .map(([key, value]) => `${extendedEncodeURIComponent(key)}=${extendedEncodeURIComponent(value)}`)
     .join("&");
 
-  const urlString = encodeUrlPath(baseUrl!) + startFlag + params;
+  const urlString = baseUrl! + startFlag + params;
 
   return getResource(urlString);
 }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/8033

### Description
Encode Cloudfront URL path before signing

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
