### PR TITLE
chore(scripts): modify api-snapshot to allow automated updates to lib-dynamodb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ api-snapshot:
 	node ./scripts/validation/api-snapshot.js
 	git diff --exit-code scripts/validation/api.json
 
+update-lib-dynamodb-snapshot:
+	node ./scripts/validation/api-snapshot.js --update-lib-dynamodb
+
 test-endpoints:
 	npx vitest run -c ./tests/endpoints-2.0/vitest.config.mts
 

--- a/scripts/validation/api-snapshot.js
+++ b/scripts/validation/api-snapshot.js
@@ -11,6 +11,8 @@ const fs = require("node:fs");
 const path = require("node:path");
 const ts = require("typescript");
 
+const updateLibDynamodb = process.argv.includes("--update-lib-dynamodb");
+
 const root = path.join(__dirname, "..", "..");
 const dataPath = path.join(root, "scripts", "validation", "api.json");
 const api = require(dataPath);
@@ -190,8 +192,14 @@ function checkModule(name, version, module, typeExports) {
 
       if (inCurrent && !inSnapshot) {
         const kind = inRuntime ? typeof module[symbol] : typeExports.get(symbol);
-        errors.push(`You must commit changes in api.json adding ${symbol} (${kind}) to ${name}.`);
-        api[name][symbol] = kind;
+        if (name === "@aws-sdk/lib-dynamodb" && !updateLibDynamodb) {
+          console.warn(
+            `⚠️  New symbol ${symbol} (${kind}) found in ${name} but not added to api snapshot. Run with --update-lib-dynamodb to update.`
+          );
+        } else {
+          errors.push(`You must commit changes in api.json adding ${symbol} (${kind}) to ${name}.`);
+          api[name][symbol] = kind;
+        }
       }
       if (!inCurrent && inSnapshot) {
         errors.push(`Symbol [${symbol}] is missing from ${name}, (${api[name][symbol]}).`);


### PR DESCRIPTION
### Issue
P441280701

### Description
allow generated changes to lib-dynamodb's api surface

### Testing
CI (make api-snapshot)

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
