### PR TITLE
fix(client-dynamodb): dynamodb special retry config fixed to be merge-compatible with user-supplied retry config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ sync:
 	make -f Makefile.private.mk sync
 
 bundles: build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle
+	node ./packages-internal/core/scripts/browser-build/esbuild.js
 
 test-unit: bundles
 	yarn g:vitest run -c vitest.config.mts

--- a/clients/client-dynamodb-streams/src/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/src/DynamoDBStreamsClient.ts
@@ -30,6 +30,7 @@ import {
   type RetryResolvedConfig,
   getRetryPlugin,
   resolveRetryConfig,
+  Retry,
 } from "@smithy/core/retry";
 import { getSchemaSerdePlugin } from "@smithy/core/schema";
 import type {
@@ -302,7 +303,7 @@ export class DynamoDBStreamsClient extends __Client<
     this.initConfig = _config_0;
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveUserAgentConfig(_config_1);
-    const _config_3 = resolveRetryConfig(_config_2);
+    const _config_3 = resolveRetryConfig(_config_2, { defaultBaseDelay: Retry.v2026 ? 25 : undefined, defaultMaxAttempts: Retry.v2026 ? 4 : undefined });
     const _config_4 = resolveRegionConfig(_config_3);
     const _config_5 = resolveHostHeaderConfig(_config_4);
     const _config_6 = resolveEndpointConfig(_config_5);

--- a/clients/client-dynamodb-streams/src/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb-streams/src/runtimeConfig.browser.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_USE_FIPS_ENDPOINT,
   resolveDefaultsModeConfig,
 } from "@smithy/core/config";
-import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/core/retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE, Retry } from "@smithy/core/retry";
 import { calculateBodyLength } from "@smithy/core/serde";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
 
@@ -32,7 +32,7 @@ export const getRuntimeConfig = (config: DynamoDBStreamsClientConfig) => {
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
     credentialDefaultProvider: config?.credentialDefaultProvider ?? ((_: unknown) => () => Promise.reject(new Error("Credential is missing"))),
     defaultUserAgentProvider: config?.defaultUserAgentProvider ?? createDefaultUserAgentProvider({serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version}),
-    maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    maxAttempts: config?.maxAttempts ?? (Retry.v2026 ? 4 : DEFAULT_MAX_ATTEMPTS),
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),

--- a/clients/client-dynamodb-streams/src/runtimeConfig.shared.ts
+++ b/clients/client-dynamodb-streams/src/runtimeConfig.shared.ts
@@ -3,7 +3,6 @@ import { AwsSdkSigV4Signer } from "@aws-sdk/core/httpAuthSchemes";
 import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { NoOpLogger } from "@smithy/core/client";
 import { parseUrl } from "@smithy/core/protocols";
-import { Retry, StandardRetryStrategy } from "@smithy/core/retry";
 import { fromBase64, fromUtf8, toBase64, toUtf8 } from "@smithy/core/serde";
 import type { IdentityProviderConfig } from "@smithy/types";
 
@@ -41,14 +40,6 @@ export const getRuntimeConfig = (config: DynamoDBStreamsClientConfig) => {
       version: "2012-08-10",
       serviceTarget: "DynamoDBStreams_20120810",
     },
-    retryStrategy: config?.retryStrategy ?? (
-      config?.maxAttempts == null && config?.retryMode == null && Retry.v2026
-        ? new StandardRetryStrategy({
-            maxAttempts: 4,
-            baseDelay: 25,
-          })
-        : undefined
-    ),
     serviceId: config?.serviceId ?? "DynamoDB Streams",
     urlParser: config?.urlParser ?? parseUrl,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,

--- a/clients/client-dynamodb-streams/src/runtimeConfig.ts
+++ b/clients/client-dynamodb-streams/src/runtimeConfig.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_RETRY_MODE,
   NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
   NODE_RETRY_MODE_CONFIG_OPTIONS,
+  Retry,
 } from "@smithy/core/retry";
 import { calculateBodyLength, Hash } from "@smithy/core/serde";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
@@ -51,7 +52,7 @@ export const getRuntimeConfig = (config: DynamoDBStreamsClientConfig) => {
     bodyLengthChecker: config?.bodyLengthChecker ?? calculateBodyLength,
     credentialDefaultProvider: config?.credentialDefaultProvider ?? credentialDefaultProvider,
     defaultUserAgentProvider: config?.defaultUserAgentProvider ?? createDefaultUserAgentProvider({serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version}),
-    maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
+    maxAttempts: config?.maxAttempts ?? loadNodeConfig(Retry.v2026 ? { ...NODE_MAX_ATTEMPT_CONFIG_OPTIONS, default: 4 } : NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
     region: config?.region ?? loadNodeConfig(
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}

--- a/clients/client-dynamodb/src/DynamoDBClient.ts
+++ b/clients/client-dynamodb/src/DynamoDBClient.ts
@@ -41,6 +41,7 @@ import {
   type RetryResolvedConfig,
   getRetryPlugin,
   resolveRetryConfig,
+  Retry,
 } from "@smithy/core/retry";
 import { getSchemaSerdePlugin } from "@smithy/core/schema";
 import type {
@@ -586,7 +587,7 @@ export class DynamoDBClient extends __Client<
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveAccountIdEndpointModeConfig(_config_1);
     const _config_3 = resolveUserAgentConfig(_config_2);
-    const _config_4 = resolveRetryConfig(_config_3);
+    const _config_4 = resolveRetryConfig(_config_3, { defaultBaseDelay: Retry.v2026 ? 25 : undefined, defaultMaxAttempts: Retry.v2026 ? 4 : undefined });
     const _config_5 = resolveRegionConfig(_config_4);
     const _config_6 = resolveHostHeaderConfig(_config_5);
     const _config_7 = resolveEndpointConfig(_config_6);

--- a/clients/client-dynamodb/src/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb/src/runtimeConfig.browser.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_USE_FIPS_ENDPOINT,
   resolveDefaultsModeConfig,
 } from "@smithy/core/config";
-import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@smithy/core/retry";
+import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE, Retry } from "@smithy/core/retry";
 import { calculateBodyLength } from "@smithy/core/serde";
 import { FetchHttpHandler as RequestHandler, streamCollector } from "@smithy/fetch-http-handler";
 
@@ -35,7 +35,7 @@ export const getRuntimeConfig = (config: DynamoDBClientConfig) => {
     credentialDefaultProvider: config?.credentialDefaultProvider ?? ((_: unknown) => () => Promise.reject(new Error("Credential is missing"))),
     defaultUserAgentProvider: config?.defaultUserAgentProvider ?? createDefaultUserAgentProvider({serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version}),
     endpointDiscoveryEnabledProvider: config?.endpointDiscoveryEnabledProvider ?? (() => Promise.resolve(undefined)),
-    maxAttempts: config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    maxAttempts: config?.maxAttempts ?? (Retry.v2026 ? 4 : DEFAULT_MAX_ATTEMPTS),
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: RequestHandler.create(config?.requestHandler ?? defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),

--- a/clients/client-dynamodb/src/runtimeConfig.shared.ts
+++ b/clients/client-dynamodb/src/runtimeConfig.shared.ts
@@ -4,7 +4,6 @@ import { AwsJson1_0Protocol } from "@aws-sdk/core/protocols";
 import { DynamoDBJsonCodec } from "@aws-sdk/dynamodb-codec";
 import { NoOpLogger } from "@smithy/core/client";
 import { parseUrl } from "@smithy/core/protocols";
-import { Retry, StandardRetryStrategy } from "@smithy/core/retry";
 import { fromBase64, fromUtf8, toBase64, toUtf8 } from "@smithy/core/serde";
 import type { IdentityProviderConfig } from "@smithy/types";
 
@@ -43,14 +42,6 @@ export const getRuntimeConfig = (config: DynamoDBClientConfig) => {
       serviceTarget: "DynamoDB_20120810",
       jsonCodec: new DynamoDBJsonCodec(),
     },
-    retryStrategy: config?.retryStrategy ?? (
-      config?.maxAttempts == null && config?.retryMode == null && Retry.v2026
-        ? new StandardRetryStrategy({
-            maxAttempts: 4,
-            baseDelay: 25,
-          })
-        : undefined
-    ),
     serviceId: config?.serviceId ?? "DynamoDB",
     urlParser: config?.urlParser ?? parseUrl,
     utf8Decoder: config?.utf8Decoder ?? fromUtf8,

--- a/clients/client-dynamodb/src/runtimeConfig.ts
+++ b/clients/client-dynamodb/src/runtimeConfig.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_RETRY_MODE,
   NODE_MAX_ATTEMPT_CONFIG_OPTIONS,
   NODE_RETRY_MODE_CONFIG_OPTIONS,
+  Retry,
 } from "@smithy/core/retry";
 import { calculateBodyLength, Hash } from "@smithy/core/serde";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@smithy/node-http-handler";
@@ -55,7 +56,7 @@ export const getRuntimeConfig = (config: DynamoDBClientConfig) => {
     credentialDefaultProvider: config?.credentialDefaultProvider ?? credentialDefaultProvider,
     defaultUserAgentProvider: config?.defaultUserAgentProvider ?? createDefaultUserAgentProvider({serviceId: clientSharedValues.serviceId, clientVersion: packageInfo.version}),
     endpointDiscoveryEnabledProvider: config?.endpointDiscoveryEnabledProvider ?? loadNodeConfig(NODE_ENDPOINT_DISCOVERY_CONFIG_OPTIONS, loaderConfig),
-    maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
+    maxAttempts: config?.maxAttempts ?? loadNodeConfig(Retry.v2026 ? { ...NODE_MAX_ATTEMPT_CONFIG_OPTIONS, default: 4 } : NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
     region: config?.region ?? loadNodeConfig(
         NODE_REGION_CONFIG_OPTIONS,
         {...NODE_REGION_CONFIG_FILE_OPTIONS, ...loaderConfig}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddRetryCustomizations.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddRetryCustomizations.java
@@ -5,6 +5,7 @@
 package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -26,10 +27,16 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Adds long poll designator for specific operations.
- * Adds custom retryStrategy for DynamoDB.
+ * Adds custom retry defaults for DynamoDB (baseDelay: 25ms, maxAttempts: 4).
  */
 @SmithyInternalApi
 public class AddRetryCustomizations implements TypeScriptIntegration {
+
+    @Override
+    public byte priority() {
+        // Run after the default retry runtime config writer so our maxAttempts override takes effect.
+        return -1;
+    }
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
@@ -48,36 +55,99 @@ public class AddRetryCustomizations implements TypeScriptIntegration {
     }
 
     @Override
+    public void mutateClientPlugins(List<RuntimeClientPlugin> plugins) {
+        for (int i = 0; i < plugins.size(); i++) {
+            RuntimeClientPlugin plugin = plugins.get(i);
+            if (
+                plugin.getResolveFunction().isPresent()
+                    && plugin.getResolveFunction().get().getSymbol().getName().equals("resolveRetryConfig")
+            ) {
+                plugins.set(
+                    i,
+                    plugin.toBuilder()
+                        .additionalResolveFunctionParamsSupplier((model, service, operation) -> {
+                            if (service != null && isDynamoDB(service)) {
+                                return Map.of(
+                                    "defaultMaxAttempts",
+                                    Symbol.builder()
+                                        .name("Retry.v2026 ? 4 : undefined")
+                                        .build(),
+                                    "defaultBaseDelay",
+                                    Symbol.builder()
+                                        .name("Retry.v2026 ? 25 : undefined")
+                                        .build()
+                                );
+                            }
+                            return Collections.emptyMap();
+                        })
+                        .build()
+                );
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void addConfigInterfaceFields(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
+    ) {
+        ServiceShape service = settings.getService(model);
+        if (isDynamoDB(service)) {
+            writer.addImportSubmodule("Retry", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.RETRY);
+        }
+    }
+
+    @Override
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
         TypeScriptSettings settings,
         Model model,
         SymbolProvider symbolProvider,
         LanguageTarget target
     ) {
-        if (LanguageTarget.SHARED.equals(target) && isDynamoDB(settings.getService(model))) {
-            return Map.of(
-                "retryStrategy",
-                (w) -> {
-                    w.addImportSubmodule(
-                        "StandardRetryStrategy",
+        ServiceShape service = settings.getService(model);
+        if (isDynamoDB(service)) {
+            Map<String, Consumer<TypeScriptWriter>> configs = new HashMap<>();
+            if (target.equals(LanguageTarget.NODE)) {
+                configs.put("maxAttempts", writer -> {
+                    writer.addImportSubmodule(
+                        "NODE_MAX_ATTEMPT_CONFIG_OPTIONS",
                         null,
                         TypeScriptDependency.SMITHY_CORE,
                         SmithyCoreSubmodules.RETRY
                     );
-                    w.addImportSubmodule("Retry", null, TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.RETRY);
-
-                    // todo(retry): Retry.v2026 condition can be removed when made permanent.
-                    w.write("""
-                            (
-                              config?.maxAttempts == null && config?.retryMode == null && Retry.v2026
-                                ? new StandardRetryStrategy({
-                                    maxAttempts: 4,
-                                    baseDelay: 25,
-                                  })
-                                : undefined
-                            )""");
-                }
-            );
+                    writer.addImportSubmodule(
+                        "Retry",
+                        null,
+                        TypeScriptDependency.SMITHY_CORE,
+                        SmithyCoreSubmodules.RETRY
+                    );
+                    writer.write(
+                        "loadNodeConfig("
+                            + "Retry.v2026 ? { ...NODE_MAX_ATTEMPT_CONFIG_OPTIONS, default: 4 }"
+                            + " : NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config)"
+                    );
+                });
+            } else if (target.equals(LanguageTarget.BROWSER)) {
+                configs.put("maxAttempts", writer -> {
+                    writer.addImportSubmodule(
+                        "Retry",
+                        null,
+                        TypeScriptDependency.SMITHY_CORE,
+                        SmithyCoreSubmodules.RETRY
+                    );
+                    writer.addImportSubmodule(
+                        "DEFAULT_MAX_ATTEMPTS",
+                        null,
+                        TypeScriptDependency.SMITHY_CORE,
+                        SmithyCoreSubmodules.RETRY
+                    );
+                    writer.write("(Retry.v2026 ? 4 : DEFAULT_MAX_ATTEMPTS)");
+                });
+            }
+            return configs;
         }
         return Collections.emptyMap();
     }

--- a/packages-internal/core/.gitignore
+++ b/packages-internal/core/.gitignore
@@ -1,1 +1,2 @@
 src/submodules/client/util-endpoints/lib/aws/partitions.ts
+scripts/browser-build/browser-dynamodb-bundle.js

--- a/packages-internal/core/integ/retry-customizations.browser.integ.spec.ts
+++ b/packages-internal/core/integ/retry-customizations.browser.integ.spec.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+import { beforeAll, describe, expect, test as it } from "vitest";
+
+let DynamoDB: any;
+let Retry: any;
+
+describe("retry customization (browser bundle)", () => {
+  const credentials = { accessKeyId: "INTEG", secretAccessKey: "INTEG" };
+
+  beforeAll(async () => {
+    const bundle = await import("../scripts/browser-build/browser-dynamodb-bundle");
+    DynamoDB = bundle.DynamoDB;
+    Retry = bundle.Retry;
+  });
+
+  describe("DynamoDB w/ Retry.v2026", () => {
+    beforeAll(() => {
+      Retry.v2026 = true;
+    });
+
+    it("defaults to 4 attempts", async () => {
+      const client = new DynamoDB({ region: "us-west-2", credentials });
+      expect(client.config.runtime).toBe("browser");
+      const maxAttempts = await client.config.maxAttempts();
+      expect(maxAttempts).toBe(4);
+    });
+
+    it("user-provided maxAttempts overrides the default", async () => {
+      const client = new DynamoDB({ region: "us-west-2", credentials, maxAttempts: 10 });
+      expect(client.config.runtime).toBe("browser");
+      const maxAttempts = await client.config.maxAttempts();
+      expect(maxAttempts).toBe(10);
+    });
+  });
+
+  describe("DynamoDB WITHOUT Retry.v2026", () => {
+    beforeAll(() => {
+      Retry.v2026 = false;
+    });
+
+    it("defaults to 3 attempts", async () => {
+      const client = new DynamoDB({ region: "us-west-2", credentials });
+      expect(client.config.runtime).toBe("browser");
+      const maxAttempts = await client.config.maxAttempts();
+      expect(maxAttempts).toBe(3);
+    });
+
+    it("user-provided maxAttempts overrides the default", async () => {
+      const client = new DynamoDB({ region: "us-west-2", credentials, maxAttempts: 10 });
+      expect(client.config.runtime).toBe("browser");
+      const maxAttempts = await client.config.maxAttempts();
+      expect(maxAttempts).toBe(10);
+    });
+  });
+});

--- a/packages-internal/core/integ/retry-customizations.integ.spec.ts
+++ b/packages-internal/core/integ/retry-customizations.integ.spec.ts
@@ -8,54 +8,100 @@ import { Readable } from "node:stream";
 import { beforeAll, describe, expect, test as it } from "vitest";
 
 describe("retry customization", () => {
+  const credentials = { accessKeyId: "INTEG", secretAccessKey: "INTEG" };
+
   for (const DDBCtor of [DynamoDB, DynamoDBStreams]) {
-    describe(DDBCtor.name, () => {
+    describe(DDBCtor.name + " w/ Retry.v2026", () => {
       beforeAll(async () => {
         Retry.v2026 = true;
       });
 
-      it("has a custom retry strategy when no maxAttempts or retryMode are set", async () => {
-        const streams = new DDBCtor({
-          region: "us-west-2",
-          credentials: {
-            accessKeyId: "INTEG",
-            secretAccessKey: "INTEG",
-          },
-        });
-        const retryStrategy = await streams.config.retryStrategy();
+      it("defaults to 4 attempts with 25ms delay base, standard retry strategy", async () => {
+        const client = new DDBCtor({ region: "us-west-2", credentials });
+        const retryStrategy = await client.config.retryStrategy();
         expect(retryStrategy).toBeInstanceOf(StandardRetryStrategy);
-
         expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(4);
         expect((retryStrategy as any).baseDelay).toBe(25);
       });
 
-      it("uses derived retryStrategy when retryMode is set", async () => {
-        const streams = new DDBCtor({
-          region: "us-west-2",
-          credentials: {
-            accessKeyId: "INTEG",
-            secretAccessKey: "INTEG",
-          },
-          retryMode: "adaptive",
-        });
-        const retryStrategy = await streams.config.retryStrategy();
+      it("preserves 4 attempts and 25ms delay base if adaptive mode is set", async () => {
+        const client = new DDBCtor({ region: "us-west-2", credentials, retryMode: "adaptive" });
+        const retryStrategy = await client.config.retryStrategy();
         expect(retryStrategy).toBeInstanceOf(AdaptiveRetryStrategy);
+        expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(4);
+        expect((retryStrategy as any).standardRetryStrategy.baseDelay).toBe(25);
       });
 
-      it("uses derived retryStrategy when maxAttempts is set", async () => {
-        const streams = new DDBCtor({
-          region: "us-west-2",
-          credentials: {
-            accessKeyId: "INTEG",
-            secretAccessKey: "INTEG",
-          },
-          maxAttempts: 5,
-        });
-        const retryStrategy = await streams.config.retryStrategy();
+      it("preserves standard mode and 25ms delay base if 10 attempts are set", async () => {
+        const client = new DDBCtor({ region: "us-west-2", credentials, maxAttempts: 10 });
+        const retryStrategy = await client.config.retryStrategy();
         expect(retryStrategy).toBeInstanceOf(StandardRetryStrategy);
+        expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(10);
+        expect((retryStrategy as any).baseDelay).toBe(25);
+      });
 
-        expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(5);
-        expect((retryStrategy as any).baseDelay).toBe(50);
+      it("providing a RetryStrategy object overrides the attempt count and delay base", async () => {
+        const custom = new StandardRetryStrategy({ maxAttempts: 7, baseDelay: 100 });
+        const client = new DDBCtor({ region: "us-west-2", credentials, retryStrategy: custom });
+        const retryStrategy = await client.config.retryStrategy();
+        expect(retryStrategy).toBe(custom);
+        expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(7);
+        expect((retryStrategy as any).baseDelay).toBe(100);
+      });
+
+      it("resolves precedence: code > env > ddb default", async () => {
+        process.env.AWS_MAX_ATTEMPTS = "9";
+        try {
+          const clientWithEnv = new DDBCtor({ region: "us-west-2", credentials });
+          expect(await clientWithEnv.config.maxAttempts()).toBe(9);
+
+          const clientWithCode = new DDBCtor({ region: "us-west-2", credentials, maxAttempts: 5 });
+          expect(await clientWithCode.config.maxAttempts()).toBe(5);
+        } finally {
+          delete process.env.AWS_MAX_ATTEMPTS;
+        }
+
+        const clientDefault = new DDBCtor({ region: "us-west-2", credentials });
+        expect(await clientDefault.config.maxAttempts()).toBe(4);
+      });
+    });
+
+    describe(DDBCtor.name + " WITHOUT Retry.v2026", () => {
+      beforeAll(async () => {
+        Retry.v2026 = false;
+      });
+
+      it("defaults to 3 attempts with 100ms delay base, standard retry strategy", async () => {
+        const client = new DDBCtor({ region: "us-west-2", credentials });
+        const retryStrategy = await client.config.retryStrategy();
+        expect(retryStrategy).toBeInstanceOf(StandardRetryStrategy);
+        expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(3);
+        expect((retryStrategy as any).baseDelay).toBe(100);
+      });
+
+      it("preserves 3 attempts and 100ms delay base if adaptive mode is set", async () => {
+        const client = new DDBCtor({ region: "us-west-2", credentials, retryMode: "adaptive" });
+        const retryStrategy = await client.config.retryStrategy();
+        expect(retryStrategy).toBeInstanceOf(AdaptiveRetryStrategy);
+        expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(3);
+        expect((retryStrategy as any).standardRetryStrategy.baseDelay).toBe(100);
+      });
+
+      it("preserves standard mode and 100ms delay base if 10 attempts are set", async () => {
+        const client = new DDBCtor({ region: "us-west-2", credentials, maxAttempts: 10 });
+        const retryStrategy = await client.config.retryStrategy();
+        expect(retryStrategy).toBeInstanceOf(StandardRetryStrategy);
+        expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(10);
+        expect((retryStrategy as any).baseDelay).toBe(100);
+      });
+
+      it("providing a RetryStrategy object overrides the attempt count and delay base", async () => {
+        const custom = new StandardRetryStrategy({ maxAttempts: 7, baseDelay: 100 });
+        const client = new DDBCtor({ region: "us-west-2", credentials, retryStrategy: custom });
+        const retryStrategy = await client.config.retryStrategy();
+        expect(retryStrategy).toBe(custom);
+        expect(await (retryStrategy as any).maxAttemptsProvider()).toBe(7);
+        expect((retryStrategy as any).baseDelay).toBe(100);
       });
     });
   }

--- a/packages-internal/core/scripts/browser-build/browser-dynamodb-bundle.d.ts
+++ b/packages-internal/core/scripts/browser-build/browser-dynamodb-bundle.d.ts
@@ -1,0 +1,2 @@
+export { DynamoDB } from "@aws-sdk/client-dynamodb";
+export { Retry } from "@smithy/core/retry";

--- a/packages-internal/core/scripts/browser-build/entry.js
+++ b/packages-internal/core/scripts/browser-build/entry.js
@@ -1,0 +1,2 @@
+export { DynamoDB } from "@aws-sdk/client-dynamodb";
+export { Retry } from "@smithy/core/retry";

--- a/packages-internal/core/scripts/browser-build/esbuild.js
+++ b/packages-internal/core/scripts/browser-build/esbuild.js
@@ -1,0 +1,19 @@
+const esbuild = require("esbuild");
+const path = require("path");
+
+module.exports = async function setup() {
+  await esbuild.build({
+    platform: "browser",
+    target: ["chrome120"],
+    bundle: true,
+    format: "esm",
+    mainFields: ["module", "browser", "main"],
+    allowOverwrite: true,
+    entryPoints: [path.join(__dirname, "entry.js")],
+    supported: {
+      "dynamic-import": false,
+    },
+    outfile: path.join(__dirname, "browser-dynamodb-bundle.js"),
+    external: [],
+  });
+};

--- a/packages-internal/core/src/submodules/client/middleware-user-agent/middleware-user-agent.integ.spec.ts
+++ b/packages-internal/core/src/submodules/client/middleware-user-agent/middleware-user-agent.integ.spec.ts
@@ -4,9 +4,9 @@ import { DynamoDB } from "@aws-sdk/client-dynamodb";
 import { S3 } from "@aws-sdk/client-s3";
 import { fromTemporaryCredentials } from "@aws-sdk/credential-providers";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
-import { STSClient } from "@aws-sdk/nested-clients/sts";
 import type { AwsSdkFeatures } from "@aws-sdk/types";
-import { describe, expect, test as it, vi } from "vitest";
+import { Readable } from "node:stream";
+import { describe, expect, test as it } from "vitest";
 
 describe("middleware-user-agent", () => {
   describe(CodeCatalyst.name, () => {
@@ -32,12 +32,43 @@ describe("middleware-user-agent", () => {
 
   describe("user agent customization", () => {
     it("should propagate the application id configuration to inner clients", async () => {
+      let stsUserAgent = "";
+
       const s3 = new S3({
         region: "us-west-2",
         credentials: fromTemporaryCredentials({
           masterCredentials: {
             accessKeyId: "my-access-key",
             secretAccessKey: "my-secretKey",
+          },
+          clientConfig: {
+            region: "us-west-2",
+            requestHandler: {
+              async handle(request: any) {
+                stsUserAgent = request.headers["user-agent"] ?? "";
+                return {
+                  response: {
+                    statusCode: 200,
+                    headers: { "content-type": "text/xml" },
+                    body: Readable.from(`<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+                      <AssumeRoleResult>
+                        <Credentials>
+                          <AccessKeyId>A</AccessKeyId>
+                          <SecretAccessKey>S</SecretAccessKey>
+                          <SessionToken>T</SessionToken>
+                          <Expiration>2099-01-01T00:00:00Z</Expiration>
+                        </Credentials>
+                      </AssumeRoleResult>
+                    </AssumeRoleResponse>`),
+                  },
+                };
+              },
+              metadata: { handlerProtocol: "" },
+              updateHttpClientConfig() {},
+              httpHandlerConfigs() {
+                return {};
+              },
+            },
           },
           params: {
             RoleArn: "arn:aws:iam::1234567890:role/Rigmarole",
@@ -52,22 +83,9 @@ describe("middleware-user-agent", () => {
         },
       });
 
-      const actual = STSClient.prototype.send;
-      vi.spyOn(STSClient.prototype, "send").mockImplementation(async function (this: STSClient, ...args) {
-        if (this instanceof STSClient) {
-          expect(await this.config.userAgentAppId()).toEqual("widget-factory");
-          return {
-            Credentials: {
-              AccessKeyId: "A",
-              SecretAccessKey: "S",
-            },
-          };
-        }
-        return actual.bind(this)(...args);
-      });
-
       await s3.listBuckets();
 
+      expect(stsUserAgent).toMatch(/app\/widget-factory$/);
       expect.assertions(2);
     });
 

--- a/packages-internal/core/src/submodules/client/util-user-agent-node/util-user-agent-node.integ.spec.ts
+++ b/packages-internal/core/src/submodules/client/util-user-agent-node/util-user-agent-node.integ.spec.ts
@@ -10,9 +10,10 @@ describe("util-user-agent-node", () => {
     const client = new S3({ region: "us-west-2" });
     requireRequestsFrom(client).toMatch({
       headers: {
-        "user-agent": `aws-sdk-js/${sdkVersion} ua/2.1 os/${platform()}#${release()} lang/js md/nodejs#${
-          versions.node
-        } api/s3#${sdkVersion} m/E,g`,
+        "user-agent": new RegExp(
+          `^aws-sdk-js/${sdkVersion} ua/2\\.1 os/${platform()}#${release()} lang/js md/nodejs#${versions.node}` +
+            `(?: \\S+)* api/s3#${sdkVersion}(?: \\S+)* m/E,g$`
+        ),
       },
     });
     await client.listBuckets();

--- a/packages-internal/core/vitest.config.integ.mts
+++ b/packages-internal/core/vitest.config.integ.mts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     include: ["**/*.integ.spec.ts"],
     environment: "node",
+    globalSetup: ["./scripts/browser-build/esbuild.js"],
   },
 });

--- a/packages-internal/middleware-flexible-checksums/src/middleware-flexible-checksums.integ.spec.ts
+++ b/packages-internal/middleware-flexible-checksums/src/middleware-flexible-checksums.integ.spec.ts
@@ -282,6 +282,7 @@ describe("middleware-flexible-checksums", () => {
     describe("novel request checksum", () => {
       it("should send a request with the novel checksum in the header if the implementation is provided", async () => {
         const s3 = new S3({
+          region: "us-west-2",
           credentials: {
             accessKeyId: "INTEG",
             secretAccessKey: "INTEG",
@@ -306,6 +307,7 @@ describe("middleware-flexible-checksums", () => {
 
       it("should throw an error if the requested algorithm implementation is not available", async () => {
         const s3 = new S3({
+          region: "us-west-2",
           credentials: {
             accessKeyId: "INTEG",
             secretAccessKey: "INTEG",
@@ -336,6 +338,7 @@ describe("middleware-flexible-checksums", () => {
     describe("novel response checksum", () => {
       it("should receive a request and verify the novel checksum", async () => {
         const s3 = new S3({
+          region: "us-west-2",
           credentials: {
             accessKeyId: "INTEG",
             secretAccessKey: "INTEG",
@@ -379,6 +382,7 @@ Checksum mismatch: expected "${ex}" but received "${ac}" in response header "x-a
 
       it("should ignore the checksum header and perform no checksum validation if no matching algorithm implementation is available", async () => {
         const s3 = new S3({
+          region: "us-west-2",
           credentials: {
             accessKeyId: "INTEG",
             secretAccessKey: "INTEG",

--- a/packages-internal/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
+++ b/packages-internal/middleware-flexible-checksums/src/middleware-flexible-checksums.retry.integ.spec.ts
@@ -1,10 +1,7 @@
 import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
 import { S3 } from "@aws-sdk/client-s3";
 import { HttpResponse } from "@smithy/core/protocols";
-import { retryMiddleware } from "@smithy/core/retry";
 import { describe, expect, test as it } from "vitest";
-
-import { flexibleChecksumsMiddleware } from "./flexibleChecksumsMiddleware";
 
 describe("middleware-flexible-checksums.retry", () => {
   it("retry reuses the checksum", async () => {
@@ -25,7 +22,7 @@ describe("middleware-flexible-checksums.retry", () => {
         return next(args);
       },
       {
-        toMiddleware: flexibleChecksumsMiddleware.name,
+        toMiddleware: "flexibleChecksumsMiddleware",
         relation: "after",
       }
     );
@@ -37,7 +34,7 @@ describe("middleware-flexible-checksums.retry", () => {
         return next(args);
       },
       {
-        toMiddleware: retryMiddleware.name,
+        toMiddleware: "retryMiddleware",
         relation: "after",
       }
     );

--- a/packages-internal/middleware-sdk-sqs/src/sqs-long-poll.integ.spec.ts
+++ b/packages-internal/middleware-sdk-sqs/src/sqs-long-poll.integ.spec.ts
@@ -53,18 +53,24 @@ describe("SQS", () => {
             token: StandardRetryToken,
             errorInfo: RetryErrorInfo
           ): Promise<StandardRetryToken> {
-            try {
-              return await super.refreshRetryTokenForRetry(token, errorInfo);
-            } catch (e: any) {
-              expect(e.$backoff).toBeGreaterThanOrEqual(1);
-              throw e;
-            }
+            return super.refreshRetryTokenForRetry(token, errorInfo);
           }
         })({
-          maxAttempts: 3,
+          maxAttempts: 4,
           backoff: new DeterministicRetryBackoffStrategy(),
         }),
       });
+
+      // Drain capacity so that on the 3rd retry, quota is exhausted
+      // and the long-poll backoff path is triggered.
+      (sqs.config as any).retryStrategy().then((s: any) => {
+        // cost per transient retry = 14 (Retry.cost() when v2026=true).
+        // Set capacity to allow 2 retries but not a 3rd.
+        s.capacity = 28;
+      });
+
+      // Wait for the capacity to be set.
+      await (sqs.config as any).retryStrategy();
 
       requireRequestsFrom(sqs)
         .toMatch({
@@ -72,42 +78,33 @@ describe("SQS", () => {
         })
         .respondWith(createRetryableErrorResponse());
 
-      let i = 0;
-      while (true) {
-        const requestBegins = performance.now();
+      const requestBegins = performance.now();
 
-        const receive = await sqs
-          .receiveMessage({
-            QueueUrl: "https://sqs.us-west-2.amazonaws.com/000000000000/Glorp",
-          })
-          .catch((_) => _);
+      const receive = await sqs
+        .receiveMessage({
+          QueueUrl: "https://sqs.us-west-2.amazonaws.com/000000000000/Glorp",
+        })
+        .catch((_) => _);
 
-        const requestRetriesExhausted = performance.now();
+      const requestRetriesExhausted = performance.now();
 
-        const data = {
-          attempts: receive?.$metadata?.attempts,
-          totalRetryDelay: receive?.$metadata?.totalRetryDelay,
-          timeElapsed: requestRetriesExhausted - requestBegins,
-        };
+      const data = {
+        attempts: receive?.$metadata?.attempts,
+        totalRetryDelay: receive?.$metadata?.totalRetryDelay,
+        timeElapsed: requestRetriesExhausted - requestBegins,
+      };
 
-        expect(data.attempts).toEqual(3);
-        expect(data.totalRetryDelay).toEqual(150);
-        expect(data.timeElapsed).toBeGreaterThanOrEqual(350);
+      // 3 attempts: initial + 2 retries succeeded within capacity.
+      // 3rd retry fails capacity check but long-poll backs off before returning error.
+      // Backoff schedule (deterministic, base=50): 50, 100, 200.
+      // totalRetryDelay = 50 + 100 = 150 (2 successful retries).
+      // timeElapsed >= 350 (150 from retries + 200 from long-poll backoff on exhaustion).
+      expect(data.attempts).toEqual(3);
+      expect(data.totalRetryDelay).toEqual(150);
+      expect(data.timeElapsed).toBeGreaterThanOrEqual(350);
 
-        if (++i >= 1) {
-          break;
-        }
-      }
-
-      const requestIterations = 1;
-      const requestMatcherAssertionsPerRequest = 3; // includes retries.
-      const retryLifecycleAssertionsPerRequest = 3;
-      const metadataAssertionsPerRequest = 3;
-
-      expect.assertions(
-        requestIterations *
-          (requestMatcherAssertionsPerRequest + retryLifecycleAssertionsPerRequest + metadataAssertionsPerRequest)
-      );
+      // 2 from acquireInitialRetryToken + 3 from requireRequestsFrom (3 requests matched) + 3 metadata
+      expect.assertions(8);
     });
   });
 }, 30_000);

--- a/scripts/generate-clients/code-gen.js
+++ b/scripts/generate-clients/code-gen.js
@@ -32,10 +32,7 @@ const generateClient = async (clientName) => {
   cleanSdkCodegenOutput();
 
   // Ensure the dependency is built before using --no-rebuild.
-  const depJar = join(CODE_GEN_ROOT, "smithy-aws-typescript-codegen", "build", "libs");
-  if (!existsSync(depJar)) {
-    await spawnProcess("./gradlew", [":smithy-aws-typescript-codegen:build"], { cwd: CODE_GEN_ROOT });
-  }
+  await spawnProcess("./gradlew", [":smithy-aws-typescript-codegen:build"], { cwd: CODE_GEN_ROOT });
 
   const options = [
     ":sdk-codegen:build",

--- a/vitest.config.integ.mts
+++ b/vitest.config.integ.mts
@@ -2,8 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    exclude: ["**/*/node_modules/**/*.spec.ts", "**/*.{e2e,browser}.spec.ts", "**/snapshots.integ.spec.ts"],
-    include: ["{clients,lib,packages,private}/**/*.integ.spec.ts"],
+    exclude: ["**/*/node_modules/**/*.spec.ts", "**/*.e2e.spec.ts", "**/snapshots.integ.spec.ts"],
+    include: ["{clients,lib,packages,packages-internal,private}/**/*.integ.spec.ts"],
     environment: "node",
+    globalSetup: ["./packages-internal/core/scripts/browser-build/esbuild.js"],
   },
 });


### PR DESCRIPTION
- [x] requires https://github.com/aws/aws-sdk-js-v3/pull/8067

### Issue
JS-6872

### Description
Instead of conditionally adding a customized instantiation of a RetryStrategyV2 for DDB (needs 4 default attempts and 25ms default base as of Retry v2026), we apply the defaults in the **resolver** as the optional second arg. 

Additionally, we use codegen overrides to supply 4 as the modified default for the config-loadable max attempt value.

PR also includes some minor maintenance on the aggregate integration test suite.

### What this enables

Users will be able to select e.g. adaptive mode, or change the attempt count for DDB while still receiving the modified defaults. The old system caused any attempt at customization to revert the custom retry strategy to the default one.

### Testing
CI

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
