### PR TITLE
feat(lib-transfer-manager): add @aws-sdk/lib-transfer-manager as private package

### DIFF
--- a/lib/lib-storage/src/index.ts
+++ b/lib/lib-storage/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./Upload";
 export * from "./types";
+export { byteLength } from "./byteLength";
+export { getChunk } from "./chunker";

--- a/lib/lib-storage/src/index.ts
+++ b/lib/lib-storage/src/index.ts
@@ -1,4 +1,2 @@
 export * from "./Upload";
 export * from "./types";
-export { byteLength } from "./byteLength";
-export { getChunk } from "./chunker";

--- a/lib/lib-transfer-manager/package.json
+++ b/lib/lib-transfer-manager/package.json
@@ -5,9 +5,35 @@
   "description": "S3 Transfer Manager for AWS SDK JS v3",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
+  "browser": {
+    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.browser",
+    "./dist-es/s3-transfer-manager/join-streams": "./dist-es/s3-transfer-manager/join-streams.browser",
+    "./dist-es/s3-transfer-manager/worker-http-handler": "./dist-es/s3-transfer-manager/worker-http-handler.browser",
+    "fs": false
+  },
+  "react-native": {
+    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.native"
+  },
   "types": "./dist-types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist-types/index.d.ts",
+      "module": "./dist-es/index.js",
+      "node": "./dist-cjs/index.js",
+      "import": "./dist-es/index.js",
+      "require": "./dist-cjs/index.js"
+    },
+    "./worker": {
+      "types": "./dist-types/submodules/worker/index.d.ts",
+      "module": "./dist-es/submodules/worker/index.js",
+      "node": "./dist-cjs/submodules/worker/index.js",
+      "import": "./dist-es/submodules/worker/index.js",
+      "require": "./dist-cjs/submodules/worker/index.js"
+    }
+  },
   "scripts": {
     "build": "concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",
+    "lint": "node ../../scripts/validation/submodules-linter.js --pkg lib-transfer-manager",
     "build:cjs": "node ../../scripts/compilation/inline lib-transfer-manager",
     "build:es": "tsc -p tsconfig.es.json",
     "build:include:deps": "yarn g:turbo run build -F=\"$npm_package_name\"",
@@ -30,18 +56,16 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/config": "workspace:3.1062.0",
-    "@aws-sdk/lib-storage": "workspace:3.1062.0",
     "@smithy/core": "^3.24.6",
     "@smithy/node-http-handler": "^4.7.6",
     "@smithy/types": "^4.14.3",
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@aws-sdk/client-s3": "^3.0.0"
+    "@aws-sdk/client-s3": "workspace:^3.1063.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-s3": "workspace:3.1062.0",
+    "@aws-sdk/client-s3": "workspace:3.1063.0",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^20.14.8",
     "concurrently": "7.0.0",
@@ -56,21 +80,10 @@
       ]
     }
   },
-  "browser": {
-    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.browser",
-    "./dist-es/s3-transfer-manager/join-streams": "./dist-es/s3-transfer-manager/join-streams.browser",
-    "./dist-es/s3-transfer-manager/worker-http-handler": "./dist-es/s3-transfer-manager/worker-http-handler.browser",
-    "fs": false,
-    "stream": "stream-browserify"
-  },
-  "standaloneFiles": [
-    "s3-transfer-manager/http-request-worker.js"
-  ],
-  "react-native": {
-    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.native"
-  },
   "files": [
-    "dist-*/**"
+    "dist-*/**",
+    "./worker.js",
+    "./worker.d.ts"
   ],
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/lib/lib-transfer-manager",
   "repository": {

--- a/lib/lib-transfer-manager/package.json
+++ b/lib/lib-transfer-manager/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@aws-sdk/lib-transfer-manager",
+  "version": "0.0.1",
+  "private": true,
+  "description": "S3 Transfer Manager for AWS SDK JS v3",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
+  "scripts": {
+    "build": "concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",
+    "build:cjs": "node ../../scripts/compilation/inline lib-transfer-manager",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "yarn g:turbo run build -F=\"$npm_package_name\"",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
+    "test": "yarn g:vitest run",
+    "test:watch": "yarn g:vitest watch",
+    "test:browser": "yarn g:vitest run -c vitest.config.browser.mts",
+    "test:browser:watch": "yarn g:vitest watch -c vitest.config.browser.mts",
+    "test:e2e": "yarn g:vitest run -c vitest.config.e2e.mts --mode development",
+    "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.mts"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@aws-sdk/config": "workspace:3.1062.0",
+    "@aws-sdk/lib-storage": "workspace:3.1062.0",
+    "@smithy/core": "^3.24.6",
+    "@smithy/node-http-handler": "^4.7.6",
+    "@smithy/types": "^4.14.3",
+    "tslib": "^2.6.2"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-s3": "^3.0.0"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-s3": "workspace:3.1062.0",
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^20.14.8",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "premove": "4.0.0",
+    "typescript": "~5.8.3"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
+      ]
+    }
+  },
+  "browser": {
+    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.browser",
+    "./dist-es/s3-transfer-manager/join-streams": "./dist-es/s3-transfer-manager/join-streams.browser",
+    "./dist-es/s3-transfer-manager/worker-http-handler": "./dist-es/s3-transfer-manager/worker-http-handler.browser",
+    "fs": false,
+    "stream": "stream-browserify"
+  },
+  "standaloneFiles": [
+    "s3-transfer-manager/http-request-worker.js"
+  ],
+  "react-native": {
+    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.native"
+  },
+  "files": [
+    "dist-*/**"
+  ],
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/lib/lib-transfer-manager",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "lib/lib-transfer-manager"
+  }
+}

--- a/lib/lib-transfer-manager/src/S3TransferManager.browser.spec.ts
+++ b/lib/lib-transfer-manager/src/S3TransferManager.browser.spec.ts
@@ -1,0 +1,148 @@
+import { sdkStreamMixin } from "@smithy/core/serde";
+import type { StreamingBlobPayloadOutputTypes } from "@smithy/types";
+import { describe, expect, it, vi } from "vitest";
+
+import { joinStreams } from "./join-streams.browser";
+
+describe("join-streams tests", () => {
+  const createReadableStreamWithContent = (content: Uint8Array) =>
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(content);
+        controller.close();
+      },
+    });
+
+  const createEmptyReadableStream = () =>
+    new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+
+  const consumeReadableStream = async (stream: any): Promise<Uint8Array[]> => {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+
+    return chunks;
+  };
+
+  const testCases = [
+    {
+      name: "ReadableStream",
+      createStream: () => new ReadableStream(),
+      createWithContent: createReadableStreamWithContent,
+      createEmpty: createEmptyReadableStream,
+      consume: consumeReadableStream,
+      isInstance: (stream: any) => typeof stream.getReader === "function",
+    },
+  ];
+
+  testCases.forEach(({ name, createStream, createWithContent, createEmpty, consume, isInstance }) => {
+    describe(`joinStreams() with ${name}`, () => {
+      it("should return single stream when only one stream is provided", async () => {
+        const stream = createStream();
+        const mixedStream = sdkStreamMixin(stream);
+        const result = await joinStreams([Promise.resolve(mixedStream as StreamingBlobPayloadOutputTypes)]);
+
+        expect(result).toBeDefined();
+        expect(result).not.toBe(stream);
+        expect(isInstance(result)).toBe(true);
+      });
+
+      it("should join multiple streams into a single stream", async () => {
+        const contents = [
+          new Uint8Array([67, 104, 117, 110, 107, 32, 49]), // "Chunk 1"
+          new Uint8Array([67, 104, 117, 110, 107, 32, 50]), // "Chunk 2"
+          new Uint8Array([67, 104, 117, 110, 107, 32, 51]), // "Chunk 3"
+        ];
+
+        const streams = contents.map((content) =>
+          Promise.resolve(sdkStreamMixin(createWithContent(content)) as StreamingBlobPayloadOutputTypes)
+        );
+
+        const joinedStream = await joinStreams(streams);
+
+        const chunks = await consume(joinedStream);
+
+        expect(chunks.length).toBe(contents.length);
+        chunks.forEach((chunk, i) => {
+          expect(chunk).toEqual(contents[i]);
+        });
+      });
+
+      it("should handle consecutive calls of joining multiple streams into a single stream", async () => {
+        for (let i = 0; i <= 3; i++) {
+          const contents = [
+            new Uint8Array([67, 104, 117, 110, 107, 32, 49]), // "Chunk 1"
+            new Uint8Array([67, 104, 117, 110, 107, 32, 50]), // "Chunk 2"
+            new Uint8Array([67, 104, 117, 110, 107, 32, 51]), // "Chunk 3"
+          ];
+
+          const streams = contents.map((content) =>
+            Promise.resolve(sdkStreamMixin(createWithContent(content)) as StreamingBlobPayloadOutputTypes)
+          );
+
+          const joinedStream = await joinStreams(streams);
+
+          const chunks = await consume(joinedStream);
+
+          expect(chunks.length).toBe(contents.length);
+          chunks.forEach((chunk, i) => {
+            expect(chunk).toEqual(contents[i]);
+          });
+        }
+      });
+
+      it("should handle streams with no data", async () => {
+        const streams = [
+          Promise.resolve(sdkStreamMixin(createEmpty()) as StreamingBlobPayloadOutputTypes),
+          Promise.resolve(sdkStreamMixin(createEmpty()) as StreamingBlobPayloadOutputTypes),
+        ];
+
+        const joinedStream = await joinStreams(streams);
+
+        const chunks = await consume(joinedStream);
+
+        expect(chunks.length).toBe(0);
+      });
+
+      it("should report progress via eventListeners", async () => {
+        const streams = [
+          Promise.resolve(
+            sdkStreamMixin(createWithContent(new Uint8Array([100, 97, 116, 97]))) as StreamingBlobPayloadOutputTypes
+          ), // "data"
+          Promise.resolve(
+            sdkStreamMixin(createWithContent(new Uint8Array([109, 111, 114, 101]))) as StreamingBlobPayloadOutputTypes
+          ), // "more"
+        ];
+
+        const onBytesSpy = vi.fn();
+        const onCompletionSpy = vi.fn();
+
+        const joinedStream = await joinStreams(streams, {
+          onBytes: onBytesSpy,
+          onCompletion: onCompletionSpy,
+        });
+
+        await consume(joinedStream);
+
+        expect(onBytesSpy).toHaveBeenCalled();
+        expect(onCompletionSpy).toHaveBeenCalledWith(expect.any(Number), 1);
+      });
+
+      it("should throw error for unsupported stream types", async () => {
+        const unsupportedType = { notAStream: true };
+        await expect(
+          joinStreams([Promise.resolve(unsupportedType as unknown as StreamingBlobPayloadOutputTypes)])
+        ).rejects.toThrow("Unsupported Stream Type");
+      });
+    });
+  });
+});

--- a/lib/lib-transfer-manager/src/S3TransferManager.e2e.spec.ts
+++ b/lib/lib-transfer-manager/src/S3TransferManager.e2e.spec.ts
@@ -1,0 +1,576 @@
+import type { GetObjectCommandOutput } from "@aws-sdk/client-s3";
+import { S3 } from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
+import { afterEach, beforeAll, describe, expect, test as it } from "vitest";
+
+import { getIntegTestResources } from "../../../tests/e2e/get-integ-test-resources";
+import { internalEventHandler, S3TransferManager } from "./S3TransferManager";
+import type { S3TransferManagerConfig } from "./types";
+
+describe(S3TransferManager.name, () => {
+  const chunk = "01234567";
+
+  function data(bytes: number) {
+    let buffer = "";
+    while (buffer.length < bytes) {
+      buffer += chunk;
+    }
+    return buffer.slice(0, bytes);
+  }
+
+  function check(str = "") {
+    while (str.length > 0) {
+      expect(str.slice(0, 8)).toEqual(chunk);
+      str = str.slice(8);
+    }
+  }
+
+  let client: S3;
+  let tmPart: S3TransferManager;
+  let tmRange: S3TransferManager;
+  let Bucket: string;
+  let region: string;
+
+  beforeAll(async () => {
+    const integTestResourcesEnv = await getIntegTestResources();
+    Object.assign(process.env, integTestResourcesEnv);
+
+    region = process?.env?.AWS_SMOKE_TEST_REGION as string;
+    Bucket = process?.env?.AWS_SMOKE_TEST_BUCKET as string;
+    void getIntegTestResources;
+
+    client = new S3({
+      region,
+    });
+    tmPart = new S3TransferManager({
+      s3: client,
+      multipartDownloadType: "PART",
+    });
+    tmRange = new S3TransferManager({
+      s3: client,
+      multipartDownloadType: "RANGE",
+    });
+  }, 120_000);
+
+  describe("multi part download", () => {
+    const modes = ["PART", "RANGE"] as S3TransferManagerConfig["multipartDownloadType"][];
+    // 6 = 1 part, 11 = 2 part, 19 = 3 part
+    const sizes = [6, 11, 19, 0] as number[];
+
+    for (const mode of modes) {
+      for (const size of sizes) {
+        it(`should download an object of size ${size} with mode ${mode}`, async () => {
+          const totalSizeMB = size * 1024 * 1024;
+          const Body = data(totalSizeMB);
+          const Key = `${mode}-${size}`;
+
+          await new Upload({
+            client,
+            params: { Bucket, Key, Body },
+          }).done();
+
+          const tm: S3TransferManager = mode === "PART" ? tmPart : tmRange;
+
+          const expectBasicTransfer = (request: any, snapshot: any) => {
+            expect(request.Bucket).toEqual(Bucket);
+            expect(request.Key).toEqual(Key);
+            expect(snapshot.totalBytes).toEqual(totalSizeMB);
+          };
+
+          let bytesTransferred = 0;
+          let handleEventCalled = false;
+          const download = await tm.download(
+            { Bucket, Key },
+            {
+              eventListeners: {
+                transferInitiated: [
+                  ({ request, snapshot }) => {
+                    expectBasicTransfer(request, snapshot);
+                    expect(snapshot.transferredBytes).toEqual(0);
+                  },
+                ],
+                bytesTransferred: [
+                  ({ request, snapshot }) => {
+                    expectBasicTransfer(request, snapshot);
+                    bytesTransferred = snapshot.transferredBytes;
+                    expect(snapshot.transferredBytes).toEqual(bytesTransferred);
+                  },
+                ],
+                transferComplete: [
+                  ({ request, snapshot, response }) => {
+                    expectBasicTransfer(request, snapshot);
+                    expect(snapshot.transferredBytes).toEqual(totalSizeMB);
+                    expect(response.ETag).toBeDefined();
+                    expect((response as GetObjectCommandOutput).ContentLength).toEqual(totalSizeMB);
+                  },
+                  {
+                    handleEvent: (event: any) => {
+                      handleEventCalled = true;
+                      expect(event.request.Bucket).toEqual(Bucket);
+                      expect(event.response).toBeDefined();
+                    },
+                  },
+                ],
+              },
+            }
+          );
+          const serialized = await download.Body?.transformToString();
+          check(serialized);
+
+          expect(download.ContentLength).toEqual(totalSizeMB);
+          expect(download.ContentRange).toEqual(`bytes 0-${totalSizeMB - 1}/${totalSizeMB}`);
+          expect(bytesTransferred).toEqual(Body.length);
+          expect(handleEventCalled).toEqual(true);
+        }, 60_000);
+      }
+    }
+  });
+
+  describe("RANGE tests", () => {
+    const uploadTypes = ["multipart", "single"] as const;
+    const ranges = ["bytes=0-5242879", "bytes=0-10485759"];
+
+    for (const uploadType of uploadTypes) {
+      for (const range of ranges) {
+        it(`should download ${uploadType} uploaded object with range ${range}`, async () => {
+          const totalSizeMB = 12 * 1024 * 1024; // 12MB
+          const Body = data(totalSizeMB);
+          const Key = `RANGE-${uploadType}-${range.replace(/[^0-9]/g, "")}`;
+
+          // Upload based on type
+          if (uploadType === "multipart") {
+            await new Upload({
+              client,
+              params: { Bucket, Key, Body },
+            }).done();
+          } else {
+            await client.putObject({ Bucket, Key, Body });
+          }
+
+          const tm: S3TransferManager = tmRange;
+          const rangeEnd = parseInt(range.split("-")[1]);
+          const expectedBytes = rangeEnd + 1;
+
+          const download = await tm.download({ Bucket, Key, Range: range });
+          const serialized = await download.Body?.transformToString();
+          check(serialized);
+
+          expect(download.ContentLength).toEqual(expectedBytes);
+          expect(download.ContentRange).toEqual(`bytes 0-${rangeEnd}/${rangeEnd + 1}`);
+        }, 60_000);
+      }
+    }
+  });
+
+  describe("error handling", () => {
+    const modes = ["PART", "RANGE"] as S3TransferManagerConfig["multipartDownloadType"][];
+
+    for (const mode of modes) {
+      it(`should fail when ETag changes during a ${mode} download`, async () => {
+        const totalSizeMB = 20 * 1024 * 1024;
+        const Body = data(totalSizeMB);
+        const Key = `${mode}-etag-test`;
+
+        if (mode === "PART") {
+          await new Upload({
+            client,
+            params: { Bucket, Key, Body },
+          }).done();
+        } else {
+          await client.putObject({ Bucket, Key, Body });
+        }
+
+        let transferFailed = false;
+        const tm: S3TransferManager = mode === "PART" ? tmPart : tmRange;
+
+        try {
+          internalEventHandler.afterInitialGetObject = async () => {
+            try {
+              if (mode === "PART") {
+                await new Upload({
+                  client,
+                  params: { Bucket, Key, Body: data(20 * 1024 * 1024 - 8) },
+                }).done();
+              } else {
+                await client.putObject({ Bucket, Key, Body: data(20 * 1024 * 1024 - 8) });
+              }
+            } catch (err) {
+              // ignore errors
+            }
+            internalEventHandler.afterInitialGetObject = async () => {};
+          };
+
+          const downloadResponse = await tm.download(
+            { Bucket, Key },
+            {
+              eventListeners: {
+                transferInitiated: [],
+                bytesTransferred: [],
+                transferFailed: [
+                  () => {
+                    transferFailed = true;
+                  },
+                ],
+              },
+            }
+          );
+          await downloadResponse.Body?.transformToByteArray();
+          expect.fail("Download should have failed due to ETag mismatch");
+        } catch (error) {
+          expect(transferFailed).toBe(true);
+          expect(error.name).toEqual("PreconditionFailed");
+        } finally {
+          internalEventHandler.afterInitialGetObject = async () => {};
+        }
+      }, 60_000);
+    }
+  });
+
+  describe("download with abortController ", () => {
+    const modes = ["PART"] as S3TransferManagerConfig["multipartDownloadType"][];
+    for (const mode of modes) {
+      it(`should cancel ${mode} download on abort()`, async () => {
+        const totalSizeMB = 10 * 1024 * 1024;
+        const Body = data(totalSizeMB);
+        const Key = `${mode}-size`;
+        await new Upload({
+          client,
+          params: { Bucket, Key, Body },
+        }).done();
+        const tm: S3TransferManager = mode === "PART" ? tmPart : tmRange;
+        const controller = new AbortController();
+        try {
+          await tm.download(
+            { Bucket, Key },
+            {
+              abortSignal: controller.signal,
+              eventListeners: {
+                transferInitiated: [
+                  () => {
+                    controller.abort();
+                  },
+                ],
+              },
+            }
+          );
+          expect.fail("Download should have been aborted");
+        } catch (error) {
+          expect(error.name).toEqual("AbortError");
+        }
+      }, 60_000);
+    }
+  });
+
+  describe("Required compliance download single object tests", () => {
+    async function complianceTests(
+      objectType: "single" | "multipart",
+      multipartType: "PART" | "RANGE",
+      range: string | undefined,
+      partNumber: 2 | undefined
+    ) {
+      const Body = data(12 * 1024 * 1024);
+      const Key = `${objectType}${multipartType}${range}${partNumber}`;
+      const DEFAULT_PART_SIZE = 8 * 1024 * 1024;
+
+      if (multipartType === "PART") {
+        await new Upload({
+          client,
+          partSize: DEFAULT_PART_SIZE,
+          params: {
+            Bucket,
+            Key,
+            Body,
+          },
+        }).done();
+      } else {
+        await client.putObject({
+          Bucket,
+          Key,
+          Body,
+        });
+      }
+
+      const tm: S3TransferManager = multipartType === "PART" ? tmPart : tmRange;
+
+      const download = await tm.download({
+        Bucket,
+        Key,
+        Range: range,
+        PartNumber: partNumber,
+      });
+      const serialized = await download.Body?.transformToString();
+      check(serialized);
+      if (partNumber) {
+        expect(serialized?.length).toEqual(4 * 1024 * 1024); // Part 1 is 8MB Part 2 is 4MB
+      } else {
+        expect(serialized?.length).toEqual(Body.length);
+      }
+    }
+
+    it("single object: multipartDownloadType = PART, range = 0-12MB, partNumber = null", async () => {
+      await complianceTests("single", "PART", `bytes=0-${12 * 1024 * 1024}`, undefined);
+    }, 60_000);
+    it("multipart object: multipartDownloadType = RANGE, range = 0-12MB, partNumber = null", async () => {
+      await complianceTests("multipart", "RANGE", `bytes=0-${12 * 1024 * 1024}`, undefined);
+    }, 60_000);
+    it("single object: multipartDownloadType = PART, range = null, partNumber = null", async () => {
+      await complianceTests("single", "PART", undefined, undefined);
+    }, 60_000);
+    it("single object: multipartDownloadType = RANGE, range = null, partNumber = null", async () => {
+      await complianceTests("single", "RANGE", undefined, undefined);
+    }, 60_000);
+  });
+
+  describe("upload tests", () => {
+    let uploadTm: S3TransferManager;
+
+    afterEach(() => {
+      // Create a fresh instance for each test to prevent listener leakage
+      // when tests timeout and cleanup code doesn't execute.
+      uploadTm = new S3TransferManager({
+        s3: client,
+        multipartDownloadType: "PART",
+      });
+    });
+
+    it("should upload object below multipart threshold using single PutObject", async () => {
+      uploadTm = new S3TransferManager({ s3: client, multipartDownloadType: "PART" });
+      const Body = data(10 * 1024 * 1024); // 10MB - below 16MB threshold
+      const Key = `upload-single-${Date.now()}`;
+
+      let transferInitiated = false;
+      let bytesTransferred = 0;
+      let transferComplete = false;
+
+      const response = await uploadTm.upload(
+        { Bucket, Key, Body, ChecksumAlgorithm: "CRC32" },
+        {
+          eventListeners: {
+            transferInitiated: [
+              ({ request, snapshot }) => {
+                transferInitiated = true;
+                expect(request.Bucket).toEqual(Bucket);
+                expect(request.Key).toEqual(Key);
+                expect(snapshot.transferredBytes).toEqual(0);
+                expect(snapshot.totalBytes).toEqual(Body.length);
+              },
+            ],
+            bytesTransferred: [
+              ({ snapshot }) => {
+                bytesTransferred = snapshot.transferredBytes;
+              },
+            ],
+            transferComplete: [
+              ({ snapshot, response }) => {
+                transferComplete = true;
+                expect(snapshot.transferredBytes).toEqual(Body.length);
+                expect(response.ETag).toBeDefined();
+              },
+            ],
+          },
+        }
+      );
+
+      expect(transferInitiated).toBe(true);
+      expect(bytesTransferred).toEqual(Body.length);
+      expect(transferComplete).toBe(true);
+      expect(response.ETag).toBeDefined();
+
+      // Verify upload
+      const download = await client.getObject({ Bucket, Key });
+      const downloadedData = await download.Body?.transformToString();
+      expect(downloadedData?.length).toEqual(Body.length);
+
+      await client.deleteObject({ Bucket, Key });
+    }, 60_000);
+
+    it("should upload object above multipart threshold using multipart upload", async () => {
+      uploadTm = new S3TransferManager({ s3: client, multipartDownloadType: "PART" });
+      const Body = data(24 * 1024 * 1024); // 24MB - above 16MB threshold, 3 parts
+      const Key = `upload-multipart-${Date.now()}`;
+
+      let transferInitiated = false;
+      let bytesTransferredEvents = 0;
+      let transferComplete = false;
+
+      const response = await uploadTm.upload(
+        { Bucket, Key, Body, ChecksumAlgorithm: "CRC32" },
+        {
+          eventListeners: {
+            transferInitiated: [
+              ({ request, snapshot }) => {
+                transferInitiated = true;
+                expect(request.Bucket).toEqual(Bucket);
+                expect(request.Key).toEqual(Key);
+                expect(snapshot.transferredBytes).toEqual(0);
+                expect(snapshot.totalBytes).toEqual(Body.length);
+              },
+            ],
+            bytesTransferred: [
+              ({ snapshot }) => {
+                bytesTransferredEvents++;
+                expect(snapshot.transferredBytes).toBeGreaterThan(0);
+                expect(snapshot.transferredBytes).toBeLessThanOrEqual(Body.length);
+              },
+            ],
+            transferComplete: [
+              ({ snapshot, response }) => {
+                transferComplete = true;
+                expect(snapshot.transferredBytes).toEqual(Body.length);
+                expect(response.ETag).toBeDefined();
+              },
+            ],
+          },
+        }
+      );
+
+      expect(transferInitiated).toBe(true);
+      expect(bytesTransferredEvents).toBeGreaterThan(0);
+      expect(transferComplete).toBe(true);
+      expect(response.ETag).toBeDefined();
+
+      const download = await client.getObject({ Bucket, Key });
+      const downloadedData = await download.Body?.transformToString();
+      expect(downloadedData?.length).toEqual(Body.length);
+
+      await client.deleteObject({ Bucket, Key });
+    }, 60_000);
+
+    it("should upload multipart with uneven last part", async () => {
+      const Body = data(10 * 1024 * 1024); // 10MB - 2 parts with uneven last part
+      const Key = `upload-uneven-${Date.now()}`;
+      const customPartSize = 8 * 1024 * 1024; // 8MB parts
+      const expectedPartCount = 2;
+
+      const tmCustom = new S3TransferManager({
+        s3: client,
+        targetPartSizeBytes: customPartSize,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      });
+
+      let partCount = 0;
+      const response = await tmCustom.upload(
+        { Bucket, Key, Body, ChecksumAlgorithm: "CRC32" },
+        {
+          eventListeners: {
+            bytesTransferred: [
+              () => {
+                partCount++;
+              },
+            ],
+          },
+        }
+      );
+
+      expect(response.ETag).toBeDefined();
+      expect(partCount).toEqual(expectedPartCount);
+
+      const download = await client.getObject({ Bucket, Key });
+      const downloadedData = await download.Body?.transformToString();
+      expect(downloadedData?.length).toEqual(Body.length);
+
+      await client.deleteObject({ Bucket, Key });
+    }, 60_000);
+
+    it("should upload single object with full object checksum", async () => {
+      uploadTm = new S3TransferManager({ s3: client, multipartDownloadType: "PART" });
+      const Body = data(10 * 1024 * 1024); // 10MB
+      const Key = `upload-checksum-calc-${Date.now()}`;
+
+      const response = await uploadTm.upload({ Bucket, Key, Body, ChecksumAlgorithm: "CRC32" });
+
+      expect(response.ETag).toBeDefined();
+      expect(response.ChecksumCRC32).toBeDefined();
+      expect(response.ChecksumType).toBe("FULL_OBJECT");
+
+      const download = await client.getObject({ Bucket, Key });
+      const downloadedData = await download.Body?.transformToString();
+      expect(downloadedData?.length).toEqual(Body.length);
+
+      await client.deleteObject({ Bucket, Key });
+    }, 60_000);
+
+    it("should abort multipart upload on error", async () => {
+      uploadTm = new S3TransferManager({ s3: client, multipartDownloadType: "PART" });
+      const Body = data(24 * 1024 * 1024); // 24MB
+      const Key = `upload-abort-${Date.now()}`;
+      const controller = new AbortController();
+
+      let transferFailed = false;
+
+      try {
+        await uploadTm.upload(
+          { Bucket, Key, Body, ChecksumAlgorithm: "CRC32" },
+          {
+            abortSignal: controller.signal,
+            eventListeners: {
+              transferInitiated: [
+                () => {
+                  controller.abort();
+                },
+              ],
+              transferFailed: [
+                () => {
+                  transferFailed = true;
+                },
+              ],
+            },
+          }
+        );
+        expect.fail("Upload should have been aborted");
+      } catch (error) {
+        expect(error.name).toEqual("AbortError");
+        expect(transferFailed).toBe(true);
+      }
+    }, 60_000);
+
+    it("should upload empty file", async () => {
+      uploadTm = new S3TransferManager({ s3: client, multipartDownloadType: "PART" });
+      const Body = "";
+      const Key = `upload-empty-${Date.now()}`;
+
+      const response = await uploadTm.upload({ Bucket, Key, Body });
+
+      expect(response.ETag).toBeDefined();
+
+      const download = await client.getObject({ Bucket, Key });
+      const downloadedData = await download.Body?.transformToString();
+      expect(downloadedData?.length).toEqual(0);
+
+      await client.deleteObject({ Bucket, Key });
+    }, 60_000);
+
+    it("should upload multipart with composite checksum", async () => {
+      const Body = data(20 * 1024 * 1024); // 20MB
+      const Key = `upload-checksum-${Date.now()}`;
+
+      const clientWithChecksumCalc = new S3({
+        region,
+        requestChecksumCalculation: "WHEN_SUPPORTED",
+      });
+
+      const tmCustom = new S3TransferManager({
+        s3: clientWithChecksumCalc,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 16 * 1024 * 1024,
+      });
+
+      const response = await tmCustom.upload({
+        Bucket,
+        Key,
+        Body,
+        ChecksumAlgorithm: "CRC32",
+      });
+
+      expect(response.ETag).toBeDefined();
+      expect(response.ChecksumCRC32).toBeDefined();
+      expect(response.ChecksumType).toBe("COMPOSITE");
+
+      const download = await client.getObject({ Bucket, Key });
+      const downloadedData = await download.Body?.transformToString();
+      expect(downloadedData?.length).toEqual(Body.length);
+
+      await client.deleteObject({ Bucket, Key });
+    }, 60_000);
+  });
+});

--- a/lib/lib-transfer-manager/src/S3TransferManager.spec.ts
+++ b/lib/lib-transfer-manager/src/S3TransferManager.spec.ts
@@ -1,0 +1,1321 @@
+import { S3, S3Client } from "@aws-sdk/client-s3";
+import { Readable } from "node:stream";
+import { beforeAll, beforeEach, describe, expect, test as it, vi } from "vitest";
+
+import { S3TransferManager } from "./S3TransferManager";
+import type { TransferCompleteEvent, TransferEvent } from "./types";
+import { WorkerHttpHandler } from "./worker-http-handler";
+
+describe("S3TransferManager Unit Tests", () => {
+  let client: S3;
+  let Bucket: string;
+  let region: string;
+
+  beforeAll(async () => {
+    region = "us-west-2";
+    Bucket = `S3TransferManager-test-${Date.now()}`;
+
+    client = new S3({
+      region,
+      responseChecksumValidation: "WHEN_REQUIRED",
+    });
+  });
+
+  describe("S3TransferManager Constructor", () => {
+    it("Should create an instance of S3TransferManager with defaults given no parameters", () => {
+      const tm = new S3TransferManager() as any;
+
+      expect(tm.s3).toBeInstanceOf(S3Client);
+      expect(tm.targetPartSizeBytes).toBe(8 * 1024 * 1024);
+      expect(tm.multipartUploadThresholdBytes).toBe(16 * 1024 * 1024);
+      expect(tm.requestChecksumCalculation).toBe("WHEN_SUPPORTED");
+      expect(tm.responseChecksumValidation).toBe("WHEN_SUPPORTED");
+      expect(tm.multipartDownloadType).toBe("PART");
+      expect(tm.eventListeners).toEqual({
+        transferInitiated: [],
+        bytesTransferred: [],
+        transferComplete: [],
+        transferFailed: [],
+      });
+    });
+
+    it("Should create an instance of S3TransferManager with all given parameters", () => {
+      const eventListeners = {
+        transferInitiated: [() => console.log("transferInitiated")],
+        bytesTransferred: [() => console.log("bytesTransferred")],
+        transferComplete: [() => console.log("transferComplete")],
+        transferFailed: [() => console.log("transferFailed")],
+      };
+      const tm = new S3TransferManager({
+        s3: client,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        requestChecksumCalculation: "WHEN_SUPPORTED",
+        responseChecksumValidation: "WHEN_REQUIRED",
+        multipartDownloadType: "RANGE",
+        eventListeners: eventListeners,
+      }) as any;
+
+      expect(tm.s3).toBe(client);
+      expect(tm.targetPartSizeBytes).toBe(8 * 1024 * 1024);
+      expect(tm.requestChecksumCalculation).toBe("WHEN_SUPPORTED");
+      expect(tm.responseChecksumValidation).toBe("WHEN_REQUIRED");
+      expect(tm.multipartDownloadType).toBe("RANGE");
+      expect(tm.eventListeners).toEqual(eventListeners);
+    });
+
+    it("Should throw an error given targetPartSizeBytes smaller than minimum", () => {
+      expect(() => {
+        new S3TransferManager({
+          targetPartSizeBytes: 2 * 1024 * 1024,
+        });
+      }).toThrow(`targetPartSizeBytes must be at least ${5 * 1024 * 1024} bytes`);
+    });
+  });
+
+  describe("EventListener functions", () => {
+    let tm: S3TransferManager;
+
+    function initiated(event: TransferEvent) {
+      return {
+        request: event.request,
+        snapshot: event.snapshot,
+      };
+    }
+    function transferring(event: TransferEvent) {
+      return {
+        request: event.request,
+        snapshot: event.snapshot,
+      };
+    }
+    function completed(event: TransferCompleteEvent) {
+      return {
+        request: event.request,
+        snapshot: event.snapshot,
+        response: event.response,
+      };
+    }
+    function failed(event: TransferEvent) {
+      return {
+        request: event.request,
+        snapshot: event.snapshot,
+      };
+    }
+
+    beforeEach(async () => {
+      tm = new S3TransferManager({
+        s3: client,
+      });
+    });
+
+    describe("addEventListener()", () => {
+      it("Should register callbacks for all supported event types", () => {
+        tm.addEventListener("transferInitiated", initiated);
+        tm.addEventListener("bytesTransferred", transferring);
+        tm.addEventListener("transferComplete", completed);
+        tm.addEventListener("transferFailed", failed);
+
+        expect((tm as any).eventListeners).toEqual({
+          transferInitiated: [initiated],
+          bytesTransferred: [transferring],
+          transferComplete: [completed],
+          transferFailed: [failed],
+        });
+      });
+
+      it("Should handle registering the same listener multiple times", () => {
+        const callback1 = vi.fn();
+        tm.addEventListener("transferInitiated", callback1);
+        tm.addEventListener("transferInitiated", callback1);
+
+        expect((tm as any).eventListeners.transferInitiated).toEqual([callback1, callback1]);
+      });
+
+      it("Should handle different callbacks for the same event type", () => {
+        const callback1 = vi.fn();
+        const callback2 = vi.fn();
+
+        tm.addEventListener("bytesTransferred", callback1);
+        tm.addEventListener("bytesTransferred", callback2);
+
+        expect((tm as any).eventListeners.bytesTransferred).toEqual([callback1, callback2]);
+      });
+
+      it("Should handle object-style callbacks", () => {
+        const objectCallback = {
+          handleEvent: vi.fn(),
+        };
+        tm.addEventListener("transferInitiated", objectCallback as any);
+
+        expect((tm as any).eventListeners.transferInitiated).toEqual([objectCallback]);
+      });
+
+      it("Should handle a mix of object-style callbacks and function for the same event", () => {
+        const callback = vi.fn();
+        const objectCallback = {
+          handleEvent: vi.fn(),
+        };
+        tm.addEventListener("transferInitiated", objectCallback as any);
+        tm.addEventListener("transferInitiated", callback);
+
+        expect((tm as any).eventListeners.transferInitiated).toEqual([objectCallback, callback]);
+      });
+
+      it("Should throw an error for an invalid event type", () => {
+        expect(() => {
+          (tm as any).addEventListener("invalidEvent", initiated);
+        }).toThrow("Unknown event type: invalidEvent");
+      });
+
+      it("Should handle options.once correctly, running the listener at most once.", () => {
+        const mockCallback = vi.fn();
+        tm.addEventListener("transferInitiated", mockCallback, { once: true });
+
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+
+        tm.dispatchEvent(event);
+        tm.dispatchEvent(event);
+
+        expect(mockCallback).toHaveBeenCalledTimes(1);
+      });
+
+      it("Should not add listener if included AbortSignal is aborted", () => {
+        const controller = new AbortController();
+        const callback = vi.fn();
+        controller.abort();
+        tm.addEventListener("transferInitiated", callback, { signal: controller.signal });
+        expect((tm as any).eventListeners.transferInitiated).toEqual([]);
+      });
+
+      it("Should remove listener after included AbortSignal was aborted", () => {
+        const controller = new AbortController();
+        const callback = vi.fn();
+        tm.addEventListener("transferInitiated", callback, { signal: controller.signal });
+
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+        tm.dispatchEvent(event);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([callback]);
+
+        controller.abort();
+        expect((tm as any).eventListeners.transferInitiated).toEqual([]);
+      });
+
+      it("Should clean up abort listeners and store cleanup functions in WeakMap", () => {
+        const controller = new AbortController();
+        const callback = vi.fn();
+
+        tm.addEventListener("transferInitiated", callback, { signal: controller.signal });
+
+        expect((tm as any).eventListeners.transferInitiated).toEqual([callback]);
+        expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(true);
+
+        const cleanupFn = (tm as any).abortCleanupFunctions.get(controller.signal);
+        cleanupFn();
+        (tm as any).abortCleanupFunctions.delete(controller.signal);
+
+        expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(false);
+        controller.abort();
+        expect((tm as any).eventListeners.transferInitiated).toEqual([callback]);
+      });
+
+      it("Should handle boolean options parameter", () => {
+        tm.addEventListener("transferInitiated", initiated, true);
+        expect((tm as any).eventListeners.transferInitiated).toContain(initiated);
+      });
+
+      it("Should handle null callback", () => {
+        expect(() => {
+          (tm as any).addEventListener("transferInitiated", null);
+        }).not.toThrow();
+      });
+
+      it("Should handle object-style callback with handleEvent", () => {
+        const objectCallback = { handleEvent: vi.fn() };
+        tm.addEventListener("transferInitiated", objectCallback as any);
+        expect((tm as any).eventListeners.transferInitiated).toContain(objectCallback);
+      });
+    });
+
+    describe("dispatchEvent()", () => {
+      it("Should dispatch an event", () => {
+        const mockCallback = vi.fn();
+        tm.addEventListener("bytesTransferred", mockCallback);
+
+        const event = Object.assign(new Event("bytesTransferred"), {
+          request: {},
+          snapshot: {},
+        });
+
+        const result = tm.dispatchEvent(event);
+
+        expect(mockCallback).toHaveBeenCalledTimes(1);
+        expect(mockCallback).toHaveBeenCalledWith(event);
+        expect(result).toBe(true);
+      });
+
+      it("Should dispatch an event with request, snapshot, and response information", () => {
+        const mockCompleted = vi.fn().mockImplementation(completed);
+        tm.addEventListener("transferComplete", mockCompleted);
+
+        const event = Object.assign(new Event("transferComplete"), {
+          request: { bucket: "test" },
+          snapshot: { bytes: 100 },
+          response: { status: "success" },
+        });
+
+        tm.dispatchEvent(event);
+
+        expect(mockCompleted).toHaveBeenCalledWith(event);
+        expect(mockCompleted).toHaveReturnedWith({
+          request: { bucket: "test" },
+          snapshot: { bytes: 100 },
+          response: { status: "success" },
+        });
+      });
+
+      it("Should call multiple listeners for the same event type", () => {
+        const mockCallback = vi.fn();
+        tm.addEventListener("transferInitiated", mockCallback);
+        tm.addEventListener("transferInitiated", mockCallback);
+
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+
+        const result = tm.dispatchEvent(event);
+
+        expect(mockCallback).toHaveBeenCalledTimes(2);
+        expect(mockCallback).toHaveBeenCalledWith(event);
+        expect(result).toBe(true);
+      });
+
+      it("Should call listeners in the order they were added", () => {
+        const callOrder: number[] = [];
+        const mockCallback1 = vi.fn(() => callOrder.push(1));
+        const mockCallback2 = vi.fn(() => callOrder.push(2));
+        const mockCallback3 = vi.fn(() => callOrder.push(3));
+
+        tm.addEventListener("transferInitiated", mockCallback1);
+        tm.addEventListener("transferInitiated", mockCallback2);
+        tm.addEventListener("transferInitiated", mockCallback3);
+
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+
+        tm.dispatchEvent(event);
+
+        expect(callOrder).toEqual([1, 2, 3]);
+      });
+
+      it("Should handle object-style callbacks with handleEvent method", () => {
+        const mockCallback = vi.fn();
+        const objectCallback = {
+          handleEvent: mockCallback,
+        };
+        tm.addEventListener("transferInitiated", objectCallback as any);
+
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+
+        tm.dispatchEvent(event);
+
+        expect(mockCallback).toHaveBeenCalledTimes(1);
+        expect(mockCallback).toHaveBeenCalledWith(event);
+      });
+
+      it("Should handle events with no registered listeners", () => {
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+        const result = tm.dispatchEvent(event);
+
+        expect(result).toBe(true);
+      });
+
+      it("Should handle unknown event types", () => {
+        const event = Object.assign(new Event("unknownEvent"), {
+          request: {},
+          snapshot: {},
+        });
+
+        const results = tm.dispatchEvent(event);
+        expect(results).toBe(true);
+      });
+
+      it("Should handle a mix of object-style callbacks and functions", () => {
+        const callback = vi.fn();
+        const objectCallback = {
+          handleEvent: vi.fn(),
+        };
+        tm.addEventListener("transferInitiated", objectCallback as any);
+        tm.addEventListener("transferInitiated", callback);
+
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+
+        tm.dispatchEvent(event);
+
+        expect(objectCallback.handleEvent).toHaveBeenCalledTimes(1);
+        expect(objectCallback.handleEvent).toHaveBeenCalledWith(event);
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(event);
+      });
+    });
+
+    describe("removeEventListener()", () => {
+      it("Should remove only the specified listener, leaving other intact", () => {
+        const callback1 = vi.fn();
+        const callback2 = vi.fn();
+        tm.addEventListener("transferInitiated", callback1);
+        tm.addEventListener("transferInitiated", callback2);
+
+        tm.removeEventListener("transferInitiated", callback1);
+
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+
+        tm.dispatchEvent(event);
+
+        expect(callback1).not.toHaveBeenCalled();
+        expect(callback2).toHaveBeenCalledTimes(1);
+      });
+
+      it("Should remove object-style callback with handleEvent", () => {
+        const objectCallback = { handleEvent: vi.fn() };
+        tm.addEventListener("transferInitiated", objectCallback as any);
+        tm.removeEventListener("transferInitiated", objectCallback as any);
+
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+
+        tm.dispatchEvent(event);
+        expect(objectCallback.handleEvent).not.toHaveBeenCalled();
+      });
+
+      it("Should remove all instance of the same callback", () => {
+        const callback = vi.fn();
+        tm.addEventListener("transferInitiated", callback);
+        tm.addEventListener("transferInitiated", callback);
+
+        tm.removeEventListener("transferInitiated", callback);
+
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+
+        tm.dispatchEvent(event);
+
+        expect(callback).not.toHaveBeenCalled();
+      });
+
+      it("Should handle removing non-existing listener gracefully", () => {
+        const callback = vi.fn();
+        expect(() => {
+          tm.removeEventListener("transferInitiated", callback);
+        }).not.toThrow();
+      });
+
+      it("Should handle removing from an event type with no listeners gracefully", () => {
+        const callback = vi.fn();
+        tm.removeEventListener("transferInitiated", callback);
+
+        const event = Object.assign(new Event("transferInitiated"), {
+          request: {},
+          snapshot: {},
+        });
+
+        tm.dispatchEvent(event);
+
+        expect(callback).not.toHaveBeenCalled();
+      });
+
+      it("Should handle null callback parameter", () => {
+        expect(() => {
+          tm.removeEventListener("transferInitiated", null as any);
+        }).not.toThrow();
+      });
+    });
+  });
+
+  describe("iterateListeners()", () => {
+    let tm: S3TransferManager;
+
+    beforeEach(async () => {
+      tm = new S3TransferManager({
+        s3: client,
+      });
+    });
+
+    it("Should iterate over all listeners given a TransferManager's object of event listeners", () => {
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+      const callback3 = vi.fn();
+
+      const eventListeners = {
+        transferInitiated: [callback1],
+        bytesTransferred: [callback2, callback3],
+        transferComplete: [],
+        transferFailed: [],
+      };
+
+      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
+
+      expect(results).toHaveLength(3);
+      expect(results[0][0]).toEqual({ eventType: "transferInitiated", callback: callback1 });
+      expect(results[1][0]).toEqual({ eventType: "bytesTransferred", callback: callback2 });
+      expect(results[2][0]).toEqual({ eventType: "bytesTransferred", callback: callback3 });
+    });
+
+    it("Should handle empty event listeners object", () => {
+      const eventListeners = {
+        transferInitiated: [],
+        bytesTransferred: [],
+        transferComplete: [],
+        transferFailed: [],
+      };
+
+      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
+
+      expect(results).toHaveLength(0);
+    });
+
+    it("Should iterate over a mix of functions and objects with handleEvent callback types.", () => {
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+      const objectCallback = {
+        handleEvent: vi.fn(),
+      };
+
+      const eventListeners = {
+        transferInitiated: [callback1],
+        bytesTransferred: [],
+        transferComplete: [],
+        transferFailed: [callback2, objectCallback],
+      };
+
+      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
+
+      expect(results).toHaveLength(3);
+      expect(results[0][0]).toEqual({ eventType: "transferInitiated", callback: callback1 });
+      expect(results[1][0]).toEqual({ eventType: "transferFailed", callback: callback2 });
+      expect(results[2][0]).toEqual({ eventType: "transferFailed", callback: objectCallback });
+    });
+
+    it("Should handle event listeners with duplicate callbacks in the same event type", () => {
+      const callback = vi.fn();
+
+      const eventListeners = {
+        transferInitiated: [callback, callback],
+        bytesTransferred: [],
+        transferComplete: [callback, callback],
+        transferFailed: [],
+      };
+
+      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
+
+      expect(results).toHaveLength(4);
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i][0]).toEqual({ eventType: results[i][0].eventType, callback });
+      }
+    });
+
+    it("Should return empty iterator when no callbacks are present", () => {
+      const eventListeners = {};
+
+      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
+
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("validatePartDownload()", () => {
+    let tm: any;
+    beforeAll(async () => {
+      tm = new S3TransferManager() as any;
+    }, 120_000);
+
+    it("Should pass correct ranges based on part number without throwing an error", () => {
+      const partSize = 5242880;
+      const ranges = [
+        { partNumber: 1, range: "bytes 0-5242879/13631488" },
+        { partNumber: 2, range: "bytes 5242880-10485759/13631488" },
+        { partNumber: 3, range: "bytes 10485760-13631487/13631488" },
+      ];
+
+      for (const { partNumber, range } of ranges) {
+        expect(() => {
+          tm.validatePartDownload(range, partNumber, partSize);
+        }).not.toThrow();
+      }
+    });
+
+    it("Should throw error for incorrect start position", () => {
+      const partSize = 5242880;
+
+      expect(() => {
+        tm.validatePartDownload("bytes 5242881-10485759/13631488", 2, partSize);
+      }).toThrow("Expected part 2 to start at 5242880 but got 5242881");
+
+      expect(() => {
+        tm.validatePartDownload("bytes 5242879-10485759/13631488", 2, partSize);
+      }).toThrow("Expected part 2 to start at 5242880 but got 5242879");
+
+      expect(() => {
+        tm.validatePartDownload("bytes 0-5242879/13631488", 2, partSize);
+      }).toThrow("Expected part 2 to start at 5242880 but got 0");
+    });
+
+    it("Should throw error for incorrect end position", () => {
+      const partSize = 5242880;
+
+      expect(() => {
+        tm.validatePartDownload("bytes 5242880-10485760/13631488", 2, partSize);
+      }).toThrow("Expected part 2 to end at 10485759 but got 10485760");
+
+      expect(() => {
+        tm.validatePartDownload("bytes 10485760-13631480/13631488", 3, partSize);
+      }).toThrow("Expected part 3 to end at 13631487 but got 13631480");
+    });
+
+    it("Should handle last part correctly when not a full part size", () => {
+      const partSize = 5242880;
+
+      expect(() => {
+        tm.validatePartDownload("bytes 10485760-13631487/13631488", 3, partSize);
+      }).not.toThrow();
+    });
+
+    it("Should throw error for invalid ContentRange format", () => {
+      const partSize = 5242880;
+
+      expect(() => {
+        tm.validatePartDownload("invalid-format", 2, partSize);
+      }).toThrow("Invalid ContentRange format: invalid-format");
+    });
+
+    it("Should throw error for missing ContentRange", () => {
+      const partSize = 5242880;
+
+      expect(() => {
+        tm.validatePartDownload(undefined, 2, partSize);
+      }).toThrow("Missing ContentRange for part 2.");
+    });
+  });
+
+  describe("validateRangeDownload()", () => {
+    let tm: any;
+    beforeAll(async () => {
+      tm = new S3TransferManager() as any;
+    }, 120_000);
+
+    it("Should pass when response range matches request range", () => {
+      expect(() => {
+        tm.validateRangeDownload("bytes=0-5242879", "bytes 0-5242879/13631488");
+      }).not.toThrow();
+    });
+
+    it("Should pass when response range ends at total size", () => {
+      expect(() => {
+        tm.validateRangeDownload("bytes=10485760-13631500", "bytes 10485760-13631487/13631488");
+      }).not.toThrow();
+    });
+
+    it("Should throw error for missing response range", () => {
+      expect(() => {
+        tm.validateRangeDownload("bytes=0-5242879", undefined);
+      }).toThrow("Missing ContentRange for range bytes=0-5242879.");
+    });
+
+    it("Should throw error for invalid response range format", () => {
+      expect(() => {
+        tm.validateRangeDownload("bytes=0-5242879", "invalid-format");
+      }).toThrow("Invalid ContentRange format: invalid-format");
+    });
+
+    it("Should throw error for invalid request range format", () => {
+      expect(() => {
+        tm.validateRangeDownload("invalid-format", "bytes 0-5242879/13631488");
+      }).toThrow("Invalid Range format: invalid-format");
+    });
+
+    it("Should throw error for incorrect start position", () => {
+      expect(() => {
+        tm.validateRangeDownload("bytes=0-5242879", "bytes 1-5242879/13631488");
+      }).toThrow("Expected range to start at 0 but got 1");
+    });
+
+    it("Should throw error for incorrect end position", () => {
+      expect(() => {
+        tm.validateRangeDownload("bytes=0-5242879", "bytes 0-5242878/13631488");
+      }).toThrow("Expected range to end at 5242879 but got 5242878");
+    });
+  });
+
+  describe("validateUploadPart()", () => {
+    let tm: any;
+    beforeAll(async () => {
+      tm = new S3TransferManager() as any;
+    });
+
+    it("should pass for valid non-last part with correct size", () => {
+      const partSize = 8 * 1024 * 1024; // 8MB
+      const dataPart = {
+        data: Buffer.alloc(partSize),
+        partNumber: 2,
+        lastPart: false,
+      };
+
+      expect(() => {
+        tm.validateUploadPart(dataPart, partSize);
+      }).not.toThrow();
+    });
+
+    it("should skip validation for single-part uploads", () => {
+      const partSize = 8 * 1024 * 1024;
+      const dataPart = {
+        data: Buffer.alloc(1024), // Small size
+        partNumber: 1,
+        lastPart: true,
+      };
+
+      expect(() => {
+        tm.validateUploadPart(dataPart, partSize);
+      }).not.toThrow();
+    });
+
+    it("should allow smaller size for last part", () => {
+      const partSize = 8 * 1024 * 1024;
+      const dataPart = {
+        data: Buffer.alloc(1024 * 1024), // 1MB (smaller than partSize)
+        partNumber: 5,
+        lastPart: true,
+      };
+
+      expect(() => {
+        tm.validateUploadPart(dataPart, partSize);
+      }).not.toThrow();
+    });
+
+    it("should throw error when part size doesn't match expected size except for last part", () => {
+      const partSize = 8 * 1024 * 1024;
+      const dataPart = {
+        data: Buffer.alloc(7 * 1024 * 1024), // 7MB (less than expected)
+        partNumber: 2,
+        lastPart: false,
+      };
+
+      expect(() => {
+        tm.validateUploadPart(dataPart, partSize);
+      }).toThrow(`The byte size for part number 2, size ${7 * 1024 * 1024} does not match expected size ${partSize}`);
+    });
+
+    it("should throw error when part has zero content length", () => {
+      const partSize = 8 * 1024 * 1024;
+      const dataPart = {
+        data: Buffer.alloc(0), // Empty buffer
+        partNumber: 2,
+        lastPart: false,
+      };
+
+      expect(() => {
+        tm.validateUploadPart(dataPart, partSize);
+      }).toThrow(`The byte size for part number 2, size 0 does not match expected size ${partSize}`);
+    });
+  });
+
+  describe("calculatePartSize()", () => {
+    let tm: any;
+    beforeAll(async () => {
+      tm = new S3TransferManager() as any;
+    });
+
+    it("should use targetPartSizeBytes for small files", () => {
+      const contentLength = 50 * 1024 * 1024; // 50MB
+      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
+
+      expect(partSize).toBe(8 * 1024 * 1024); // Default 8MB
+      expect(expectedPartsCount).toBe(7); // ceil(50/8) = 7
+    });
+
+    it("should calculate larger part size for files approaching 10,000 parts limit", () => {
+      const contentLength = 100 * 1024 * 1024 * 1024; // 100GB
+      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
+
+      expect(partSize).toBeGreaterThan(8 * 1024 * 1024);
+      expect(partSize).toBe(Math.ceil(contentLength / 10_000));
+      //expectedPartsCount can be 10,001 due to Math.ceil(contentLength / partSize)
+      expect(expectedPartsCount).toBeGreaterThanOrEqual(10_000);
+      expect(expectedPartsCount).toBeLessThanOrEqual(10_001);
+    });
+
+    it("should handle very large files correctly", () => {
+      const contentLength = 5 * 1024 * 1024 * 1024 * 1024; // 5TB
+      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
+
+      expect(partSize).toBe(Math.ceil(contentLength / 10_000));
+      expect(expectedPartsCount).toBe(Math.ceil(contentLength / partSize));
+      // Note: expectedPartsCount can be 10,001 due to Math.ceil(contentLength / partSize)
+      expect(expectedPartsCount).toBeGreaterThanOrEqual(10_000);
+      expect(expectedPartsCount).toBeLessThanOrEqual(10_001);
+    });
+
+    it("should return correct values for minimum size file", () => {
+      const contentLength = 8 * 1024 * 1024; // 8MB (one part)
+      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
+
+      expect(partSize).toBe(8 * 1024 * 1024);
+      expect(expectedPartsCount).toBe(1);
+    });
+
+    it("should calculate expectedPartsCount correctly when totalBytes is known", () => {
+      const contentLength = 15 * 1024 * 1024; // 15MB
+      const customPartSize = 5 * 1024 * 1024; // 5MB
+      const tm = new S3TransferManager({
+        targetPartSizeBytes: customPartSize,
+      }) as any;
+
+      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
+
+      expect(partSize).toBe(customPartSize);
+      expect(expectedPartsCount).toBe(3); // 15MB / 5MB = 3 parts
+    });
+  });
+
+  describe("createConcurrentTaskPool() concurrency", () => {
+    it("should default maxConcurrentDownloads to 8 when not provided", () => {
+      const tm = new S3TransferManager() as any;
+      expect(tm.maxConcurrentDownloads).toBe(8);
+    });
+
+    it("should use user-provided maxConcurrentDownloads", () => {
+      const tm = new S3TransferManager({ maxConcurrentDownloads: 3 }) as any;
+      expect(tm.maxConcurrentDownloads).toBe(3);
+    });
+
+    it("should only launch up to maxConcurrent tasks initially", () => {
+      const tm = new S3TransferManager({ maxConcurrentDownloads: 3 }) as any;
+      let launched = 0;
+      const tasks = Array.from({ length: 5 }, () => () => {
+        launched++;
+        return new Promise(() => {}); // never resolves
+      });
+
+      tm.createConcurrentTaskPool(tasks, 3);
+      expect(launched).toBe(3);
+    });
+
+    it("should launch next task when onStreamConsumed is called", async () => {
+      const tm = new S3TransferManager({ maxConcurrentDownloads: 2 }) as any;
+      let launched = 0;
+      const resolvers: ((v: string) => void)[] = [];
+      const tasks = Array.from({ length: 4 }, (_, i) => () => {
+        launched++;
+        return new Promise<string>((resolve) => {
+          resolvers[i] = resolve;
+        });
+      });
+
+      const { promises, onStreamConsumed } = tm.createConcurrentTaskPool(tasks, 2);
+      expect(launched).toBe(2);
+
+      // Resolve first task and signal stream consumed
+      resolvers[0]("a");
+      await promises[0];
+      onStreamConsumed(0);
+      expect(launched).toBe(3);
+
+      // Resolve second task and signal stream consumed
+      resolvers[1]("b");
+      await promises[1];
+      onStreamConsumed(1);
+      expect(launched).toBe(4);
+    });
+
+    it("should stop launching after a task failure", async () => {
+      const tm = new S3TransferManager({ maxConcurrentDownloads: 2 }) as any;
+      let launched = 0;
+      const tasks: (() => Promise<string>)[] = [
+        () => {
+          launched++;
+          return Promise.reject(new Error("fail"));
+        },
+        () => {
+          launched++;
+          return new Promise(() => {});
+        },
+        () => {
+          launched++;
+          return Promise.resolve("c");
+        },
+      ];
+
+      const { promises, onStreamConsumed } = tm.createConcurrentTaskPool(tasks, 2);
+      expect(launched).toBe(2);
+
+      // Wait for the rejection to propagate
+      await promises[0].catch(() => {});
+
+      // After failure, onStreamConsumed should not launch more
+      onStreamConsumed(0);
+      expect(launched).toBe(2);
+    });
+  });
+
+  describe("Client-level vs Request-level listeners with mocked uploads", () => {
+    let tm: S3TransferManager;
+    let mockSend: any;
+
+    beforeEach(() => {
+      mockSend = vi.fn().mockResolvedValue({
+        ETag: '"mock-etag"',
+        $metadata: { httpStatusCode: 200 },
+      });
+
+      const mockClient = {
+        send: mockSend,
+      } as any;
+
+      tm = new S3TransferManager({
+        s3: mockClient,
+      });
+    });
+
+    it("Should fire client-level listener for every upload request", async () => {
+      const clientLevelCallback = vi.fn();
+      tm.addEventListener("transferComplete", clientLevelCallback);
+
+      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content1" });
+      await tm.upload({ Bucket: "test-bucket", Key: "file2.txt", Body: "content2" });
+      await tm.upload({ Bucket: "test-bucket", Key: "file3.txt", Body: "content3" });
+
+      expect(clientLevelCallback).toHaveBeenCalledTimes(3);
+    });
+
+    it("Should fire request-level listener only for that specific request", async () => {
+      const requestLevelCallback = vi.fn();
+
+      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content1" });
+
+      await tm.upload(
+        { Bucket: "test-bucket", Key: "file2.txt", Body: "content2" },
+        { eventListeners: { transferComplete: [requestLevelCallback] } }
+      );
+
+      await tm.upload({ Bucket: "test-bucket", Key: "file3.txt", Body: "content3" });
+
+      expect(requestLevelCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should fire both client-level and request-level listeners when both are registered", async () => {
+      const clientCallback = vi.fn();
+      const requestCallback = vi.fn();
+
+      tm.addEventListener("transferComplete", clientCallback);
+
+      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "a" });
+      await tm.upload(
+        { Bucket: "test-bucket", Key: "file2.txt", Body: "b" },
+        { eventListeners: { transferComplete: [requestCallback] } }
+      );
+      await tm.upload({ Bucket: "test-bucket", Key: "file3.txt", Body: "c" });
+
+      expect(clientCallback).toHaveBeenCalledTimes(3);
+      expect(requestCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should fire transferInitiated exactly once per upload", async () => {
+      const initiatedCallback = vi.fn();
+      tm.addEventListener("transferInitiated", initiatedCallback);
+
+      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" });
+
+      expect(initiatedCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should fire transferComplete exactly once per successful upload", async () => {
+      const completeCallback = vi.fn();
+      tm.addEventListener("transferComplete", completeCallback);
+
+      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" });
+
+      expect(completeCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should fire transferFailed exactly once when upload fails", async () => {
+      const failedCallback = vi.fn();
+      tm.addEventListener("transferFailed", failedCallback);
+
+      mockSend.mockRejectedValueOnce(new Error("Upload failed"));
+
+      await expect(tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" })).rejects.toThrow(
+        "Upload failed"
+      );
+
+      expect(failedCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should fire bytesTransferred at least once for successful upload", async () => {
+      const bytesCallback = vi.fn();
+      tm.addEventListener("bytesTransferred", bytesCallback);
+
+      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" });
+
+      expect(bytesCallback.mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("Threaded multipart upload", () => {
+    let sendCallCount = 0;
+    let sendCalls: any[] = [];
+    let mockSend: any;
+
+    function createMockClient() {
+      sendCalls = [];
+      mockSend = vi.fn().mockImplementation((command: any) => {
+        sendCallCount++;
+        sendCalls.push(command);
+        const commandName = command.constructor?.name ?? "";
+        if (commandName === "CreateMultipartUploadCommand") {
+          return Promise.resolve({ UploadId: "test-upload-id", $metadata: {} });
+        }
+        if (commandName === "UploadPartCommand") {
+          return Promise.resolve({
+            ETag: `"etag-${command.input?.PartNumber}"`,
+            ChecksumCRC32: "abc123==",
+            $metadata: {},
+          });
+        }
+        if (commandName === "CompleteMultipartUploadCommand") {
+          return Promise.resolve({ ETag: '"final-etag"', $metadata: {} });
+        }
+        if (commandName === "AbortMultipartUploadCommand") {
+          return Promise.resolve({ $metadata: {} });
+        }
+        return Promise.resolve({ ETag: '"mock-etag"', $metadata: {} });
+      });
+      return { send: mockSend, config: {} } as any;
+    }
+
+    it("should use explicit workerThreadCount and create WorkerHttpHandler", () => {
+      const tm = new S3TransferManager({ workerThreadCount: 4 }) as any;
+      expect(tm.workerThreadCount).toBe(4);
+      expect(tm.workerHttpHandler).toBeInstanceOf(WorkerHttpHandler);
+    });
+
+    it("should not create WorkerHttpHandler when workerThreadCount is 1", () => {
+      const tm = new S3TransferManager({ workerThreadCount: 1 }) as any;
+      expect(tm.workerThreadCount).toBe(1);
+      expect(tm.workerHttpHandler).toBeUndefined();
+    });
+
+    it("should route in-memory Buffer body to threadedUploadInParts when workerThreadCount > 1", async () => {
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({
+        s3: mockClient,
+        workerThreadCount: 2,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      });
+
+      // 20MB buffer - above threshold, triggers multipart
+      const body = Buffer.alloc(20 * 1024 * 1024, "x");
+
+      await tm.upload({ Bucket: "test-bucket", Key: "buffer-upload.bin", Body: body });
+
+      // Should have called CreateMPU, UploadPart (x3), CompleteMPU
+      const commandNames = sendCalls.map((c: any) => c.constructor?.name);
+      expect(commandNames).toContain("CreateMultipartUploadCommand");
+      expect(commandNames).toContain("UploadPartCommand");
+      expect(commandNames).toContain("CompleteMultipartUploadCommand");
+      expect(commandNames.filter((n: string) => n === "UploadPartCommand").length).toBe(3);
+    });
+
+    it("should route string body to threadedUploadInParts when workerThreadCount > 1", async () => {
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({
+        s3: mockClient,
+        workerThreadCount: 2,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      }) as any;
+
+      const body = "x".repeat(20 * 1024 * 1024);
+
+      await tm.upload({ Bucket: "test-bucket", Key: "string-upload.txt", Body: body });
+
+      const commandNames = sendCalls.map((c: any) => c.constructor?.name);
+      expect(commandNames).toContain("CreateMultipartUploadCommand");
+      expect(commandNames).toContain("UploadPartCommand");
+      expect(commandNames).toContain("CompleteMultipartUploadCommand");
+    });
+
+    it("should route file body (Readable with .path) to threadedUploadInPartsFromFile when workerThreadCount > 1", async () => {
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({
+        s3: mockClient,
+        workerThreadCount: 2,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      }) as any;
+
+      // Create a Readable with .path to simulate fs.createReadStream
+      const fileStream = new Readable({
+        read() {
+          this.push(null);
+        },
+      }) as Readable & { path: string };
+      fileStream.path = "/tmp/test-file.bin";
+
+      const contentLength = 20 * 1024 * 1024;
+
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "file-upload.bin",
+        Body: fileStream,
+        ContentLength: contentLength,
+      });
+
+      const commandNames = sendCalls.map((c: any) => c.constructor?.name);
+      expect(commandNames).toContain("CreateMultipartUploadCommand");
+      expect(commandNames).toContain("UploadPartCommand");
+      expect(commandNames).toContain("CompleteMultipartUploadCommand");
+    });
+
+    it("should abort multipart upload when abortSignal is triggered mid-upload", async () => {
+      const controller = new AbortController();
+      let uploadPartCallCount = 0;
+
+      const mockClient = {
+        send: vi.fn().mockImplementation((command: any) => {
+          const commandName = command.constructor?.name ?? "";
+          if (commandName === "CreateMultipartUploadCommand") {
+            return Promise.resolve({ UploadId: "abort-test-id", $metadata: {} });
+          }
+          if (commandName === "UploadPartCommand") {
+            uploadPartCallCount++;
+            // Abort after first part
+            if (uploadPartCallCount === 1) {
+              controller.abort();
+            }
+            return Promise.resolve({ ETag: `"etag-${uploadPartCallCount}"`, ChecksumCRC32: "abc==", $metadata: {} });
+          }
+          if (commandName === "AbortMultipartUploadCommand") {
+            return Promise.resolve({ $metadata: {} });
+          }
+          return Promise.resolve({ $metadata: {} });
+        }),
+        config: {},
+      } as any;
+
+      const tm = new S3TransferManager({
+        s3: mockClient,
+        workerThreadCount: 2,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      });
+
+      const body = Buffer.alloc(24 * 1024 * 1024, "a");
+
+      await expect(
+        tm.upload({ Bucket: "test-bucket", Key: "abort-test.bin", Body: body }, { abortSignal: controller.signal })
+      ).rejects.toThrow("Transfer aborted.");
+
+      // Verify AbortMultipartUpload was called
+      const abortCalls = mockClient.send.mock.calls.filter(
+        (c: any) => c[0].constructor?.name === "AbortMultipartUploadCommand"
+      );
+      expect(abortCalls.length).toBe(1);
+      expect(abortCalls[0][0].input.UploadId).toBe("abort-test-id");
+    });
+
+    it("should call AbortMultipartUpload when a part upload fails", async () => {
+      const mockClient = {
+        send: vi.fn().mockImplementation((command: any) => {
+          const commandName = command.constructor?.name ?? "";
+          if (commandName === "CreateMultipartUploadCommand") {
+            return Promise.resolve({ UploadId: "fail-test-id", $metadata: {} });
+          }
+          if (commandName === "UploadPartCommand") {
+            return Promise.reject(new Error("Network error on part upload"));
+          }
+          if (commandName === "AbortMultipartUploadCommand") {
+            return Promise.resolve({ $metadata: {} });
+          }
+          return Promise.resolve({ $metadata: {} });
+        }),
+        config: {},
+      } as any;
+
+      const tm = new S3TransferManager({
+        s3: mockClient,
+        workerThreadCount: 2,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      });
+
+      const body = Buffer.alloc(20 * 1024 * 1024, "b");
+
+      await expect(tm.upload({ Bucket: "test-bucket", Key: "fail-test.bin", Body: body })).rejects.toThrow(
+        "Network error on part upload"
+      );
+
+      const abortCalls = mockClient.send.mock.calls.filter(
+        (c: any) => c[0].constructor?.name === "AbortMultipartUploadCommand"
+      );
+      expect(abortCalls.length).toBe(1);
+      expect(abortCalls[0][0].input.UploadId).toBe("fail-test-id");
+    });
+
+    it("should fire bytesTransferred event for each part in threaded upload", async () => {
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({
+        s3: mockClient,
+        workerThreadCount: 2,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      });
+
+      const bytesEvents: number[] = [];
+      tm.addEventListener("bytesTransferred", (event: any) => {
+        bytesEvents.push(event.snapshot.transferredBytes);
+      });
+
+      const contentLength = 24 * 1024 * 1024; // 3 parts of 8MB
+      const body = Buffer.alloc(contentLength, "c");
+
+      await tm.upload({ Bucket: "test-bucket", Key: "progress-test.bin", Body: body });
+
+      // Should have 3 bytesTransferred events (one per part)
+      expect(bytesEvents.length).toBe(3);
+      // Final event should report all bytes transferred
+      expect(Math.max(...bytesEvents)).toBe(contentLength);
+    });
+
+    it("should fire transferFailed event when threaded upload fails", async () => {
+      const mockClient = {
+        send: vi.fn().mockImplementation((command: any) => {
+          const commandName = command.constructor?.name ?? "";
+          if (commandName === "CreateMultipartUploadCommand") {
+            return Promise.resolve({ UploadId: "event-fail-id", $metadata: {} });
+          }
+          if (commandName === "UploadPartCommand") {
+            return Promise.reject(new Error("Part failed"));
+          }
+          if (commandName === "AbortMultipartUploadCommand") {
+            return Promise.resolve({ $metadata: {} });
+          }
+          return Promise.resolve({ $metadata: {} });
+        }),
+        config: {},
+      } as any;
+
+      const tm = new S3TransferManager({
+        s3: mockClient,
+        workerThreadCount: 2,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      });
+
+      const failedCallback = vi.fn();
+      tm.addEventListener("transferFailed", failedCallback);
+
+      const body = Buffer.alloc(20 * 1024 * 1024, "d");
+
+      await expect(tm.upload({ Bucket: "test-bucket", Key: "event-fail.bin", Body: body })).rejects.toThrow(
+        "Part failed"
+      );
+
+      expect(failedCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should use non-threaded uploadInParts when workerThreadCount is 1", async () => {
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({
+        s3: mockClient,
+        workerThreadCount: 1,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      }) as any;
+
+      expect(tm.workerHttpHandler).toBeUndefined();
+
+      const body = Buffer.alloc(20 * 1024 * 1024, "e");
+      await tm.upload({ Bucket: "test-bucket", Key: "no-thread.bin", Body: body });
+
+      // Still completes multipart upload successfully via non-threaded path
+      const commandNames = sendCalls.map((c: any) => c.constructor?.name);
+      expect(commandNames).toContain("CreateMultipartUploadCommand");
+      expect(commandNames).toContain("UploadPartCommand");
+      expect(commandNames).toContain("CompleteMultipartUploadCommand");
+    });
+
+    it("should respect maxConcurrentUploads for threaded upload", () => {
+      const tm = new S3TransferManager({
+        workerThreadCount: 4,
+        maxConcurrentUploads: 16,
+      }) as any;
+
+      expect(tm.maxConcurrentUploads).toBe(16);
+      expect(tm.workerThreadCount).toBe(4);
+      expect(tm.workerHttpHandler).toBeInstanceOf(WorkerHttpHandler);
+    });
+
+    it("should sort completed parts by PartNumber before calling CompleteMPU", async () => {
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({
+        s3: mockClient,
+        workerThreadCount: 2,
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      });
+
+      const body = Buffer.alloc(24 * 1024 * 1024, "f"); // 3 parts
+      await tm.upload({ Bucket: "test-bucket", Key: "sort-test.bin", Body: body });
+
+      const completeCalls = sendCalls.filter((c: any) => c.constructor?.name === "CompleteMultipartUploadCommand");
+      expect(completeCalls.length).toBe(1);
+
+      const parts = completeCalls[0].input.MultipartUpload.Parts;
+      for (let i = 1; i < parts.length; i++) {
+        expect(parts[i].PartNumber).toBeGreaterThan(parts[i - 1].PartNumber);
+      }
+    });
+
+    it("should set ChecksumAlgorithm on CreateMPU when requestChecksumCalculation is WHEN_SUPPORTED", async () => {
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({
+        s3: mockClient,
+        workerThreadCount: 2,
+        requestChecksumCalculation: "WHEN_SUPPORTED",
+        targetPartSizeBytes: 8 * 1024 * 1024,
+        multipartUploadThresholdBytes: 8 * 1024 * 1024,
+      });
+
+      const body = Buffer.alloc(20 * 1024 * 1024, "g");
+      await tm.upload({ Bucket: "test-bucket", Key: "checksum-test.bin", Body: body });
+
+      const createCalls = sendCalls.filter((c: any) => c.constructor?.name === "CreateMultipartUploadCommand");
+      expect(createCalls[0].input.ChecksumAlgorithm).toBe("CRC32");
+    });
+  });
+});

--- a/lib/lib-transfer-manager/src/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/S3TransferManager.ts
@@ -20,13 +20,13 @@ import {
   S3Client,
   UploadPartCommand,
 } from "@aws-sdk/client-s3";
-import { type Logger, LogLevel } from "@aws-sdk/config/logger";
-import type { RawDataPart } from "@aws-sdk/lib-storage";
-import { byteLength, getChunk } from "@aws-sdk/lib-storage";
+import type { Logger } from "@smithy/types";
 import { type StreamingBlobPayloadOutputTypes } from "@smithy/types";
 
+import { type RawDataPart, byteLength, getChunk } from "./chunker";
 import type { AddEventListenerOptions, EventListener, RemoveEventListenerOptions } from "./event-listener-types";
 import { joinStreams } from "./join-streams";
+import { LogLevel } from "./log-level";
 import type {
   DownloadRequest,
   DownloadResponse,

--- a/lib/lib-transfer-manager/src/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/S3TransferManager.ts
@@ -1,0 +1,1558 @@
+import type {
+  _Object as S3Object,
+  AbortMultipartUploadCommandInput,
+  CompletedPart,
+  CompleteMultipartUploadCommandInput,
+  CompleteMultipartUploadCommandOutput,
+  CreateMultipartUploadCommandInput,
+  GetObjectCommandInput,
+  PutObjectCommandInput,
+  PutObjectCommandOutput,
+  UploadPartCommandInput,
+} from "@aws-sdk/client-s3";
+import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateMultipartUploadCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  UploadPartCommand,
+} from "@aws-sdk/client-s3";
+import { type Logger, LogLevel } from "@aws-sdk/config/logger";
+import type { RawDataPart } from "@aws-sdk/lib-storage";
+import { byteLength, getChunk } from "@aws-sdk/lib-storage";
+import { type StreamingBlobPayloadOutputTypes } from "@smithy/types";
+
+import type { AddEventListenerOptions, EventListener, RemoveEventListenerOptions } from "./event-listener-types";
+import { joinStreams } from "./join-streams";
+import type {
+  DownloadRequest,
+  DownloadResponse,
+  IS3TransferManager,
+  S3TransferManagerConfig,
+  TransferCompleteEvent,
+  TransferEvent,
+  TransferEventListeners,
+  TransferOptions,
+  UploadRequest,
+  UploadResponse,
+} from "./types";
+import { type DataSource, createEmptyReadable, defaultWorkerCount, WorkerHttpHandler } from "./worker-http-handler";
+
+/**
+ * Client for efficient transfer of objects to and from Amazon S3.
+ * Provides methods to optimize uploading and downloading individual objects
+ * as well as entire directories, with support for multipart operations,
+ * concurrency control, and request cancellation.
+ * Implements an eventTarget-based progress tracking system with methods to register,
+ * dispatch, and remove listeners for transfer lifecycle events.
+ *
+ * @alpha
+ */
+
+export class S3TransferManager implements IS3TransferManager {
+  private static MIN_PART_SIZE = 5 * 1024 * 1024; // 5MB
+
+  private readonly s3: S3Client;
+  private readonly targetPartSizeBytes: number;
+  private readonly multipartUploadThresholdBytes: number;
+  private readonly requestChecksumCalculation: "WHEN_SUPPORTED" | "WHEN_REQUIRED";
+  private readonly responseChecksumValidation: "WHEN_SUPPORTED" | "WHEN_REQUIRED";
+  private readonly multipartDownloadType: "PART" | "RANGE";
+  private readonly eventListeners: TransferEventListeners;
+  private readonly abortCleanupFunctions = new WeakMap<AbortSignal, () => void>();
+  private readonly maxConcurrentDownloads: number;
+  private readonly maxConcurrentUploads: number;
+  private readonly workerThreadCount: number;
+  private readonly workerHttpHandler: WorkerHttpHandler | undefined;
+  private readonly logger: Logger;
+
+  public constructor(config: S3TransferManagerConfig = {}) {
+    this.requestChecksumCalculation = config.requestChecksumCalculation ?? "WHEN_SUPPORTED";
+    this.responseChecksumValidation = config.responseChecksumValidation ?? "WHEN_SUPPORTED";
+    this.maxConcurrentUploads = config.maxConcurrentUploads ?? 32;
+    this.workerThreadCount = config.workerThreadCount ?? defaultWorkerCount();
+
+    this.s3 =
+      config.s3 ??
+      new S3Client({
+        requestChecksumCalculation: this.requestChecksumCalculation,
+        responseChecksumValidation: this.responseChecksumValidation,
+      });
+
+    if (this.workerThreadCount > 1) {
+      this.workerHttpHandler = new WorkerHttpHandler({
+        workerThreadCount: this.workerThreadCount,
+        maxConcurrentUploads: this.maxConcurrentUploads,
+      });
+      if (this.s3.config) {
+        this.s3.config.requestHandler = this.workerHttpHandler as any;
+      }
+    }
+
+    this.targetPartSizeBytes = config.targetPartSizeBytes ?? 8 * 1024 * 1024; // 8 MB
+    this.multipartUploadThresholdBytes = config.multipartUploadThresholdBytes ?? 16 * 1024 * 1024; // 16 MB
+
+    this.multipartDownloadType = config.multipartDownloadType ?? "PART";
+    this.maxConcurrentDownloads = config.maxConcurrentDownloads ?? 8;
+    this.logger = config.logger ?? new LogLevel("warn");
+    this.eventListeners = {
+      transferInitiated: config.eventListeners?.transferInitiated ?? [],
+      bytesTransferred: config.eventListeners?.bytesTransferred ?? [],
+      transferComplete: config.eventListeners?.transferComplete ?? [],
+      transferFailed: config.eventListeners?.transferFailed ?? [],
+    };
+
+    this.validateConfig();
+  }
+
+  /**
+   * Registers a callback function to be executed when a specific transfer event occurs.
+   * Supports monitoring the full lifecycle of transfers.
+   *
+   * @param type - The type of event to listen for.
+   * @param callback - Function to execute when the specified event occurs.
+   * @param options - Optional configuration for event listener behavior.
+   *
+   * @alpha
+   */
+  public addEventListener(
+    type: "transferInitiated",
+    callback: EventListener<TransferEvent>,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  public addEventListener(
+    type: "bytesTransferred",
+    callback: EventListener<TransferEvent>,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  public addEventListener(
+    type: "transferComplete",
+    callback: EventListener<TransferCompleteEvent>,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  public addEventListener(
+    type: "transferFailed",
+    callback: EventListener<TransferEvent>,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  public addEventListener(type: string, callback: EventListener, options?: AddEventListenerOptions | boolean): void;
+  public addEventListener(type: string, callback: EventListener, options?: AddEventListenerOptions | boolean): void {
+    const eventType = type as keyof TransferEventListeners;
+    const listeners = this.eventListeners[eventType];
+
+    if (!listeners) {
+      throw new Error(`Unknown event type: ${eventType}`);
+    }
+
+    const once = typeof options !== "boolean" && options?.once;
+    const signal = typeof options !== "boolean" ? options?.signal : undefined;
+    let updatedCallback = callback;
+
+    if (signal?.aborted) {
+      return;
+    }
+
+    if (signal) {
+      const removeListenerAfterAbort = () => {
+        this.removeEventListener(eventType, updatedCallback);
+        this.abortCleanupFunctions.delete(signal);
+      };
+
+      this.abortCleanupFunctions.set(signal, () => signal.removeEventListener("abort", removeListenerAfterAbort));
+      signal.addEventListener("abort", removeListenerAfterAbort, { once: true });
+    }
+
+    if (once) {
+      updatedCallback = (event: Event) => {
+        if (typeof callback === "function") {
+          callback(event);
+        } else {
+          callback.handleEvent(event);
+        }
+        this.removeEventListener(eventType, updatedCallback);
+      };
+    }
+    listeners.push(updatedCallback);
+  }
+
+  /**
+   * Dispatches an event to the registered event listeners.
+   * Triggers callbacks registered via addEventListener with matching event types.
+   *
+   * @param event - The event object to dispatch.
+   * @returns whether the event ran to completion
+   *
+   * @alpha
+   */
+  public dispatchEvent(event: Event & TransferEvent): boolean;
+  public dispatchEvent(event: Event & TransferCompleteEvent): boolean;
+  public dispatchEvent(event: Event): boolean;
+  public dispatchEvent(event: Event): boolean {
+    const eventType = event.type;
+    const listeners = this.eventListeners[eventType as keyof TransferEventListeners] as EventListener[];
+
+    if (listeners) {
+      for (const listener of listeners) {
+        if (typeof listener === "function") {
+          listener(event);
+        } else {
+          listener.handleEvent(event);
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Removes a previously registered event listener from the specified event type.
+   * Stops the callback from being invoked when the event occurs.
+   *
+   * @param type - The type of event to stop listening for.
+   * @param callback - The function that was previously registered.
+   * @param options - Optional configuration for the event listener.
+   *
+   * @alpha
+   */
+  public removeEventListener(
+    type: "transferInitiated",
+    callback: EventListener<TransferEvent>,
+    options?: RemoveEventListenerOptions | boolean
+  ): void;
+  public removeEventListener(
+    type: "bytesTransferred",
+    callback: EventListener<TransferEvent>,
+    options?: RemoveEventListenerOptions | boolean
+  ): void;
+  public removeEventListener(
+    type: "transferComplete",
+    callback: EventListener<TransferCompleteEvent>,
+    options?: RemoveEventListenerOptions | boolean
+  ): void;
+  public removeEventListener(
+    type: "transferFailed",
+    callback: EventListener<TransferEvent>,
+    options?: RemoveEventListenerOptions | boolean
+  ): void;
+  public removeEventListener(
+    type: string,
+    callback: EventListener,
+    options?: RemoveEventListenerOptions | boolean
+  ): void;
+  public removeEventListener(
+    type: string,
+    callback: EventListener,
+    options?: RemoveEventListenerOptions | boolean
+  ): void {
+    const eventType = type as keyof TransferEventListeners;
+    const listeners = this.eventListeners[eventType];
+
+    if (listeners) {
+      if (
+        eventType === "transferInitiated" ||
+        eventType === "bytesTransferred" ||
+        eventType === "transferFailed" ||
+        eventType === "transferComplete"
+      ) {
+        const eventListener = callback as EventListener<TransferEvent>;
+        let index = listeners.indexOf(eventListener);
+        while (index !== -1) {
+          listeners.splice(index, 1);
+          index = listeners.indexOf(eventListener);
+        }
+      } else {
+        throw new Error(`Unknown event type: ${type}`);
+      }
+    }
+  }
+
+  /**
+   * Uploads objects to S3 with automatic multipart upload handling.
+   * Automatically chooses between single object upload or multipart upload based on content length threshold.
+   *
+   * @param request - PutObjectCommandInput and CreateMultipartUploadCommandInput parameters for single or multipart uploads.
+   * @param transferOptions - Optional abort signal and event listeners for transfer lifecycle monitoring.
+   *
+   * @returns S3 PutObject or CompleteMultipartUpload response with transfer event dispatching.
+   *
+   */
+  public async upload(request: UploadRequest, transferOptions?: TransferOptions): Promise<UploadResponse> {
+    const totalContentLength = request.ContentLength ?? byteLength(request.Body);
+
+    if (totalContentLength === undefined) {
+      throw new Error("Unable to determine content length for upload");
+    }
+
+    this.checkAborted(transferOptions);
+    this.addEventListeners(transferOptions?.eventListeners);
+    this.dispatchTransferInitiatedEvent(request, totalContentLength);
+
+    const removeLocalEventListeners = () => {
+      this.removeEventListeners(transferOptions?.eventListeners);
+      if (transferOptions?.abortSignal) {
+        this.abortCleanupFunctions.get(transferOptions.abortSignal as AbortSignal)?.();
+        this.abortCleanupFunctions.delete(transferOptions.abortSignal as AbortSignal);
+      }
+    };
+
+    try {
+      let response: UploadResponse;
+
+      if (totalContentLength < this.multipartUploadThresholdBytes) {
+        response = await this.uploadSinglePart(request, totalContentLength, transferOptions);
+      } else if (this.workerThreadCount > 1 && this.isFileBody(request.Body)) {
+        response = await this.threadedUploadInPartsFromFile(request, totalContentLength, transferOptions);
+      } else if (this.workerThreadCount > 1 && this.isInMemoryBody(request.Body)) {
+        if (typeof request.Body === "string") {
+          request = { ...request, Body: new TextEncoder().encode(request.Body) };
+        }
+        response = await this.threadedUploadInParts(request, totalContentLength, transferOptions);
+      } else {
+        response = await this.uploadInParts(request, totalContentLength, transferOptions);
+      }
+
+      this.dispatchEvent(
+        Object.assign(new Event("transferComplete"), {
+          request,
+          response,
+          snapshot: {
+            transferredBytes: totalContentLength,
+            totalBytes: totalContentLength,
+          },
+        })
+      );
+      removeLocalEventListeners();
+      return response;
+    } catch (error) {
+      this.dispatchTransferFailedEvent(request, totalContentLength, error as Error);
+      removeLocalEventListeners();
+      throw error;
+    }
+  }
+
+  /**
+   * Downloads single objects from S3 with automatic multipart handling.
+   * Automatically chooses between PART or RANGE download strategies and joins streams into a single response.
+   *
+   * @param request - GetObjectCommandInput parameters. PartNumber is not supported - use GetObjectCommand directly for specific parts.
+   * @param transferOptions - Optional abort signal and event listeners for transfer lifecycle monitoring.
+   *
+   * @returns S3 GetObject response with joined Body stream and transfer event dispatching.
+   *
+   * @alpha
+   */
+  public async download(request: DownloadRequest, transferOptions?: TransferOptions): Promise<DownloadResponse> {
+    const partNumber = request.PartNumber;
+    if (typeof partNumber === "number") {
+      throw new Error(
+        "partNumber included: S3 Transfer Manager does not support downloads for specific parts. Use GetObjectCommand instead"
+      );
+    }
+
+    const metadata = {} as Omit<DownloadResponse, "Body">;
+    const streams = [] as Promise<StreamingBlobPayloadOutputTypes>[];
+    const requests = [] as GetObjectCommandInput[];
+
+    let totalSize: number | undefined;
+
+    this.checkAborted(transferOptions);
+    this.addEventListeners(transferOptions?.eventListeners);
+
+    const checksumValidationEnabled =
+      request.ChecksumMode === "ENABLED" || this.responseChecksumValidation === "WHEN_SUPPORTED";
+
+    let onStreamConsumed: ((index: number) => void) | undefined;
+
+    if (this.multipartDownloadType === "PART") {
+      const responseMetadata = await this.downloadByPart(
+        request,
+        transferOptions ?? {},
+        streams,
+        requests,
+        metadata,
+        checksumValidationEnabled
+      );
+      totalSize = responseMetadata.totalSize;
+      onStreamConsumed = responseMetadata.onStreamConsumed;
+    } else if (this.multipartDownloadType === "RANGE") {
+      const responseMetadata = await this.downloadByRange(
+        request,
+        transferOptions ?? {},
+        streams,
+        requests,
+        metadata,
+        checksumValidationEnabled
+      );
+      totalSize = responseMetadata.totalSize;
+      onStreamConsumed = responseMetadata.onStreamConsumed;
+    }
+
+    const removeLocalEventListeners = () => {
+      this.removeEventListeners(transferOptions?.eventListeners);
+      if (transferOptions?.abortSignal) {
+        this.abortCleanupFunctions.get(transferOptions.abortSignal as AbortSignal)?.();
+        this.abortCleanupFunctions.delete(transferOptions.abortSignal as AbortSignal);
+      }
+    };
+
+    const response = {
+      ...metadata,
+      Body: await joinStreams(streams, {
+        onBytes: (byteLength: number, index) => {
+          this.dispatchEvent(
+            Object.assign(new Event("bytesTransferred"), {
+              request: requests[index],
+              snapshot: {
+                transferredBytes: byteLength,
+                totalBytes: totalSize,
+              },
+            })
+          );
+        },
+        onCompletion: (byteLength: number, index) => {
+          this.dispatchEvent(
+            Object.assign(new Event("transferComplete"), {
+              request: requests[index],
+              response,
+              snapshot: {
+                transferredBytes: byteLength,
+                totalBytes: totalSize,
+              },
+            })
+          );
+          removeLocalEventListeners();
+        },
+        onFailure: (error: unknown, index) => {
+          this.dispatchEvent(
+            Object.assign(new Event("transferFailed"), {
+              request: requests[index],
+              snapshot: {
+                transferredBytes: error,
+                totalBytes: totalSize,
+              },
+            })
+          );
+          removeLocalEventListeners();
+        },
+        onStreamConsumed,
+      }),
+    };
+
+    return response;
+  }
+
+  /**
+   * Uploads all files in a directory recursively to an S3 bucket.
+   * Automatically maps local file paths to S3 object keys using prefix and delimiter configuration.
+   *
+   * @param options - Configuration including bucket, source directory, filtering, failure handling, and transfer settings.
+   *
+   * @returns the number of objects that have been uploaded and the number of objects that have failed.
+   *
+   * @alpha
+   */
+  public uploadAll(options: {
+    bucket: string;
+    source: string;
+    followSymbolicLinks?: boolean;
+    recursive?: boolean;
+    s3Prefix?: string;
+    filter?: (filepath: string) => boolean;
+    s3Delimiter?: string;
+    putObjectRequestCallback?: (putObjectRequest: PutObjectCommandInput) => Promise<void>;
+    failurePolicy?: (error?: unknown) => Promise<void>;
+    transferOptions?: TransferOptions;
+  }): Promise<{ objectsUploaded: number; objectsFailed: number }> {
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * Downloads all objects in a bucket to a local directory.
+   * Uses ListObjectsV2 to retrieve objects and automatically maps S3 object keys to local file paths.
+   *
+   * @param options - Configuration including bucket, destination directory, filtering, failure handling, and transfer settings.
+   *
+   * @returns The number of objects that have been downloaded and the number of objects that have failed.
+   *
+   * @alpha
+   */
+  public downloadAll(options: {
+    bucket: string;
+    destination: string;
+    s3Prefix?: string;
+    s3Delimiter?: string;
+    recursive?: boolean;
+    filter?: (object?: S3Object) => boolean;
+    getObjectRequestCallback?: (getObjectRequest: GetObjectCommandInput) => Promise<void>;
+    failurePolicy?: (error?: unknown) => Promise<void>;
+    transferOptions?: TransferOptions;
+  }): Promise<{ objectsDownloaded: number; objectsFailed: number }> {
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * Downloads object using part-based strategy with concurrent part requests.
+   * Only initiates up to maxConcurrentDownloads requests in-flight, with new
+   * requests triggered as previous ones complete.
+   *
+   * @internal
+   */
+  protected async downloadByPart(
+    request: DownloadRequest,
+    transferOptions: TransferOptions,
+    streams: Promise<StreamingBlobPayloadOutputTypes>[],
+    requests: GetObjectCommandInput[],
+    metadata: Omit<DownloadResponse, "Body">,
+    checksumValidationEnabled: boolean
+  ): Promise<{ totalSize: number | undefined; onStreamConsumed?: (index: number) => void }> {
+    let totalSize: number | undefined;
+    let streamConsumedCallback: ((index: number) => void) | undefined;
+    this.checkAborted(transferOptions);
+
+    if (request.Range == null) {
+      const initialPartRequest = {
+        ...request,
+        PartNumber: 1,
+        ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+      };
+      try {
+        const initialPart = await this.s3.send(new GetObjectCommand(initialPartRequest), transferOptions);
+        await internalEventHandler.afterInitialGetObject();
+        const partSize = initialPart.ContentLength;
+        const initialETag = initialPart.ETag ?? undefined;
+        totalSize = initialPart.ContentRange ? Number.parseInt(initialPart.ContentRange.split("/")[1]) : 0;
+        this.dispatchTransferInitiatedEvent(request, totalSize);
+        if (initialPart.Body) {
+          if (initialPart.Body && typeof (initialPart.Body as any).getReader === "function") {
+            const reader = (initialPart.Body as any).getReader();
+            (initialPart.Body as any).getReader = function () {
+              return reader;
+            };
+          }
+          streams.push(Promise.resolve(initialPart.Body));
+          requests.push(initialPartRequest);
+        }
+
+        this.processResponseMetadata(initialPart, metadata, totalSize);
+
+        let partCount = 1;
+        if (initialPart.PartsCount! > 1) {
+          const partTasks: (() => Promise<StreamingBlobPayloadOutputTypes>)[] = [];
+          const partRequests: GetObjectCommandInput[] = [];
+
+          for (let part = 2; part <= initialPart.PartsCount!; part++) {
+            const getObjectRequest = {
+              ...request,
+              PartNumber: part,
+              IfMatch: initialETag,
+              ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+            };
+            partRequests.push(getObjectRequest);
+
+            partTasks.push(() => {
+              this.checkAborted(transferOptions);
+              return this.s3
+                .send(new GetObjectCommand(getObjectRequest), transferOptions)
+                .then((response) => {
+                  this.validatePartDownload(response.ContentRange, part, partSize ?? 0);
+                  if (response.Body && typeof (response.Body as any).getReader === "function") {
+                    const reader = (response.Body as any).getReader();
+                    (response.Body as any).getReader = function () {
+                      return reader;
+                    };
+                  }
+                  return response.Body!;
+                })
+                .catch((error) => {
+                  this.dispatchTransferFailedEvent(getObjectRequest, totalSize, error as Error);
+                  throw error;
+                });
+            });
+          }
+
+          // Lazily prefetch streams — only maxConcurrentDownloads requests in-flight.
+          // New requests fire as previous ones complete, and joinStreams can start
+          // consuming immediately without waiting for all parts to be fetched.
+          const { promises: pendingStreams, onStreamConsumed } = this.createConcurrentTaskPool(
+            partTasks,
+            this.maxConcurrentDownloads
+          );
+          streams.push(...pendingStreams);
+          requests.push(...partRequests);
+          streamConsumedCallback = onStreamConsumed;
+          partCount += partTasks.length;
+
+          if (partCount !== initialPart.PartsCount) {
+            throw new Error(
+              `The number of parts downloaded (${partCount}) does not match the expected number (${initialPart.PartsCount})`
+            );
+          }
+        }
+      } catch (error) {
+        this.dispatchTransferFailedEvent(request, totalSize, error);
+        throw error;
+      }
+    } else {
+      this.checkAborted(transferOptions);
+
+      try {
+        const getObjectRequest = {
+          ...request,
+          ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+        };
+
+        const getObject = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
+        totalSize = getObject.ContentRange ? Number.parseInt(getObject.ContentRange.split("/")[1]) : 0;
+
+        this.dispatchTransferInitiatedEvent(request, totalSize);
+        if (getObject.Body) {
+          streams.push(Promise.resolve(getObject.Body));
+          requests.push(getObjectRequest);
+        }
+        this.processResponseMetadata(getObject, metadata, totalSize);
+      } catch (error) {
+        this.dispatchTransferFailedEvent(request, undefined, error);
+        throw error;
+      }
+    }
+
+    return {
+      totalSize,
+      onStreamConsumed: streamConsumedCallback,
+    };
+  }
+
+  /**
+   * Downloads object using range-based strategy with lazy concurrent range requests.
+   * Only initiates up to maxConcurrentDownloads requests in-flight, with new
+   * requests triggered as previous ones complete — preventing idle connection timeouts.
+   *
+   * @internal
+   */
+  protected async downloadByRange(
+    request: DownloadRequest,
+    transferOptions: TransferOptions,
+    streams: Promise<StreamingBlobPayloadOutputTypes>[],
+    requests: GetObjectCommandInput[],
+    metadata: Omit<DownloadResponse, "Body">,
+    checksumValidationEnabled: boolean
+  ): Promise<{ totalSize: number | undefined; onStreamConsumed?: (index: number) => void }> {
+    let streamConsumedCallback: ((index: number) => void) | undefined;
+    this.checkAborted(transferOptions);
+
+    const headResponse = await this.s3.send(
+      new HeadObjectCommand({ Bucket: request.Bucket, Key: request.Key }),
+      transferOptions
+    );
+
+    if (headResponse.ContentLength === 0) {
+      const getObjectRequest = { ...request, ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }) };
+      const response = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
+
+      this.dispatchTransferInitiatedEvent(request, 0);
+      if (response.Body) streams.push(Promise.resolve(response.Body));
+      requests.push(getObjectRequest);
+
+      this.processResponseMetadata(response, metadata, 0);
+      return { totalSize: 0 };
+    }
+
+    let left = 0;
+    let right = this.targetPartSizeBytes - 1;
+    let maxRange = Number.POSITIVE_INFINITY;
+    let remainingLength = 1;
+    let totalSize: number | undefined;
+    let initialETag: string | undefined;
+
+    if (request.Range != null) {
+      const [userRangeLeft, userRangeRight] = request.Range.replace("bytes=", "").split("-").map(Number);
+      maxRange = userRangeRight;
+      left = userRangeLeft;
+      right = Math.min(userRangeRight, left + S3TransferManager.MIN_PART_SIZE - 1);
+      totalSize = userRangeRight + 1;
+    }
+
+    try {
+      const getObjectRequest: GetObjectCommandInput = {
+        ...request,
+        Range: `bytes=${left}-${right}`,
+        ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+      };
+      const initialRangeGet = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
+      await internalEventHandler.afterInitialGetObject();
+      this.validateRangeDownload(`bytes=${left}-${right}`, initialRangeGet.ContentRange);
+      initialETag = initialRangeGet.ETag ?? undefined;
+      if (!totalSize) {
+        totalSize = initialRangeGet.ContentRange
+          ? Number.parseInt(initialRangeGet.ContentRange.split("/")[1])
+          : undefined;
+      }
+
+      if (initialRangeGet.Body && typeof (initialRangeGet.Body as any).getReader === "function") {
+        const reader = (initialRangeGet.Body as any).getReader();
+        (initialRangeGet.Body as any).getReader = function () {
+          return reader;
+        };
+      }
+
+      this.dispatchTransferInitiatedEvent(request, totalSize);
+      streams.push(Promise.resolve(initialRangeGet.Body!));
+      requests.push(getObjectRequest);
+      this.processResponseMetadata(initialRangeGet, metadata, totalSize);
+    } catch (error) {
+      this.dispatchTransferFailedEvent(request, totalSize, error as Error);
+      throw error;
+    }
+
+    let expectedRequestCount = 1;
+    if (totalSize) {
+      const contentLength = totalSize;
+      const remainingBytes = Math.max(0, contentLength - (right - left + 1));
+      const additionalRequests = Math.ceil(remainingBytes / S3TransferManager.MIN_PART_SIZE);
+      expectedRequestCount += additionalRequests;
+    }
+
+    left = right + 1;
+    right = Math.min(left + S3TransferManager.MIN_PART_SIZE - 1, maxRange);
+    remainingLength = totalSize ? Math.min(right - left + 1, Math.max(0, totalSize - left)) : 0;
+    const rangeTasks: (() => Promise<StreamingBlobPayloadOutputTypes>)[] = [];
+    const rangeRequests: GetObjectCommandInput[] = [];
+
+    while (remainingLength > 0) {
+      const range = `bytes=${left}-${right}`;
+      const getObjectRequest: GetObjectCommandInput = {
+        ...request,
+        Range: range,
+        IfMatch: initialETag,
+        ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+      };
+      rangeRequests.push(getObjectRequest);
+
+      rangeTasks.push(() => {
+        this.checkAborted(transferOptions);
+        return this.s3
+          .send(new GetObjectCommand(getObjectRequest), transferOptions)
+          .then((response) => {
+            this.validateRangeDownload(range, response.ContentRange);
+            if (response.Body && typeof (response.Body as any).getReader === "function") {
+              const reader = (response.Body as any).getReader();
+              (response.Body as any).getReader = function () {
+                return reader;
+              };
+            }
+            return response.Body!;
+          })
+          .catch((error) => {
+            this.dispatchTransferFailedEvent(getObjectRequest, totalSize, error);
+            throw error;
+          });
+      });
+
+      left = right + 1;
+      right = Math.min(left + S3TransferManager.MIN_PART_SIZE - 1, maxRange);
+      remainingLength = totalSize ? Math.min(right - left + 1, Math.max(0, totalSize - left)) : 0;
+    }
+
+    if (rangeTasks.length > 0) {
+      // Lazily prefetch streams — only maxConcurrentDownloads requests in-flight.
+      // New requests fire as previous ones complete, and joinStreams can start
+      // consuming immediately without waiting for all ranges to be fetched.
+      const { promises: pendingStreams, onStreamConsumed } = this.createConcurrentTaskPool(
+        rangeTasks,
+        this.maxConcurrentDownloads
+      );
+      streams.push(...pendingStreams);
+      requests.push(...rangeRequests);
+      streamConsumedCallback = onStreamConsumed;
+    }
+
+    const actualRequestCount = 1 + rangeTasks.length;
+    if (expectedRequestCount !== actualRequestCount) {
+      throw new Error(
+        `The number of ranged GET requests sent (${actualRequestCount}) does not match the expected number (${expectedRequestCount})`
+      );
+    }
+
+    return {
+      totalSize,
+      onStreamConsumed: streamConsumedCallback,
+    };
+  }
+
+  /**
+   * Adds all event listeners from provided collection to the transfer manager.
+   *
+   * @internal
+   */
+  private addEventListeners(eventListeners?: TransferEventListeners): void {
+    for (const listeners of this.iterateListeners(eventListeners)) {
+      for (const listener of listeners) {
+        this.addEventListener(listener.eventType, listener.callback as EventListener);
+      }
+    }
+  }
+
+  /**
+   * Removes event listeners from provided collection from the transfer manager.
+   *
+   * @internal
+   */
+  private removeEventListeners(eventListeners?: TransferEventListeners): void {
+    for (const listeners of this.iterateListeners(eventListeners)) {
+      for (const listener of listeners) {
+        this.removeEventListener(listener.eventType, listener.callback as EventListener);
+      }
+    }
+  }
+
+  /**
+   * Copies all response properties except Body to the container object.
+   *
+   * @internal
+   */
+  private assignMetadata(container: any, response: any) {
+    for (const key in response) {
+      if (key === "Body") {
+        continue;
+      }
+      container[key] = response[key];
+    }
+  }
+
+  /**
+   * Updates response ContentLength and ContentRange based on total object size.
+   *
+   * @internal
+   */
+  private updateResponseLengthAndRange(response: DownloadResponse, totalSize: number | undefined): void {
+    if (totalSize !== undefined) {
+      response.ContentLength = totalSize;
+      response.ContentRange = `bytes 0-${totalSize - 1}/${totalSize}`;
+    }
+  }
+
+  /**
+   * Clears checksum values for composite multipart downloads.
+   *
+   * @internal
+   */
+  private updateChecksumValues(initialPart: DownloadResponse, metadata: Omit<DownloadResponse, "Body">) {
+    if (initialPart.ChecksumType === "COMPOSITE") {
+      metadata.ChecksumCRC32 = undefined;
+      metadata.ChecksumCRC32C = undefined;
+      metadata.ChecksumSHA1 = undefined;
+      metadata.ChecksumSHA256 = undefined;
+    }
+  }
+
+  /**
+   * Processes response metadata by updating length, copying properties, and handling checksums.
+   *
+   * @internal
+   */
+  private processResponseMetadata(
+    response: DownloadResponse,
+    metadata: Omit<DownloadResponse, "Body">,
+    totalSize: number | undefined
+  ): void {
+    this.updateResponseLengthAndRange(response, totalSize);
+    this.assignMetadata(metadata, response);
+    this.updateChecksumValues(response, metadata);
+  }
+
+  /**
+   * Throws AbortError if the transfer has been aborted via signal.
+   *
+   * @internal
+   */
+  private checkAborted(transferOptions?: TransferOptions): void {
+    if (transferOptions?.abortSignal?.aborted) {
+      throw Object.assign(new Error("Transfer aborted."), { name: "AbortError" });
+    }
+  }
+
+  /**
+   * Validates if configuration parameters meets minimum requirements.
+   *
+   * @internal
+   */
+  private validateConfig(): void {
+    if (this.targetPartSizeBytes < S3TransferManager.MIN_PART_SIZE) {
+      throw new Error(`targetPartSizeBytes must be at least ${S3TransferManager.MIN_PART_SIZE} bytes`);
+    }
+  }
+
+  /**
+   * Dispatches transferInitiated event with initial progress snapshot.
+   *
+   * @internal
+   */
+  private dispatchTransferInitiatedEvent(request: DownloadRequest | UploadRequest, totalSize?: number): boolean {
+    this.dispatchEvent(
+      Object.assign(new Event("transferInitiated"), {
+        request,
+        snapshot: {
+          transferredBytes: 0,
+          totalBytes: totalSize,
+        },
+      })
+    );
+    return true;
+  }
+
+  /**
+   * Dispatches transferFailed event with error details and progress snapshot.
+   *
+   * @internal
+   */
+  private dispatchTransferFailedEvent(
+    request: DownloadRequest | UploadRequest,
+    totalSize?: number,
+    error?: Error
+  ): boolean {
+    this.dispatchEvent(
+      Object.assign(new Event("transferFailed"), {
+        request,
+        error,
+        snapshot: {
+          transferredBytes: 0,
+          totalBytes: totalSize,
+        },
+      })
+    );
+    return true;
+  }
+
+  /**
+   * Generator that yields event listeners from the provided collection for iteration.
+   *
+   * @internal
+   */
+  private *iterateListeners(eventListeners: TransferEventListeners = {}) {
+    for (const key in eventListeners) {
+      const eventType = key as keyof TransferEventListeners;
+      const listeners = eventListeners[eventType as keyof TransferEventListeners];
+      if (Array.isArray(listeners)) {
+        for (const callback of listeners) {
+          yield [
+            {
+              eventType: eventType,
+              callback: callback,
+            },
+          ];
+        }
+      }
+    }
+  }
+
+  /**
+   * Creates a concurrent task pool using a sliding window concurrency model.
+   * Each task is a deferred S3 request (e.g., GetObject for part/range downloads) that returns a promise.
+   * It seeds up to `maxConcurrent` tasks initially. When a stream is fully consumed by the caller,
+   * the `onStreamConsumed` callback launches the next pending task, keeping at most `maxConcurrent`
+   * requests in-flight at any time.
+   *
+   * @param tasks - Array of deferred task functions, each returning a promise.
+   * @param maxConcurrent - Maximum number of HTTP requests in-flight at any time.
+   * @returns An object containing the array of promises (one per task) and an `onStreamConsumed` callback
+   *          to signal that a stream has been consumed and the next task can be launched.
+   *
+   * @internal
+   */
+  private createConcurrentTaskPool<T>(
+    tasks: (() => Promise<T>)[],
+    maxConcurrent: number
+  ): {
+    promises: Promise<T>[];
+    onStreamConsumed: (index: number) => void;
+  } {
+    if (tasks.length === 0) return { promises: [], onStreamConsumed: () => {} };
+
+    const resolvers: Array<{ resolve: (value: T) => void; reject: (error: unknown) => void }> = [];
+    const promises: Promise<T>[] = tasks.map(() => {
+      let resolve!: (value: T) => void;
+      let reject!: (error: unknown) => void;
+      const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      resolvers.push({ resolve, reject });
+      return promise;
+    });
+
+    let nextToLaunch = 0;
+    let failed = false;
+
+    const launchTask = (index: number): void => {
+      tasks[index]().then(
+        (result) => {
+          resolvers[index].resolve(result);
+        },
+        (error) => {
+          failed = true;
+          resolvers[index].reject(error);
+        }
+      );
+    };
+
+    // Seed initial batch
+    const initialBatch = Math.min(maxConcurrent, tasks.length);
+    for (let i = 0; i < initialBatch; i++) {
+      launchTask(nextToLaunch++);
+    }
+
+    const onStreamConsumed = (_index: number): void => {
+      if (failed || nextToLaunch >= tasks.length) return;
+      launchTask(nextToLaunch++);
+    };
+
+    return { promises, onStreamConsumed };
+  }
+
+  /**
+   * Validates part download ContentRange matches expected part boundaries.
+   *
+   * @internal
+   */
+  private validatePartDownload(contentRange: string | undefined, partNumber: number, partSize: number) {
+    if (!contentRange) {
+      throw new Error(`Missing ContentRange for part ${partNumber}.`);
+    }
+
+    const match = contentRange.match(/bytes (\d+)-(\d+)\/(\d+)/);
+    if (!match) throw new Error(`Invalid ContentRange format: ${contentRange}`);
+
+    const start = Number.parseInt(match[1]);
+    const end = Number.parseInt(match[2]);
+    const total = Number.parseInt(match[3]) - 1;
+
+    const expectedStart = (partNumber - 1) * partSize;
+    const expectedEnd = Math.min(expectedStart + partSize - 1, total);
+
+    if (start !== expectedStart) {
+      throw new Error(`Expected part ${partNumber} to start at ${expectedStart} but got ${start}`);
+    }
+
+    if (end !== expectedEnd) {
+      throw new Error(`Expected part ${partNumber} to end at ${expectedEnd} but got ${end}`);
+    }
+  }
+
+  /**
+   * Validates range download ContentRange matches requested byte range.
+   *
+   * @internal
+   */
+  private validateRangeDownload(requestRange: string, responseRange: string | undefined) {
+    if (!responseRange) {
+      throw new Error(`Missing ContentRange for range ${requestRange}.`);
+    }
+
+    const match = responseRange.match(/bytes (\d+)-(\d+)\/(\d+)/);
+    if (!match) throw new Error(`Invalid ContentRange format: ${responseRange}`);
+
+    const start = Number.parseInt(match[1]);
+    const end = Number.parseInt(match[2]);
+    const total = Number.parseInt(match[3]) - 1;
+
+    const rangeMatch = requestRange.match(/bytes=(\d+)-(\d+)/);
+    if (!rangeMatch) throw new Error(`Invalid Range format: ${requestRange}`);
+
+    const expectedStart = Number.parseInt(rangeMatch[1]);
+    const expectedEnd = Number.parseInt(rangeMatch[2]);
+
+    if (start !== expectedStart) {
+      throw new Error(`Expected range to start at ${expectedStart} but got ${start}`);
+    }
+
+    if (end === expectedEnd) {
+      return;
+    }
+
+    if (end === total) {
+      return;
+    }
+
+    throw new Error(`Expected range to end at ${expectedEnd} but got ${end}`);
+  }
+
+  /**
+   * Uploads a single object to S3 using PutObject operation.
+   * Used when content length is below the multipart upload threshold.
+   *
+   * @internal
+   */
+  private async uploadSinglePart(
+    request: UploadRequest,
+    contentLength: number,
+    transferOptions?: TransferOptions
+  ): Promise<PutObjectCommandOutput> {
+    const putObjectRequest: PutObjectCommandInput = { ...request };
+
+    this.checkAborted(transferOptions);
+    const response = await this.s3.send(new PutObjectCommand(putObjectRequest), transferOptions);
+
+    this.dispatchEvent(
+      Object.assign(new Event("bytesTransferred"), {
+        request,
+        snapshot: {
+          transferredBytes: contentLength,
+          totalBytes: contentLength,
+        },
+      })
+    );
+
+    return response;
+  }
+
+  /**
+   * Calculates part size and expected parts count.
+   *
+   * @internal
+   */
+  private calculatePartSize(contentLength: number): { partSize: number; expectedPartsCount: number } {
+    const partSize = Math.max(this.targetPartSizeBytes, Math.ceil(contentLength / 10_000));
+    const expectedPartsCount = Math.ceil(contentLength / partSize);
+    return { partSize, expectedPartsCount };
+  }
+
+  /**
+   * Checks if the body is a file read stream with a .path property.
+   * @internal
+   */
+  private isFileBody(body: any): boolean {
+    return typeof body?.pipe === "function" && typeof (body as any).path === "string";
+  }
+
+  /**
+   * Checks if the body is fully in memory (Buffer, Uint8Array, or string).
+   * @internal
+   */
+  private isInMemoryBody(body: any): body is Uint8Array | string {
+    return body instanceof Uint8Array || typeof body === "string";
+  }
+
+  /**
+   * Uploads using worker threads from a file source. Workers read file slices
+   * directly from disk, compute checksum, and send data in aws-chunked format
+   * with trailing checksums.
+   *
+   * @internal
+   */
+  private async threadedUploadInPartsFromFile(
+    request: UploadRequest,
+    contentLength: number,
+    transferOptions?: TransferOptions
+  ): Promise<CompleteMultipartUploadCommandOutput> {
+    const { partSize } = this.calculatePartSize(contentLength);
+    const filePath = (request.Body as any).path as string;
+
+    const buildDataSource = (checksumAlgorithm?: string, checksumHeader?: string): DataSource => ({
+      type: "file",
+      filePath,
+      partSize,
+      totalFileSize: contentLength,
+      checksumAlgorithm,
+      checksumHeader,
+    });
+
+    return this.threadedMultipartUpload(request, contentLength, buildDataSource, transferOptions);
+  }
+
+  /**
+   * Uploads using worker threads with in-memory data. Copies the user's Buffer
+   * into a SharedArrayBuffer once, then workers read slices by offset —
+   * zero-copy per part.
+   *
+   * @internal
+   */
+  private async threadedUploadInParts(
+    request: UploadRequest,
+    contentLength: number,
+    transferOptions?: TransferOptions
+  ): Promise<CompleteMultipartUploadCommandOutput> {
+    const { partSize } = this.calculatePartSize(contentLength);
+    const body = request.Body as Uint8Array;
+
+    // One-time copy into SharedArrayBuffer so all workers can read by offset.
+    const sharedBuffer = new SharedArrayBuffer(body.byteLength);
+    new Uint8Array(sharedBuffer).set(body);
+
+    const buildDataSource = (checksumAlgorithm?: string, checksumHeader?: string): DataSource => ({
+      type: "sharedBuffer",
+      sharedBuffer,
+      partSize,
+      totalSize: contentLength,
+      checksumAlgorithm,
+      checksumHeader,
+    });
+
+    return this.threadedMultipartUpload(request, contentLength, buildDataSource, transferOptions);
+  }
+
+  /**
+   * Common implementation for threaded multipart uploads.
+   * Handles CreateMPU, concurrent UploadPart dispatch, and CompleteMPU/AbortMPU.
+   * The buildDataSource factory is called with checksum info to produce the
+   * per-request data source passed to the WorkerHttpHandler.
+   *
+   * @internal
+   */
+  private async threadedMultipartUpload(
+    request: UploadRequest,
+    contentLength: number,
+    buildDataSource: (checksumAlgorithm?: string, checksumHeader?: string) => DataSource,
+    transferOptions?: TransferOptions
+  ): Promise<CompleteMultipartUploadCommandOutput> {
+    const { partSize, expectedPartsCount } = this.calculatePartSize(contentLength);
+
+    this.checkAborted(transferOptions);
+
+    const createMpuRequest: CreateMultipartUploadCommandInput = { ...request };
+    const hasFullObjectChecksum =
+      request.ContentMD5 ||
+      request.ChecksumCRC32 ||
+      request.ChecksumCRC32C ||
+      request.ChecksumCRC64NVME ||
+      request.ChecksumSHA1 ||
+      request.ChecksumSHA256;
+
+    if (hasFullObjectChecksum) {
+      createMpuRequest.ChecksumType = "FULL_OBJECT";
+    }
+    if (!createMpuRequest.ChecksumAlgorithm && this.requestChecksumCalculation === "WHEN_SUPPORTED") {
+      createMpuRequest.ChecksumAlgorithm = request.ChecksumAlgorithm ?? "CRC32";
+    }
+
+    const createMpuResponse = await this.s3.send(new CreateMultipartUploadCommand(createMpuRequest), transferOptions);
+    const uploadId = createMpuResponse.UploadId!;
+
+    const checksumAlgorithm = createMpuRequest.ChecksumAlgorithm;
+    const checksumHeader = checksumAlgorithm ? `x-amz-checksum-${checksumAlgorithm.toLowerCase()}` : undefined;
+    const dataSource = buildDataSource(checksumAlgorithm, checksumHeader);
+
+    const abortController = new AbortController();
+    const uploadAbortSignal = abortController.signal;
+
+    try {
+      const completedParts: CompletedPart[] = [];
+      let bytesUploaded = 0;
+      let nextPartNumber = 1;
+
+      const uploadPart = async (): Promise<void> => {
+        while (true) {
+          const partNumber = nextPartNumber++;
+          if (partNumber > expectedPartsCount) return;
+
+          if (uploadAbortSignal.aborted) {
+            throw Object.assign(new Error("Upload aborted due to part failure."), { name: "AbortError" });
+          }
+          this.checkAborted(transferOptions);
+
+          const offset = (partNumber - 1) * partSize;
+          const length = Math.min(partSize, contentLength - offset);
+
+          // Readable placeholder — the checksum middleware sees a stream,
+          // sets up aws-chunked headers, and the signer signs them.
+          // The worker fulfills this contract by sending aws-chunked framed data.
+          const placeholderBody = createEmptyReadable();
+
+          const partRequest: UploadPartCommandInput = {
+            ...request,
+            Body: placeholderBody,
+            UploadId: uploadId,
+            PartNumber: partNumber,
+            ContentLength: length,
+            ...(checksumAlgorithm && { ChecksumAlgorithm: checksumAlgorithm as any }),
+          };
+
+          const partResponse = await this.s3.send(new UploadPartCommand(partRequest), {
+            ...transferOptions,
+            dataSource,
+          } as any);
+
+          const completedPart: CompletedPart = {
+            PartNumber: partNumber,
+            ETag: partResponse.ETag,
+          };
+          if (partResponse.ChecksumCRC32) completedPart.ChecksumCRC32 = partResponse.ChecksumCRC32;
+          if (partResponse.ChecksumCRC32C) completedPart.ChecksumCRC32C = partResponse.ChecksumCRC32C;
+          if (partResponse.ChecksumCRC64NVME) completedPart.ChecksumCRC64NVME = partResponse.ChecksumCRC64NVME;
+          if (partResponse.ChecksumSHA1) completedPart.ChecksumSHA1 = partResponse.ChecksumSHA1;
+          if (partResponse.ChecksumSHA256) completedPart.ChecksumSHA256 = partResponse.ChecksumSHA256;
+
+          completedParts.push(completedPart);
+          bytesUploaded += length;
+
+          this.dispatchEvent(
+            Object.assign(new Event("bytesTransferred"), {
+              request,
+              snapshot: {
+                transferredBytes: bytesUploaded,
+                totalBytes: contentLength,
+              },
+            })
+          );
+        }
+      };
+
+      const partUploads: Promise<void>[] = [];
+      for (let i = 0; i < this.maxConcurrentUploads; i++) {
+        partUploads.push(
+          uploadPart().catch((error) => {
+            abortController.abort();
+            throw error;
+          })
+        );
+      }
+
+      await Promise.all(partUploads);
+
+      if (completedParts.length !== expectedPartsCount) {
+        throw new Error(`Expected ${expectedPartsCount} parts but uploaded ${completedParts.length} parts`);
+      }
+
+      completedParts.sort((a, b) => a.PartNumber! - b.PartNumber!);
+      this.checkAborted(transferOptions);
+
+      const { Body: _body, ...completeRequestFields } = request;
+      const completeRequest: CompleteMultipartUploadCommandInput = {
+        ...completeRequestFields,
+        UploadId: uploadId,
+        MultipartUpload: { Parts: completedParts },
+        MpuObjectSize: contentLength,
+      };
+
+      if (hasFullObjectChecksum) {
+        completeRequest.ChecksumType = "FULL_OBJECT";
+        if (request.ChecksumCRC32) completeRequest.ChecksumCRC32 = request.ChecksumCRC32;
+        if (request.ChecksumCRC32C) completeRequest.ChecksumCRC32C = request.ChecksumCRC32C;
+        if (request.ChecksumCRC64NVME) completeRequest.ChecksumCRC64NVME = request.ChecksumCRC64NVME;
+      }
+
+      try {
+        return await this.s3.send(new CompleteMultipartUploadCommand(completeRequest), transferOptions);
+      } catch (completeMpuError) {
+        this.logger.warn(
+          `CompleteMultipartUpload failed for upload ID ${uploadId}: ${(completeMpuError as Error).message}`
+        );
+        throw completeMpuError;
+      }
+    } catch (error) {
+      const { Body: _abortBody, ...abortRequestFields } = request;
+      const abortRequest: AbortMultipartUploadCommandInput = {
+        ...abortRequestFields,
+        UploadId: uploadId,
+      };
+
+      try {
+        await this.s3.send(new AbortMultipartUploadCommand(abortRequest), transferOptions);
+      } catch (abortError) {
+        this.logger.warn(`Failed to abort multipart upload ${uploadId}:`, abortError);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Uploads an object to S3 using multipart upload operation.
+   * Used when content length exceeds the multipart upload threshold.
+   * Streams the body chunk-by-chunk via getChunk without buffering
+   * the entire content into memory.
+   *
+   * @internal
+   */
+  private async uploadInParts(
+    request: UploadRequest,
+    contentLength: number,
+    transferOptions?: TransferOptions
+  ): Promise<CompleteMultipartUploadCommandOutput> {
+    const { partSize, expectedPartsCount } = this.calculatePartSize(contentLength);
+
+    this.checkAborted(transferOptions);
+
+    const createMpuRequest: CreateMultipartUploadCommandInput = { ...request };
+
+    const hasFullObjectChecksum =
+      request.ContentMD5 ||
+      request.ChecksumCRC32 ||
+      request.ChecksumCRC32C ||
+      request.ChecksumCRC64NVME ||
+      request.ChecksumSHA1 ||
+      request.ChecksumSHA256;
+
+    if (hasFullObjectChecksum) {
+      createMpuRequest.ChecksumType = "FULL_OBJECT";
+    }
+    if (!createMpuRequest.ChecksumAlgorithm && this.requestChecksumCalculation === "WHEN_SUPPORTED") {
+      createMpuRequest.ChecksumAlgorithm = request.ChecksumAlgorithm ?? "CRC32";
+    }
+    const createMpuResponse = await this.s3.send(new CreateMultipartUploadCommand(createMpuRequest), transferOptions);
+    const uploadId = createMpuResponse.UploadId!;
+
+    const abortController = new AbortController();
+    const uploadAbortSignal = abortController.signal;
+
+    try {
+      const completedParts: CompletedPart[] = [];
+      const dataFeeder = getChunk(request.Body, partSize);
+      let bytesUploaded = 0;
+
+      const uploadPart = async (dataFeeder: AsyncGenerator<RawDataPart, void, undefined>) => {
+        for await (const dataPart of dataFeeder) {
+          if (uploadAbortSignal.aborted) {
+            throw Object.assign(new Error("Upload aborted due to part failure."), { name: "AbortError" });
+          }
+          this.checkAborted(transferOptions);
+
+          this.validateUploadPart(dataPart, partSize);
+
+          const partRequest: UploadPartCommandInput = {
+            ...request,
+            Body: dataPart.data,
+            UploadId: uploadId,
+            PartNumber: dataPart.partNumber,
+            ContentLength: byteLength(dataPart.data),
+            ...(this.requestChecksumCalculation === "WHEN_SUPPORTED" && {
+              ChecksumAlgorithm: request.ChecksumAlgorithm,
+            }),
+          };
+
+          const partResponse = await this.s3.send(new UploadPartCommand(partRequest), transferOptions);
+
+          const checksumAlgorithm = partRequest.ChecksumAlgorithm;
+          if (
+            checksumAlgorithm &&
+            !partResponse.ChecksumCRC32 &&
+            !partResponse.ChecksumCRC32C &&
+            !partResponse.ChecksumCRC64NVME &&
+            !partResponse.ChecksumSHA1 &&
+            !partResponse.ChecksumSHA256
+          ) {
+            throw new Error(
+              `Checksum was requested for part ${dataPart.partNumber} using ${checksumAlgorithm}, but no checksum was returned in the response. ` +
+                `If running in a browser, ensure your S3 bucket CORS configuration is enabled. `
+            );
+          }
+
+          const completedPart: CompletedPart = {
+            PartNumber: dataPart.partNumber,
+            ETag: partResponse.ETag,
+          };
+          if (partResponse.ChecksumCRC32) completedPart.ChecksumCRC32 = partResponse.ChecksumCRC32;
+          if (partResponse.ChecksumCRC32C) completedPart.ChecksumCRC32C = partResponse.ChecksumCRC32C;
+          if (partResponse.ChecksumCRC64NVME) completedPart.ChecksumCRC64NVME = partResponse.ChecksumCRC64NVME;
+          if (partResponse.ChecksumSHA1) completedPart.ChecksumSHA1 = partResponse.ChecksumSHA1;
+          if (partResponse.ChecksumSHA256) completedPart.ChecksumSHA256 = partResponse.ChecksumSHA256;
+
+          completedParts.push(completedPart);
+
+          const partLength = byteLength(dataPart.data)!;
+          bytesUploaded += partLength;
+
+          this.dispatchEvent(
+            Object.assign(new Event("bytesTransferred"), {
+              request,
+              snapshot: {
+                transferredBytes: bytesUploaded,
+                totalBytes: contentLength,
+              },
+            })
+          );
+        }
+      };
+
+      const partUploads: Promise<void>[] = [];
+      for (let i = 0; i < this.maxConcurrentUploads; i++) {
+        partUploads.push(
+          uploadPart(dataFeeder).catch((error) => {
+            abortController.abort();
+            throw error;
+          })
+        );
+      }
+
+      await Promise.all(partUploads);
+
+      if (completedParts.length !== expectedPartsCount) {
+        throw new Error(`Expected ${expectedPartsCount} parts but uploaded ${completedParts.length} parts`);
+      }
+
+      completedParts.sort((a, b) => a.PartNumber! - b.PartNumber!);
+
+      this.checkAborted(transferOptions);
+      const { Body: _body, ...completeRequestFields } = request;
+      const completeRequest: CompleteMultipartUploadCommandInput = {
+        ...completeRequestFields,
+        UploadId: uploadId,
+        MultipartUpload: { Parts: completedParts },
+        MpuObjectSize: contentLength,
+      };
+
+      if (hasFullObjectChecksum) {
+        completeRequest.ChecksumType = "FULL_OBJECT";
+        if (request.ChecksumCRC32) completeRequest.ChecksumCRC32 = request.ChecksumCRC32;
+        if (request.ChecksumCRC32C) completeRequest.ChecksumCRC32C = request.ChecksumCRC32C;
+        if (request.ChecksumCRC64NVME) completeRequest.ChecksumCRC64NVME = request.ChecksumCRC64NVME;
+      }
+
+      try {
+        return await this.s3.send(new CompleteMultipartUploadCommand(completeRequest), transferOptions);
+      } catch (completeMpuError) {
+        this.logger.warn(
+          `CompleteMultipartUpload failed for upload ID ${uploadId}: ${(completeMpuError as Error).message}`
+        );
+        throw completeMpuError;
+      }
+    } catch (error) {
+      const { Body: _abortBody, ...abortRequestFields } = request;
+      const abortRequest: AbortMultipartUploadCommandInput = {
+        ...abortRequestFields,
+        UploadId: uploadId,
+      };
+
+      try {
+        await this.s3.send(new AbortMultipartUploadCommand(abortRequest), transferOptions);
+      } catch (abortError) {
+        this.logger.warn(`Failed to abort multipart upload ${uploadId}:`, abortError);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Validates that a data part has a measurable size and matches the expected part size.
+   *
+   * @internal
+   */
+  private validateUploadPart(dataPart: RawDataPart, partSize: number): void {
+    const actualPartSize = byteLength(dataPart.data);
+
+    if (actualPartSize === undefined) {
+      throw new Error(
+        `A dataPart was generated without a measurable data chunk size for part number ${dataPart.partNumber}`
+      );
+    }
+
+    if (dataPart.partNumber === 1 && dataPart.lastPart) {
+      return;
+    }
+
+    if (!dataPart.lastPart && actualPartSize !== partSize) {
+      throw new Error(
+        `The byte size for part number ${dataPart.partNumber}, size ${actualPartSize} does not match expected size ${partSize}`
+      );
+    }
+  }
+}
+
+/**
+ * Internal event handler for download lifecycle hooks.
+ *
+ * @internal
+ */
+export const internalEventHandler = {
+  async afterInitialGetObject() {},
+};

--- a/lib/lib-transfer-manager/src/chunker.ts
+++ b/lib/lib-transfer-manager/src/chunker.ts
@@ -1,0 +1,130 @@
+// eslint-disable-next-line n/prefer-node-protocol
+import { Buffer } from "buffer";
+import { lstatSync, ReadStream } from "node:fs";
+
+export interface RawDataPart {
+  partNumber: number;
+  data: Uint8Array;
+  lastPart?: boolean;
+}
+
+export const byteLength = (input: any): number | undefined => {
+  if (input == null) {
+    return 0;
+  }
+  if (typeof input === "string") {
+    return Buffer.byteLength(input);
+  }
+  if (typeof input.byteLength === "number") {
+    return input.byteLength;
+  } else if (typeof input.length === "number") {
+    return input.length;
+  } else if (typeof input.size === "number") {
+    return input.size;
+  } else if (typeof input.start === "number" && typeof input.end === "number") {
+    return input.end + 1 - input.start;
+  } else if (input instanceof ReadStream) {
+    try {
+      return lstatSync(input.path).size;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+};
+
+interface Buffers {
+  chunks: Uint8Array[];
+  length: number;
+}
+
+async function* getChunkStream<T>(
+  data: T,
+  partSize: number,
+  getNextData: (data: T) => AsyncGenerator<Uint8Array>
+): AsyncGenerator<RawDataPart, void, undefined> {
+  let partNumber = 1;
+  const currentBuffer: Buffers = { chunks: [], length: 0 };
+
+  for await (const datum of getNextData(data)) {
+    currentBuffer.chunks.push(datum);
+    currentBuffer.length += datum.byteLength;
+
+    while (currentBuffer.length > partSize) {
+      const dataChunk = currentBuffer.chunks.length > 1 ? Buffer.concat(currentBuffer.chunks) : currentBuffer.chunks[0];
+      yield { partNumber, data: dataChunk.subarray(0, partSize) };
+      currentBuffer.chunks = [dataChunk.subarray(partSize)];
+      currentBuffer.length = currentBuffer.chunks[0].byteLength;
+      partNumber += 1;
+    }
+  }
+
+  yield {
+    partNumber,
+    data: currentBuffer.chunks.length !== 1 ? Buffer.concat(currentBuffer.chunks) : currentBuffer.chunks[0],
+    lastPart: true,
+  };
+}
+
+async function* getChunkUint8Array(data: Uint8Array, partSize: number): AsyncGenerator<RawDataPart, void, undefined> {
+  let partNumber = 1;
+  let startByte = 0;
+  let endByte = partSize;
+
+  while (endByte < data.byteLength) {
+    yield { partNumber, data: data.subarray(startByte, endByte) };
+    partNumber += 1;
+    startByte = endByte;
+    endByte = startByte + partSize;
+  }
+
+  yield { partNumber, data: data.subarray(startByte), lastPart: true };
+}
+
+async function* getDataReadable(data: AsyncIterable<any>): AsyncGenerator<Uint8Array> {
+  for await (const chunk of data) {
+    if (Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
+      yield chunk;
+    } else {
+      yield Buffer.from(chunk);
+    }
+  }
+}
+
+async function* getDataReadableStream(data: ReadableStream): AsyncGenerator<Uint8Array> {
+  const reader = data.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+        yield value;
+      } else {
+        yield Buffer.from(value);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export const getChunk = (data: any, partSize: number): AsyncGenerator<RawDataPart, void, undefined> => {
+  if (data instanceof Uint8Array) {
+    return getChunkUint8Array(data, partSize);
+  }
+  if (data instanceof String || typeof data === "string") {
+    return getChunkUint8Array(Buffer.from(data), partSize);
+  }
+  if (data instanceof ReadableStream) {
+    return getChunkStream<ReadableStream>(data, partSize, getDataReadableStream);
+  }
+  if (typeof (data as any).stream === "function") {
+    return getChunkStream<ReadableStream>((data as any).stream(), partSize, getDataReadableStream);
+  }
+  if (Symbol.asyncIterator in data || typeof data[Symbol.asyncIterator] === "function") {
+    return getChunkStream<AsyncIterable<any>>(data, partSize, getDataReadable);
+  }
+  throw new Error(
+    "Body Data is unsupported format, expected data to be one of: string | Uint8Array | Buffer | Readable | ReadableStream | Blob;."
+  );
+};

--- a/lib/lib-transfer-manager/src/event-listener-types.ts
+++ b/lib/lib-transfer-manager/src/event-listener-types.ts
@@ -1,0 +1,58 @@
+/**
+ * Function type for handling transfer events in the transfer manager.
+ * Represents a callback that receives event data during transfer operations.
+ * 
+ * @param event - The event object containing transfer details and progress information.
+
+ * @alpha
+ */
+export type EventListenerFunction<E = Event> = (event: Event & E) => void;
+
+/**
+ * Union type for handling transfer events in the transfer manager.
+ * Can be a function or an object.
+ *
+ * @alpha
+ */
+export type EventListener<E = Event> = EventListenerFunction<E> | EventListenerObject<E>;
+
+/**
+ * Object type for handling transfer events in the transfer manager.
+ * Represents an object that implements the `handleEvent` method to handle transfer events.
+ *
+ * @alpha
+ */
+export type EventListenerObject<E = Event> = {
+  handleEvent: EventListenerFunction<E>;
+};
+
+/**
+ * Configuration options for registering event listeners in the transfer manager.
+ * Controls the behavior of event listeners for transfer events.
+ *
+ * @alpha
+ */
+export type AddEventListenerOptions = {
+  /**
+   * A boolean value indicating that the listener should be invoked at most once
+   * after being added. If true, the listener would be automatically removed when invoked.
+   * If not specified, defaults to false.
+   */
+  once?: boolean;
+  /**
+   * An AbortSignal. The listener will be removed when the abort() method of the
+   * AbortController which owns the AbortSignal is called. If not specified, no
+   * AbortSignal is associated with the listener.
+   */
+  signal?: AbortSignal;
+};
+
+/**
+ * Configuration options for removing event listeners in the transfer manager.
+ * Controls the behavior of event listeners for transfer events.
+ *
+ * @alpha
+ */
+export type RemoveEventListenerOptions = {
+  capture?: boolean;
+};

--- a/lib/lib-transfer-manager/src/http-request-worker.ts
+++ b/lib/lib-transfer-manager/src/http-request-worker.ts
@@ -1,0 +1,159 @@
+/**
+ * Worker thread that receives signed HTTP requests and sends them.
+ * For file-based requests, reads the file slice, computes CRC32,
+ * and sends the body in aws-chunked format with a trailing checksum.
+ *
+ * @internal
+ */
+import { HttpRequest } from "@smithy/core/protocols";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { open } from "node:fs/promises";
+import { Agent as httpsAgent } from "node:https";
+import { parentPort } from "node:worker_threads";
+import { crc32 } from "node:zlib";
+
+import type {
+  HttpWorkerConfigMessage,
+  HttpWorkerErrorMessage,
+  HttpWorkerInboundMessage,
+  HttpWorkerReadyMessage,
+  HttpWorkerRequestMessage,
+  HttpWorkerResponseMessage,
+} from "./worker-http-handler";
+
+function toBase64(n: number): string {
+  const buf = Buffer.allocUnsafe(4);
+  buf.writeUInt32BE(n >>> 0, 0);
+  return buf.toString("base64");
+}
+
+if (parentPort) {
+  let handler: NodeHttpHandler | undefined;
+  const port = parentPort;
+
+  const readFileSlice = async (filePath: string, offset: number, length: number): Promise<Buffer> => {
+    const fh = await open(filePath, "r");
+    try {
+      const buffer = Buffer.allocUnsafe(length);
+      await fh.read(buffer, 0, length, offset);
+      return buffer;
+    } finally {
+      await fh.close();
+    }
+  };
+
+  const buildAwsChunkedBody = (data: Buffer, checksumHeader?: string, checksumValue?: string): Buffer => {
+    const hexLen = data.byteLength.toString(16);
+    const parts: Buffer[] = [Buffer.from(`${hexLen}\r\n`), data, Buffer.from("\r\n0\r\n")];
+    if (checksumHeader && checksumValue) {
+      parts.push(Buffer.from(`${checksumHeader}:${checksumValue}\r\n`));
+    }
+    parts.push(Buffer.from("\r\n"));
+    return Buffer.concat(parts);
+  };
+
+  const processRequest = async (msg: HttpWorkerRequestMessage): Promise<void> => {
+    const { id, request: serialized } = msg;
+
+    try {
+      let body: Buffer | undefined;
+
+      if (msg.type === "httpRequestFromRAM") {
+        const fileData = Buffer.from(msg.sharedBuffer, msg.offset, msg.length);
+
+        if (msg.checksumAlgorithm && msg.checksumHeader) {
+          const crcValue = crc32(fileData);
+          const checksumValue = toBase64(crcValue);
+          body = buildAwsChunkedBody(fileData, msg.checksumHeader, checksumValue);
+        } else {
+          body = fileData;
+        }
+      } else if (msg.type === "httpRequestFromFile") {
+        const fileData = await readFileSlice(msg.filePath, msg.offset, msg.length);
+
+        if (msg.checksumAlgorithm && msg.checksumHeader) {
+          // Compute checksum and wrap in aws-chunked framing with trailing checksum.
+          const crcValue = crc32(fileData);
+          const checksumValue = toBase64(crcValue);
+          body = buildAwsChunkedBody(fileData, msg.checksumHeader, checksumValue);
+        } else {
+          // No checksum requested — send raw data.
+          body = fileData;
+        }
+      }
+
+      const request = new HttpRequest({
+        method: serialized.method,
+        protocol: serialized.protocol,
+        hostname: serialized.hostname,
+        port: serialized.port,
+        path: serialized.path,
+        query: serialized.query,
+        headers: serialized.headers,
+        body,
+      });
+
+      const { response } = await handler!.handle(request);
+
+      const chunks: Buffer[] = [];
+      if (response.body) {
+        for await (const chunk of response.body) {
+          chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+        }
+      }
+
+      let responseBody: Uint8Array | undefined;
+      const transferList: ArrayBuffer[] = [];
+      if (chunks.length > 0) {
+        const concatenated = Buffer.concat(chunks);
+        const ab = new ArrayBuffer(concatenated.byteLength);
+        new Uint8Array(ab).set(concatenated);
+        responseBody = new Uint8Array(ab);
+        transferList.push(ab);
+      }
+
+      port.postMessage(
+        {
+          type: "httpResponse",
+          id,
+          response: {
+            statusCode: response.statusCode,
+            headers: response.headers,
+            body: responseBody,
+          },
+        } satisfies HttpWorkerResponseMessage,
+        transferList
+      );
+    } catch (err) {
+      port.postMessage({
+        type: "httpError",
+        id,
+        error: (err as Error).message ?? String(err),
+        code: (err as any).code,
+        name: (err as Error).name,
+      } satisfies HttpWorkerErrorMessage);
+    }
+  };
+
+  port.on("message", (msg: HttpWorkerInboundMessage) => {
+    if (msg.type === "done") {
+      handler?.destroy();
+      process.exit(0);
+      return;
+    }
+
+    if (msg.type === "config") {
+      const { maxSockets } = msg as HttpWorkerConfigMessage;
+      handler = new NodeHttpHandler({
+        httpsAgent: new httpsAgent({ maxSockets }),
+      });
+      return;
+    }
+
+    if (msg.type === "httpRequestFromFile" || msg.type === "httpRequestFromRAM") {
+      processRequest(msg);
+    }
+  });
+
+  port.postMessage({ type: "ready" } satisfies HttpWorkerReadyMessage);
+}

--- a/lib/lib-transfer-manager/src/index.ts
+++ b/lib/lib-transfer-manager/src/index.ts
@@ -1,0 +1,3 @@
+export { S3TransferManager } from "./S3TransferManager";
+export type { IS3TransferManager } from "./types";
+export type {} from "./event-listener-types";

--- a/lib/lib-transfer-manager/src/join-streams.browser.spec.ts
+++ b/lib/lib-transfer-manager/src/join-streams.browser.spec.ts
@@ -1,0 +1,375 @@
+import { sdkStreamMixin } from "@smithy/core/serde";
+import { describe, expect, test as it } from "vitest";
+
+import { joinStreams } from "./join-streams.browser";
+
+describe(joinStreams.name, () => {
+  it("should join web API ReadableStreams together", async () => {
+    const streams = [
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("abcd"));
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("efgh"));
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("ijkl"));
+              c.close();
+            },
+          })
+        )
+      ),
+    ];
+
+    const joined = (await joinStreams(streams)) as ReadableStream;
+    const reader = joined.getReader();
+
+    expect((await reader.read()).value).toEqual(Buffer.from("abcd"));
+    expect((await reader.read()).value).toEqual(Buffer.from("efgh"));
+    expect((await reader.read()).value).toEqual(Buffer.from("ijkl"));
+  });
+
+  it("should not fail to handle an empty stream", async () => {
+    const streams = [
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("abcd"));
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("ijkl"));
+              c.close();
+            },
+          })
+        )
+      ),
+    ];
+
+    const joined = (await joinStreams(streams)) as ReadableStream;
+    const reader = joined.getReader();
+
+    expect((await reader.read()).value).toEqual(Buffer.from("abcd"));
+    expect((await reader.read()).value).toEqual(Buffer.from("ijkl"));
+    expect((await reader.read()).done).toBe(true);
+  });
+
+  it("should throw an error when there is an error during any of the streams", async () => {
+    const streams = [
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("abcd"));
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.error(new Error("error in stream"));
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("ijkl"));
+              c.close();
+            },
+          })
+        )
+      ),
+    ];
+
+    const joined = (await joinStreams(streams)) as ReadableStream;
+    const reader = joined.getReader();
+
+    // Read first chunk successfully
+    expect((await reader.read()).value).toEqual(Buffer.from("abcd"));
+
+    // Second stream errors
+    await expect(reader.read()).rejects.toThrow("error in stream");
+  });
+
+  it("should release all locks and cancel all streams if an error is thrown during any stream", async () => {
+    let stream3Cancelled = false;
+
+    const streams = [
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("abcd"));
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.error(new Error("error in stream"));
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("ijkl"));
+              c.close();
+            },
+            cancel() {
+              stream3Cancelled = true;
+            },
+          })
+        )
+      ),
+    ];
+
+    const joined = (await joinStreams(streams)) as ReadableStream;
+    const reader = joined.getReader();
+
+    try {
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    } catch (e) {
+      // expected
+    }
+
+    expect(stream3Cancelled).toBe(true);
+  });
+
+  it("should release all locks and cancel all streams if any stream promise rejects", async () => {
+    let stream3Cancelled = false;
+
+    const streams = [
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("abcd"));
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.reject(new Error("promise rejected")),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("ijkl"));
+              c.close();
+            },
+            cancel() {
+              stream3Cancelled = true;
+            },
+          })
+        )
+      ),
+    ];
+
+    streams[1].catch(() => {});
+
+    const joined = (await joinStreams(streams)) as ReadableStream;
+    const reader = joined.getReader();
+
+    // Read first chunk successfully
+    expect((await reader.read()).value).toEqual(Buffer.from("abcd"));
+
+    // Second promise rejects
+    await expect(reader.read()).rejects.toThrow("promise rejected");
+
+    expect(stream3Cancelled).toBe(true);
+  });
+
+  it("should throw error for unsupported stream types", async () => {
+    const streams = [Promise.resolve(Buffer.from("not a stream") as any)];
+
+    await expect(joinStreams(streams)).rejects.toThrow("Unsupported Stream Type");
+  });
+
+  it("should call onBytes with cumulative byte count for ReadableStreams", async () => {
+    const streams = [
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("abcdef")); // 6 bytes
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("efgh")); // 4 bytes
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("ijkl")); // 4 bytes
+              c.close();
+            },
+          })
+        )
+      ),
+    ];
+
+    const byteCounts: number[] = [];
+    const joined = (await joinStreams(streams, {
+      onBytes: (bytes) => byteCounts.push(bytes),
+    })) as ReadableStream;
+
+    const reader = joined.getReader();
+    while (!(await reader.read()).done) {}
+
+    expect(byteCounts).toEqual([6, 10, 14]);
+  });
+
+  it("should call onCompletion when all streams are consumed", async () => {
+    const streams = [
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("abcd")); // 4 bytes
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("efgh")); // 4 bytes
+              c.close();
+            },
+          })
+        )
+      ),
+    ];
+
+    let completionData: { bytes: number; index: number } | null = null;
+    const joined = (await joinStreams(streams, {
+      onCompletion: (bytes, index) => {
+        completionData = { bytes, index };
+      },
+    })) as ReadableStream;
+
+    const reader = joined.getReader();
+    while (!(await reader.read()).done) {}
+
+    expect(completionData).toEqual({ bytes: 8, index: 1 });
+  });
+
+  it("should handle Blob streams", async () => {
+    const streams = [
+      Promise.resolve(new Blob(["abcd"]) as any),
+      Promise.resolve(new Blob(["efgh"]) as any),
+      Promise.resolve(new Blob(["ijkl"]) as any),
+    ];
+
+    const joined = (await joinStreams(streams)) as ReadableStream;
+    const reader = joined.getReader();
+
+    const chunks: string[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(new TextDecoder().decode(value));
+    }
+
+    expect(chunks).toEqual(["abcd", "efgh", "ijkl"]);
+  });
+
+  it("should handle mixed ReadableStream and Blob streams", async () => {
+    const streams = [
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode("abcd"));
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(new Blob(["efgh"]) as any),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode("ijkl"));
+              c.close();
+            },
+          })
+        )
+      ),
+    ];
+
+    const joined = (await joinStreams(streams)) as ReadableStream;
+    const reader = joined.getReader();
+
+    const chunks: string[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(new TextDecoder().decode(value));
+    }
+
+    expect(chunks).toEqual(["abcd", "efgh", "ijkl"]);
+  });
+});

--- a/lib/lib-transfer-manager/src/join-streams.browser.ts
+++ b/lib/lib-transfer-manager/src/join-streams.browser.ts
@@ -1,0 +1,121 @@
+import { isReadableStream, sdkStreamMixin } from "@smithy/core/serde";
+import type { StreamingBlobPayloadOutputTypes } from "@smithy/types";
+
+import type { JoinStreamIterationEvents } from "./types";
+
+/**
+ * Joins multiple stream promises into a single stream with event callbacks.
+ *
+ * @internal
+ */
+export async function joinStreams(
+  streams: Promise<StreamingBlobPayloadOutputTypes>[],
+  eventListeners?: JoinStreamIterationEvents
+): Promise<StreamingBlobPayloadOutputTypes> {
+  const firstStream = await streams[0];
+  if (isReadableStream(firstStream) || firstStream instanceof Blob) {
+    const newReadableStream = new ReadableStream({
+      async start(controller) {
+        for await (const chunk of iterateStreams(streams, eventListeners)) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+    return sdkStreamMixin(newReadableStream);
+  } else {
+    throw new Error("Unsupported Stream Type");
+  }
+}
+
+/**
+ * Iterates through stream promises sequentially, yielding chunks with progress tracking.
+ *
+ * @internal
+ */
+export async function* iterateStreams(
+  promises: Promise<StreamingBlobPayloadOutputTypes>[],
+  eventListeners?: JoinStreamIterationEvents
+): AsyncIterable<Uint8Array, void, void> {
+  let bytesTransferred = 0;
+  let index = 0;
+  for (const streamPromise of promises) {
+    let stream: Awaited<(typeof promises)[0]>;
+    try {
+      stream = await streamPromise;
+    } catch (e) {
+      await destroy(promises);
+      eventListeners?.onFailure?.(e, index);
+      throw e;
+    }
+
+    if (isReadableStream(stream)) {
+      const reader = stream.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          yield value;
+          bytesTransferred += value.byteLength;
+          eventListeners?.onBytes?.(bytesTransferred, index);
+        }
+      } catch (e) {
+        reader.releaseLock();
+        await destroy(promises);
+        eventListeners?.onFailure?.(e, index);
+        throw e;
+      } finally {
+        reader.releaseLock();
+      }
+    } else if (stream instanceof Blob) {
+      // Blob response body when using XMLHttpRequest handler & receiving arraybuffer response type
+      const blobStream = stream.stream();
+      const reader = blobStream.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          yield value;
+          bytesTransferred += value.byteLength;
+          eventListeners?.onBytes?.(bytesTransferred, index);
+        }
+      } catch (e) {
+        await destroy(promises);
+        eventListeners?.onFailure?.(e, index);
+        throw e;
+      } finally {
+        reader.releaseLock();
+      }
+    } else {
+      await destroy(promises);
+      const failure = new Error(`unhandled stream type ${(stream as any)?.constructor?.name}`);
+      eventListeners?.onFailure?.(failure, index);
+      throw failure;
+    }
+    // Signal that this stream has been fully consumed, triggering next prefetch
+    eventListeners?.onStreamConsumed?.(index);
+    index++;
+  }
+  eventListeners?.onCompletion?.(bytesTransferred, index - 1);
+}
+
+/**
+ * @internal
+ */
+async function destroy(promises: Promise<StreamingBlobPayloadOutputTypes>[]): Promise<void> {
+  await Promise.all(
+    promises.map(async (streamPromise) => {
+      return streamPromise
+        .then((stream) => {
+          if (isReadableStream(stream)) {
+            return stream.cancel();
+          }
+        })
+        .catch((e: unknown) => {});
+    })
+  );
+}

--- a/lib/lib-transfer-manager/src/join-streams.spec.ts
+++ b/lib/lib-transfer-manager/src/join-streams.spec.ts
@@ -1,0 +1,288 @@
+import { sdkStreamMixin } from "@smithy/core/serde";
+import { Readable } from "node:stream";
+import { describe, expect, test as it } from "vitest";
+
+import { joinStreams } from "./join-streams";
+
+describe(joinStreams.name, () => {
+  it("should join Node.js Readable streams together", async () => {
+    const streams = [
+      Promise.resolve(sdkStreamMixin(Readable.from(Buffer.from("abcd")))),
+      Promise.resolve(sdkStreamMixin(Readable.from(Buffer.from("efgh")))),
+      Promise.resolve(sdkStreamMixin(Readable.from(Buffer.from("ijkl")))),
+    ];
+
+    const joined = (await joinStreams(streams)) as Readable;
+
+    const it = joined[Symbol.asyncIterator]();
+
+    expect((await it.next()).value).toEqual(Buffer.from("abcd"));
+    expect((await it.next()).value).toEqual(Buffer.from("efgh"));
+    expect((await it.next()).value).toEqual(Buffer.from("ijkl"));
+  });
+
+  it("should throw error for unsupported stream types and clean up all streams", async () => {
+    const stream1 = Readable.from(Buffer.from("abcd"));
+    const stream3 = Readable.from(Buffer.from("ijkl"));
+
+    const streams = [
+      Promise.resolve(sdkStreamMixin(stream1)),
+      Promise.resolve(Buffer.from("not a stream") as any),
+      Promise.resolve(sdkStreamMixin(stream3)),
+    ];
+
+    const joined = (await joinStreams(streams)) as Readable;
+
+    await expect(async () => {
+      for await (const _ of joined) {
+        // consume
+      }
+    }).rejects.toThrow("unhandled stream type Buffer");
+  });
+
+  it("should join web API ReadableStreams together", async () => {
+    const streams = [
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("abcd"));
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("efgh"));
+              c.close();
+            },
+          })
+        )
+      ),
+      Promise.resolve(
+        sdkStreamMixin(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.from("ijkl"));
+              c.close();
+            },
+          })
+        )
+      ),
+    ];
+
+    const joined = (await joinStreams(streams)) as ReadableStream;
+    const reader = joined.getReader();
+
+    expect((await reader.read()).value).toEqual(Buffer.from("abcd"));
+    expect((await reader.read()).value).toEqual(Buffer.from("efgh"));
+    expect((await reader.read()).value).toEqual(Buffer.from("ijkl"));
+  });
+
+  it("should not fail to handle an empty stream", async () => {
+    const streams = [
+      Promise.resolve(sdkStreamMixin(Readable.from([Buffer.from("abcd")]))),
+      Promise.resolve(sdkStreamMixin(Readable.from([]))),
+      Promise.resolve(sdkStreamMixin(Readable.from([Buffer.from("ijkl")]))),
+    ];
+
+    const joined = (await joinStreams(streams)) as Readable;
+    const it = joined[Symbol.asyncIterator]();
+
+    expect((await it.next()).value).toEqual(Buffer.from("abcd"));
+    expect((await it.next()).value).toEqual(Buffer.from("ijkl"));
+    expect((await it.next()).done).toBe(true);
+  });
+
+  it("should throw an error when there is an error during any of the streams", async () => {
+    const streams = [
+      Promise.resolve(sdkStreamMixin(Readable.from(Buffer.from("abcd")))),
+      Promise.resolve(
+        sdkStreamMixin(
+          Readable.from({
+            async *[Symbol.asyncIterator]() {
+              yield Buffer.from("ef");
+              throw new Error("error in stream");
+            },
+          })
+        )
+      ),
+      Promise.resolve(sdkStreamMixin(Readable.from(Buffer.from("ijkl")))),
+    ];
+
+    const joined = (await joinStreams(streams)) as Readable;
+
+    const it = joined[Symbol.asyncIterator]();
+    const observedChunks = [];
+
+    while (true) {
+      try {
+        const { done, value } = await it.next();
+        if (done) {
+          break;
+        }
+        observedChunks.push(value.toString("utf-8"));
+      } catch (e) {
+        expect(e.message).toEqual("error in stream");
+      }
+    }
+    expect(observedChunks).toEqual(["abcd", "ef"]);
+    expect.assertions(2);
+  });
+
+  it("should release all locks and cancel all streams if an error is thrown during any stream", async () => {
+    const stream1 = Readable.from(Buffer.from("abcd"));
+    const stream2 = Readable.from({
+      async *[Symbol.asyncIterator]() {
+        yield Buffer.from("ef");
+        throw new Error("error in stream");
+      },
+    });
+    const stream3 = Readable.from(Buffer.from("ijkl"));
+
+    const streams = [
+      Promise.resolve(sdkStreamMixin(stream1)),
+      Promise.resolve(sdkStreamMixin(stream2)),
+      Promise.resolve(sdkStreamMixin(stream3)),
+    ];
+
+    const joined = (await joinStreams(streams)) as Readable;
+    const it = joined[Symbol.asyncIterator]();
+    const observedChunks: string[] = [];
+
+    try {
+      while (true) {
+        const { done, value } = await it.next();
+        if (done) break;
+        observedChunks.push(value.toString("utf-8"));
+      }
+    } catch (e) {
+      expect((e as Error).message).toEqual("error in stream");
+    }
+    expect(observedChunks).toEqual(["abcd", "ef"]);
+    expect(stream1.destroyed).toBe(true);
+    expect(stream2.destroyed).toBe(true);
+    expect(stream3.destroyed).toBe(true);
+  });
+
+  it("should release all locks and cancel all streams if any stream promise rejects", async () => {
+    const stream1 = Readable.from(Buffer.from("abcd"));
+    const stream3 = Readable.from(Buffer.from("ijkl"));
+
+    const streams = [
+      Promise.resolve(sdkStreamMixin(stream1)),
+      Promise.reject(new Error("promise rejected")),
+      Promise.resolve(sdkStreamMixin(stream3)),
+    ];
+
+    streams[1].catch(() => {});
+
+    const joined = (await joinStreams(streams)) as Readable;
+    const it = joined[Symbol.asyncIterator]();
+    const observedChunks: string[] = [];
+
+    try {
+      while (true) {
+        const { done, value } = await it.next();
+        if (done) break;
+        observedChunks.push(value.toString("utf-8"));
+      }
+    } catch (e) {
+      expect((e as Error).message).toEqual("promise rejected");
+    }
+
+    // Only first stream was read before the rejected promise
+    expect(observedChunks).toEqual(["abcd"]);
+    // ALL streams are now properly cleaned up
+    expect(stream1.destroyed).toBe(true);
+    expect(stream3.destroyed).toBe(true);
+  });
+
+  it("should call onBytes with cumulative byte count for Readable streams", async () => {
+    const streams = [
+      Promise.resolve(sdkStreamMixin(Readable.from(Buffer.from("abcdef")))), // 6 bytes
+      Promise.resolve(sdkStreamMixin(Readable.from(Buffer.from("efgh")))), // 4 bytes
+      Promise.resolve(sdkStreamMixin(Readable.from(Buffer.from("ijkl")))), // 4 bytes
+    ];
+
+    const byteCounts: number[] = [];
+    const joined = (await joinStreams(streams, {
+      onBytes: (bytes) => byteCounts.push(bytes),
+    })) as Readable;
+
+    for await (const _ of joined) {
+    }
+
+    expect(byteCounts).toEqual([6, 10, 14]);
+  });
+
+  it("should call onCompletion when all streams are consumed", async () => {
+    const streams = [
+      Promise.resolve(sdkStreamMixin(Readable.from(Buffer.from("abcd")))), // 4 bytes
+      Promise.resolve(sdkStreamMixin(Readable.from(Buffer.from("efgh")))), // 4 bytes
+    ];
+
+    let completionData: { bytes: number; index: number } | null = null;
+    const joined = (await joinStreams(streams, {
+      onCompletion: (bytes, index) => {
+        completionData = { bytes, index };
+      },
+    })) as Readable;
+
+    for await (const _ of joined) {
+    }
+
+    expect(completionData).toEqual({ bytes: 8, index: 1 });
+  });
+
+  it("should handle backpressure when consumer is slow", async () => {
+    const readTimestamps: number[] = [];
+    let readCount = 0;
+    const totalChunks = 20;
+
+    const stream = new Readable({
+      highWaterMark: 1,
+      read() {
+        readCount++;
+        readTimestamps.push(Date.now());
+        if (readCount <= totalChunks) {
+          this.push(Buffer.from(`chunk${readCount}`));
+        } else {
+          this.push(null);
+        }
+      },
+    });
+
+    const streams = [Promise.resolve(sdkStreamMixin(stream))];
+    const joined = (await joinStreams(streams)) as Readable;
+    const chunks: string[] = [];
+
+    for await (const chunk of joined) {
+      chunks.push(chunk.toString());
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    // Verify all data received
+    for (let i = 1; i <= totalChunks; i++) {
+      expect(chunks.join("")).toContain(`chunk${i}`);
+    }
+
+    // Verify data received in order
+    const joinedChunks = chunks.join("");
+    for (let i = 1; i < totalChunks; i++) {
+      expect(joinedChunks.indexOf(`chunk${i}`)).toBeLessThan(joinedChunks.indexOf(`chunk${i + 1}`));
+    }
+
+    // Verify backpressure - reads were spread over time, not all at once
+    const timeSpan = readTimestamps[readTimestamps.length - 1] - readTimestamps[0];
+    // Technically this should be 50 * 20 = 1000ms.
+    // But not sure why it's 452, but can confirm that reads are spread over time
+    expect(timeSpan).toBeGreaterThanOrEqual(400);
+
+    // Verify read() was called multiple times due to backpressure
+    expect(readCount).toBeGreaterThan(totalChunks);
+  });
+});

--- a/lib/lib-transfer-manager/src/join-streams.ts
+++ b/lib/lib-transfer-manager/src/join-streams.ts
@@ -1,0 +1,125 @@
+import { isReadableStream, sdkStreamMixin } from "@smithy/core/serde";
+import type { StreamingBlobPayloadOutputTypes } from "@smithy/types";
+import { Readable } from "node:stream";
+
+import type { JoinStreamIterationEvents } from "./types";
+
+/**
+ * Joins multiple stream promises into a single stream with event callbacks.
+ *
+ * @internal
+ */
+export async function joinStreams(
+  streams: Promise<StreamingBlobPayloadOutputTypes>[],
+  eventListeners?: JoinStreamIterationEvents
+): Promise<StreamingBlobPayloadOutputTypes> {
+  const firstStream = await streams[0];
+  if (isReadableStream(firstStream)) {
+    const newReadableStream = new ReadableStream({
+      async start(controller) {
+        for await (const chunk of iterateStreams(streams, eventListeners)) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+    return sdkStreamMixin(newReadableStream);
+  } else {
+    streams.forEach((stream) => stream?.catch(() => {}));
+
+    return sdkStreamMixin(Readable.from(iterateStreams(streams, eventListeners)));
+  }
+}
+
+/**
+ * Iterates through stream promises sequentially, yielding chunks with progress tracking.
+ *
+ * @internal
+ */
+export async function* iterateStreams(
+  promises: Promise<StreamingBlobPayloadOutputTypes>[],
+  eventListeners?: JoinStreamIterationEvents
+): AsyncIterable<StreamingBlobPayloadOutputTypes, void, void> {
+  for (const p of promises) {
+    p?.catch(() => {});
+  }
+  let bytesTransferred = 0;
+  let index = 0;
+  for (const streamPromise of promises) {
+    if (!streamPromise) {
+      throw new Error("Stream promise is undefined - lazy prefetch may not have completed");
+    }
+    let stream: Awaited<(typeof promises)[0]>;
+    try {
+      stream = await streamPromise;
+    } catch (e) {
+      await destroy(promises);
+      eventListeners?.onFailure?.(e, index);
+      throw e;
+    }
+
+    if (isReadableStream(stream)) {
+      const reader = stream.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          yield value;
+          bytesTransferred += value.byteLength;
+          eventListeners?.onBytes?.(bytesTransferred, index);
+        }
+      } catch (e) {
+        await destroy(promises);
+        eventListeners?.onFailure?.(e, index);
+        throw e;
+      } finally {
+        reader.releaseLock();
+      }
+    } else if (stream instanceof Readable) {
+      try {
+        for await (const chunk of stream) {
+          yield chunk;
+          const chunkSize = Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(chunk);
+          bytesTransferred += chunkSize;
+          eventListeners?.onBytes?.(bytesTransferred, index);
+        }
+      } catch (e) {
+        await destroy(promises);
+        eventListeners?.onFailure?.(e, index);
+        throw e;
+      }
+    } else {
+      await destroy(promises);
+      const failure = new Error(`unhandled stream type ${(stream as any)?.constructor?.name}`);
+      eventListeners?.onFailure?.(failure, index);
+      throw failure;
+    }
+    // Signal that this stream has been fully consumed, triggering next prefetch
+    eventListeners?.onStreamConsumed?.(index);
+    index++;
+  }
+  eventListeners?.onCompletion?.(bytesTransferred, index - 1);
+}
+
+/**
+ * @internal
+ */
+async function destroy(promises: Promise<StreamingBlobPayloadOutputTypes>[]): Promise<void> {
+  await Promise.all(
+    promises.map(async (streamPromise) => {
+      if (!streamPromise) return;
+      return streamPromise
+        .then((stream) => {
+          if (stream instanceof Readable) {
+            stream.destroy();
+            return;
+          } else if (isReadableStream(stream)) {
+            return stream.cancel();
+          }
+        })
+        .catch((e: unknown) => {});
+    })
+  );
+}

--- a/lib/lib-transfer-manager/src/log-level.ts
+++ b/lib/lib-transfer-manager/src/log-level.ts
@@ -1,0 +1,35 @@
+import type { Logger } from "@smithy/types";
+
+export class LogLevel implements Logger {
+  private static LEVELS = ["trace", "debug", "info", "warn", "error"];
+
+  private readonly level: number = 5;
+
+  public constructor(private minimum: keyof Logger, private logger: Logger = console) {
+    const index = LogLevel.LEVELS.indexOf(minimum);
+    if (index === -1) {
+      throw new Error(`Log level must be one of ${LogLevel.LEVELS.join(", ")}`);
+    }
+    this.level = index;
+  }
+
+  public trace(...args: any[]) {
+    this.level <= 0 && this.logger.trace?.(...args);
+  }
+
+  public debug(...args: any[]) {
+    this.level <= 1 && this.logger.debug?.(...args);
+  }
+
+  public info(...args: any[]) {
+    this.level <= 2 && this.logger.info?.(...args);
+  }
+
+  public warn(...args: any[]) {
+    this.level <= 3 && this.logger.warn?.(...args);
+  }
+
+  public error(...args: any[]) {
+    this.level <= 4 && this.logger.error?.(...args);
+  }
+}

--- a/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
+++ b/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
@@ -12,14 +12,74 @@ import { Agent as httpsAgent } from "node:https";
 import { parentPort } from "node:worker_threads";
 import { crc32 } from "node:zlib";
 
-import type {
-  HttpWorkerConfigMessage,
-  HttpWorkerErrorMessage,
-  HttpWorkerInboundMessage,
-  HttpWorkerReadyMessage,
-  HttpWorkerRequestMessage,
-  HttpWorkerResponseMessage,
-} from "./worker-http-handler";
+/**
+ * Types duplicated from worker-http-handler to avoid cross-submodule imports.
+ * @internal
+ */
+interface WorkerHttpRequest {
+  method: string;
+  protocol: string;
+  hostname: string;
+  port?: number;
+  path: string;
+  query?: Record<string, string | string[]>;
+  headers: Record<string, string>;
+  body?: Uint8Array;
+}
+
+interface BaseHttpWorkerRequestMessage {
+  id: number;
+  request: WorkerHttpRequest;
+}
+
+interface HttpWorkerFileRequestMessage extends BaseHttpWorkerRequestMessage {
+  type: "httpRequestFromFile";
+  filePath: string;
+  offset: number;
+  length: number;
+  checksumAlgorithm?: string;
+  checksumHeader?: string;
+}
+
+interface HttpWorkerRAMRequestMessage extends BaseHttpWorkerRequestMessage {
+  type: "httpRequestFromRAM";
+  sharedBuffer: SharedArrayBuffer;
+  offset: number;
+  length: number;
+  checksumAlgorithm?: string;
+  checksumHeader?: string;
+}
+
+type HttpWorkerRequestMessage = HttpWorkerFileRequestMessage | HttpWorkerRAMRequestMessage;
+
+interface HttpWorkerConfigMessage {
+  type: "config";
+  maxSockets: number;
+}
+
+interface HttpWorkerDoneMessage {
+  type: "done";
+}
+
+type HttpWorkerInboundMessage = HttpWorkerRequestMessage | HttpWorkerConfigMessage | HttpWorkerDoneMessage;
+
+interface HttpWorkerResponseMessage {
+  type: "httpResponse";
+  id: number;
+  response: { statusCode: number; headers: Record<string, string>; body?: Uint8Array };
+}
+
+interface HttpWorkerErrorMessage {
+  type: "httpError";
+  id: number;
+  error: string;
+  code?: string;
+  name?: string;
+}
+
+interface HttpWorkerReadyMessage {
+  type: "ready";
+}
 
 function toBase64(n: number): string {
   const buf = Buffer.allocUnsafe(4);
@@ -72,12 +132,10 @@ if (parentPort) {
         const fileData = await readFileSlice(msg.filePath, msg.offset, msg.length);
 
         if (msg.checksumAlgorithm && msg.checksumHeader) {
-          // Compute checksum and wrap in aws-chunked framing with trailing checksum.
           const crcValue = crc32(fileData);
           const checksumValue = toBase64(crcValue);
           body = buildAwsChunkedBody(fileData, msg.checksumHeader, checksumValue);
         } else {
-          // No checksum requested — send raw data.
           body = fileData;
         }
       }

--- a/lib/lib-transfer-manager/src/submodules/worker/index.ts
+++ b/lib/lib-transfer-manager/src/submodules/worker/index.ts
@@ -1,0 +1,1 @@
+import "./http-request-worker";

--- a/lib/lib-transfer-manager/src/types.ts
+++ b/lib/lib-transfer-manager/src/types.ts
@@ -1,0 +1,365 @@
+import type {
+  _Object as S3Object,
+  CompleteMultipartUploadCommandOutput,
+  CreateMultipartUploadCommandInput,
+  GetObjectCommandInput,
+  GetObjectCommandOutput,
+  PutObjectCommandInput,
+  PutObjectCommandOutput,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import type { HttpHandlerOptions, Logger } from "@smithy/types";
+
+import type { AddEventListenerOptions, EventListener, RemoveEventListenerOptions } from "./event-listener-types";
+
+/**
+ * Constructor parameters for the S3 Transfer Manager configuration.
+ *
+ * @alpha
+ */
+export interface S3TransferManagerConfig {
+  /**
+   * The low level S3 client that will be used to send requests to S3.
+   */
+  s3?: S3Client;
+  /**
+   * The desired part size to use in a multipart transfer. Defaults to 8 MB.
+   * Does not apply to the last part. The actual part size may be larger than
+   * the configured value if it would require more than 10,000 parts, which
+   * is the maximum number of parts S3 allows for multipart upload.
+   * Does not apply to downloads if multipartDownloadType is PART.
+   */
+  targetPartSizeBytes?: number;
+  /**
+   * The size threshold, in bytes, for when to use multipart upload.
+   */
+  multipartUploadThresholdBytes?: number;
+  /**
+   * Specifies when a checksum will be calculated for request payloads.
+   * Takes precedence over the config on the S3 client.
+   */
+  requestChecksumCalculation?: "WHEN_SUPPORTED" | "WHEN_REQUIRED";
+  /**
+   * Specifies when checksum validation will be performed on response payloads.
+   * Takes precedence over the config on the S3 client.
+   */
+  responseChecksumValidation?: "WHEN_SUPPORTED" | "WHEN_REQUIRED";
+  /**
+   * How the SDK should perform multipart download, either RANGE or PART.
+   */
+  multipartDownloadType?: "RANGE" | "PART";
+  /**
+   * Collection of callbacks for monitoring transfer lifecycle events. Allows tracking statuses of all transfers from the client.
+   */
+  eventListeners?: TransferEventListeners;
+  /**
+   * Maximum number of concurrent HTTP requests for multipart download operations.
+   */
+  maxConcurrentDownloads?: number;
+  /**
+   * Maximum number of concurrent HTTP requests for multipart upload operations.
+   */
+  maxConcurrentUploads?: number;
+  /**
+   * Number of worker threads for multipart upload HTTP request dispatch.
+   * When set to 1, all operations run on the main thread itself using S3 client's default handler.
+   * When >1, spawns N worker threads
+   * Defaults to os.cpus().length (in node.js)
+   */
+  workerThreadCount?: number;
+  /**
+   * Logger for S3 Transfer Manager operations.
+   */
+  logger?: Logger;
+}
+
+/**
+ * Uses intersection because requests includes all the required parameters from
+ * both PutObjectCommandInput and CreateMultipartUploadCommandInput to support both single object
+ * and multipart upload requests.
+ *
+ * @alpha
+ */
+export type UploadRequest = PutObjectCommandInput & CreateMultipartUploadCommandInput;
+
+/**
+ * Uses union because the responses can vary from single object upload response to multipart upload
+ * response depending on the request.
+ *
+ * @alpha
+ */
+export type UploadResponse = PutObjectCommandOutput | CompleteMultipartUploadCommandOutput;
+
+/**
+ * Features the same properties as SDK JS S3 Command GetObjectCommandInput.
+ * Created to standardize naming convention for TM APIs.
+ *
+ * @alpha
+ */
+export type DownloadRequest = GetObjectCommandInput;
+
+/**
+ * Features the same properties as SDK JS S3 Command GetObjectCommandOutput.
+ * Created to standardize naming convention for TM APIs.
+ *
+ * @alpha
+ */
+export type DownloadResponse = GetObjectCommandOutput;
+
+/**
+ * Options for transfer operations that combine HTTP handler options with transfer event listeners.
+ *
+ * @property eventListeners - Collection of callbacks for monitoring transfer lifecycle events
+ *
+ * @alpha
+ */
+export type TransferOptions = HttpHandlerOptions & { eventListeners?: TransferEventListeners };
+
+/**
+ * Client for efficient transfer of objects to and from Amazon S3.
+ * Provides methods to optimize uploading and downloading individual objects
+ * as well as entire directories, with support for multipart operations,
+ * concurrency control, and request cancellation.
+ * Implements an event-based progress tracking system with methods to register,
+ * dispatch, and remove listeners for transfer lifecycle events.
+ *
+ * @alpha
+ */
+export interface IS3TransferManager {
+  /**
+   * Lets users upload single objects from a given directory to a given bucket.
+   * Supports multipart upload, single object upload, and transfer progress listeners.
+   *
+   * @param request - All properties of a single or multipart upload request.
+   * @param transferOptions - Allows users to specify cancel functions for the request and a collection of callbacks for monitoring transfer lifecycle events. Allows tracking statuses per request.
+   *
+   * @returns The response from the S3 API for the upload request.
+   */
+  upload(request: UploadRequest, transferOptions?: TransferOptions): Promise<UploadResponse>;
+
+  /**
+   * Lets users download single objects from a given bucket to a given directory.
+   * Supports multipart download, single object download, and transfer progress listeners.
+   *
+   * @param request - All properties of a single or multipart upload request.
+   * @param transferOptions - Allows users to specify cancel functions for the request and a collection of callbacks for monitoring transfer lifecycle events. Allows tracking statuses per request.
+   *
+   * @returns the response from the S3 API for the download request.
+   */
+  download(request: DownloadRequest, transferOptions?: TransferOptions): Promise<DownloadResponse>;
+
+  /**
+   * Represents an API to upload all files under the given directory to the provided S3 bucket.
+   *
+   * @param options.bucket - The name of the bucket to upload objects to.
+   * @param options.source - The source directory to upload.
+   * @param options.followSymbolicLinks - Whether to follow symbolic links when traversing the file tree.
+   * @param options.recursive - Whether to upload directories recursively.
+   * @param options.s3Prefix - The S3 key prefix to use for each object. If not provided, files will be uploaded to the root of the bucket todo().
+   * @param options.filter - A callback to allow users to filter out unwanted S3 object. It is invoked for each S3 object. An example implementation is a predicate that takes an S3Object and returns a boolean indicating whether this S3Object should be uploaded.
+   * @param options.s3Delimiter - Default "/". The S3 delimiter. A delimiter causes a list operation to roll up all the keys that share a common prefix into a single summary list result.
+   * @param options.putObjectRequestCallback - A callback mechanism to allow customers to update individual putObjectRequest that the S3 Transfer Manager generates.
+   * @param options.failurePolicy - The failure policy to handle failed requests.
+   * @param options.transferOptions - Allows supplying an AbortSignal and/or transfer event listeners.
+   *
+   * @returns the number of objects that have been uploaded and the number of objects that have failed
+   */
+  uploadAll(options: {
+    bucket: string;
+    source: string;
+    followSymbolicLinks?: boolean;
+    recursive?: boolean;
+    s3Prefix?: string;
+    filter?: (filepath: string) => boolean;
+    s3Delimiter?: string;
+    putObjectRequestCallback?: (putObjectRequest: PutObjectCommandInput) => Promise<void>;
+    failurePolicy?: (error?: unknown) => Promise<void>;
+    transferOptions?: TransferOptions;
+  }): Promise<{
+    objectsUploaded: number;
+    objectsFailed: number;
+  }>;
+
+  /**
+   * Represents an API to download all objects under a bucket to the provided local directory.
+   *
+   * @param options.bucket - The name of the bucket.
+   * @param options.destination - The destination directory.
+   * @param options.s3Prefix - Specify the S3 prefix that limits the response to keys that begin with the specified prefix.
+   * @param options.s3Delimiter - Specify the S3 delimiter.
+   * @param options.recursive - Whether to upload directories recursively.
+   * @param options.filter - A callback to allow users to filter out unwanted S3 object. It is invoked for each S3 object. An example implementation is a predicate that takes an S3Object and returns a boolean indicating whether this S3Object should be downloaded.
+   * @param options.getObjectRequestCallback - A callback mechanism to allow customers to update individual getObjectRequest that the S3 Transfer Manager generates.
+   * @param options.failurePolicy - The failure policy to handle failed requests.
+   * @param options.transferOptions - Allows supplying an AbortSignal and/or transfer event listeners.
+   *
+   * @returns The number of objects that have been uploaded and the number of objects that have failed
+   */
+  downloadAll(options: {
+    bucket: string;
+    destination: string;
+    s3Prefix?: string;
+    s3Delimiter?: string;
+    recursive?: boolean;
+    filter?: (object?: S3Object) => boolean;
+    getObjectRequestCallback?: (getObjectRequest: GetObjectCommandInput) => Promise<void>;
+    failurePolicy?: (error?: unknown) => Promise<void>;
+    transferOptions?: TransferOptions;
+  }): Promise<{
+    objectsDownloaded: number;
+    objectsFailed: number;
+  }>;
+
+  /**
+   * Registers a callback function to be executed when a specific transfer event occurs.
+   * Supports monitoring the full lifecycle of transfers.
+   *
+   * @param type - The type of event to listen for.
+   * @param callback - Function to execute when the specified event occurs.
+   * @param options - Optional configuration for event listener behavior.
+   *
+   * @alpha
+   */
+  addEventListener(
+    type: "transferInitiated",
+    callback: EventListener<TransferEvent>,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  addEventListener(
+    type: "bytesTransferred",
+    callback: EventListener<TransferEvent>,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  addEventListener(
+    type: "transferComplete",
+    callback: EventListener<TransferCompleteEvent>,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  addEventListener(
+    type: "transferFailed",
+    callback: EventListener<TransferEvent>,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  addEventListener(type: string, callback: EventListener, options?: AddEventListenerOptions | boolean): void;
+
+  /**
+   * Dispatches an event to the registered event listeners.
+   * Triggers callbacks registered via addEventListener with matching event types.
+   *
+   * @param event - The event object to dispatch.
+   * @returns whether the event ran to completion
+   *
+   * @alpha
+   */
+  dispatchEvent(event: Event & TransferEvent): boolean;
+  dispatchEvent(event: Event & TransferCompleteEvent): boolean;
+  dispatchEvent(event: Event): boolean;
+
+  /**
+   * Removes a previously registered event listener from the specified event type.
+   * Stops the callback from being invoked when the event occurs.
+   *
+   * @param type - The type of event to stop listening for.
+   * @param callback - The function that was previously registered.
+   * @param options - Optional configuration for the event listener.
+   *
+   * @alpha
+   */
+  removeEventListener(
+    type: "transferInitiated",
+    callback: EventListener<TransferEvent>,
+    options?: RemoveEventListenerOptions | boolean
+  ): void;
+  removeEventListener(
+    type: "bytesTransferred",
+    callback: EventListener<TransferEvent>,
+    options?: RemoveEventListenerOptions | boolean
+  ): void;
+  removeEventListener(
+    type: "transferComplete",
+    callback: EventListener<TransferCompleteEvent>,
+    options?: RemoveEventListenerOptions | boolean
+  ): void;
+  removeEventListener(
+    type: "transferFailed",
+    callback: EventListener<TransferEvent>,
+    options?: RemoveEventListenerOptions | boolean
+  ): void;
+  removeEventListener(type: string, callback: EventListener, options?: RemoveEventListenerOptions | boolean): void;
+}
+
+/**
+ * Provides a snapshot of the progress during a single object transfer.
+ *
+ * @alpha
+ */
+export interface SingleObjectProgressSnapshot {
+  transferredBytes: number;
+  totalBytes?: number;
+  response?: UploadResponse | DownloadResponse;
+}
+
+/**
+ * Provides a snapshot of the progress during a directory transfer.
+ *
+ * @alpha
+ */
+export interface DirectoryProgressSnapshot {
+  transferredBytes: number;
+  totalBytes?: number;
+  transferredFiles: number;
+  totalFiles?: number;
+}
+
+/**
+ * Progress snapshot for either single object transfers or directory transfers.
+ *
+ * @alpha
+ */
+export type TransferProgressSnapshot = SingleObjectProgressSnapshot | DirectoryProgressSnapshot;
+
+/**
+ * Event interface for transfer progress events.
+ * Used for tracking ongoing transfers with the original request and progress snapshot.
+ *
+ * @alpha
+ */
+export interface TransferEvent extends Event {
+  request: UploadRequest | DownloadRequest;
+  snapshot: TransferProgressSnapshot;
+}
+
+/**
+ * Event interface for transfer completion.
+ * Extends TransferEvent with response data that is received after a completed transfer.
+ *
+ * @alpha
+ */
+export interface TransferCompleteEvent extends TransferEvent {
+  response: UploadResponse | DownloadResponse;
+}
+
+/**
+ * Collection of event handlers to monitor transfer lifecycle events.
+ * Allows a way to register callbacks for each stage of the transfer process.
+ *
+ * @alpha
+ */
+export interface TransferEventListeners {
+  transferInitiated?: EventListener<TransferEvent>[];
+  bytesTransferred?: EventListener<TransferEvent>[];
+  transferComplete?: EventListener<TransferCompleteEvent>[];
+  transferFailed?: EventListener<TransferEvent>[];
+}
+
+/**
+ * Event listener type.
+ *
+ * @alpha
+ */
+export interface JoinStreamIterationEvents {
+  onBytes?: (byteLength: number, index: number) => void;
+  onCompletion?: (byteLength: number, index: number) => void;
+  onFailure?: (error: unknown, index: number) => void;
+  onStreamConsumed?: (index: number) => void;
+}

--- a/lib/lib-transfer-manager/src/worker-http-handler.browser.ts
+++ b/lib/lib-transfer-manager/src/worker-http-handler.browser.ts
@@ -1,0 +1,29 @@
+/**
+ * Browser stub for worker-http-handler.
+ * Worker threads are not available in browser environments.
+ * @internal
+ */
+
+export type DataSource = any;
+
+export function defaultWorkerCount(): number {
+  return 1;
+}
+
+export function createEmptyReadable(): any {
+  throw new Error("WorkerHttpHandler is not supported in browser environments.");
+}
+
+export class WorkerHttpHandler {
+  constructor() {
+    throw new Error("WorkerHttpHandler is not supported in browser environments.");
+  }
+  async handle(): Promise<any> {
+    throw new Error("WorkerHttpHandler is not supported in browser environments.");
+  }
+  updateHttpClientConfig(): void {}
+  httpHandlerConfigs(): Record<string, unknown> {
+    return {};
+  }
+  destroy(): void {}
+}

--- a/lib/lib-transfer-manager/src/worker-http-handler.ts
+++ b/lib/lib-transfer-manager/src/worker-http-handler.ts
@@ -1,0 +1,386 @@
+/**
+ * HTTP handler that delegates signed HTTP requests to a pool of worker threads.
+ *
+ * For UploadPart requests with a file source, the handler forwards the signed
+ * headers (including aws-chunked encoding headers) and file offset info to a
+ * worker. The worker reads the file slice, computes CRC32, and sends the data
+ * in aws-chunked format with a trailing checksum — fulfilling the contract
+ * that the checksum middleware set up on the main thread.
+ *
+ * @internal
+ */
+import { HttpResponse } from "@smithy/core/protocols";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import type { HttpHandlerOptions, HttpRequest, HttpResponse as HttpResponseShape } from "@smithy/types";
+import { existsSync } from "node:fs";
+import { cpus } from "node:os";
+import * as path from "node:path";
+import { Readable } from "node:stream";
+import { Worker } from "node:worker_threads";
+
+/**
+ * Creates an empty Readable stream that immediately ends.
+ * Used as a placeholder body for UploadPart in threaded uploads.
+ * @internal
+ */
+export function createEmptyReadable(): Readable {
+  return new Readable({
+    read() {
+      this.push(null);
+    },
+  });
+}
+
+/**
+ * Serializable subset of HttpRequest.
+ * @internal
+ */
+export interface WorkerHttpRequest extends Omit<HttpRequest, "body"> {
+  body?: Uint8Array;
+}
+
+/**
+ * Serializable subset of HttpResponse.
+ * @internal
+ */
+export interface WorkerHttpResponse extends Omit<HttpResponseShape, "body"> {
+  body?: Uint8Array;
+}
+
+interface BaseHttpWorkerRequestMessage {
+  id: number;
+  request: WorkerHttpRequest;
+}
+
+export interface HttpWorkerFileRequestMessage extends BaseHttpWorkerRequestMessage {
+  type: "httpRequestFromFile";
+  filePath: string;
+  offset: number;
+  length: number;
+  checksumAlgorithm?: string;
+  checksumHeader?: string;
+}
+
+export interface HttpWorkerRAMRequestMessage extends BaseHttpWorkerRequestMessage {
+  type: "httpRequestFromRAM";
+  sharedBuffer: SharedArrayBuffer;
+  offset: number;
+  length: number;
+  checksumAlgorithm?: string;
+  checksumHeader?: string;
+}
+
+export type HttpWorkerRequestMessage = HttpWorkerFileRequestMessage | HttpWorkerRAMRequestMessage;
+
+export interface HttpWorkerConfigMessage {
+  type: "config";
+  maxSockets: number;
+}
+
+export interface HttpWorkerDoneMessage {
+  type: "done";
+}
+
+export type HttpWorkerInboundMessage = HttpWorkerRequestMessage | HttpWorkerConfigMessage | HttpWorkerDoneMessage;
+
+export interface HttpWorkerResponseMessage {
+  type: "httpResponse";
+  id: number;
+  response: WorkerHttpResponse;
+}
+
+export interface HttpWorkerErrorMessage {
+  type: "httpError";
+  id: number;
+  error: string;
+  code?: string;
+  name?: string;
+}
+
+export interface HttpWorkerReadyMessage {
+  type: "ready";
+}
+
+export type HttpWorkerOutboundMessage = HttpWorkerResponseMessage | HttpWorkerErrorMessage | HttpWorkerReadyMessage;
+
+/** @internal */
+export function defaultWorkerCount(): number {
+  return cpus().length;
+}
+
+/** @internal */
+export interface FileSource {
+  type: "file";
+  filePath: string;
+  partSize: number;
+  totalFileSize: number;
+  checksumAlgorithm?: string;
+  checksumHeader?: string;
+}
+
+/** @internal */
+export interface SharedBufferSource {
+  type: "sharedBuffer";
+  sharedBuffer: SharedArrayBuffer;
+  partSize: number;
+  totalSize: number;
+  checksumAlgorithm?: string;
+  checksumHeader?: string;
+}
+
+/**
+ * Data source passed per-request to handle().
+ * Tells the worker where to read the body from.
+ * @internal
+ */
+export type DataSource = FileSource | SharedBufferSource;
+
+/**
+ * Options for WorkerHttpHandler.handle() that extend standard HttpHandlerOptions
+ * with an optional data source for UploadPart requests.
+ * @internal
+ */
+export interface WorkerHttpHandlerOptions extends HttpHandlerOptions {
+  dataSource?: DataSource;
+}
+
+export class WorkerHttpHandler {
+  private workers: Worker[] = [];
+  private inflightRequests = new Map<
+    number,
+    { resolve: (value: { response: HttpResponse }) => void; reject: (error: unknown) => void; workerIndex: number }
+  >();
+  private nextRequestId = 0;
+  private workerInflightCounts: number[] = [];
+  private workerThreadCount: number;
+  private maxConcurrentUploads: number;
+  private initialized = false;
+  private initPromise: Promise<void> | undefined;
+  private fallbackHandler: NodeHttpHandler;
+
+  readonly metadata = { handlerProtocol: "http/1.1" };
+
+  constructor(options?: { workerThreadCount?: number; maxConcurrentUploads?: number }) {
+    this.workerThreadCount = options?.workerThreadCount ?? defaultWorkerCount();
+    this.maxConcurrentUploads = options?.maxConcurrentUploads ?? 32;
+    this.fallbackHandler = new NodeHttpHandler();
+  }
+
+  /**
+   * Returns the worker script file path.
+   */
+  private resolveWorkerConfig(): { workerPath: string; workerOptions?: { execArgv: string[] } } {
+    const jsPath = path.join(__dirname, "http-request-worker.js");
+    if (existsSync(jsPath)) {
+      return { workerPath: jsPath };
+    }
+    // Subdirectory path (inlined CJS bundle: __dirname = dist-cjs/).
+    const subDirJsPath = path.join(__dirname, "s3-transfer-manager", "http-request-worker.js");
+    if (existsSync(subDirJsPath)) {
+      return { workerPath: subDirJsPath };
+    }
+    const tsPath = path.join(__dirname, "http-request-worker.ts");
+    if (existsSync(tsPath)) {
+      return { workerPath: tsPath, workerOptions: { execArgv: ["--require", "tsx/cjs"] } };
+    }
+    return { workerPath: jsPath };
+  }
+
+  private ensureInitialized(): Promise<void> {
+    if (this.initialized) return Promise.resolve();
+    if (this.initPromise) return this.initPromise;
+
+    this.initPromise = new Promise<void>((resolve, reject) => {
+      const { workerPath, workerOptions } = this.resolveWorkerConfig();
+      let readyCount = 0;
+      let errorCount = 0;
+      let settled = false;
+      this.workerInflightCounts = new Array(this.workerThreadCount).fill(0);
+
+      for (let i = 0; i < this.workerThreadCount; i++) {
+        const worker = new Worker(workerPath, workerOptions);
+        this.workers.push(worker);
+        const workerIndex = i;
+
+        worker.on("message", (msg: HttpWorkerOutboundMessage) => {
+          if (msg.type === "ready") {
+            worker.postMessage({
+              type: "config",
+              maxSockets: Math.max(50, Math.ceil(this.maxConcurrentUploads / this.workerThreadCount)),
+            } satisfies HttpWorkerConfigMessage);
+            readyCount++;
+            if (!settled && readyCount === this.workerThreadCount) {
+              settled = true;
+              this.initialized = true;
+              resolve();
+            }
+            return;
+          }
+
+          if (msg.type === "httpResponse") {
+            const pending = this.inflightRequests.get(msg.id);
+            this.inflightRequests.delete(msg.id);
+            if (pending) {
+              this.workerInflightCounts[pending.workerIndex]--;
+              pending.resolve({
+                response: new HttpResponse({
+                  statusCode: msg.response.statusCode,
+                  headers: msg.response.headers,
+                  body: msg.response.body,
+                }),
+              });
+            }
+            return;
+          }
+
+          if (msg.type === "httpError") {
+            const pending = this.inflightRequests.get(msg.id);
+            this.inflightRequests.delete(msg.id);
+            if (pending) {
+              this.workerInflightCounts[pending.workerIndex]--;
+              const error = Object.assign(new Error(msg.error), {
+                ...(msg.code && { code: msg.code }),
+                ...(msg.name && { name: msg.name }),
+              });
+              pending.reject(error);
+            }
+            return;
+          }
+        });
+
+        worker.on("error", (err) => {
+          if (!settled) {
+            errorCount++;
+            if (errorCount + readyCount === this.workerThreadCount) {
+              settled = true;
+              this.initPromise = undefined;
+              reject(new Error(`Failed to initialize worker threads: ${err.message}`));
+            }
+          }
+          // Only reject requests that were dispatched to this specific worker.
+          for (const [id, pending] of this.inflightRequests) {
+            if (pending.workerIndex === workerIndex) {
+              pending.reject(err);
+              this.inflightRequests.delete(id);
+            }
+          }
+          // Mark this worker as dead so pickWorkerIndex() never routes to it.
+          this.workerInflightCounts[workerIndex] = Infinity;
+        });
+      }
+    });
+
+    return this.initPromise;
+  }
+
+  /**
+   * Returns the index of the worker with the fewest in-flight requests.
+   */
+  private pickWorkerIndex(): number {
+    let minIndex = 0;
+    for (let i = 1; i < this.workerInflightCounts.length; i++) {
+      if (this.workerInflightCounts[i] < this.workerInflightCounts[minIndex]) {
+        minIndex = i;
+      }
+    }
+    return minIndex;
+  }
+
+  /**
+   * Dispatches a message to the least-busy worker and tracks the in-flight count.
+   */
+  private dispatchToWorker(id: number, message: HttpWorkerRequestMessage): Promise<{ response: HttpResponse }> {
+    const workerIndex = this.pickWorkerIndex();
+    this.workerInflightCounts[workerIndex]++;
+    return new Promise((resolve, reject) => {
+      this.inflightRequests.set(id, { resolve, reject, workerIndex });
+      this.workers[workerIndex].postMessage(message);
+    });
+  }
+
+  private extractPartNumber(request: HttpRequest): number | undefined {
+    const partNumber = request.query?.partNumber;
+    if (partNumber) {
+      return Number(Array.isArray(partNumber) ? partNumber[0] : partNumber);
+    }
+    return undefined;
+  }
+
+  async handle(request: HttpRequest, options?: WorkerHttpHandlerOptions): Promise<{ response: HttpResponse }> {
+    const dataSource = options?.dataSource;
+    const partNumber = this.extractPartNumber(request);
+
+    // Fall back to default Node HTTP handler for non-upload-part requests
+    // (CreateMPU, CompleteMPU, GetObject, HeadObject, etc.).
+    if (!dataSource || !partNumber) {
+      return this.fallbackHandler.handle(request as any, options as HttpHandlerOptions);
+    }
+
+    await this.ensureInitialized();
+
+    const id = this.nextRequestId++;
+
+    const serializedRequest: WorkerHttpRequest = {
+      method: request.method,
+      protocol: request.protocol,
+      hostname: request.hostname,
+      port: request.port,
+      path: request.path,
+      query: request.query,
+      headers: request.headers,
+    };
+
+    if (dataSource.type === "file") {
+      const { filePath, partSize, totalFileSize, checksumAlgorithm, checksumHeader } = dataSource;
+      const offset = (partNumber - 1) * partSize;
+      const length = Math.min(partSize, totalFileSize - offset);
+
+      const message: HttpWorkerFileRequestMessage = {
+        type: "httpRequestFromFile",
+        id,
+        request: serializedRequest,
+        filePath,
+        offset,
+        length,
+        checksumAlgorithm,
+        checksumHeader,
+      };
+
+      return this.dispatchToWorker(id, message);
+    }
+
+    const { sharedBuffer, partSize, totalSize, checksumAlgorithm, checksumHeader } = dataSource;
+    const offset = (partNumber - 1) * partSize;
+    const length = Math.min(partSize, totalSize - offset);
+
+    const message: HttpWorkerRAMRequestMessage = {
+      type: "httpRequestFromRAM",
+      id,
+      request: serializedRequest,
+      sharedBuffer,
+      offset,
+      length,
+      checksumAlgorithm,
+      checksumHeader,
+    };
+
+    return this.dispatchToWorker(id, message);
+  }
+
+  updateHttpClientConfig(_key: string, _value: unknown): void {}
+
+  httpHandlerConfigs(): Record<string, unknown> {
+    return {};
+  }
+
+  destroy(): void {
+    for (const worker of this.workers) {
+      worker.postMessage({ type: "done" } satisfies HttpWorkerDoneMessage);
+    }
+    this.workers = [];
+    this.workerInflightCounts = [];
+    this.initialized = false;
+    this.initPromise = undefined;
+    this.fallbackHandler.destroy();
+  }
+}

--- a/lib/lib-transfer-manager/src/worker-http-handler.ts
+++ b/lib/lib-transfer-manager/src/worker-http-handler.ts
@@ -170,20 +170,16 @@ export class WorkerHttpHandler {
    * Returns the worker script file path.
    */
   private resolveWorkerConfig(): { workerPath: string; workerOptions?: { execArgv: string[] } } {
-    const jsPath = path.join(__dirname, "http-request-worker.js");
-    if (existsSync(jsPath)) {
-      return { workerPath: jsPath };
+    // Submodule path (dist-cjs/submodules/worker/index.js).
+    const submodulePath = path.join(__dirname, "submodules", "worker", "index.js");
+    if (existsSync(submodulePath)) {
+      return { workerPath: submodulePath };
     }
-    // Subdirectory path (inlined CJS bundle: __dirname = dist-cjs/).
-    const subDirJsPath = path.join(__dirname, "s3-transfer-manager", "http-request-worker.js");
-    if (existsSync(subDirJsPath)) {
-      return { workerPath: subDirJsPath };
-    }
-    const tsPath = path.join(__dirname, "http-request-worker.ts");
+    const tsPath = path.join(__dirname, "submodules", "worker", "index.ts");
     if (existsSync(tsPath)) {
       return { workerPath: tsPath, workerOptions: { execArgv: ["--require", "tsx/cjs"] } };
     }
-    return { workerPath: jsPath };
+    return { workerPath: submodulePath };
   }
 
   private ensureInitialized(): Promise<void> {

--- a/lib/lib-transfer-manager/tsconfig.cjs.json
+++ b/lib/lib-transfer-manager/tsconfig.cjs.json
@@ -1,11 +1,22 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection", "dom"],
+    "lib": [
+      "es5",
+      "es2015.collection",
+      "dom"
+    ],
     "outDir": "dist-cjs",
     "rootDir": "src",
-    "noCheck": true
+    "noCheck": true,
+    "paths": {
+      "@aws-sdk/lib-transfer-manager/worker": [
+        "./src/submodules/worker/index.ts"
+      ]
+    }
   },
   "extends": "../../tsconfig.cjs.json",
-  "include": ["src/"]
+  "include": [
+    "src/"
+  ]
 }

--- a/lib/lib-transfer-manager/tsconfig.cjs.json
+++ b/lib/lib-transfer-manager/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["es5", "es2015.collection", "dom"],
+    "outDir": "dist-cjs",
+    "rootDir": "src",
+    "noCheck": true
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/lib/lib-transfer-manager/tsconfig.es.json
+++ b/lib/lib-transfer-manager/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["dom"],
+    "outDir": "dist-es",
+    "rootDir": "src",
+    "noCheck": true
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/lib/lib-transfer-manager/tsconfig.es.json
+++ b/lib/lib-transfer-manager/tsconfig.es.json
@@ -1,11 +1,20 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom"],
+    "lib": [
+      "dom"
+    ],
     "outDir": "dist-es",
     "rootDir": "src",
-    "noCheck": true
+    "noCheck": true,
+    "paths": {
+      "@aws-sdk/lib-transfer-manager/worker": [
+        "./src/submodules/worker/index.ts"
+      ]
+    }
   },
   "extends": "../../tsconfig.es.json",
-  "include": ["src/"]
+  "include": [
+    "src/"
+  ]
 }

--- a/lib/lib-transfer-manager/tsconfig.types.json
+++ b/lib/lib-transfer-manager/tsconfig.types.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src",
+    "paths": {
+      "@smithy/core/*": ["../../node_modules/@smithy/core/dist-types/submodules/*/index.d.ts"],
+      "@aws-sdk/config/*": ["../../packages/config/dist-types/submodules/*/index.d.ts"]
+    }
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/lib/lib-transfer-manager/tsconfig.types.json
+++ b/lib/lib-transfer-manager/tsconfig.types.json
@@ -4,10 +4,19 @@
     "declarationDir": "dist-types",
     "rootDir": "src",
     "paths": {
-      "@smithy/core/*": ["../../node_modules/@smithy/core/dist-types/submodules/*/index.d.ts"],
-      "@aws-sdk/config/*": ["../../packages/config/dist-types/submodules/*/index.d.ts"]
+      "@smithy/core/*": [
+        "../../node_modules/@smithy/core/dist-types/submodules/*/index.d.ts"
+      ],
+      "@aws-sdk/config/*": [
+        "../../packages/config/dist-types/submodules/*/index.d.ts"
+      ],
+      "@aws-sdk/lib-transfer-manager/worker": [
+        "./src/submodules/worker/index.ts"
+      ]
     }
   },
   "extends": "../../tsconfig.types.json",
-  "include": ["src/"]
+  "include": [
+    "src/"
+  ]
 }

--- a/lib/lib-transfer-manager/vitest.config.browser.mts
+++ b/lib/lib-transfer-manager/vitest.config.browser.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.browser.spec.ts"],
+    environment: "happy-dom",
+  },
+});

--- a/lib/lib-transfer-manager/vitest.config.browser.ts
+++ b/lib/lib-transfer-manager/vitest.config.browser.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.browser.spec.ts"],
+    environment: "happy-dom",
+  },
+});

--- a/lib/lib-transfer-manager/vitest.config.e2e.mts
+++ b/lib/lib-transfer-manager/vitest.config.e2e.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.e2e.spec.ts"],
+    environment: "node",
+  },
+});

--- a/lib/lib-transfer-manager/vitest.config.mts
+++ b/lib/lib-transfer-manager/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["**/*.{integ,e2e,browser}.spec.ts"],
+    include: ["**/*.spec.ts"],
+    environment: "node",
+  },
+});

--- a/lib/lib-transfer-manager/worker.d.ts
+++ b/lib/lib-transfer-manager/worker.d.ts
@@ -1,0 +1,9 @@
+
+  /**
+   * Do not edit:
+   * This is a compatibility redirect for contexts that do not understand package.json exports field.
+   */
+  declare module "@aws-sdk/lib-transfer-manager/worker" {
+    export * from "@aws-sdk/lib-transfer-manager/dist-types/submodules/worker/index.d";
+  }
+  

--- a/lib/lib-transfer-manager/worker.js
+++ b/lib/lib-transfer-manager/worker.js
@@ -1,0 +1,7 @@
+
+  /**
+   * Do not edit:
+   * This is a compatibility redirect for contexts that do not understand package.json exports field.
+   */
+  module.exports = require("./dist-cjs/submodules/worker/index.js");
+  

--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -22,6 +22,7 @@ module.exports = class Inliner {
     this.isPackage = !this.isInternalPackage && fs.existsSync(path.join(root, "packages", pkg));
     this.isLib = fs.existsSync(path.join(root, "lib", pkg));
     this.reExportStubs = false;
+    this.standaloneFiles = [];
     this.subfolder = (() => {
       if (this.isInternalPackage) {
         return "packages-internal";
@@ -48,6 +49,10 @@ module.exports = class Inliner {
      * If the react entrypoint is another file entirely, then bail out of inlining.
      */
     this.bailout = typeof this.pkgJson["react-native"] === "string";
+    /**
+     * Files that must remain as separate output files in dist-cjs and not bundled.
+     */
+    this.standaloneFiles = (this.pkgJson.standaloneFiles || []).map((f) => (f.endsWith(".js") ? f : f + ".js"));
   }
 
   /**
@@ -255,7 +260,8 @@ module.exports = class Inliner {
     });
 
     // Bundle main index.js (no variants externalized for submodule packages).
-    const mainExternals = this.hasSubmodules ? [] : variantExternalsForRollup;
+    const standaloneExternals = this.standaloneFiles.map((f) => f.replace(/.js$/, ""));
+    const mainExternals = this.hasSubmodules ? [] : [...variantExternalsForRollup, ...standaloneExternals];
     const bundle = await rollup.rollup(makeInputOptions(entryPoint, mainExternals));
     await bundle.write(outputOptions(path.dirname(this.outfile)));
     await bundle.close();
@@ -354,6 +360,13 @@ module.exports = class Inliner {
       if (this.variantExternals.find((external) => relativePath.endsWith(external))) {
         if (this.verbose) {
           console.log("Not rewriting.", relativePath, "is variant.");
+        }
+        continue;
+      }
+
+      if (this.standaloneFiles.find((standalone) => relativePath === standalone)) {
+        if (this.verbose) {
+          console.log("Not rewriting.", relativePath, "is standalone file.");
         }
         continue;
       }

--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -22,7 +22,6 @@ module.exports = class Inliner {
     this.isPackage = !this.isInternalPackage && fs.existsSync(path.join(root, "packages", pkg));
     this.isLib = fs.existsSync(path.join(root, "lib", pkg));
     this.reExportStubs = false;
-    this.standaloneFiles = [];
     this.subfolder = (() => {
       if (this.isInternalPackage) {
         return "packages-internal";
@@ -49,10 +48,6 @@ module.exports = class Inliner {
      * If the react entrypoint is another file entirely, then bail out of inlining.
      */
     this.bailout = typeof this.pkgJson["react-native"] === "string";
-    /**
-     * Files that must remain as separate output files in dist-cjs and not bundled.
-     */
-    this.standaloneFiles = (this.pkgJson.standaloneFiles || []).map((f) => (f.endsWith(".js") ? f : f + ".js"));
   }
 
   /**
@@ -260,8 +255,7 @@ module.exports = class Inliner {
     });
 
     // Bundle main index.js (no variants externalized for submodule packages).
-    const standaloneExternals = this.standaloneFiles.map((f) => f.replace(/.js$/, ""));
-    const mainExternals = this.hasSubmodules ? [] : [...variantExternalsForRollup, ...standaloneExternals];
+    const mainExternals = this.hasSubmodules ? [] : variantExternalsForRollup;
     const bundle = await rollup.rollup(makeInputOptions(entryPoint, mainExternals));
     await bundle.write(outputOptions(path.dirname(this.outfile)));
     await bundle.close();
@@ -360,13 +354,6 @@ module.exports = class Inliner {
       if (this.variantExternals.find((external) => relativePath.endsWith(external))) {
         if (this.verbose) {
           console.log("Not rewriting.", relativePath, "is variant.");
-        }
-        continue;
-      }
-
-      if (this.standaloneFiles.find((standalone) => relativePath === standalone)) {
-        if (this.verbose) {
-          console.log("Not rewriting.", relativePath, "is standalone file.");
         }
         continue;
       }

--- a/scripts/runtime-dependency-version-check/check-dependencies.js
+++ b/scripts/runtime-dependency-version-check/check-dependencies.js
@@ -45,6 +45,7 @@ const node_libraries = [
   "tls",
   "url",
   "util",
+  "worker_threads",
   "zlib",
 ];
 

--- a/scripts/validation/api.json
+++ b/scripts/validation/api.json
@@ -533,12 +533,18 @@
   },
   "@aws-sdk/lib-storage": {
     "BodyDataTypes": "type(union)",
+    "byteLength": "function",
     "Configuration": "type(interface)",
+    "getChunk": "function",
     "Options": "type(interface)",
     "Progress": "type(interface)",
     "RawDataPart": "type(interface)",
     "ServiceClients": "type(object)",
     "Upload": "function"
+  },
+  "@aws-sdk/lib-transfer-manager": {
+    "IS3TransferManager": "type(interface)",
+    "S3TransferManager": "function"
   },
   "@aws-sdk/middleware-api-key": {
     "ApiKeyInputConfig": "type(interface)",

--- a/scripts/validation/api.json
+++ b/scripts/validation/api.json
@@ -533,9 +533,7 @@
   },
   "@aws-sdk/lib-storage": {
     "BodyDataTypes": "type(union)",
-    "byteLength": "function",
     "Configuration": "type(interface)",
-    "getChunk": "function",
     "Options": "type(interface)",
     "Progress": "type(interface)",
     "RawDataPart": "type(interface)",
@@ -546,6 +544,7 @@
     "IS3TransferManager": "type(interface)",
     "S3TransferManager": "function"
   },
+  "@aws-sdk/lib-transfer-manager/worker": {},
   "@aws-sdk/middleware-api-key": {
     "ApiKeyInputConfig": "type(interface)",
     "apiKeyMiddleware": "function",

--- a/scripts/validation/submodules-linter.js
+++ b/scripts/validation/submodules-linter.js
@@ -9,15 +9,19 @@ const submodulePackages = singlePkg
   : [
       ...fs.readdirSync(path.join(__dirname, "..", "..", "packages")),
       ...fs.readdirSync(path.join(__dirname, "..", "..", "packages-internal")),
+      ...fs.readdirSync(path.join(__dirname, "..", "..", "lib")),
     ].filter((pkg) => {
-      const [a, b] = [
+      const [a, b, c] = [
         path.join(__dirname, "..", "..", "packages", pkg),
         path.join(__dirname, "..", "..", "packages-internal", pkg),
+        path.join(__dirname, "..", "..", "lib", pkg),
       ];
       const dir = fs.existsSync(path.join(a, "package.json"))
         ? a
         : fs.existsSync(path.join(b, "package.json"))
         ? b
+        : fs.existsSync(path.join(c, "package.json"))
+        ? c
         : null;
       if (!dir) return false;
       return (
@@ -29,11 +33,12 @@ const submodulePackages = singlePkg
 (async () => {
   const errors = [];
   for (const submodulePackage of submodulePackages) {
-    const [a, b] = [
+    const [a, b, c] = [
       path.join(__dirname, "..", "..", "packages", submodulePackage),
       path.join(__dirname, "..", "..", "packages-internal", submodulePackage),
+      path.join(__dirname, "..", "..", "lib", submodulePackage),
     ];
-    const root = fs.existsSync(a) ? a : b;
+    const root = fs.existsSync(a) ? a : fs.existsSync(b) ? b : c;
 
     const pkgJson = require(path.join(root, "package.json"));
     if (!pkgJson.exports) {
@@ -197,7 +202,7 @@ const submodulePackages = singlePkg
         if (relativeImportDepth >= depth && i !== "../../../package.json") {
           errors.push(
             `relative import ${i} in ${item
-              .split("packages/")
+              .split(/(?:packages|packages-internal|lib)\//)
               .pop()} crosses submodule boundaries. Use @scope/package/submodule import instead.`
           );
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10792,7 +10792,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/config@workspace:3.1062.0, @aws-sdk/config@workspace:packages/config":
+"@aws-sdk/config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/config@workspace:packages/config"
   dependencies:
@@ -11212,7 +11212,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/lib-storage@workspace:3.1062.0, @aws-sdk/lib-storage@workspace:lib/lib-storage":
+"@aws-sdk/lib-storage@workspace:lib/lib-storage":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/lib-storage@workspace:lib/lib-storage"
   dependencies:
@@ -11239,9 +11239,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk/lib-transfer-manager@workspace:lib/lib-transfer-manager"
   dependencies:
-    "@aws-sdk/client-s3": "workspace:3.1062.0"
-    "@aws-sdk/config": "workspace:3.1062.0"
-    "@aws-sdk/lib-storage": "workspace:3.1062.0"
+    "@aws-sdk/client-s3": "workspace:3.1063.0"
     "@smithy/core": "npm:^3.24.6"
     "@smithy/node-http-handler": "npm:^4.7.6"
     "@smithy/types": "npm:^4.14.3"
@@ -11253,7 +11251,7 @@ __metadata:
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.8.3"
   peerDependencies:
-    "@aws-sdk/client-s3": ^3.0.0
+    "@aws-sdk/client-s3": "workspace:^3.1063.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10792,7 +10792,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/config@workspace:packages/config":
+"@aws-sdk/config@workspace:3.1062.0, @aws-sdk/config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/config@workspace:packages/config"
   dependencies:
@@ -11212,7 +11212,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/lib-storage@workspace:lib/lib-storage":
+"@aws-sdk/lib-storage@workspace:3.1062.0, @aws-sdk/lib-storage@workspace:lib/lib-storage":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/lib-storage@workspace:lib/lib-storage"
   dependencies:
@@ -11232,6 +11232,28 @@ __metadata:
     web-streams-polyfill: "npm:3.2.1"
   peerDependencies:
     "@aws-sdk/client-s3": "workspace:^3.1063.0"
+  languageName: unknown
+  linkType: soft
+
+"@aws-sdk/lib-transfer-manager@workspace:lib/lib-transfer-manager":
+  version: 0.0.0-use.local
+  resolution: "@aws-sdk/lib-transfer-manager@workspace:lib/lib-transfer-manager"
+  dependencies:
+    "@aws-sdk/client-s3": "workspace:3.1062.0"
+    "@aws-sdk/config": "workspace:3.1062.0"
+    "@aws-sdk/lib-storage": "workspace:3.1062.0"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
+    "@tsconfig/recommended": "npm:1.0.1"
+    "@types/node": "npm:^20.14.8"
+    concurrently: "npm:7.0.0"
+    downlevel-dts: "npm:0.10.1"
+    premove: "npm:4.0.0"
+    tslib: "npm:^2.6.2"
+    typescript: "npm:~5.8.3"
+  peerDependencies:
+    "@aws-sdk/client-s3": ^3.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description
This is a work in progress high level library to interact with S3 which provides support for multipart upload using worker threads.

### Testing
```
$ yarn test:e2e

 Test Files  1 passed (1)
      Tests  26 passed (26)
   Start at  16:16:36
   Duration  277.44s (transform 188ms, setup 0ms, import 370ms, tests 276.94s, environment 0ms)
```

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [x] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [ ] I didn't add any public functions.
- [x] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [ ] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
