### PR TITLE
feat(rds-signer): automatically refresh AWS credentials before getting token

### DIFF
--- a/packages/rds-signer/src/Signer.spec.ts
+++ b/packages/rds-signer/src/Signer.spec.ts
@@ -104,4 +104,108 @@ describe("rds-signer", () => {
     const token = await signer.getAuthToken();
     expect(token).toBe("testhost:5432?other=url&parameters=here");
   });
+
+  describe("credential refresh wrapper", () => {
+    it("should not force refresh when credentials have no expiration", async () => {
+      const provider = vi.fn().mockResolvedValue({
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+      });
+      const signer = new Signer({ ...minimalParams, credentials: provider });
+      await signer.getAuthToken();
+      //@ts-ignore
+      const wrappedProvider = SignatureV4.mock.calls[0][0].credentials;
+      await wrappedProvider();
+      expect(provider).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not force refresh when credentials expire in more than 15 minutes", async () => {
+      const provider = vi.fn().mockResolvedValue({
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+        expiration: new Date(Date.now() + 20 * 60_000),
+      });
+      const signer = new Signer({ ...minimalParams, credentials: provider });
+      await signer.getAuthToken();
+      //@ts-ignore
+      const wrappedProvider = SignatureV4.mock.calls[0][0].credentials;
+      await wrappedProvider();
+      expect(provider).toHaveBeenCalledTimes(1);
+    });
+
+    it("should force refresh when credentials expire within 15 minutes", async () => {
+      const refreshedCreds = {
+        accessKeyId: "refreshed",
+        secretAccessKey: "secret",
+        expiration: new Date(Date.now() + 60 * 60_000),
+      };
+      const provider = vi
+        .fn()
+        .mockResolvedValueOnce({
+          accessKeyId: "expiring",
+          secretAccessKey: "secret",
+          expiration: new Date(Date.now() + 2 * 60_000),
+        })
+        .mockResolvedValueOnce(refreshedCreds);
+      const signer = new Signer({ ...minimalParams, credentials: provider });
+      await signer.getAuthToken();
+      //@ts-ignore
+      const wrappedProvider = SignatureV4.mock.calls[0][0].credentials;
+      const result = await wrappedProvider();
+      expect(provider).toHaveBeenCalledTimes(2);
+      expect(provider).toHaveBeenLastCalledWith(expect.objectContaining({ forceRefresh: true }));
+      expect(result).toEqual(refreshedCreds);
+    });
+
+    it("should return original credentials if refresh still expires within 15 minutes", async () => {
+      const originalCreds = {
+        accessKeyId: "expiring",
+        secretAccessKey: "secret",
+        expiration: new Date(Date.now() + 2 * 60_000),
+      };
+      const provider = vi
+        .fn()
+        .mockResolvedValueOnce(originalCreds)
+        .mockResolvedValueOnce({
+          accessKeyId: "still-expiring",
+          secretAccessKey: "secret",
+          expiration: new Date(Date.now() + 3 * 60_000),
+        });
+      const signer = new Signer({ ...minimalParams, credentials: provider });
+      await signer.getAuthToken();
+      //@ts-ignore
+      const wrappedProvider = SignatureV4.mock.calls[0][0].credentials;
+      const result = await wrappedProvider();
+      expect(provider).toHaveBeenCalledTimes(2);
+      expect(result).toEqual(originalCreds);
+    });
+
+    it("should return original credentials if force refresh throws", async () => {
+      const originalCreds = {
+        accessKeyId: "expiring",
+        secretAccessKey: "secret",
+        expiration: new Date(Date.now() + 2 * 60_000),
+      };
+      const provider = vi.fn().mockResolvedValueOnce(originalCreds).mockRejectedValueOnce(new Error("refresh failed"));
+      const signer = new Signer({ ...minimalParams, credentials: provider });
+      await signer.getAuthToken();
+      //@ts-ignore
+      const wrappedProvider = SignatureV4.mock.calls[0][0].credentials;
+      const result = await wrappedProvider();
+      expect(provider).toHaveBeenCalledTimes(2);
+      expect(result).toEqual(originalCreds);
+    });
+
+    it("should not wrap static credential objects", async () => {
+      const staticCreds = {
+        accessKeyId: "static",
+        secretAccessKey: "secret",
+        expiration: new Date(Date.now() + 2 * 60_000),
+      };
+      const signer = new Signer({ ...minimalParams, credentials: staticCreds });
+      await signer.getAuthToken();
+      //@ts-ignore
+      expect(SignatureV4.mock.calls[0][0].credentials).toEqual(staticCreds);
+    });
+  });
 });

--- a/packages/rds-signer/src/Signer.ts
+++ b/packages/rds-signer/src/Signer.ts
@@ -50,6 +50,8 @@ export interface SignerConfig {
   profile?: string;
 }
 
+const MINUTE_MS = 60_000;
+
 /**
  * The signer class that generates an auth token to a database.
  */
@@ -66,7 +68,8 @@ export class Signer {
   constructor(configuration: SignerConfig) {
     const runtimeConfiguration = __getRuntimeConfig(configuration);
 
-    this.credentials = runtimeConfiguration.credentials;
+    const creds = runtimeConfiguration.credentials;
+    this.credentials = typeof creds === "function" ? this.createCredentialsWrapper(creds) : creds;
     this.hostname = runtimeConfiguration.hostname;
     this.port = runtimeConfiguration.port;
     this.region = runtimeConfiguration.region;
@@ -103,5 +106,25 @@ export class Signer {
     // RDS requires the scheme to be removed
     // https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html
     return formatUrl(presigned).replace(`${this.protocol}//`, "");
+  }
+
+  /**
+   * Wraps a credential provider to force refresh when the resolved credentials
+   * expire within 15 minutes. A presigned URL cannot outlive the credentials
+   * used to sign it, so near-expiry credentials would produce a short-lived token.
+   */
+  private createCredentialsWrapper(provider: AwsCredentialIdentityProvider): AwsCredentialIdentityProvider {
+    return async (identityProperties?: Record<string, any>) => {
+      const credentials = await provider(identityProperties);
+      if (credentials.expiration && credentials.expiration.getTime() - Date.now() < 15 * MINUTE_MS) {
+        try {
+          const refreshed = await provider({ ...identityProperties, forceRefresh: true });
+          if (!refreshed.expiration || refreshed.expiration.getTime() - Date.now() >= 15 * MINUTE_MS) {
+            return refreshed;
+          }
+        } catch {}
+      }
+      return credentials;
+    };
   }
 }

--- a/packages/rds-signer/src/rds-signer.integ.spec.ts
+++ b/packages/rds-signer/src/rds-signer.integ.spec.ts
@@ -28,4 +28,40 @@ describe("rds-signer integration", () => {
       /X-Amz-SignedHeaders=host/,
     ]);
   });
+
+  it("force refreshes credentials expiring within 15 minutes", async () => {
+    let callCount = 0;
+
+    const provider = async (options?: Record<string, any>) => {
+      ++callCount;
+      if (callCount === 1) {
+        return {
+          accessKeyId: "EXPIRING_KEY",
+          secretAccessKey: "secret",
+          expiration: new Date(Date.now() + 14 * 60_000),
+        };
+      }
+      return {
+        accessKeyId: "REFRESHED_KEY",
+        secretAccessKey: "secret",
+        expiration: new Date(Date.now() + 60 * 60_000),
+      };
+    };
+
+    const signer = new Signer({
+      credentials: provider,
+      username: "me",
+      hostname: "localhost",
+      port: 443,
+      region: "us-west-2",
+    });
+
+    const token = await signer.getAuthToken();
+
+    expect(callCount).toBe(2);
+    expect(token).toContain("X-Amz-Credential=REFRESHED_KEY");
+    expect(token).not.toContain("EXPIRING_KEY");
+    expect(token).toContain("X-Amz-Expires=900");
+    expect(token).not.toMatch(/^https?:\/\//);
+  });
 });


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8047

### Description
make one attempt to refresh credentials from the provider function if the current credentials would not lease an RDS token of at least 15 minutes.

### Testing
added unit tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
