### PR TITLE
feat(cloudfront-signer): enable SHA256 for cloudfront-signer

### DIFF
--- a/packages/cloudfront-signer/package.json
+++ b/packages/cloudfront-signer/package.json
@@ -11,7 +11,11 @@
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
     "extract:docs": "api-extractor run --local",
     "test": "yarn g:vitest run",
-    "test:watch": "yarn g:vitest watch"
+    "test:watch": "yarn g:vitest watch",
+    "test:integration": "yarn g:vitest run -c vitest.config.integ.mts",
+    "test:integration:watch": "yarn g:vitest watch -c vitest.config.integ.mts",
+    "test:e2e": "yarn g:vitest run -c vitest.config.e2e.mts",
+    "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.mts"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/cloudfront-signer/src/cloudfront-signer.e2e.spec.ts
+++ b/packages/cloudfront-signer/src/cloudfront-signer.e2e.spec.ts
@@ -1,0 +1,290 @@
+import { getE2eTestResources } from "@aws-sdk/aws-util-test/src";
+import { CloudFront } from "@aws-sdk/client-cloudfront";
+import { S3 } from "@aws-sdk/client-s3";
+import { STS } from "@aws-sdk/client-sts";
+import { createPublicKey, generateKeyPairSync } from "node:crypto";
+import { beforeAll, describe, expect, test as it } from "vitest";
+
+import { getSignedUrl } from "./index";
+
+const RESOURCE_PREFIX = "aws-sdk-js-cf-signer-e2e";
+const REGION = "us-west-2";
+const OBJECT_KEY = "test-object.txt";
+const OBJECT_BODY = "cloudfront-signer e2e test content";
+
+describe("@aws-sdk/cloudfront-signer e2e", () => {
+  let domain: string;
+  let keyPairId: string;
+  let privateKey: string;
+
+  beforeAll(async () => {
+    const e2eTestResourcesEnv = await getE2eTestResources();
+    Object.assign(process.env, e2eTestResourcesEnv);
+
+    const cf = new CloudFront({ region: REGION });
+    const s3 = new S3({ region: REGION });
+    const sts = new STS({ region: REGION });
+
+    // Derive account-regional namespace bucket name
+    const { Account } = await sts.getCallerIdentity({});
+    const BUCKET = `${RESOURCE_PREFIX}-${Account}-${REGION}-an`;
+
+    // Create bucket in account regional namespace if it doesn't exist
+    try {
+      await s3.headBucket({ Bucket: BUCKET });
+    } catch (e: any) {
+      if (e.name === "NotFound" || e.$metadata?.httpStatusCode === 404) {
+        await s3.createBucket({
+          Bucket: BUCKET,
+          BucketNamespace: "account-regional",
+          CreateBucketConfiguration: { LocationConstraint: REGION },
+        });
+      } else {
+        throw e;
+      }
+    }
+
+    // Bucket policy is set during distribution creation (scoped to distribution ARN).
+    // On subsequent runs the policy is already in place.
+
+    // Generate or retrieve RSA key pair for CloudFront signing.
+    // The key is stored in S3 so subsequent runs reuse the same key
+    // that matches the CloudFront public key. This key can only be used
+    // to sign URLs for this test distribution.
+    const privateKeyS3Key = `${RESOURCE_PREFIX}-private-key.pem`;
+    let publicKeyPem: string;
+
+    try {
+      const existing = await s3.getObject({ Bucket: BUCKET, Key: privateKeyS3Key });
+      privateKey = (await existing.Body!.transformToString()) as string;
+      publicKeyPem = createPublicKey(privateKey).export({ type: "spki", format: "pem" }) as string;
+    } catch (e: any) {
+      if (e.name === "NoSuchKey") {
+        const keyPair = generateKeyPairSync("rsa", {
+          modulusLength: 2048,
+          publicKeyEncoding: { type: "spki", format: "pem" },
+          privateKeyEncoding: { type: "pkcs1", format: "pem" },
+        });
+        privateKey = keyPair.privateKey as string;
+        publicKeyPem = keyPair.publicKey as string;
+        try {
+          // Conditional write: only succeeds if the key doesn't already exist.
+          // Prevents race conditions when multiple runs start concurrently.
+          await s3.putObject({
+            Bucket: BUCKET,
+            Key: privateKeyS3Key,
+            Body: privateKey,
+            ContentType: "text/plain",
+            IfNoneMatch: "*",
+          });
+        } catch (putErr: any) {
+          if (putErr.$metadata?.httpStatusCode === 412) {
+            // Another run wrote the key first — read theirs.
+            const winner = await s3.getObject({ Bucket: BUCKET, Key: privateKeyS3Key });
+            privateKey = (await winner.Body!.transformToString()) as string;
+            publicKeyPem = createPublicKey(privateKey).export({ type: "spki", format: "pem" }) as string;
+          } else {
+            throw putErr;
+          }
+        }
+      } else {
+        throw e;
+      }
+    }
+
+    // Upload test object to S3
+    await s3.putObject({
+      Bucket: BUCKET,
+      Key: OBJECT_KEY,
+      Body: OBJECT_BODY,
+      ContentType: "text/plain",
+    });
+
+    // Create or reuse CloudFront public key
+    const publicKeyName = `${RESOURCE_PREFIX}-public-key`;
+    let publicKeyId: string;
+    try {
+      const result = await cf.createPublicKey({
+        PublicKeyConfig: {
+          CallerReference: publicKeyName,
+          Name: publicKeyName,
+          EncodedKey: publicKeyPem,
+        },
+      });
+      publicKeyId = result.PublicKey!.Id!;
+    } catch (e: any) {
+      if (e.name === "PublicKeyAlreadyExists") {
+        const list = await cf.listPublicKeys({});
+        const existing = list.PublicKeyList?.Items?.find((k) => k.Name === publicKeyName);
+        if (!existing) {
+          throw new Error("Public key exists but not found in list");
+        }
+        publicKeyId = existing.Id!;
+      } else {
+        throw e;
+      }
+    }
+
+    // Create or reuse key group
+    const keyGroupName = `${RESOURCE_PREFIX}-key-group`;
+    let keyGroupId: string;
+    try {
+      const result = await cf.createKeyGroup({
+        KeyGroupConfig: {
+          Name: keyGroupName,
+          Items: [publicKeyId],
+        },
+      });
+      keyGroupId = result.KeyGroup!.Id!;
+    } catch (e: any) {
+      if (e.name === "KeyGroupAlreadyExists") {
+        const list = await cf.listKeyGroups({});
+        const existing = list.KeyGroupList?.Items?.find((k) => k.KeyGroup?.KeyGroupConfig?.Name === keyGroupName);
+        if (!existing) {
+          throw new Error("Key group exists but not found in list");
+        }
+        keyGroupId = existing.KeyGroup!.Id!;
+      } else {
+        throw e;
+      }
+    }
+
+    keyPairId = publicKeyId;
+
+    // Create or reuse distribution
+    const distributionComment = RESOURCE_PREFIX;
+    const distributions = await cf.listDistributions({});
+    const existingDist = distributions.DistributionList?.Items?.find((d) => d.Comment === distributionComment);
+
+    if (existingDist) {
+      domain = existingDist.DomainName!;
+    } else {
+      // Create Origin Access Control for S3
+      const oacName = `${RESOURCE_PREFIX}-oac`;
+      let oacId: string;
+      try {
+        const oacResult = await cf.createOriginAccessControl({
+          OriginAccessControlConfig: {
+            Name: oacName,
+            SigningProtocol: "sigv4",
+            SigningBehavior: "always",
+            OriginAccessControlOriginType: "s3",
+          },
+        });
+        oacId = oacResult.OriginAccessControl!.Id!;
+      } catch (e: any) {
+        if (e.name === "OriginAccessControlAlreadyExists") {
+          const list = await cf.listOriginAccessControls({});
+          const existing = list.OriginAccessControlList?.Items?.find((o) => o.Name === oacName);
+          if (!existing) {
+            throw new Error("OAC exists but not found in list");
+          }
+          oacId = existing.Id!;
+        } else {
+          throw e;
+        }
+      }
+
+      const result = await cf.createDistribution({
+        DistributionConfig: {
+          CallerReference: `${RESOURCE_PREFIX}-${Date.now()}`,
+          Comment: distributionComment,
+          Enabled: true,
+          Origins: {
+            Quantity: 1,
+            Items: [
+              {
+                Id: "S3Origin",
+                DomainName: `${BUCKET}.s3.${REGION}.amazonaws.com`,
+                OriginAccessControlId: oacId,
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "S3Origin",
+            ViewerProtocolPolicy: "https-only",
+            TrustedKeyGroups: {
+              Enabled: true,
+              Quantity: 1,
+              Items: [keyGroupId],
+            },
+            ForwardedValues: { QueryString: false, Cookies: { Forward: "none" } },
+            MinTTL: 0,
+          },
+          DefaultRootObject: "",
+        },
+      });
+      domain = result.Distribution!.DomainName!;
+      const distributionId = result.Distribution!.Id!;
+      const distributionArn = result.Distribution!.ARN!;
+
+      // Set bucket policy to allow this distribution to read via OAC
+      const bucketPolicy = JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Sid: "AllowCloudFrontOAC",
+            Effect: "Allow",
+            Principal: { Service: "cloudfront.amazonaws.com" },
+            Action: "s3:GetObject",
+            Resource: `arn:aws:s3:::${BUCKET}/*`,
+            Condition: { StringEquals: { "AWS:SourceArn": distributionArn } },
+          },
+        ],
+      });
+      await s3.putBucketPolicy({ Bucket: BUCKET, Policy: bucketPolicy });
+
+      // Wait for distribution to deploy
+      let status = "InProgress";
+      while (status === "InProgress") {
+        console.log(`[${new Date().toISOString()}] Waiting for distribution to deploy (status: ${status})...`);
+        await new Promise((r) => setTimeout(r, 30_000));
+        const check = await cf.getDistribution({ Id: distributionId });
+        status = check.Distribution!.Status!;
+      }
+      console.log(`[${new Date().toISOString()}] Distribution deployed (status: ${status}).`);
+    }
+  }, 600_000);
+
+  it("should access private content with SHA1-signed URL (default)", async () => {
+    const signedUrl = getSignedUrl({
+      url: `https://${domain}/${OBJECT_KEY}`,
+      keyPairId,
+      privateKey,
+      dateLessThan: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const response = await fetch(signedUrl);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(OBJECT_BODY);
+  });
+
+  it("should access private content with SHA256-signed URL", async () => {
+    const signedUrl = getSignedUrl({
+      url: `https://${domain}/${OBJECT_KEY}`,
+      keyPairId,
+      privateKey,
+      dateLessThan: new Date(Date.now() + 60_000).toISOString(),
+      algorithm: "SHA256",
+    });
+
+    expect(signedUrl).toContain("Hash-Algorithm=SHA256");
+    const response = await fetch(signedUrl);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(OBJECT_BODY);
+  });
+
+  it("should reject expired SHA256-signed URL", async () => {
+    const signedUrl = getSignedUrl({
+      url: `https://${domain}/${OBJECT_KEY}`,
+      keyPairId,
+      privateKey,
+      dateLessThan: "2020-01-01",
+      algorithm: "SHA256",
+    });
+
+    const response = await fetch(signedUrl);
+    expect(response.status).toBe(403);
+  });
+}, 660_000);

--- a/packages/cloudfront-signer/src/cloudfront-signer.integ.spec.ts
+++ b/packages/cloudfront-signer/src/cloudfront-signer.integ.spec.ts
@@ -1,0 +1,151 @@
+import { createVerify, generateKeyPairSync } from "node:crypto";
+import { describe, expect, test as it } from "vitest";
+
+import { getSignedCookies, getSignedUrl } from "./index";
+
+/**
+ * Integration tests for CloudFront signer SHA-256 support.
+ * These tests use dynamically generated RSA keys and verify
+ * end-to-end signing behavior without calling AWS services.
+ */
+describe("cloudfront-signer SHA-256 integration", () => {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs1", format: "pem" },
+    publicKeyEncoding: { type: "pkcs1", format: "pem" },
+  });
+
+  const keyPairId = "K2JCJMDEHXQW7F";
+  const url = "https://d111111abcdef8.cloudfront.net/images/photo.jpg";
+  const dateLessThan = "2030-01-01T00:00:00Z";
+
+  function verifySignature(policy: string, signature: string, algorithm: "RSA-SHA1" | "RSA-SHA256"): boolean {
+    // Denormalize CloudFront base64
+    const standardBase64 = signature.replace(/-/g, "+").replace(/_/g, "=").replace(/~/g, "/");
+    const verifier = createVerify(algorithm);
+    verifier.update(policy);
+    return verifier.verify(publicKey, standardBase64, "base64");
+  }
+
+  describe("getSignedUrl", () => {
+    it("should produce a verifiable RSA-SHA256 signature with canned policy", () => {
+      const signedUrl = getSignedUrl({
+        url,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+        algorithm: "SHA256",
+      });
+
+      const urlObj = new URL(signedUrl);
+      expect(urlObj.searchParams.get("Hash-Algorithm")).toBe("SHA256");
+      expect(urlObj.searchParams.get("Key-Pair-Id")).toBe(keyPairId);
+
+      const signature = urlObj.searchParams.get("Signature")!;
+      const epochTime = Math.round(new Date(dateLessThan).getTime() / 1000);
+      const expectedPolicy = JSON.stringify({
+        Statement: [{ Resource: url, Condition: { DateLessThan: { "AWS:EpochTime": epochTime } } }],
+      });
+
+      expect(verifySignature(expectedPolicy, signature, "RSA-SHA256")).toBe(true);
+      // Verify it does NOT validate with SHA1
+      expect(verifySignature(expectedPolicy, signature, "RSA-SHA1")).toBe(false);
+    });
+
+    it("should produce a verifiable RSA-SHA1 signature by default", () => {
+      const signedUrl = getSignedUrl({
+        url,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+      });
+
+      const urlObj = new URL(signedUrl);
+      expect(urlObj.searchParams.get("Hash-Algorithm")).toBeNull();
+
+      const signature = urlObj.searchParams.get("Signature")!;
+      const epochTime = Math.round(new Date(dateLessThan).getTime() / 1000);
+      const expectedPolicy = JSON.stringify({
+        Statement: [{ Resource: url, Condition: { DateLessThan: { "AWS:EpochTime": epochTime } } }],
+      });
+
+      expect(verifySignature(expectedPolicy, signature, "RSA-SHA1")).toBe(true);
+    });
+
+    it("should produce a verifiable RSA-SHA256 signature with custom policy", () => {
+      const customPolicy = JSON.stringify({
+        Statement: [
+          {
+            Resource: "https://d111111abcdef8.cloudfront.net/*",
+            Condition: {
+              DateLessThan: { "AWS:EpochTime": 1893456000 },
+              IpAddress: { "AWS:SourceIp": "192.168.1.0/24" },
+            },
+          },
+        ],
+      });
+
+      const signedUrl = getSignedUrl({
+        url,
+        keyPairId,
+        privateKey,
+        policy: customPolicy,
+        algorithm: "SHA256",
+      });
+
+      const urlObj = new URL(signedUrl);
+      expect(urlObj.searchParams.get("Hash-Algorithm")).toBe("SHA256");
+      expect(urlObj.searchParams.get("Policy")).toBeDefined();
+
+      const signature = urlObj.searchParams.get("Signature")!;
+      expect(verifySignature(customPolicy, signature, "RSA-SHA256")).toBe(true);
+    });
+  });
+
+  describe("getSignedCookies", () => {
+    it("should produce a verifiable RSA-SHA256 signature in cookies", () => {
+      const cookies = getSignedCookies({
+        url,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+        algorithm: "SHA256",
+      });
+
+      expect(cookies["CloudFront-Key-Pair-Id"]).toBe(keyPairId);
+      expect(cookies["CloudFront-Hash-Algorithm"]).toBe("SHA256");
+
+      const epochTime = Math.round(new Date(dateLessThan).getTime() / 1000);
+      const expectedPolicy = JSON.stringify({
+        Statement: [{ Resource: url, Condition: { DateLessThan: { "AWS:EpochTime": epochTime } } }],
+      });
+
+      expect(verifySignature(expectedPolicy, cookies["CloudFront-Signature"], "RSA-SHA256")).toBe(true);
+    });
+
+    it("should not include CloudFront-Hash-Algorithm when using default", () => {
+      const cookies = getSignedCookies({
+        url,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+      });
+      expect(cookies["CloudFront-Hash-Algorithm"]).toBeUndefined();
+    });
+  });
+
+  describe("algorithm backward compatibility", () => {
+    it("should default to SHA1 when algorithm is not specified", () => {
+      const signedUrl = getSignedUrl({ url, keyPairId, dateLessThan, privateKey });
+      const urlObj = new URL(signedUrl);
+      expect(urlObj.searchParams.get("Hash-Algorithm")).toBeNull();
+      expect(urlObj.searchParams.get("Expires")).toBeDefined();
+    });
+
+    it("should explicitly accept SHA1 algorithm", () => {
+      const signedUrl = getSignedUrl({ url, keyPairId, dateLessThan, privateKey, algorithm: "SHA1" });
+      const urlObj = new URL(signedUrl);
+      expect(urlObj.searchParams.get("Hash-Algorithm")).toBeNull();
+    });
+  });
+});

--- a/packages/cloudfront-signer/src/index.ts
+++ b/packages/cloudfront-signer/src/index.ts
@@ -1,1 +1,10 @@
-export * from "./sign";
+export type {
+  CloudfrontSignerAlgorithm,
+  CloudfrontSignerCredentials,
+  CloudfrontSignInput,
+  CloudfrontSignInputWithParameters,
+  CloudfrontSignInputWithPolicy,
+  CloudfrontSignedCookiesOutput,
+  CloudfrontSignInputBase,
+} from "./sign";
+export { getSignedUrl, getSignedCookies } from "./sign";

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -973,3 +973,131 @@ describe("url component encoding", () => {
     expect(signedUrl.slice(0, target.length)).toBe(target);
   });
 });
+
+describe("SHA-256 algorithm support", () => {
+  describe("getSignedUrl with algorithm SHA256", () => {
+    it("should include Hash-Algorithm=SHA256 query parameter", () => {
+      const signedUrl = getSignedUrl({
+        url,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+        algorithm: "SHA256",
+      });
+      const parsed = parseUrl(signedUrl);
+      expect(parsed.query?.["Hash-Algorithm"]).toBe("SHA256");
+    });
+
+    it("should produce a valid RSA-SHA256 signature", () => {
+      const signedUrl = getSignedUrl({
+        url,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+        algorithm: "SHA256",
+      });
+      const parsed = parseUrl(signedUrl);
+      const signature = denormalizeBase64(parsed.query!["Signature"] as string);
+
+      // Build the expected canned policy
+      const expectedPolicy = JSON.stringify({
+        Statement: [
+          {
+            Resource: "https://d111111abcdef8.cloudfront.net/private-content/private.jpeg",
+            Condition: { DateLessThan: { "AWS:EpochTime": epochDateLessThan } },
+          },
+        ],
+      });
+
+      const verifier = createVerify("RSA-SHA256");
+      verifier.update(expectedPolicy);
+      expect(verifier.verify(privateKey, signature, "base64")).toBe(true);
+    });
+
+    it("should produce a different signature than SHA1 for the same input", () => {
+      const sha1Url = getSignedUrl({ url, keyPairId, dateLessThan, privateKey, algorithm: "SHA1" });
+      const sha256Url = getSignedUrl({ url, keyPairId, dateLessThan, privateKey, algorithm: "SHA256" });
+
+      const sha1Sig = parseUrl(sha1Url).query!["Signature"];
+      const sha256Sig = parseUrl(sha256Url).query!["Signature"];
+      expect(sha1Sig).not.toBe(sha256Sig);
+    });
+
+    it("should not include Hash-Algorithm param when algorithm is SHA1 (default)", () => {
+      const signedUrl = getSignedUrl({
+        url,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+      });
+      const parsed = parseUrl(signedUrl);
+      expect(parsed.query?.["Hash-Algorithm"]).toBeUndefined();
+    });
+
+    it("should work with custom policy and SHA256", () => {
+      const customPolicy = JSON.stringify({
+        Statement: [
+          {
+            Resource: url,
+            Condition: {
+              DateLessThan: { "AWS:EpochTime": epochDateLessThan },
+              DateGreaterThan: { "AWS:EpochTime": epochDateGreaterThan },
+            },
+          },
+        ],
+      });
+      const signedUrl = getSignedUrl({
+        url,
+        keyPairId,
+        privateKey,
+        policy: customPolicy,
+        algorithm: "SHA256",
+      });
+      const parsed = parseUrl(signedUrl);
+      expect(parsed.query?.["Hash-Algorithm"]).toBe("SHA256");
+      expect(parsed.query?.["Policy"]).toBeDefined();
+
+      const signature = denormalizeBase64(parsed.query!["Signature"] as string);
+      const verifier = createVerify("RSA-SHA256");
+      verifier.update(customPolicy);
+      expect(verifier.verify(privateKey, signature, "base64")).toBe(true);
+    });
+  });
+
+  describe("getSignedCookies with algorithm SHA256", () => {
+    it("should produce a valid RSA-SHA256 signature in cookies", () => {
+      const cookies = getSignedCookies({
+        url,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+        algorithm: "SHA256",
+      });
+
+      const signature = denormalizeBase64(cookies["CloudFront-Signature"]);
+      const expectedPolicy = JSON.stringify({
+        Statement: [
+          {
+            Resource: "https://d111111abcdef8.cloudfront.net/private-content/private.jpeg",
+            Condition: { DateLessThan: { "AWS:EpochTime": epochDateLessThan } },
+          },
+        ],
+      });
+
+      const verifier = createVerify("RSA-SHA256");
+      verifier.update(expectedPolicy);
+      expect(verifier.verify(privateKey, signature, "base64")).toBe(true);
+      expect(cookies["CloudFront-Hash-Algorithm"]).toBe("SHA256");
+    });
+
+    it("should not include CloudFront-Hash-Algorithm when using default SHA1", () => {
+      const cookies = getSignedCookies({
+        url,
+        keyPairId,
+        dateLessThan,
+        privateKey,
+      });
+      expect(cookies["CloudFront-Hash-Algorithm"]).toBeUndefined();
+    });
+  });
+});

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -8,6 +8,13 @@ import { createSign } from "node:crypto";
 export type CloudfrontSignInput = CloudfrontSignInputWithParameters | CloudfrontSignInputWithPolicy;
 
 /**
+ * The hash algorithm used for signing.
+ * @see https://aws.amazon.com/about-aws/whats-new/2026/04/amazon-cloudfront-sha-256-signed-urls/
+ * @public
+ */
+export type CloudfrontSignerAlgorithm = "SHA1" | "SHA256";
+
+/**
  * @public
  */
 export type CloudfrontSignerCredentials = {
@@ -17,8 +24,17 @@ export type CloudfrontSignerCredentials = {
   /** The content of the Cloudfront private key. */
   privateKey: string | Buffer;
 
-  /** The passphrase of RSA-SHA1 key*/
+  /** The passphrase of the RSA key. */
   passphrase?: string;
+
+  /**
+   * The hash algorithm to use for signing.
+   * When set to "SHA256", the signed URL will include a Hash-Algorithm=SHA256 query parameter
+   * as required by CloudFront for FIPS 140-3 compliance.
+   *
+   * Default "SHA1".
+   */
+  algorithm?: CloudfrontSignerAlgorithm;
 };
 
 /**
@@ -86,6 +102,9 @@ export interface CloudfrontSignedCookiesOutput {
 
   /** Base64-encoded version of the JSON policy. */
   "CloudFront-Policy"?: string;
+
+  /** The hash algorithm used for signing. Present when algorithm is SHA256. */
+  "CloudFront-Hash-Algorithm"?: string;
 }
 
 /**
@@ -102,11 +121,13 @@ export function getSignedUrl({
   ipAddress,
   policy,
   passphrase,
+  algorithm,
 }: CloudfrontSignInput): string {
   const cloudfrontSignBuilder = new CloudfrontSignBuilder({
     keyPairId,
     privateKey,
     passphrase,
+    algorithm,
   });
 
   if (!url && !policy) {
@@ -142,7 +163,11 @@ export function getSignedUrl({
   }
 
   const startFlag = baseUrl!.includes("?") ? "&" : "?";
-  const params = Object.entries(cloudfrontSignBuilder.createCloudfrontAttribute())
+  const attributes = cloudfrontSignBuilder.createCloudfrontAttribute();
+  if (algorithm === "SHA256") {
+    attributes["Hash-Algorithm"] = "SHA256";
+  }
+  const params = Object.entries(attributes)
     .filter(([, value]) => value !== undefined)
     .map(([key, value]) => `${extendedEncodeURIComponent(key)}=${extendedEncodeURIComponent(value)}`)
     .join("&");
@@ -166,11 +191,13 @@ export function getSignedCookies({
   dateGreaterThan,
   policy,
   passphrase,
+  algorithm,
 }: CloudfrontSignInput): CloudfrontSignedCookiesOutput {
   const cloudfrontSignBuilder = new CloudfrontSignBuilder({
     keyPairId,
     privateKey,
     passphrase,
+    algorithm,
   });
   if (policy) {
     cloudfrontSignBuilder.setCustomPolicy(policy);
@@ -192,6 +219,9 @@ export function getSignedCookies({
   }
   if (cloudfrontCookieAttributes["Policy"]) {
     cookies["CloudFront-Policy"] = cloudfrontCookieAttributes["Policy"];
+  }
+  if (algorithm === "SHA256") {
+    cookies["CloudFront-Hash-Algorithm"] = "SHA256";
   }
   return cookies;
 }
@@ -239,6 +269,7 @@ interface CloudfrontAttributes {
   Policy?: string;
   "Key-Pair-Id": string;
   Signature: string;
+  "Hash-Algorithm"?: string;
 }
 
 /**
@@ -325,15 +356,17 @@ class CloudfrontSignBuilder {
   private keyPairId: string;
   private privateKey: string | Buffer;
   private passphrase?: string;
+  private algorithm: CloudfrontSignerAlgorithm;
   private policy: string;
   private customPolicy = false;
   private dateLessThan?: number | undefined;
 
-  constructor({ privateKey, keyPairId, passphrase }: CloudfrontSignerCredentials) {
+  constructor({ privateKey, keyPairId, passphrase, algorithm }: CloudfrontSignerCredentials) {
     this.keyPairId = keyPairId;
     this.privateKey = privateKey;
     this.policy = "";
     this.passphrase = passphrase;
+    this.algorithm = algorithm ?? "SHA1";
   }
 
   private buildPolicy(args: BuildPolicyInput): Policy {
@@ -447,7 +480,7 @@ class CloudfrontSignBuilder {
   }
 
   private signData(data: string, privateKey: string | Buffer, passphrase?: string): string {
-    const sign = createSign("RSA-SHA1");
+    const sign = createSign(this.algorithm === "SHA256" ? "RSA-SHA256" : "RSA-SHA1");
     sign.update(data);
     return sign.sign({ key: privateKey, passphrase }, "base64");
   }

--- a/packages/cloudfront-signer/vitest.config.e2e.mts
+++ b/packages/cloudfront-signer/vitest.config.e2e.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.e2e.spec.ts"],
+    environment: "node",
+  },
+});

--- a/packages/cloudfront-signer/vitest.config.integ.mts
+++ b/packages/cloudfront-signer/vitest.config.integ.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.integ.spec.ts"],
+    environment: "node",
+  },
+});

--- a/scripts/validation/api.json
+++ b/scripts/validation/api.json
@@ -10,6 +10,7 @@
   },
   "@aws-sdk/cloudfront-signer": {
     "CloudfrontSignedCookiesOutput": "type(interface)",
+    "CloudfrontSignerAlgorithm": "type(union)",
     "CloudfrontSignerCredentials": "type(object)",
     "CloudfrontSignInput": "type(union)",
     "CloudfrontSignInputBase": "type(object)",


### PR DESCRIPTION
### Issue
https://aws.amazon.com/about-aws/whats-new/2026/04/amazon-cloudfront-sha-256-signed-urls/

### Description
Updates `@aws-sdk/cloudfront-signer` to enable use of the new option introduced by Amazon CloudFront.

### Testing
added unit, integ, e2e tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [x] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [ ] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
