### PR TITLE
chore(lib-dynamodb): fix eslint ignore paths

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,11 +34,11 @@ module.exports = {
   ignorePatterns: [
     "packages/nested-clients/src/submodules/**/protocols/*.ts",
     "packages/nested-clients/src/submodules/**/models/*.ts",
-    "lib/lib-dynamodb/commands/*.ts",
-    "lib/lib-dynamodb/pagination/*.ts",
-    "lib/lib-dynamodb/DynamoDBDocument.ts",
-    "lib/lib-dynamodb/DynamoDBDocumentClient.ts",
-    "lib/lib-dynamodb/index.ts",
+    "lib/lib-dynamodb/src/commands/*.ts",
+    "lib/lib-dynamodb/src/pagination/*.ts",
+    "lib/lib-dynamodb/src/DynamoDBDocument.ts",
+    "lib/lib-dynamodb/src/DynamoDBDocumentClient.ts",
+    "lib/lib-dynamodb/src/index.ts",
   ],
   overrides: [
     {


### PR DESCRIPTION
### Issue
P443391196

### Description
eslint ignore paths are incorrect for ignoring changes to lib-dynamodb caused by regeneration caused by updates to client-dynamodb

### Testing
n/a

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
