### PR TITLE
ci: declare workflow-level contents: read on 2 lint workflows

### DIFF
--- a/.github/workflows/commit-message-lint.yml
+++ b/.github/workflows/commit-message-lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.