### PR TITLE
fix(lib-storage): avoid forwarding object-level params to UploadPart

### DIFF
--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -201,6 +201,29 @@ describe(Upload.name, () => {
     expect(PutObjectTaggingCommand).toHaveBeenCalledTimes(0);
   });
 
+  it("should preserve object-level params when uploading using PUT", async () => {
+    const actionParams = {
+      ...params,
+      IfNoneMatch: "*",
+      ContentType: "application/json",
+      ContentMD5: "object-level-md5-base64==",
+      ChecksumSHA256: "object-level-sha256-base64==",
+    };
+    const upload = new Upload({
+      params: actionParams,
+      client: new S3({}),
+    });
+
+    await upload.done();
+
+    expect(PutObjectCommand).toHaveBeenCalledTimes(1);
+    expect(PutObjectCommand).toHaveBeenCalledWith({
+      ...actionParams,
+      Body: Buffer.from(params.Body),
+    });
+    expect(UploadPartCommand).toHaveBeenCalledTimes(0);
+  });
+
   it("should upload using PUT when parts are smaller than one part stream", async () => {
     const streamBody = Readable.from(
       (function* () {
@@ -400,18 +423,26 @@ describe(Upload.name, () => {
         });
         // upload parts is called correctly.
         expect(UploadPartCommand).toHaveBeenCalledTimes(2);
-        expect(UploadPartCommand).toHaveBeenNthCalledWith(1, {
-          ...actionParams,
-          Body: firstBuffer,
-          PartNumber: 1,
-          UploadId: "mockuploadId",
-        });
-        expect(UploadPartCommand).toHaveBeenNthCalledWith(2, {
-          ...actionParams,
-          Body: secondBuffer,
-          PartNumber: 2,
-          UploadId: "mockuploadId",
-        });
+        expect(UploadPartCommand).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            Bucket: actionParams.Bucket,
+            Key: actionParams.Key,
+            Body: firstBuffer,
+            PartNumber: 1,
+            UploadId: "mockuploadId",
+          })
+        );
+        expect(UploadPartCommand).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            Bucket: actionParams.Bucket,
+            Key: actionParams.Key,
+            Body: secondBuffer,
+            PartNumber: 2,
+            UploadId: "mockuploadId",
+          })
+        );
         // complete multipart upload is called correctly.
         expect(CompleteMultipartUploadCommand).toHaveBeenCalledTimes(1);
         expect(CompleteMultipartUploadCommand).toHaveBeenLastCalledWith({
@@ -468,19 +499,27 @@ describe(Upload.name, () => {
         // upload parts is called correctly.
         expect(UploadPartCommand).toHaveBeenCalledTimes(2);
 
-        expect(UploadPartCommand).toHaveBeenNthCalledWith(1, {
-          ...actionParams,
-          Body: firstBuffer,
-          PartNumber: 1,
-          UploadId: "mockuploadId",
-        });
-        expect(UploadPartCommand).toHaveBeenNthCalledWith(2, {
-          ...actionParams,
-          // @ts-ignore
-          Body: secondBuffer,
-          PartNumber: 2,
-          UploadId: "mockuploadId",
-        });
+        expect(UploadPartCommand).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            Bucket: actionParams.Bucket,
+            Key: actionParams.Key,
+            Body: firstBuffer,
+            PartNumber: 1,
+            UploadId: "mockuploadId",
+          })
+        );
+        expect(UploadPartCommand).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            Bucket: actionParams.Bucket,
+            Key: actionParams.Key,
+            // @ts-ignore
+            Body: secondBuffer,
+            PartNumber: 2,
+            UploadId: "mockuploadId",
+          })
+        );
         // complete multipart upload is called correctly.
         expect(CompleteMultipartUploadCommand).toHaveBeenCalledTimes(1);
         expect(CompleteMultipartUploadCommand).toHaveBeenLastCalledWith({
@@ -505,6 +544,43 @@ describe(Upload.name, () => {
         // put was not called
         expect(PutObjectCommand).toHaveBeenCalledTimes(0);
       });
+    });
+
+    it("should only pass part-safe params to UploadPart", async () => {
+      const largeBuffer = Buffer.from("#".repeat(MOCK_PART_SIZE + 10));
+      const upload = new Upload({
+        params: {
+          ...params,
+          Body: largeBuffer,
+          IfNoneMatch: "*",
+          ContentType: "application/json",
+          ContentMD5: "object-level-md5-base64==",
+          ChecksumSHA256: "object-level-sha256-base64==",
+          SSECustomerAlgorithm: "AES256",
+          RequestPayer: "requester",
+          ExpectedBucketOwner: "123456789012",
+        },
+        partSize: MOCK_PART_SIZE,
+        client: new S3({}),
+      });
+
+      await upload.done();
+
+      expect(UploadPartCommand).toHaveBeenCalledTimes(2);
+      expect(UploadPartCommand).not.toHaveBeenCalledWith(expect.objectContaining({ IfNoneMatch: "*" }));
+      expect(UploadPartCommand).not.toHaveBeenCalledWith(expect.objectContaining({ ContentType: "application/json" }));
+      expect(UploadPartCommand).not.toHaveBeenCalledWith(
+        expect.objectContaining({ ContentMD5: "object-level-md5-base64==" })
+      );
+      expect(UploadPartCommand).not.toHaveBeenCalledWith(
+        expect.objectContaining({ ChecksumSHA256: "object-level-sha256-base64==" })
+      );
+
+      expect(UploadPartCommand).toHaveBeenCalledWith(expect.objectContaining({ SSECustomerAlgorithm: "AES256" }));
+      expect(UploadPartCommand).toHaveBeenCalledWith(expect.objectContaining({ RequestPayer: "requester" }));
+      expect(UploadPartCommand).toHaveBeenCalledWith(expect.objectContaining({ ExpectedBucketOwner: "123456789012" }));
+
+      expect(CompleteMultipartUploadCommand).toHaveBeenCalledWith(expect.objectContaining({ IfNoneMatch: "*" }));
     });
   });
 

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -306,9 +306,27 @@ export class Upload extends EventEmitter {
 
       this.__validateUploadPart(dataPart);
 
+      const {
+        Bucket,
+        Key,
+        ChecksumAlgorithm: partChecksumAlgorithm,
+        SSECustomerAlgorithm,
+        SSECustomerKey,
+        SSECustomerKeyMD5,
+        RequestPayer,
+        ExpectedBucketOwner,
+      } = this.params;
+
       const partResult = await this.client.send(
         new UploadPartCommand({
-          ...this.params,
+          Bucket,
+          Key,
+          ChecksumAlgorithm: partChecksumAlgorithm,
+          SSECustomerAlgorithm,
+          SSECustomerKey,
+          SSECustomerKeyMD5,
+          RequestPayer,
+          ExpectedBucketOwner,
           // dataPart.data is chunked into a non-streaming buffer
           // so the ContentLength from the input should not be used for MPU.
           ContentLength: undefined,


### PR DESCRIPTION
### Issue
Fixes #8020

### Description
This narrows the params passed to `UploadPartCommand` in multipart `Upload` so object-level `Upload` params are not forwarded into every part upload.

The multipart path now avoids copying fields such as `IfNoneMatch`, `ContentType`, `ContentMD5`, and concrete user-supplied `Checksum*` values into `UploadPartCommand`.

`ChecksumAlgorithm` is still passed through so the SDK checksum middleware can compute checksums for the actual part body.

This also keeps the single-part `PutObjectCommand` path unchanged, so object-level params are still preserved when the upload does not use multipart.

Related to #8029. This follows the same `UploadPartCommand` boundary issue, but also excludes concrete user-supplied `Checksum*` values from multipart part requests.

### Testing
Added regression coverage for:
- single-part `PutObjectCommand` preserving object-level params
- multipart `UploadPartCommand` not receiving object-level headers/checksum values
- valid part-level fields still reaching `UploadPartCommand`
- `CompleteMultipartUploadCommand` still receiving `IfNoneMatch`

Ran:

```powershell
yarn exec vitest run lib/lib-storage/src/Upload.spec.ts
yarn exec vitest run -c lib/lib-storage/vitest.config.mts lib/lib-storage/src
```

Also verified locally with a custom request handler using the real `S3Client` serializer path. Multipart `UploadPart` requests no longer carried the object-level conditional/checksum headers, while the single `PutObject` path still preserved them.

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - It’s not a feature.
- [x] My E2E tests are resilient to concurrent I/O.
  - I didn’t write any E2E tests.
- [x] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - I didn’t add any public functions.
- [x] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - No stream lifecycle changes.