### PR TITLE
fix(credential-provider-node): update cached credential on forceRefresh

### DIFF
--- a/packages-internal/credential-provider-node/src/runtime/memoize-chain.spec.ts
+++ b/packages-internal/credential-provider-node/src/runtime/memoize-chain.spec.ts
@@ -136,26 +136,60 @@ describe("memoize runtime config aware AWS credential chain", () => {
   it("can be force refreshed", async () => {
     const provider = memoizeChain([expiringCredentials], credentialsWillNeedRefresh);
 
-    const credentials = await Promise.all([
+    // Initial call to populate cache with sequence 0.
+    await provider();
+    expect(expiringCredentials).toHaveBeenCalledTimes(1);
+
+    // Force refresh gets new credentials.
+    const refreshed = await provider({ forceRefresh: true });
+    expect(expiringCredentials).toHaveBeenCalledTimes(2);
+    expect(refreshed).toEqual({
+      accessKeyId: "",
+      secretAccessKey: "",
+      expiration,
+      sequence: 1,
+      runtimeOptions: ["forceRefresh"],
+    });
+  });
+
+  it("should coalesce concurrent forceRefresh calls to prevent stampede", async () => {
+    const provider = memoizeChain([expiringCredentials], credentialsWillNeedRefresh);
+
+    // Populate cache first.
+    await provider();
+    expect(expiringCredentials).toHaveBeenCalledTimes(1);
+
+    // 5 concurrent forceRefresh calls should coalesce into 1 upstream call.
+    const results = await Promise.all([
       provider({ forceRefresh: true }),
       provider({ forceRefresh: true }),
       provider({ forceRefresh: true }),
       provider({ forceRefresh: true }),
       provider({ forceRefresh: true }),
     ]);
-    let sequence = 0;
+    expect(expiringCredentials).toHaveBeenCalledTimes(2);
 
-    for (const c of credentials) {
-      expect(c).toEqual({
-        accessKeyId: "",
-        secretAccessKey: "",
-        expiration,
-        sequence: sequence++,
-        runtimeOptions: ["forceRefresh"],
-      });
+    // All results should be the same credentials object.
+    for (const r of results) {
+      expect(r).toBe(results[0]);
     }
+  });
 
-    expect(expiringCredentials).toHaveBeenCalledTimes(5);
+  it("should update cache on forceRefresh so subsequent calls return refreshed credentials", async () => {
+    const provider = memoizeChain([staticCredentials], credentialsWillNeedRefresh);
+
+    // Initial call populates cache.
+    await provider();
+    expect(staticCredentials).toHaveBeenCalledTimes(1);
+
+    // Force refresh updates cache.
+    const refreshed = await provider({ forceRefresh: true });
+    expect(staticCredentials).toHaveBeenCalledTimes(2);
+
+    // Subsequent call without forceRefresh returns cached (refreshed) value.
+    const cached = await provider();
+    expect(staticCredentials).toHaveBeenCalledTimes(2);
+    expect(cached).toBe(refreshed);
   });
 
   it("should release locks on credential resolution failure at the end of the chain", async () => {

--- a/packages-internal/credential-provider-node/src/runtime/memoize-chain.ts
+++ b/packages-internal/credential-provider-node/src/runtime/memoize-chain.ts
@@ -30,9 +30,21 @@ export function memoizeChain(
   let passiveLock: Promise<void> | undefined;
   let credentials: AwsCredentialIdentity | undefined;
 
+  let forceRefreshLock: Promise<void> | undefined;
+
   const provider = async (options?: AwsIdentityProperties & { forceRefresh?: boolean }) => {
     if (options?.forceRefresh) {
-      return await chain(options);
+      if (!forceRefreshLock) {
+        forceRefreshLock = chain(options)
+          .then((c) => {
+            credentials = c;
+          })
+          .finally(() => {
+            forceRefreshLock = undefined;
+          });
+      }
+      await forceRefreshLock;
+      return credentials!;
     }
     if (credentials?.expiration) {
       if (credentials?.expiration?.getTime() < Date.now()) {

--- a/packages-internal/credential-provider-node/tests/credential-provider-node.integ.spec.ts
+++ b/packages-internal/credential-provider-node/tests/credential-provider-node.integ.spec.ts
@@ -1327,6 +1327,60 @@ describe("credential-provider-node integration test", () => {
     });
   });
 
+  describe("forceRefresh should update credentials returned by the cache", () => {
+    it("subsequent calls without forceRefresh return the refreshed credentials", async () => {
+      process.env.AWS_ACCESS_KEY_ID = "ORIGINAL_KEY";
+      process.env.AWS_SECRET_ACCESS_KEY = "ORIGINAL_SECRET";
+
+      const provider = defaultProvider();
+
+      const credentials1 = await provider();
+      expect(credentials1.accessKeyId).toBe("ORIGINAL_KEY");
+
+      process.env.AWS_ACCESS_KEY_ID = "REFRESHED_KEY";
+      process.env.AWS_SECRET_ACCESS_KEY = "REFRESHED_SECRET";
+
+      const credentials2 = await provider();
+      expect(credentials2.accessKeyId).toBe("ORIGINAL_KEY");
+
+      const credentials3 = await provider({ forceRefresh: true });
+      expect(credentials3.accessKeyId).toBe("REFRESHED_KEY");
+
+      const credentials4 = await provider();
+      expect(credentials4.accessKeyId).toBe("REFRESHED_KEY");
+    });
+
+    it("works with INI profile credentials", async () => {
+      setIniProfileData({
+        default: {
+          aws_access_key_id: "INI_ORIGINAL",
+          aws_secret_access_key: "INI_SECRET",
+        },
+      });
+
+      const provider = defaultProvider();
+
+      const credentials1 = await provider();
+      expect(credentials1.accessKeyId).toBe("INI_ORIGINAL");
+
+      setIniProfileData({
+        default: {
+          aws_access_key_id: "INI_REFRESHED",
+          aws_secret_access_key: "INI_SECRET",
+        },
+      });
+
+      const credentials2 = await provider();
+      expect(credentials2.accessKeyId).toBe("INI_ORIGINAL");
+
+      const credentials3 = await provider({ forceRefresh: true });
+      expect(credentials3.accessKeyId).toBe("INI_REFRESHED");
+
+      const credentials4 = await provider();
+      expect(credentials4.accessKeyId).toBe("INI_REFRESHED");
+    });
+  });
+
   describe("No credentials available", () => {
     it("should throw CredentialsProviderError", async () => {
       process.env.AWS_EC2_METADATA_DISABLED = "true";


### PR DESCRIPTION
### Issue
noticed during https://github.com/aws/aws-sdk-js-v3/pull/8054

### Description
Change memoization behavior. When forceRefresh is called, save the new credentials as cached so they are returned on subsequent calls.

This is consistent with memoization of providers done in `@smithy`, which was originally used by the SDK.

### Testing
new integ tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
