### PR TITLE
chore(codegen): improve formatting of generated lib-dynamodb files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,4 +11,11 @@ clients/**/test/snapshots.integ.spec.ts
 private/**
 !private/aws-client-api-test/src/**/*
 packages/nested-clients/src/submodules/**/*.ts
+packages-internal/nested-clients/src/
+lib/lib-dynamodb/src/DynamoDBDocument.ts
+lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
+lib/lib-dynamodb/src/index.ts
+lib/lib-dynamodb/src/commands/*Command.ts
+lib/lib-dynamodb/src/commands/index.ts
+lib/lib-dynamodb/src/pagination/
 **/*.java

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
@@ -150,10 +150,10 @@ public class AddDocumentClientPlugin implements TypeScriptIntegration {
             );
 
             writerFactory.accept(String.format("%sindex.ts", DocumentClientUtils.DOC_CLIENT_PREFIX), writer -> {
-                writer.write("export * from './commands';");
-                writer.write("export * from './pagination';");
-                writer.write("export * from './$L';", DocumentClientUtils.CLIENT_NAME);
-                writer.write("export * from './$L';", DocumentClientUtils.CLIENT_FULL_NAME);
+                writer.write("export * from \"./commands\";");
+                writer.write("export * from \"./pagination\";");
+                writer.write("export * from \"./$L\";", DocumentClientUtils.CLIENT_NAME);
+                writer.write("export * from \"./$L\";", DocumentClientUtils.CLIENT_FULL_NAME);
                 writer.write("");
                 writer.write(
                     """

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentAggregatedClientGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentAggregatedClientGenerator.java
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.aws.typescript.codegen;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 import java.util.TreeSet;
@@ -54,7 +55,7 @@ final class DocumentAggregatedClientGenerator implements Runnable {
     public void run() {
         // Note: using addImport would register this dependency on the dynamodb client, which must be avoided.
         writer.write("""
-                     import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+                     import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
                      """);
         writer.addRelativeImport(
             DocumentClientUtils.CLIENT_NAME,
@@ -107,14 +108,14 @@ final class DocumentAggregatedClientGenerator implements Runnable {
                 );
                 SymbolReference options = ApplicationProtocol.createDefaultHttpApplicationProtocol().getOptionsType();
 
-                String commandFileLocation = String.format(
-                    "./%s/%s",
+                Path commandFilePath = Paths.get(
+                    ".",
                     DocumentClientUtils.CLIENT_COMMANDS_FOLDER,
                     name
                 );
-                writer.addImport(name, name, commandFileLocation);
-                writer.addImport(input, input, commandFileLocation);
-                writer.addImport(output, output, commandFileLocation);
+                writer.addRelativeImport(name, name, commandFilePath);
+                writer.addRelativeTypeImport(input, input, commandFilePath);
+                writer.addRelativeTypeImport(output, output, commandFilePath);
 
                 String methodName = StringUtils.uncapitalize(
                     DocumentClientUtils.getModifiedName(operationSymbol.getName().replaceAll("Command$", ""))
@@ -134,7 +135,7 @@ final class DocumentAggregatedClientGenerator implements Runnable {
                     """
                     public $1L(
                       args: $2L,
-                      options?: $3T,
+                      options?: $3T
                     ): Promise<$4L>;
                     public $1L(
                       args: $2L,
@@ -150,17 +151,17 @@ final class DocumentAggregatedClientGenerator implements Runnable {
                       optionsOrCb?: $3T | ((err: any, data?: $4L) => void),
                       cb?: (err: any, data?: $4L) => void
                     ): Promise<$4L> | void {
-                        const command = new $5L(args);
-                        if (typeof optionsOrCb === "function") {
-                          this.send(command, optionsOrCb);
-                        } else if (typeof cb === "function") {
-                          if (typeof optionsOrCb !== "object") {
-                            throw new Error(`Expect http options but get $${typeof optionsOrCb}`)
-                          }
-                          this.send(command, optionsOrCb || {}, cb);
-                        } else {
-                          return this.send(command, optionsOrCb);
+                      const command = new $5L(args);
+                      if (typeof optionsOrCb === "function") {
+                        this.send(command, optionsOrCb);
+                      } else if (typeof cb === "function") {
+                        if (typeof optionsOrCb !== "object") {
+                          throw new Error(`Expect http options but get $${typeof optionsOrCb}`);
                         }
+                        this.send(command, optionsOrCb || {}, cb);
+                      } else {
+                        return this.send(command, optionsOrCb);
+                      }
                     }""",
                     methodName,
                     input,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
@@ -4,6 +4,8 @@
  */
 package software.amazon.smithy.aws.typescript.codegen;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -61,13 +63,13 @@ final class DocumentBareBonesClientGenerator implements Runnable {
         // Add required imports.
         // Note: using addImport would register these dependencies on the dynamodb client, which must be avoided.
         writer.write("""
-                     import {
+                     import type {
                        DynamoDBClient,
                        DynamoDBClientResolvedConfig,
                        ServiceInputTypes as __ServiceInputTypes,
                        ServiceOutputTypes as __ServiceOutputTypes,
                      } from "@aws-sdk/client-dynamodb";
-                     import { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
+                     import type { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
                      """);
 
         writer.addImportSubmodule("Client", "__Client", TypeScriptDependency.SMITHY_CORE, SmithyCoreSubmodules.CLIENT);
@@ -124,13 +126,13 @@ final class DocumentBareBonesClientGenerator implements Runnable {
                     operationSymbol.expectProperty("outputType", Symbol.class).getName()
                 );
 
-                String commandFileLocation = String.format(
-                    "./%s/%s",
+                Path commandFileLocation = Paths.get(
+                    ".",
                     DocumentClientUtils.CLIENT_COMMANDS_FOLDER,
                     name
                 );
-                writer.addImport(input, input, commandFileLocation);
-                writer.addImport(output, output, commandFileLocation);
+                writer.addRelativeTypeImport(input, input, commandFileLocation);
+                writer.addRelativeTypeImport(output, output, commandFileLocation);
             }
         }
     }
@@ -147,8 +149,10 @@ final class DocumentBareBonesClientGenerator implements Runnable {
             .map(operationtypeName -> DocumentClientUtils.getModifiedName(operationtypeName))
             .collect(Collectors.toList());
 
-        writer.write("export type $L = $L", typeName, String.format("__%s", typeName));
+        writer.writeInline("export type $L =", typeName);
+        writer.write("");
         writer.indent();
+        writer.write("| $L", String.format("__%s", typeName));
         for (int i = 0; i < operationTypeNames.size(); i++) {
             writer.write("| $L$L", operationTypeNames.get(i), i == operationTypeNames.size() - 1 ? ";" : "");
         }
@@ -184,7 +188,7 @@ final class DocumentBareBonesClientGenerator implements Runnable {
 
     private void generateClientConstructor() {
         writer.openBlock(
-            "protected constructor(client: $L, translateConfig?: $L){",
+            "protected constructor(client: $L, translateConfig?: $L) {",
             "}",
             symbol.getName(),
             DocumentClientUtils.CLIENT_TRANSLATE_CONFIG_TYPE,
@@ -194,14 +198,14 @@ final class DocumentBareBonesClientGenerator implements Runnable {
                 writer.write("this.config = client.config;");
                 writer.write("this.config.translateConfig = translateConfig;");
                 writer.write("this.middlewareStack = client.middlewareStack;");
-                writer.write("""
-                             if (this.config?.cacheMiddleware) {
-                                 throw new Error(
-                                     "@aws-sdk/lib-dynamodb - cacheMiddleware=true is not compatible with the"
-                                       + " DynamoDBDocumentClient. This option must be set to false."
-                                 );
-                             }
-                             """);
+                writer.openBlock("if (this.config?.cacheMiddleware) {", "}", () -> {
+                    writer.write("throw new Error(");
+                    writer.indent();
+                    writer.write("\"@aws-sdk/lib-dynamodb - cacheMiddleware=true is not compatible with the\" +");
+                    writer.write("  \" DynamoDBDocumentClient. This option must be set to false.\"");
+                    writer.dedent();
+                    writer.write(");");
+                });
                 writer.popState();
             }
         );
@@ -211,7 +215,7 @@ final class DocumentBareBonesClientGenerator implements Runnable {
         writer.pushState(CLIENT_CONFIG_SECTION);
         String translateConfigType = DocumentClientUtils.CLIENT_TRANSLATE_CONFIG_TYPE;
         writer.writeDocs("@public");
-        writer.openBlock("export type $L = {", "}", translateConfigType, () -> {
+        writer.openBlock("export type $L = {", "};", translateConfigType, () -> {
             generateTranslateConfigOption(DocumentClientUtils.CLIENT_MARSHALL_OPTIONS);
             generateTranslateConfigOption(DocumentClientUtils.CLIENT_UNMARSHALL_OPTIONS);
         });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
@@ -99,17 +99,16 @@ final class DocumentClientCommandGenerator implements Runnable {
 
         // Note: using addImport would register these dependencies on the dynamodb client, which must be avoided.
         writer.write(
-            """
-            import { %s as %s } from "%s";
-            """.formatted(
+            "import { %s as %s } from \"%s\";".formatted(
                 clientCommandClassName,
                 clientCommandLocalName,
                 AwsDependency.CLIENT_DYNAMODB_PEER.getPackageName()
             )
         );
+        writer.write("");
 
         // Add required imports.
-        writer.addRelativeImport(configType, configType, servicePath);
+        writer.addRelativeTypeImport(configType, configType, servicePath);
         writer.addImport(
             "DynamoDBDocumentClientCommand",
             "DynamoDBDocumentClientCommand",
@@ -122,26 +121,21 @@ final class DocumentClientCommandGenerator implements Runnable {
 
         generateInputAndOutputTypes();
 
-        String ioTypes = String.join(
-            ", ",
-            new String[] {
-                inputTypeName,
-                outputTypeName,
-                "__" + originalInputTypeName,
-                "__" + originalOutputTypeName
-            }
-        );
-
         String name = DocumentClientUtils.getModifiedName(symbol.getName());
         writer.writeDocs(
             DocumentClientUtils.getCommandDocs(symbol.getName())
                 + "\n\n@public"
         );
         writer.openBlock(
-            "export class $L extends DynamoDBDocumentClientCommand<" + ioTypes + ", $L> {",
+            "export class $L extends DynamoDBDocumentClientCommand<\n"
+                + "  " + inputTypeName + ",\n"
+                + "  " + outputTypeName + ",\n"
+                + "  __" + originalInputTypeName + ",\n"
+                + "  __" + originalOutputTypeName + ",\n"
+                + "  " + configType + "\n"
+                + "> {",
             "}",
             name,
-            configType,
             () -> {
                 // Section for adding custom command properties.
                 writer.pushState(COMMAND_PROPERTIES_SECTION);
@@ -174,16 +168,12 @@ final class DocumentClientCommandGenerator implements Runnable {
         // Note: using addImport would register these dependencies on the dynamodb client, which must be avoided.
         writer.write("");
         orderedUncheckedImports.forEach((dep, symbols) -> {
-            writer.openBlock("import type {", """
-                                              } from "%s";
-                                              """.formatted(dep), () -> {
+            writer.openBlock("import type {", "} from \"" + dep + "\";", () -> {
                 symbols.forEach((externalName, localName) -> {
                     if (externalName.equals(localName)) {
-                        writer.writeInline(localName).write(",");
+                        writer.write("$L,", localName);
                     } else {
-                        writer.write("""
-                                     %s as %s,
-                                     """.formatted(externalName, localName));
+                        writer.write("$L as $L,", externalName, localName);
                     }
                 });
             });
@@ -210,10 +200,10 @@ final class DocumentClientCommandGenerator implements Runnable {
         String middlewareStack = "MiddlewareStack";
 
         Path servicePath = Paths.get(".", DocumentClientUtils.CLIENT_NAME);
-        writer.addRelativeImport(serviceInputTypes, serviceInputTypes, servicePath);
-        writer.addRelativeImport(serviceOutputTypes, serviceOutputTypes, servicePath);
-        writer.addImport(handler, handler, TypeScriptDependency.SMITHY_TYPES);
-        writer.addImport(middlewareStack, middlewareStack, TypeScriptDependency.SMITHY_TYPES);
+        writer.addRelativeTypeImport(serviceInputTypes, serviceInputTypes, servicePath);
+        writer.addRelativeTypeImport(serviceOutputTypes, serviceOutputTypes, servicePath);
+        writer.addTypeImport(handler, handler, TypeScriptDependency.SMITHY_TYPES);
+        writer.addTypeImport(middlewareStack, middlewareStack, TypeScriptDependency.SMITHY_TYPES);
 
         writer.write("resolveMiddleware(")
             .indent()
@@ -226,9 +216,7 @@ final class DocumentClientCommandGenerator implements Runnable {
             String commandVarName = "this.clientCommand";
 
             // marshall middlewares
-            writer.openBlock("this.addMarshallingMiddleware(", ");", () -> {
-                writer.write("configuration");
-            });
+            writer.write("this.addMarshallingMiddleware(configuration);");
 
             writer.write("const stack = clientStack.concat(this.middlewareStack as typeof clientStack);");
 
@@ -243,20 +231,58 @@ final class DocumentClientCommandGenerator implements Runnable {
             if (outputMembersWithAttr.isEmpty()) {
                 writer.write("return $L;", handlerVarName);
             } else {
-                writer.write("return async () => handler($L)", commandVarName);
+                writer.write("return async () => handler($L);", commandVarName);
             }
         });
     }
 
     private void writeKeyNodes(List<MemberShape> membersWithAttr) {
         for (MemberShape member : membersWithAttr) {
-            writer.openBlock("'$L': ", ",", symbolProvider.toMemberName(member), () -> {
-                writeKeyNode(member);
-            });
+            writeKeyNodeEntry(member);
         }
     }
 
-    private void writeKeyNode(MemberShape member) {
+    private void writeKeyNodeEntry(MemberShape member) {
+        String memberName = symbolProvider.toMemberName(member);
+        Shape memberTarget = model.expectShape(member.getTarget());
+        // For simple leaf nodes (map with AttributeValue, set/list of AttributeValue, SELF),
+        // write them inline without openBlock to avoid extra indentation.
+        if (memberTarget.isMapShape()) {
+            MemberShape mapMember = ((MapShape) memberTarget).getValue();
+            Shape mapMemberTarget = model.expectShape(mapMember.getTarget());
+            if (
+                mapMemberTarget.isUnionShape()
+                    && symbolProvider.toSymbol(mapMemberTarget).getName().equals("AttributeValue")
+            ) {
+                writer.addImport("ALL_VALUES", null, "./commands/utils");
+                writer.write("$L: ALL_VALUES, // map with AttributeValue", memberName);
+                return;
+            }
+        } else if (memberTarget instanceof CollectionShape) {
+            MemberShape collectionMember = ((CollectionShape) memberTarget).getMember();
+            Shape collectionMemberTarget = model.expectShape(collectionMember.getTarget());
+            if (
+                collectionMemberTarget.isUnionShape()
+                    && symbolProvider.toSymbol(collectionMemberTarget).getName().equals("AttributeValue")
+            ) {
+                writer.addImport("ALL_MEMBERS", null, "./commands/utils");
+                writer.write("$L: ALL_MEMBERS, // set/list of AttributeValue", memberName);
+                return;
+            }
+        } else if (memberTarget.isUnionShape()) {
+            if (symbolProvider.toSymbol(memberTarget).getName().equals("AttributeValue")) {
+                writer.addImport("SELF", null, "./commands/utils");
+                writer.write("$L: SELF,", memberName);
+                return;
+            }
+        }
+        // For complex/nested nodes, use block formatting
+        writer.writeInline("$L: ", memberName);
+        writeKeyNodeValue(member, true);
+    }
+
+    private void writeKeyNodeValue(MemberShape member, boolean trailingComma) {
+        String closeBrace = trailingComma ? "}," : "}";
         Shape memberTarget = model.expectShape(member.getTarget());
         if (memberTarget instanceof CollectionShape) {
             MemberShape collectionMember = ((CollectionShape) memberTarget).getMember();
@@ -266,17 +292,17 @@ final class DocumentClientCommandGenerator implements Runnable {
                     && symbolProvider.toSymbol(collectionMemberTarget).getName().equals("AttributeValue")
             ) {
                 writer.addImport("ALL_MEMBERS", null, "./commands/utils");
-                writer.write("ALL_MEMBERS // set/list of AttributeValue");
+                writer.write("ALL_MEMBERS, // set/list of AttributeValue");
                 return;
             }
-            writer.openBlock("{", "}", () -> {
-                writer.write("'*':");
-                writeKeyNode(collectionMember);
+            writer.openBlock("{", closeBrace, () -> {
+                writer.writeInline("\"*\": ");
+                writeKeyNodeValue(collectionMember, true);
             });
         } else if (memberTarget.isUnionShape()) {
             if (symbolProvider.toSymbol(memberTarget).getName().equals("AttributeValue")) {
                 writer.addImport("SELF", null, "./commands/utils");
-                writer.write("SELF");
+                writer.write("SELF,");
                 return;
             } else {
                 // An AttributeValue inside Union is not present as of Q1 2021, and is less
@@ -296,26 +322,25 @@ final class DocumentClientCommandGenerator implements Runnable {
                     && symbolProvider.toSymbol(mapMemberTarget).getName().equals("AttributeValue")
             ) {
                 writer.addImport("ALL_VALUES", null, "./commands/utils");
-                writer.write("ALL_VALUES // map with AttributeValue");
+                writer.write("ALL_VALUES, // map with AttributeValue");
                 return;
             } else {
-                writer.openBlock("{", "}", () -> {
-                    writer.write("'*':");
-                    writeKeyNode(mapMember);
+                writer.openBlock("{", closeBrace, () -> {
+                    writer.writeInline("\"*\": ");
+                    writeKeyNodeValue(mapMember, true);
                 });
             }
         } else if (memberTarget.isStructureShape()) {
-            writeStructureKeyNode((StructureShape) memberTarget);
+            writeStructureKeyNode((StructureShape) memberTarget, trailingComma);
         }
     }
 
-    private void writeStructureKeyNode(StructureShape structureTarget) {
+    private void writeStructureKeyNode(StructureShape structureTarget, boolean trailingComma) {
+        String closeBrace = trailingComma ? "}," : "}";
         List<MemberShape> membersWithAttr = getStructureMembersWithAttr(Optional.of(structureTarget));
-        writer.openBlock("{", "}", () -> {
+        writer.openBlock("{", closeBrace, () -> {
             for (MemberShape member : membersWithAttr) {
-                writer.openBlock("'$L': ", ",", symbolProvider.toMemberName(member), () -> {
-                    writeKeyNode(member);
-                });
+                writeKeyNodeEntry(member);
             }
         });
     }
@@ -358,7 +383,7 @@ final class DocumentClientCommandGenerator implements Runnable {
                 writer.write("export type $L = __$L;", typeName, originalTypeName);
             } else {
                 String memberUnionToOmit = membersWithAttr.stream()
-                    .map(member -> "'" + symbolProvider.toMemberName(member) + "'")
+                    .map(member -> "\"" + symbolProvider.toMemberName(member) + "\"")
                     .collect(Collectors.joining(" | "));
                 writer.openBlock(
                     "export type $L = Omit<__$L, $L> & {",
@@ -379,10 +404,10 @@ final class DocumentClientCommandGenerator implements Runnable {
         }
     }
 
-    private void writeStructureOmitType(StructureShape structureTarget) {
+    private void writeStructureOmitType(StructureShape structureTarget, String suffix) {
         List<MemberShape> membersWithAttr = getStructureMembersWithAttr(Optional.of(structureTarget));
         String memberUnionToOmit = membersWithAttr.stream()
-            .map(memberWithAttr -> "'" + symbolProvider.toMemberName(memberWithAttr) + "'")
+            .map(memberWithAttr -> "\"" + symbolProvider.toMemberName(memberWithAttr) + "\"")
             .collect(Collectors.joining(" | "));
         String typeNameToOmit = symbolProvider.toSymbol(structureTarget).getName();
         registerTypeImport(
@@ -390,9 +415,10 @@ final class DocumentClientCommandGenerator implements Runnable {
             typeNameToOmit,
             AwsDependency.CLIENT_DYNAMODB_PEER.getPackageName()
         );
+        String closeBlock = "}" + suffix;
         writer.openBlock(
             "Omit<$L, $L> & {",
-            "}",
+            closeBlock,
             typeNameToOmit,
             memberUnionToOmit,
             () -> {
@@ -405,24 +431,25 @@ final class DocumentClientCommandGenerator implements Runnable {
 
     private void writeStructureMemberOmitType(MemberShape member) {
         String optionalSuffix = isRequiredMember(member) ? "" : "?";
-        writer.openBlock(
-            "${L}${L}: ",
-            ";",
-            symbolProvider.toMemberName(member),
-            optionalSuffix,
-            () -> {
-                writeMemberOmitType(member, true);
-            }
-        );
+        String memberName = symbolProvider.toMemberName(member);
+        writer.writeInline("$L$L: ", memberName, optionalSuffix);
+        writeMemberOmitType(member, true, ";");
     }
 
     private void writeMemberOmitType(MemberShape member, boolean allowUndefined) {
+        writeMemberOmitType(member, allowUndefined, "");
+    }
+
+    private void writeMemberOmitType(MemberShape member, boolean allowUndefined, String terminator) {
         Shape memberTarget = model.expectShape(member.getTarget());
+        String undefinedSuffix = allowUndefined ? " | undefined" : "";
+        String suffix = undefinedSuffix + terminator;
         if (memberTarget.isStructureShape()) {
-            writeStructureOmitType((StructureShape) memberTarget);
+            writeStructureOmitType((StructureShape) memberTarget, suffix);
         } else if (memberTarget.isUnionShape()) {
             if (symbolProvider.toSymbol(memberTarget).getName().equals("AttributeValue")) {
-                writeNativeAttributeValue();
+                registerNativeAttributeValueImport();
+                writeTypeLeaf("NativeAttributeValue" + suffix, terminator);
             } else {
                 // An AttributeValue inside Union is not present as of Q1 2021, and is less
                 // likely to appear in future. Writing Omit for it is not straightforward, skipping.
@@ -435,28 +462,70 @@ final class DocumentClientCommandGenerator implements Runnable {
             }
         } else if (memberTarget.isMapShape()) {
             MemberShape mapMember = ((MapShape) memberTarget).getValue();
-            writer.openBlock("Record<string, ", ">", () -> {
-                writeMemberOmitType(mapMember, false);
-            });
+            Shape mapMemberTarget = model.expectShape(mapMember.getTarget());
+            if (
+                mapMemberTarget.isUnionShape()
+                    && symbolProvider.toSymbol(mapMemberTarget).getName().equals("AttributeValue")
+            ) {
+                registerNativeAttributeValueImport();
+                writeTypeLeaf("Record<string, NativeAttributeValue>" + suffix, terminator);
+            } else {
+                String closeRecord = ">" + suffix;
+                writer.openBlock("Record<", closeRecord, () -> {
+                    writer.writeInline("string,");
+                    writer.write("");
+                    writeMemberOmitType(mapMember, false);
+                });
+            }
         } else if (memberTarget instanceof CollectionShape) {
             MemberShape collectionMember = ((CollectionShape) memberTarget).getMember();
-            writer.openBlock("(", ")[]", () -> {
-                writeMemberOmitType(collectionMember, false);
-            });
-        }
-        if (allowUndefined) {
-            writer.write(" | undefined");
+            Shape collectionMemberTarget = model.expectShape(collectionMember.getTarget());
+            if (
+                collectionMemberTarget.isUnionShape()
+                    && symbolProvider.toSymbol(collectionMemberTarget).getName().equals("AttributeValue")
+            ) {
+                registerNativeAttributeValueImport();
+                writeTypeLeaf("NativeAttributeValue[]" + suffix, terminator);
+            } else if (
+                collectionMemberTarget.isMapShape()
+                    && isSimpleNativeAttributeValueMap(collectionMemberTarget)
+            ) {
+                // Simple case: Record<string, NativeAttributeValue>[]
+                registerNativeAttributeValueImport();
+                writeTypeLeaf("Record<string, NativeAttributeValue>[]" + suffix, terminator);
+            } else {
+                String closeArray = ")[]" + suffix;
+                writer.openBlock("(", closeArray, () -> {
+                    writeMemberOmitType(collectionMember, false);
+                });
+            }
         }
     }
 
-    private void writeNativeAttributeValue() {
+    /**
+     * Writes a leaf type with a trailing newline.
+     */
+    private void writeTypeLeaf(String text, String terminator) {
+        writer.write(text);
+    }
+
+    private void registerNativeAttributeValueImport() {
         String nativeAttributeValue = "NativeAttributeValue";
         registerTypeImport(
             nativeAttributeValue,
             nativeAttributeValue,
             AwsDependency.UTIL_DYNAMODB.getPackageName()
         );
-        writer.write(nativeAttributeValue);
+    }
+
+    private boolean isSimpleNativeAttributeValueMap(Shape mapShape) {
+        if (!mapShape.isMapShape()) {
+            return false;
+        }
+        MemberShape mapValue = ((MapShape) mapShape).getValue();
+        Shape mapValueTarget = model.expectShape(mapValue.getTarget());
+        return mapValueTarget.isUnionShape()
+            && symbolProvider.toSymbol(mapValueTarget).getName().equals("AttributeValue");
     }
 
     /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -61,8 +61,8 @@ final class DocumentClientPaginationGenerator implements Runnable {
             DocumentClientUtils.getModifiedName(operationTypeName)
         );
         writer.addRelativeImport(operationTypeName, operationTypeName, commandFileLocation);
-        writer.addRelativeImport(inputTypeName, inputTypeName, commandFileLocation);
-        writer.addRelativeImport(outputTypeName, outputTypeName, commandFileLocation);
+        writer.addRelativeTypeImport(inputTypeName, inputTypeName, commandFileLocation);
+        writer.addRelativeTypeImport(outputTypeName, outputTypeName, commandFileLocation);
         writer.addRelativeImport(
             DocumentClientUtils.CLIENT_NAME,
             DocumentClientUtils.CLIENT_NAME,
@@ -72,14 +72,14 @@ final class DocumentClientPaginationGenerator implements Runnable {
         // Import Pagination types
         writer.addImport("Paginator", "Paginator", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("createPaginator", "createPaginator", TypeScriptDependency.SMITHY_CORE);
-        writer.addRelativeImport(
+        writer.addRelativeTypeImport(
             paginationType,
             paginationType,
             Paths.get(".", getInterfaceFilelocation().replace(".ts", ""))
         );
 
         writer.writeDocs("@public");
-        writer.write("export { Paginator }");
+        writer.write("export { Paginator };");
 
         writePager();
     }

--- a/lib/lib-dynamodb/src/DynamoDBDocument.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocument.ts
@@ -2,36 +2,44 @@
 import type { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
 
 import {
+  type BatchExecuteStatementCommandInput,
+  type BatchExecuteStatementCommandOutput,
   BatchExecuteStatementCommand,
-  BatchExecuteStatementCommandInput,
-  BatchExecuteStatementCommandOutput,
 } from "./commands/BatchExecuteStatementCommand";
-import { BatchGetCommand, BatchGetCommandInput, BatchGetCommandOutput } from "./commands/BatchGetCommand";
-import { BatchWriteCommand, BatchWriteCommandInput, BatchWriteCommandOutput } from "./commands/BatchWriteCommand";
-import { DeleteCommand, DeleteCommandInput, DeleteCommandOutput } from "./commands/DeleteCommand";
+import { type BatchGetCommandInput, type BatchGetCommandOutput, BatchGetCommand } from "./commands/BatchGetCommand";
 import {
+  type BatchWriteCommandInput,
+  type BatchWriteCommandOutput,
+  BatchWriteCommand,
+} from "./commands/BatchWriteCommand";
+import { type DeleteCommandInput, type DeleteCommandOutput, DeleteCommand } from "./commands/DeleteCommand";
+import {
+  type ExecuteStatementCommandInput,
+  type ExecuteStatementCommandOutput,
   ExecuteStatementCommand,
-  ExecuteStatementCommandInput,
-  ExecuteStatementCommandOutput,
 } from "./commands/ExecuteStatementCommand";
 import {
+  type ExecuteTransactionCommandInput,
+  type ExecuteTransactionCommandOutput,
   ExecuteTransactionCommand,
-  ExecuteTransactionCommandInput,
-  ExecuteTransactionCommandOutput,
 } from "./commands/ExecuteTransactionCommand";
-import { GetCommand, GetCommandInput, GetCommandOutput } from "./commands/GetCommand";
-import { PutCommand, PutCommandInput, PutCommandOutput } from "./commands/PutCommand";
-import { QueryCommand, QueryCommandInput, QueryCommandOutput } from "./commands/QueryCommand";
-import { ScanCommand, ScanCommandInput, ScanCommandOutput } from "./commands/ScanCommand";
-import { TransactGetCommand, TransactGetCommandInput, TransactGetCommandOutput } from "./commands/TransactGetCommand";
+import { type GetCommandInput, type GetCommandOutput, GetCommand } from "./commands/GetCommand";
+import { type PutCommandInput, type PutCommandOutput, PutCommand } from "./commands/PutCommand";
+import { type QueryCommandInput, type QueryCommandOutput, QueryCommand } from "./commands/QueryCommand";
+import { type ScanCommandInput, type ScanCommandOutput, ScanCommand } from "./commands/ScanCommand";
 import {
+  type TransactGetCommandInput,
+  type TransactGetCommandOutput,
+  TransactGetCommand,
+} from "./commands/TransactGetCommand";
+import {
+  type TransactWriteCommandInput,
+  type TransactWriteCommandOutput,
   TransactWriteCommand,
-  TransactWriteCommandInput,
-  TransactWriteCommandOutput,
 } from "./commands/TransactWriteCommand";
-import { UpdateCommand, UpdateCommandInput, UpdateCommandOutput } from "./commands/UpdateCommand";
+import { type UpdateCommandInput, type UpdateCommandOutput, UpdateCommand } from "./commands/UpdateCommand";
 import { DynamoDBDocumentClient, TranslateConfig } from "./DynamoDBDocumentClient";
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import type { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 
 /**
  * The document client simplifies working with items in Amazon DynamoDB by
@@ -129,8 +137,14 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
    */
-  public batchGet(args: BatchGetCommandInput, options?: __HttpHandlerOptions): Promise<BatchGetCommandOutput>;
-  public batchGet(args: BatchGetCommandInput, cb: (err: any, data?: BatchGetCommandOutput) => void): void;
+  public batchGet(
+    args: BatchGetCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<BatchGetCommandOutput>;
+  public batchGet(
+    args: BatchGetCommandInput,
+    cb: (err: any, data?: BatchGetCommandOutput) => void
+  ): void;
   public batchGet(
     args: BatchGetCommandInput,
     options: __HttpHandlerOptions,
@@ -161,8 +175,14 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
    */
-  public batchWrite(args: BatchWriteCommandInput, options?: __HttpHandlerOptions): Promise<BatchWriteCommandOutput>;
-  public batchWrite(args: BatchWriteCommandInput, cb: (err: any, data?: BatchWriteCommandOutput) => void): void;
+  public batchWrite(
+    args: BatchWriteCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<BatchWriteCommandOutput>;
+  public batchWrite(
+    args: BatchWriteCommandInput,
+    cb: (err: any, data?: BatchWriteCommandOutput) => void
+  ): void;
   public batchWrite(
     args: BatchWriteCommandInput,
     options: __HttpHandlerOptions,
@@ -193,8 +213,14 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
    */
-  public delete(args: DeleteCommandInput, options?: __HttpHandlerOptions): Promise<DeleteCommandOutput>;
-  public delete(args: DeleteCommandInput, cb: (err: any, data?: DeleteCommandOutput) => void): void;
+  public delete(
+    args: DeleteCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<DeleteCommandOutput>;
+  public delete(
+    args: DeleteCommandInput,
+    cb: (err: any, data?: DeleteCommandOutput) => void
+  ): void;
   public delete(
     args: DeleteCommandInput,
     options: __HttpHandlerOptions,
@@ -301,8 +327,14 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
    */
-  public get(args: GetCommandInput, options?: __HttpHandlerOptions): Promise<GetCommandOutput>;
-  public get(args: GetCommandInput, cb: (err: any, data?: GetCommandOutput) => void): void;
+  public get(
+    args: GetCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<GetCommandOutput>;
+  public get(
+    args: GetCommandInput,
+    cb: (err: any, data?: GetCommandOutput) => void
+  ): void;
   public get(
     args: GetCommandInput,
     options: __HttpHandlerOptions,
@@ -333,8 +365,14 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
    */
-  public put(args: PutCommandInput, options?: __HttpHandlerOptions): Promise<PutCommandOutput>;
-  public put(args: PutCommandInput, cb: (err: any, data?: PutCommandOutput) => void): void;
+  public put(
+    args: PutCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<PutCommandOutput>;
+  public put(
+    args: PutCommandInput,
+    cb: (err: any, data?: PutCommandOutput) => void
+  ): void;
   public put(
     args: PutCommandInput,
     options: __HttpHandlerOptions,
@@ -365,8 +403,14 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
    */
-  public query(args: QueryCommandInput, options?: __HttpHandlerOptions): Promise<QueryCommandOutput>;
-  public query(args: QueryCommandInput, cb: (err: any, data?: QueryCommandOutput) => void): void;
+  public query(
+    args: QueryCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<QueryCommandOutput>;
+  public query(
+    args: QueryCommandInput,
+    cb: (err: any, data?: QueryCommandOutput) => void
+  ): void;
   public query(
     args: QueryCommandInput,
     options: __HttpHandlerOptions,
@@ -397,8 +441,14 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
    */
-  public scan(args: ScanCommandInput, options?: __HttpHandlerOptions): Promise<ScanCommandOutput>;
-  public scan(args: ScanCommandInput, cb: (err: any, data?: ScanCommandOutput) => void): void;
+  public scan(
+    args: ScanCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<ScanCommandOutput>;
+  public scan(
+    args: ScanCommandInput,
+    cb: (err: any, data?: ScanCommandOutput) => void
+  ): void;
   public scan(
     args: ScanCommandInput,
     options: __HttpHandlerOptions,
@@ -429,8 +479,14 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
    */
-  public transactGet(args: TransactGetCommandInput, options?: __HttpHandlerOptions): Promise<TransactGetCommandOutput>;
-  public transactGet(args: TransactGetCommandInput, cb: (err: any, data?: TransactGetCommandOutput) => void): void;
+  public transactGet(
+    args: TransactGetCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<TransactGetCommandOutput>;
+  public transactGet(
+    args: TransactGetCommandInput,
+    cb: (err: any, data?: TransactGetCommandOutput) => void
+  ): void;
   public transactGet(
     args: TransactGetCommandInput,
     options: __HttpHandlerOptions,
@@ -499,8 +555,14 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
    * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
    * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
    */
-  public update(args: UpdateCommandInput, options?: __HttpHandlerOptions): Promise<UpdateCommandOutput>;
-  public update(args: UpdateCommandInput, cb: (err: any, data?: UpdateCommandOutput) => void): void;
+  public update(
+    args: UpdateCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<UpdateCommandOutput>;
+  public update(
+    args: UpdateCommandInput,
+    cb: (err: any, data?: UpdateCommandOutput) => void
+  ): void;
   public update(
     args: UpdateCommandInput,
     options: __HttpHandlerOptions,
@@ -523,4 +585,5 @@ export class DynamoDBDocument extends DynamoDBDocumentClient {
       return this.send(command, optionsOrCb);
     }
   }
+
 }

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
@@ -2,29 +2,32 @@
 import { Client as __Client } from "@smithy/core/client";
 import type { HttpHandlerOptions as __HttpHandlerOptions } from "@smithy/types";
 
-import {
+import type {
   BatchExecuteStatementCommandInput,
   BatchExecuteStatementCommandOutput,
 } from "./commands/BatchExecuteStatementCommand";
-import { BatchGetCommandInput, BatchGetCommandOutput } from "./commands/BatchGetCommand";
-import { BatchWriteCommandInput, BatchWriteCommandOutput } from "./commands/BatchWriteCommand";
-import { DeleteCommandInput, DeleteCommandOutput } from "./commands/DeleteCommand";
-import { ExecuteStatementCommandInput, ExecuteStatementCommandOutput } from "./commands/ExecuteStatementCommand";
-import { ExecuteTransactionCommandInput, ExecuteTransactionCommandOutput } from "./commands/ExecuteTransactionCommand";
-import { GetCommandInput, GetCommandOutput } from "./commands/GetCommand";
-import { PutCommandInput, PutCommandOutput } from "./commands/PutCommand";
-import { QueryCommandInput, QueryCommandOutput } from "./commands/QueryCommand";
-import { ScanCommandInput, ScanCommandOutput } from "./commands/ScanCommand";
-import { TransactGetCommandInput, TransactGetCommandOutput } from "./commands/TransactGetCommand";
-import { TransactWriteCommandInput, TransactWriteCommandOutput } from "./commands/TransactWriteCommand";
-import { UpdateCommandInput, UpdateCommandOutput } from "./commands/UpdateCommand";
-import {
+import type { BatchGetCommandInput, BatchGetCommandOutput } from "./commands/BatchGetCommand";
+import type { BatchWriteCommandInput, BatchWriteCommandOutput } from "./commands/BatchWriteCommand";
+import type { DeleteCommandInput, DeleteCommandOutput } from "./commands/DeleteCommand";
+import type { ExecuteStatementCommandInput, ExecuteStatementCommandOutput } from "./commands/ExecuteStatementCommand";
+import type {
+  ExecuteTransactionCommandInput,
+  ExecuteTransactionCommandOutput,
+} from "./commands/ExecuteTransactionCommand";
+import type { GetCommandInput, GetCommandOutput } from "./commands/GetCommand";
+import type { PutCommandInput, PutCommandOutput } from "./commands/PutCommand";
+import type { QueryCommandInput, QueryCommandOutput } from "./commands/QueryCommand";
+import type { ScanCommandInput, ScanCommandOutput } from "./commands/ScanCommand";
+import type { TransactGetCommandInput, TransactGetCommandOutput } from "./commands/TransactGetCommand";
+import type { TransactWriteCommandInput, TransactWriteCommandOutput } from "./commands/TransactWriteCommand";
+import type { UpdateCommandInput, UpdateCommandOutput } from "./commands/UpdateCommand";
+import type {
   DynamoDBClient,
   DynamoDBClientResolvedConfig,
   ServiceInputTypes as __ServiceInputTypes,
   ServiceOutputTypes as __ServiceOutputTypes,
 } from "@aws-sdk/client-dynamodb";
-import { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
+import type { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
 
 /**
  * @public
@@ -131,12 +134,7 @@ export type DynamoDBDocumentClientResolvedConfig = DynamoDBClientResolvedConfig 
  *
  * @public
  */
-export class DynamoDBDocumentClient extends __Client<
-  __HttpHandlerOptions,
-  ServiceInputTypes,
-  ServiceOutputTypes,
-  DynamoDBDocumentClientResolvedConfig
-> {
+export class DynamoDBDocumentClient extends __Client<__HttpHandlerOptions, ServiceInputTypes, ServiceOutputTypes, DynamoDBDocumentClientResolvedConfig> {
   readonly config: DynamoDBDocumentClientResolvedConfig;
 
   protected constructor(client: DynamoDBClient, translateConfig?: TranslateConfig) {

--- a/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_MEMBERS, ALL_VALUES } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { BatchExecuteStatementCommand as __BatchExecuteStatementCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -16,27 +20,25 @@ export { DynamoDBDocumentClientCommand, $Command };
  * @public
  */
 export type BatchExecuteStatementCommandInput = Omit<__BatchExecuteStatementCommandInput, "Statements"> & {
-  Statements:
-    | (Omit<BatchStatementRequest, "Parameters"> & {
-        Parameters?: NativeAttributeValue[] | undefined;
-      })[]
-    | undefined;
+  Statements: (
+    Omit<BatchStatementRequest, "Parameters"> & {
+      Parameters?: NativeAttributeValue[] | undefined;
+    }
+  )[] | undefined;
 };
 
 /**
  * @public
  */
 export type BatchExecuteStatementCommandOutput = Omit<__BatchExecuteStatementCommandOutput, "Responses"> & {
-  Responses?:
-    | (Omit<BatchStatementResponse, "Error" | "Item"> & {
-        Error?:
-          | (Omit<BatchStatementError, "Item"> & {
-              Item?: Record<string, NativeAttributeValue> | undefined;
-            })
-          | undefined;
+  Responses?: (
+    Omit<BatchStatementResponse, "Error" | "Item"> & {
+      Error?: Omit<BatchStatementError, "Item"> & {
         Item?: Record<string, NativeAttributeValue> | undefined;
-      })[]
-    | undefined;
+      } | undefined;
+      Item?: Record<string, NativeAttributeValue> | undefined;
+    }
+  )[] | undefined;
 };
 
 /**
@@ -74,10 +76,8 @@ export class BatchExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __BatchExecuteStatementCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    BatchExecuteStatementCommandInput | __BatchExecuteStatementCommandInput,
-    BatchExecuteStatementCommandOutput | __BatchExecuteStatementCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<BatchExecuteStatementCommandInput | __BatchExecuteStatementCommandInput,
+  BatchExecuteStatementCommandOutput | __BatchExecuteStatementCommandOutput>;
 
   constructor(readonly input: BatchExecuteStatementCommandInput) {
     super();
@@ -108,5 +108,6 @@ import type {
   BatchStatementRequest,
   BatchStatementResponse,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_VALUES } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { BatchGetItemCommand as __BatchGetItemCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -16,29 +20,28 @@ export { DynamoDBDocumentClientCommand, $Command };
  * @public
  */
 export type BatchGetCommandInput = Omit<__BatchGetItemCommandInput, "RequestItems"> & {
-  RequestItems:
-    | Record<
-        string,
-        Omit<KeysAndAttributes, "Keys"> & {
-          Keys: Record<string, NativeAttributeValue>[] | undefined;
-        }
-      >
-    | undefined;
+  RequestItems: Record<
+    string,
+    Omit<KeysAndAttributes, "Keys"> & {
+      Keys: Record<string, NativeAttributeValue>[] | undefined;
+    }
+  > | undefined;
 };
 
 /**
  * @public
  */
 export type BatchGetCommandOutput = Omit<__BatchGetItemCommandOutput, "Responses" | "UnprocessedKeys"> & {
-  Responses?: Record<string, Record<string, NativeAttributeValue>[]> | undefined;
-  UnprocessedKeys?:
-    | Record<
-        string,
-        Omit<KeysAndAttributes, "Keys"> & {
-          Keys: Record<string, NativeAttributeValue>[] | undefined;
-        }
-      >
-    | undefined;
+  Responses?: Record<
+    string,
+    Record<string, NativeAttributeValue>[]
+  > | undefined;
+  UnprocessedKeys?: Record<
+    string,
+    Omit<KeysAndAttributes, "Keys"> & {
+      Keys: Record<string, NativeAttributeValue>[] | undefined;
+    }
+  > | undefined;
 };
 
 /**
@@ -82,10 +85,8 @@ export class BatchGetCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __BatchGetItemCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    BatchGetCommandInput | __BatchGetItemCommandInput,
-    BatchGetCommandOutput | __BatchGetItemCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<BatchGetCommandInput | __BatchGetItemCommandInput,
+  BatchGetCommandOutput | __BatchGetItemCommandOutput>;
 
   constructor(readonly input: BatchGetCommandInput) {
     super();
@@ -114,5 +115,6 @@ import type {
   BatchGetItemCommandOutput as __BatchGetItemCommandOutput,
   KeysAndAttributes,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_VALUES } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { BatchWriteItemCommand as __BatchWriteItemCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -16,57 +20,46 @@ export { DynamoDBDocumentClientCommand, $Command };
  * @public
  */
 export type BatchWriteCommandInput = Omit<__BatchWriteItemCommandInput, "RequestItems"> & {
-  RequestItems:
-    | Record<
-        string,
-        (Omit<WriteRequest, "PutRequest" | "DeleteRequest"> & {
-          PutRequest?:
-            | (Omit<PutRequest, "Item"> & {
-                Item: Record<string, NativeAttributeValue> | undefined;
-              })
-            | undefined;
-          DeleteRequest?:
-            | (Omit<DeleteRequest, "Key"> & {
-                Key: Record<string, NativeAttributeValue> | undefined;
-              })
-            | undefined;
-        })[]
-      >
-    | undefined;
+  RequestItems: Record<
+    string,
+    (
+      Omit<WriteRequest, "PutRequest" | "DeleteRequest"> & {
+        PutRequest?: Omit<PutRequest, "Item"> & {
+          Item: Record<string, NativeAttributeValue> | undefined;
+        } | undefined;
+        DeleteRequest?: Omit<DeleteRequest, "Key"> & {
+          Key: Record<string, NativeAttributeValue> | undefined;
+        } | undefined;
+      }
+    )[]
+  > | undefined;
 };
 
 /**
  * @public
  */
-export type BatchWriteCommandOutput = Omit<
-  __BatchWriteItemCommandOutput,
-  "UnprocessedItems" | "ItemCollectionMetrics"
-> & {
-  UnprocessedItems?:
-    | Record<
-        string,
-        (Omit<WriteRequest, "PutRequest" | "DeleteRequest"> & {
-          PutRequest?:
-            | (Omit<PutRequest, "Item"> & {
-                Item: Record<string, NativeAttributeValue> | undefined;
-              })
-            | undefined;
-          DeleteRequest?:
-            | (Omit<DeleteRequest, "Key"> & {
-                Key: Record<string, NativeAttributeValue> | undefined;
-              })
-            | undefined;
-        })[]
-      >
-    | undefined;
-  ItemCollectionMetrics?:
-    | Record<
-        string,
-        (Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
-          ItemCollectionKey?: Record<string, NativeAttributeValue> | undefined;
-        })[]
-      >
-    | undefined;
+export type BatchWriteCommandOutput = Omit<__BatchWriteItemCommandOutput, "UnprocessedItems" | "ItemCollectionMetrics"> & {
+  UnprocessedItems?: Record<
+    string,
+    (
+      Omit<WriteRequest, "PutRequest" | "DeleteRequest"> & {
+        PutRequest?: Omit<PutRequest, "Item"> & {
+          Item: Record<string, NativeAttributeValue> | undefined;
+        } | undefined;
+        DeleteRequest?: Omit<DeleteRequest, "Key"> & {
+          Key: Record<string, NativeAttributeValue> | undefined;
+        } | undefined;
+      }
+    )[]
+  > | undefined;
+  ItemCollectionMetrics?: Record<
+    string,
+    (
+      Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
+        ItemCollectionKey?: Record<string, NativeAttributeValue> | undefined;
+      }
+    )[]
+  > | undefined;
 };
 
 /**
@@ -122,10 +115,8 @@ export class BatchWriteCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __BatchWriteItemCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    BatchWriteCommandInput | __BatchWriteItemCommandInput,
-    BatchWriteCommandOutput | __BatchWriteItemCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<BatchWriteCommandInput | __BatchWriteItemCommandInput,
+  BatchWriteCommandOutput | __BatchWriteItemCommandOutput>;
 
   constructor(readonly input: BatchWriteCommandInput) {
     super();
@@ -157,5 +148,6 @@ import type {
   PutRequest,
   WriteRequest,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/DeleteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/DeleteCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_MEMBERS, ALL_VALUES, SELF } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { DeleteItemCommand as __DeleteItemCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -17,15 +21,13 @@ export { DynamoDBDocumentClientCommand, $Command };
  */
 export type DeleteCommandInput = Omit<__DeleteItemCommandInput, "Key" | "Expected" | "ExpressionAttributeValues"> & {
   Key: Record<string, NativeAttributeValue> | undefined;
-  Expected?:
-    | Record<
-        string,
-        Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
-          Value?: NativeAttributeValue | undefined;
-          AttributeValueList?: NativeAttributeValue[] | undefined;
-        }
-      >
-    | undefined;
+  Expected?: Record<
+    string,
+    Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
+      Value?: NativeAttributeValue | undefined;
+      AttributeValueList?: NativeAttributeValue[] | undefined;
+    }
+  > | undefined;
   ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
 };
 
@@ -34,11 +36,9 @@ export type DeleteCommandInput = Omit<__DeleteItemCommandInput, "Key" | "Expecte
  */
 export type DeleteCommandOutput = Omit<__DeleteItemCommandOutput, "Attributes" | "ItemCollectionMetrics"> & {
   Attributes?: Record<string, NativeAttributeValue> | undefined;
-  ItemCollectionMetrics?:
-    | (Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
-        ItemCollectionKey?: Record<string, NativeAttributeValue> | undefined;
-      })
-    | undefined;
+  ItemCollectionMetrics?: Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
+    ItemCollectionKey?: Record<string, NativeAttributeValue> | undefined;
+  } | undefined;
 };
 
 /**
@@ -75,10 +75,8 @@ export class DeleteCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __DeleteItemCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    DeleteCommandInput | __DeleteItemCommandInput,
-    DeleteCommandOutput | __DeleteItemCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<DeleteCommandInput | __DeleteItemCommandInput,
+  DeleteCommandOutput | __DeleteItemCommandOutput>;
 
   constructor(readonly input: DeleteCommandInput) {
     super();
@@ -108,5 +106,6 @@ import type {
   ExpectedAttributeValue,
   ItemCollectionMetrics,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_MEMBERS, ALL_VALUES } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { ExecuteStatementCommand as __ExecuteStatementCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -54,10 +58,8 @@ export class ExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __ExecuteStatementCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    ExecuteStatementCommandInput | __ExecuteStatementCommandInput,
-    ExecuteStatementCommandOutput | __ExecuteStatementCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<ExecuteStatementCommandInput | __ExecuteStatementCommandInput,
+  ExecuteStatementCommandOutput | __ExecuteStatementCommandOutput>;
 
   constructor(readonly input: ExecuteStatementCommandInput) {
     super();
@@ -85,5 +87,6 @@ import type {
   ExecuteStatementCommandInput as __ExecuteStatementCommandInput,
   ExecuteStatementCommandOutput as __ExecuteStatementCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_MEMBERS, ALL_VALUES } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { ExecuteTransactionCommand as __ExecuteTransactionCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -16,22 +20,22 @@ export { DynamoDBDocumentClientCommand, $Command };
  * @public
  */
 export type ExecuteTransactionCommandInput = Omit<__ExecuteTransactionCommandInput, "TransactStatements"> & {
-  TransactStatements:
-    | (Omit<ParameterizedStatement, "Parameters"> & {
-        Parameters?: NativeAttributeValue[] | undefined;
-      })[]
-    | undefined;
+  TransactStatements: (
+    Omit<ParameterizedStatement, "Parameters"> & {
+      Parameters?: NativeAttributeValue[] | undefined;
+    }
+  )[] | undefined;
 };
 
 /**
  * @public
  */
 export type ExecuteTransactionCommandOutput = Omit<__ExecuteTransactionCommandOutput, "Responses"> & {
-  Responses?:
-    | (Omit<ItemResponse, "Item"> & {
-        Item?: Record<string, NativeAttributeValue> | undefined;
-      })[]
-    | undefined;
+  Responses?: (
+    Omit<ItemResponse, "Item"> & {
+      Item?: Record<string, NativeAttributeValue> | undefined;
+    }
+  )[] | undefined;
 };
 
 /**
@@ -66,10 +70,8 @@ export class ExecuteTransactionCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __ExecuteTransactionCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    ExecuteTransactionCommandInput | __ExecuteTransactionCommandInput,
-    ExecuteTransactionCommandOutput | __ExecuteTransactionCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<ExecuteTransactionCommandInput | __ExecuteTransactionCommandInput,
+  ExecuteTransactionCommandOutput | __ExecuteTransactionCommandOutput>;
 
   constructor(readonly input: ExecuteTransactionCommandInput) {
     super();
@@ -99,5 +101,6 @@ import type {
   ItemResponse,
   ParameterizedStatement,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/GetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/GetCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_VALUES } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { GetItemCommand as __GetItemCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -50,10 +54,8 @@ export class GetCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __GetItemCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    GetCommandInput | __GetItemCommandInput,
-    GetCommandOutput | __GetItemCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<GetCommandInput | __GetItemCommandInput,
+  GetCommandOutput | __GetItemCommandOutput>;
 
   constructor(readonly input: GetCommandInput) {
     super();
@@ -81,5 +83,6 @@ import type {
   GetItemCommandInput as __GetItemCommandInput,
   GetItemCommandOutput as __GetItemCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/PutCommand.ts
+++ b/lib/lib-dynamodb/src/commands/PutCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_MEMBERS, ALL_VALUES, SELF } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { PutItemCommand as __PutItemCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -17,15 +21,13 @@ export { DynamoDBDocumentClientCommand, $Command };
  */
 export type PutCommandInput = Omit<__PutItemCommandInput, "Item" | "Expected" | "ExpressionAttributeValues"> & {
   Item: Record<string, NativeAttributeValue> | undefined;
-  Expected?:
-    | Record<
-        string,
-        Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
-          Value?: NativeAttributeValue | undefined;
-          AttributeValueList?: NativeAttributeValue[] | undefined;
-        }
-      >
-    | undefined;
+  Expected?: Record<
+    string,
+    Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
+      Value?: NativeAttributeValue | undefined;
+      AttributeValueList?: NativeAttributeValue[] | undefined;
+    }
+  > | undefined;
   ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
 };
 
@@ -34,11 +36,9 @@ export type PutCommandInput = Omit<__PutItemCommandInput, "Item" | "Expected" | 
  */
 export type PutCommandOutput = Omit<__PutItemCommandOutput, "Attributes" | "ItemCollectionMetrics"> & {
   Attributes?: Record<string, NativeAttributeValue> | undefined;
-  ItemCollectionMetrics?:
-    | (Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
-        ItemCollectionKey?: Record<string, NativeAttributeValue> | undefined;
-      })
-    | undefined;
+  ItemCollectionMetrics?: Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
+    ItemCollectionKey?: Record<string, NativeAttributeValue> | undefined;
+  } | undefined;
 };
 
 /**
@@ -75,10 +75,8 @@ export class PutCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __PutItemCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    PutCommandInput | __PutItemCommandInput,
-    PutCommandOutput | __PutItemCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<PutCommandInput | __PutItemCommandInput,
+  PutCommandOutput | __PutItemCommandOutput>;
 
   constructor(readonly input: PutCommandInput) {
     super();
@@ -108,5 +106,6 @@ import type {
   PutItemCommandInput as __PutItemCommandInput,
   PutItemCommandOutput as __PutItemCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/QueryCommand.ts
+++ b/lib/lib-dynamodb/src/commands/QueryCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_MEMBERS, ALL_VALUES } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { QueryCommand as __QueryCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -15,26 +19,19 @@ export { DynamoDBDocumentClientCommand, $Command };
 /**
  * @public
  */
-export type QueryCommandInput = Omit<
-  __QueryCommandInput,
-  "KeyConditions" | "QueryFilter" | "ExclusiveStartKey" | "ExpressionAttributeValues"
-> & {
-  KeyConditions?:
-    | Record<
-        string,
-        Omit<Condition, "AttributeValueList"> & {
-          AttributeValueList?: NativeAttributeValue[] | undefined;
-        }
-      >
-    | undefined;
-  QueryFilter?:
-    | Record<
-        string,
-        Omit<Condition, "AttributeValueList"> & {
-          AttributeValueList?: NativeAttributeValue[] | undefined;
-        }
-      >
-    | undefined;
+export type QueryCommandInput = Omit<__QueryCommandInput, "KeyConditions" | "QueryFilter" | "ExclusiveStartKey" | "ExpressionAttributeValues"> & {
+  KeyConditions?: Record<
+    string,
+    Omit<Condition, "AttributeValueList"> & {
+      AttributeValueList?: NativeAttributeValue[] | undefined;
+    }
+  > | undefined;
+  QueryFilter?: Record<
+    string,
+    Omit<Condition, "AttributeValueList"> & {
+      AttributeValueList?: NativeAttributeValue[] | undefined;
+    }
+  > | undefined;
   ExclusiveStartKey?: Record<string, NativeAttributeValue> | undefined;
   ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
 };
@@ -85,10 +82,8 @@ export class QueryCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __QueryCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    QueryCommandInput | __QueryCommandInput,
-    QueryCommandOutput | __QueryCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<QueryCommandInput | __QueryCommandInput,
+  QueryCommandOutput | __QueryCommandOutput>;
 
   constructor(readonly input: QueryCommandInput) {
     super();
@@ -117,5 +112,6 @@ import type {
   QueryCommandInput as __QueryCommandInput,
   QueryCommandOutput as __QueryCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/ScanCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ScanCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_MEMBERS, ALL_VALUES } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { ScanCommand as __ScanCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -15,18 +19,13 @@ export { DynamoDBDocumentClientCommand, $Command };
 /**
  * @public
  */
-export type ScanCommandInput = Omit<
-  __ScanCommandInput,
-  "ScanFilter" | "ExclusiveStartKey" | "ExpressionAttributeValues"
-> & {
-  ScanFilter?:
-    | Record<
-        string,
-        Omit<Condition, "AttributeValueList"> & {
-          AttributeValueList?: NativeAttributeValue[] | undefined;
-        }
-      >
-    | undefined;
+export type ScanCommandInput = Omit<__ScanCommandInput, "ScanFilter" | "ExclusiveStartKey" | "ExpressionAttributeValues"> & {
+  ScanFilter?: Record<
+    string,
+    Omit<Condition, "AttributeValueList"> & {
+      AttributeValueList?: NativeAttributeValue[] | undefined;
+    }
+  > | undefined;
   ExclusiveStartKey?: Record<string, NativeAttributeValue> | undefined;
   ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
 };
@@ -72,10 +71,8 @@ export class ScanCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __ScanCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    ScanCommandInput | __ScanCommandInput,
-    ScanCommandOutput | __ScanCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<ScanCommandInput | __ScanCommandInput,
+  ScanCommandOutput | __ScanCommandOutput>;
 
   constructor(readonly input: ScanCommandInput) {
     super();
@@ -104,5 +101,6 @@ import type {
   ScanCommandInput as __ScanCommandInput,
   ScanCommandOutput as __ScanCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_VALUES } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { TransactGetItemsCommand as __TransactGetItemsCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -16,26 +20,24 @@ export { DynamoDBDocumentClientCommand, $Command };
  * @public
  */
 export type TransactGetCommandInput = Omit<__TransactGetItemsCommandInput, "TransactItems"> & {
-  TransactItems:
-    | (Omit<TransactGetItem, "Get"> & {
-        Get:
-          | (Omit<Get, "Key"> & {
-              Key: Record<string, NativeAttributeValue> | undefined;
-            })
-          | undefined;
-      })[]
-    | undefined;
+  TransactItems: (
+    Omit<TransactGetItem, "Get"> & {
+      Get: Omit<Get, "Key"> & {
+        Key: Record<string, NativeAttributeValue> | undefined;
+      } | undefined;
+    }
+  )[] | undefined;
 };
 
 /**
  * @public
  */
 export type TransactGetCommandOutput = Omit<__TransactGetItemsCommandOutput, "Responses"> & {
-  Responses?:
-    | (Omit<ItemResponse, "Item"> & {
-        Item?: Record<string, NativeAttributeValue> | undefined;
-      })[]
-    | undefined;
+  Responses?: (
+    Omit<ItemResponse, "Item"> & {
+      Item?: Record<string, NativeAttributeValue> | undefined;
+    }
+  )[] | undefined;
 };
 
 /**
@@ -72,10 +74,8 @@ export class TransactGetCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __TransactGetItemsCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    TransactGetCommandInput | __TransactGetItemsCommandInput,
-    TransactGetCommandOutput | __TransactGetItemsCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<TransactGetCommandInput | __TransactGetItemsCommandInput,
+  TransactGetCommandOutput | __TransactGetItemsCommandOutput>;
 
   constructor(readonly input: TransactGetCommandInput) {
     super();
@@ -106,5 +106,6 @@ import type {
   TransactGetItemsCommandInput as __TransactGetItemsCommandInput,
   TransactGetItemsCommandOutput as __TransactGetItemsCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_VALUES } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { TransactWriteItemsCommand as __TransactWriteItemsCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -16,48 +20,40 @@ export { DynamoDBDocumentClientCommand, $Command };
  * @public
  */
 export type TransactWriteCommandInput = Omit<__TransactWriteItemsCommandInput, "TransactItems"> & {
-  TransactItems:
-    | (Omit<TransactWriteItem, "ConditionCheck" | "Put" | "Delete" | "Update"> & {
-        ConditionCheck?:
-          | (Omit<ConditionCheck, "Key" | "ExpressionAttributeValues"> & {
-              Key: Record<string, NativeAttributeValue> | undefined;
-              ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
-            })
-          | undefined;
-        Put?:
-          | (Omit<Put, "Item" | "ExpressionAttributeValues"> & {
-              Item: Record<string, NativeAttributeValue> | undefined;
-              ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
-            })
-          | undefined;
-        Delete?:
-          | (Omit<Delete, "Key" | "ExpressionAttributeValues"> & {
-              Key: Record<string, NativeAttributeValue> | undefined;
-              ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
-            })
-          | undefined;
-        Update?:
-          | (Omit<Update, "Key" | "ExpressionAttributeValues"> & {
-              Key: Record<string, NativeAttributeValue> | undefined;
-              ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
-            })
-          | undefined;
-      })[]
-    | undefined;
+  TransactItems: (
+    Omit<TransactWriteItem, "ConditionCheck" | "Put" | "Delete" | "Update"> & {
+      ConditionCheck?: Omit<ConditionCheck, "Key" | "ExpressionAttributeValues"> & {
+        Key: Record<string, NativeAttributeValue> | undefined;
+        ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
+      } | undefined;
+      Put?: Omit<Put, "Item" | "ExpressionAttributeValues"> & {
+        Item: Record<string, NativeAttributeValue> | undefined;
+        ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
+      } | undefined;
+      Delete?: Omit<Delete, "Key" | "ExpressionAttributeValues"> & {
+        Key: Record<string, NativeAttributeValue> | undefined;
+        ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
+      } | undefined;
+      Update?: Omit<Update, "Key" | "ExpressionAttributeValues"> & {
+        Key: Record<string, NativeAttributeValue> | undefined;
+        ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
+      } | undefined;
+    }
+  )[] | undefined;
 };
 
 /**
  * @public
  */
 export type TransactWriteCommandOutput = Omit<__TransactWriteItemsCommandOutput, "ItemCollectionMetrics"> & {
-  ItemCollectionMetrics?:
-    | Record<
-        string,
-        (Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
-          ItemCollectionKey?: Record<string, NativeAttributeValue> | undefined;
-        })[]
-      >
-    | undefined;
+  ItemCollectionMetrics?: Record<
+    string,
+    (
+      Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
+        ItemCollectionKey?: Record<string, NativeAttributeValue> | undefined;
+      }
+    )[]
+  > | undefined;
 };
 
 /**
@@ -109,10 +105,8 @@ export class TransactWriteCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __TransactWriteItemsCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    TransactWriteCommandInput | __TransactWriteItemsCommandInput,
-    TransactWriteCommandOutput | __TransactWriteItemsCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<TransactWriteCommandInput | __TransactWriteItemsCommandInput,
+  TransactWriteCommandOutput | __TransactWriteItemsCommandOutput>;
 
   constructor(readonly input: TransactWriteCommandInput) {
     super();
@@ -146,5 +140,6 @@ import type {
   TransactWriteItemsCommandOutput as __TransactWriteItemsCommandOutput,
   Update,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/commands/UpdateCommand.ts
+++ b/lib/lib-dynamodb/src/commands/UpdateCommand.ts
@@ -1,10 +1,14 @@
 // smithy-typescript generated code
 import { Command as $Command } from "@smithy/core/client";
-import { type HttpHandlerOptions as __HttpHandlerOptions, Handler, MiddlewareStack } from "@smithy/types";
+import type { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { ALL_MEMBERS, ALL_VALUES, SELF } from "../commands/utils";
-import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
+import type {
+  DynamoDBDocumentClientResolvedConfig,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+} from "../DynamoDBDocumentClient";
 import { UpdateItemCommand as __UpdateItemCommand } from "@aws-sdk/client-dynamodb";
 
 /**
@@ -15,28 +19,21 @@ export { DynamoDBDocumentClientCommand, $Command };
 /**
  * @public
  */
-export type UpdateCommandInput = Omit<
-  __UpdateItemCommandInput,
-  "Key" | "AttributeUpdates" | "Expected" | "ExpressionAttributeValues"
-> & {
+export type UpdateCommandInput = Omit<__UpdateItemCommandInput, "Key" | "AttributeUpdates" | "Expected" | "ExpressionAttributeValues"> & {
   Key: Record<string, NativeAttributeValue> | undefined;
-  AttributeUpdates?:
-    | Record<
-        string,
-        Omit<AttributeValueUpdate, "Value"> & {
-          Value?: NativeAttributeValue | undefined;
-        }
-      >
-    | undefined;
-  Expected?:
-    | Record<
-        string,
-        Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
-          Value?: NativeAttributeValue | undefined;
-          AttributeValueList?: NativeAttributeValue[] | undefined;
-        }
-      >
-    | undefined;
+  AttributeUpdates?: Record<
+    string,
+    Omit<AttributeValueUpdate, "Value"> & {
+      Value?: NativeAttributeValue | undefined;
+    }
+  > | undefined;
+  Expected?: Record<
+    string,
+    Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
+      Value?: NativeAttributeValue | undefined;
+      AttributeValueList?: NativeAttributeValue[] | undefined;
+    }
+  > | undefined;
   ExpressionAttributeValues?: Record<string, NativeAttributeValue> | undefined;
 };
 
@@ -45,11 +42,9 @@ export type UpdateCommandInput = Omit<
  */
 export type UpdateCommandOutput = Omit<__UpdateItemCommandOutput, "Attributes" | "ItemCollectionMetrics"> & {
   Attributes?: Record<string, NativeAttributeValue> | undefined;
-  ItemCollectionMetrics?:
-    | (Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
-        ItemCollectionKey?: Record<string, NativeAttributeValue> | undefined;
-      })
-    | undefined;
+  ItemCollectionMetrics?: Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
+    ItemCollectionKey?: Record<string, NativeAttributeValue> | undefined;
+  } | undefined;
 };
 
 /**
@@ -91,10 +86,8 @@ export class UpdateCommand extends DynamoDBDocumentClientCommand<
   };
 
   protected readonly clientCommand: __UpdateItemCommand;
-  public readonly middlewareStack: MiddlewareStack<
-    UpdateCommandInput | __UpdateItemCommandInput,
-    UpdateCommandOutput | __UpdateItemCommandOutput
-  >;
+  public readonly middlewareStack: MiddlewareStack<UpdateCommandInput | __UpdateItemCommandInput,
+  UpdateCommandOutput | __UpdateItemCommandOutput>;
 
   constructor(readonly input: UpdateCommandInput) {
     super();
@@ -125,5 +118,6 @@ import type {
   UpdateItemCommandInput as __UpdateItemCommandInput,
   UpdateItemCommandOutput as __UpdateItemCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-
-import type { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+import type {
+  NativeAttributeValue,
+} from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
@@ -2,9 +2,9 @@
 import { createPaginator } from "@smithy/core";
 import { Paginator } from "@smithy/types";
 
-import { QueryCommand, QueryCommandInput, QueryCommandOutput } from "../commands/QueryCommand";
+import { type QueryCommandInput, type QueryCommandOutput, QueryCommand } from "../commands/QueryCommand";
 import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
-import { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
+import type { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
 
 /**
  * @public

--- a/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
@@ -2,9 +2,9 @@
 import { createPaginator } from "@smithy/core";
 import { Paginator } from "@smithy/types";
 
-import { ScanCommand, ScanCommandInput, ScanCommandOutput } from "../commands/ScanCommand";
+import { type ScanCommandInput, type ScanCommandOutput, ScanCommand } from "../commands/ScanCommand";
 import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
-import { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
+import type { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
 
 /**
  * @public


### PR DESCRIPTION
### Issue
n/a

### Description
Updates the codegen formatting for lib-dynamodb to avoid diff thrashing.

### Testing
generate client-dynamodb

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
