### PR TITLE
test(clients): add client error deserialization tests

### DIFF
--- a/clients/client-dynamodb/test/dynamodb-features.e2e.spec.ts
+++ b/clients/client-dynamodb/test/dynamodb-features.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { DynamoDB } from "@aws-sdk/client-dynamodb";
+import { DynamoDB, DynamoDBServiceException, ResourceNotFoundException } from "@aws-sdk/client-dynamodb";
 import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
 
 describe(DynamoDB.name, () => {
@@ -110,34 +110,6 @@ describe(DynamoDB.name, () => {
     });
   });
 
-  describe("UTF-8 support", () => {
-    it("should handle UTF-8 characters and return ResourceNotFoundException for non-existent table", async () => {
-      await expect(
-        client.deleteItem({
-          TableName: "table",
-          Key: { id: { S: "føø" } },
-        })
-      ).rejects.toThrow(
-        expect.objectContaining({
-          name: "ResourceNotFoundException",
-        })
-      );
-    });
-  });
-
-  describe("Improper table deletion", () => {
-    it("should return ValidationException for empty table parameter", async () => {
-      await expect(client.deleteTable({ TableName: "" })).rejects.toThrow(
-        expect.objectContaining({
-          name: "ValidationException",
-          $metadata: expect.objectContaining({
-            httpStatusCode: 400,
-          }),
-        })
-      );
-    });
-  });
-
   describe("Recursive Attributes", () => {
     it("should handle complex nested attributes", async () => {
       // Put recursive item
@@ -174,6 +146,37 @@ describe(DynamoDB.name, () => {
       // Verify deeply nested attribute: data.M.attr1.L[1].L[0].M.attr12.S
       const nestedValue = getResult.Item?.data?.M?.attr1?.L?.[1]?.L?.[0]?.M?.attr12?.S;
       expect(nestedValue).toBe("value2");
+    });
+  });
+
+  describe("Error types", () => {
+    it("should throw a modeled ResourceNotFoundException for non-existent table", async () => {
+      try {
+        await client.deleteItem({
+          TableName: "nonexistent-table-sdk-e2e-test",
+          Key: { id: { S: "føø" } },
+        });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(ResourceNotFoundException);
+        expect(e).toBeInstanceOf(DynamoDBServiceException);
+        expect(e.name).toBe("ResourceNotFoundException");
+        expect(e.$metadata.httpStatusCode).toBe(400);
+        expect(e.__type).toBe("com.amazonaws.dynamodb.v20120810#ResourceNotFoundException");
+      }
+    });
+
+    it("should throw a base DynamoDBServiceException for validation error", async () => {
+      try {
+        await client.deleteTable({ TableName: "" });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(DynamoDBServiceException);
+        expect(Object.getPrototypeOf(e)).toBe(DynamoDBServiceException.prototype);
+        expect(e.name).toBe("ValidationException");
+        expect(e.$metadata.httpStatusCode).toBe(400);
+        expect(e.__type).toBe("com.amazon.coral.validate#ValidationException");
+      }
     });
   });
 });

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -14,6 +14,8 @@
     "generate:client": "node ../../scripts/generate-clients/single-service --solo ec2",
     "test": "yarn g:vitest run --passWithNoTests",
     "test:index": "tsc --noEmit ./test/index-types.ts && node ./test/index-objects.spec.mjs",
+    "test:e2e": "yarn g:vitest run -c vitest.config.e2e.mts --mode development",
+    "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.mts",
     "test:integration": "yarn g:vitest run --passWithNoTests -c vitest.config.integ.mts",
     "test:integration:watch": "yarn g:vitest run --passWithNoTests -c vitest.config.integ.mts",
     "test:watch": "yarn g:vitest watch --passWithNoTests"

--- a/clients/client-ec2/test/ec2-features.e2e.spec.ts
+++ b/clients/client-ec2/test/ec2-features.e2e.spec.ts
@@ -1,0 +1,58 @@
+import { EC2, EC2ServiceException } from "@aws-sdk/client-ec2";
+import { beforeAll, describe, expect, test as it } from "vitest";
+
+describe(EC2.name, () => {
+  let client: EC2;
+
+  beforeAll(async () => {
+    client = new EC2({ region: "us-west-2", credentials: aws?.testCredentials });
+  });
+
+  describe("Describe regions", () => {
+    it("should return a list of AWS regions", async () => {
+      const result = await client.describeRegions({});
+
+      expect(result.$metadata?.httpStatusCode).toBe(200);
+      expect(Array.isArray(result.Regions)).toBe(true);
+      expect(result.Regions!.length).toBeGreaterThan(0);
+
+      const regionNames = result.Regions!.map((r) => r.RegionName);
+      expect(regionNames).toContain("us-west-2");
+    });
+  });
+
+  describe("Describe instances", () => {
+    it("should successfully describe instances", async () => {
+      const result = await client.describeInstances({});
+
+      expect(result.$metadata?.httpStatusCode).toBe(200);
+      expect(Array.isArray(result.Reservations)).toBe(true);
+    });
+  });
+
+  describe("Error types", () => {
+    it("should throw an error for non-existent VPC", async () => {
+      try {
+        await client.describeVpcs({ VpcIds: ["vpc-0123456789abcdef0"] });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(EC2ServiceException);
+        expect(Object.getPrototypeOf(e)).toBe(EC2ServiceException.prototype);
+        expect(e.name).toBe("InvalidVpcID.NotFound");
+        expect(e.$metadata.httpStatusCode).toBe(400);
+      }
+    });
+
+    it("should throw a base EC2ServiceException for malformed input", async () => {
+      try {
+        await client.describeInstances({ InstanceIds: ["not-valid"] });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(EC2ServiceException);
+        expect(Object.getPrototypeOf(e)).toBe(EC2ServiceException.prototype);
+        expect(e.name).toBe("InvalidInstanceID.Malformed");
+        expect(e.$metadata.httpStatusCode).toBe(400);
+      }
+    });
+  });
+});

--- a/clients/client-ec2/vitest.config.e2e.mts
+++ b/clients/client-ec2/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["../../vitest.nodejs.setup.mts"],
+    exclude: ["**/*.browser.e2e.spec.ts"],
+    include: ["**/*.e2e.spec.ts"],
+    environment: "node",
+  },
+  mode: "development",
+});

--- a/clients/client-kms/test/kms-features.e2e.spec.ts
+++ b/clients/client-kms/test/kms-features.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { KMS } from "@aws-sdk/client-kms";
+import { KMS, KMSServiceException, NotFoundException } from "@aws-sdk/client-kms";
 import { beforeAll, describe, expect, test as it } from "vitest";
 
 describe(KMS.name, () => {
@@ -17,18 +17,31 @@ describe(KMS.name, () => {
     });
   });
 
-  describe("Error handling", () => {
-    it("should contain validation error for invalid alias creation", async () => {
-      await expect(
-        client.createAlias({
-          AliasName: "alias",
-          TargetKeyId: "non-existent",
-        })
-      ).rejects.toThrow(
-        expect.objectContaining({
-          name: "ValidationException",
-        })
-      );
+  describe("Error types", () => {
+    it("should throw a modeled NotFoundException for non-existent key", async () => {
+      try {
+        await client.describeKey({ KeyId: "00000000-0000-0000-0000-000000000000" });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(NotFoundException);
+        expect(e).toBeInstanceOf(KMSServiceException);
+        expect(e.name).toBe("NotFoundException");
+        expect(e.$metadata.httpStatusCode).toBe(400);
+        expect(e.__type).toBe("NotFoundException");
+      }
+    });
+
+    it("should throw a base KMSServiceException for validation error", async () => {
+      try {
+        await client.createAlias({ AliasName: "alias", TargetKeyId: "non-existent" });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(KMSServiceException);
+        expect(Object.getPrototypeOf(e)).toBe(KMSServiceException.prototype);
+        expect(e.name).toBe("ValidationException");
+        expect(e.$metadata.httpStatusCode).toBe(400);
+        expect(e.__type).toBe("ValidationException");
+      }
     });
   });
 });

--- a/clients/client-lambda/test/lambda-features.e2e.spec.ts
+++ b/clients/client-lambda/test/lambda-features.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { Lambda } from "@aws-sdk/client-lambda";
+import { Lambda, LambdaServiceException, ResourceNotFoundException } from "@aws-sdk/client-lambda";
 import { beforeAll, describe, expect, test as it } from "vitest";
 
 describe(Lambda.name, () => {
@@ -17,17 +17,34 @@ describe(Lambda.name, () => {
     });
   });
 
-  describe("Error handling", () => {
-    it("should contain resource not found error for non-existent function", async () => {
-      await expect(
-        client.invoke({
-          FunctionName: "non-exist",
-        })
-      ).rejects.toThrow(
-        expect.objectContaining({
-          name: "ResourceNotFoundException",
-        })
-      );
+  describe("Error types", () => {
+    it("should throw a modeled ResourceNotFoundException", async () => {
+      try {
+        await client.getFunction({ FunctionName: "nonexistent-fn-sdk-e2e-test" });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(ResourceNotFoundException);
+        expect(e).toBeInstanceOf(LambdaServiceException);
+        expect(e.name).toBe("ResourceNotFoundException");
+        expect(e.$metadata.httpStatusCode).toBe(404);
+        if (e.$response?.headers?.["x-amzn-errortype"]) {
+          expect(e.$response.headers["x-amzn-errortype"]).toBe("ResourceNotFoundException");
+        }
+      }
+    });
+
+    it("should throw a base LambdaServiceException for invalid parameter", async () => {
+      try {
+        await client.getFunction({ FunctionName: "!!!invalid!!!" });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(LambdaServiceException);
+        expect(Object.getPrototypeOf(e)).toBe(LambdaServiceException.prototype);
+        expect(e.$metadata.httpStatusCode).toBe(400);
+        if (e.$response?.headers?.["x-amzn-errortype"]) {
+          expect(e.$response.headers["x-amzn-errortype"]).toBe("ValidationException");
+        }
+      }
     });
   });
 });

--- a/clients/client-rds/test/rds-features.e2e.spec.ts
+++ b/clients/client-rds/test/rds-features.e2e.spec.ts
@@ -1,4 +1,9 @@
-import { paginateDescribeReservedDBInstancesOfferings, RDS } from "@aws-sdk/client-rds";
+import {
+  DBInstanceNotFoundFault,
+  paginateDescribeReservedDBInstancesOfferings,
+  RDS,
+  RDSServiceException,
+} from "@aws-sdk/client-rds";
 import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
 
 describe(RDS.name, () => {
@@ -54,20 +59,6 @@ describe(RDS.name, () => {
     });
   });
 
-  describe("Error handling", () => {
-    it("should get InvalidParameterValue with 400 status for empty security group name", async () => {
-      try {
-        await client.createDBSecurityGroup({
-          DBSecurityGroupName: "", // Empty name should cause InvalidParameterValue
-          DBSecurityGroupDescription: "Test security group",
-        });
-      } catch (error: any) {
-        expect(error.name).toBe("InvalidParameterValue");
-        expect(error.$metadata?.httpStatusCode).toBe(400);
-      }
-    });
-  });
-
   describe("Paginating responses", () => {
     it("should paginate describeReservedDBInstancesOfferings with more than one page", async () => {
       const maxPages = 3;
@@ -98,6 +89,35 @@ describe(RDS.name, () => {
       // Should get more than one page
       expect(numPages).toBeGreaterThan(1);
       expect(numMarkers).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Error types", () => {
+    it("should throw a modeled DBInstanceNotFoundFault", async () => {
+      try {
+        await client.describeDBInstances({ DBInstanceIdentifier: "nonexistent-instance-sdk-e2e-test" });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(DBInstanceNotFoundFault);
+        expect(e).toBeInstanceOf(RDSServiceException);
+        expect(e.name).toBe("DBInstanceNotFoundFault");
+        expect(e.$metadata.httpStatusCode).toBe(404);
+      }
+    });
+
+    it("should throw a base RDSServiceException for invalid parameter", async () => {
+      try {
+        await client.createDBSecurityGroup({
+          DBSecurityGroupName: "",
+          DBSecurityGroupDescription: "test",
+        });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(RDSServiceException);
+        expect(Object.getPrototypeOf(e)).toBe(RDSServiceException.prototype);
+        expect(e.name).toBe("InvalidParameterValue");
+        expect(e.$metadata.httpStatusCode).toBe(400);
+      }
     });
   });
 });

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -14,6 +14,8 @@
     "generate:client": "node ../../scripts/generate-clients/single-service --solo s3-control",
     "test": "yarn g:vitest run",
     "test:index": "tsc --noEmit ./test/index-types.ts && node ./test/index-objects.spec.mjs",
+    "test:e2e": "yarn g:vitest run -c vitest.config.e2e.mts --mode development",
+    "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.mts",
     "test:integration": "yarn g:vitest run --passWithNoTests -c vitest.config.integ.mts",
     "test:integration:watch": "yarn g:vitest run --passWithNoTests -c vitest.config.integ.mts",
     "test:watch": "yarn g:vitest watch"

--- a/clients/client-s3-control/test/s3-control-features.e2e.spec.ts
+++ b/clients/client-s3-control/test/s3-control-features.e2e.spec.ts
@@ -1,0 +1,70 @@
+import { S3Control, S3ControlServiceException, TooManyTagsException } from "@aws-sdk/client-s3-control";
+import { STS } from "@aws-sdk/client-sts";
+import { beforeAll, describe, expect, test as it } from "vitest";
+
+describe(S3Control.name, () => {
+  let client: S3Control;
+  let accountId: string;
+
+  beforeAll(async () => {
+    client = new S3Control({ region: "us-west-2", credentials: aws?.testCredentials });
+    const sts = new STS({ region: "us-west-2", credentials: aws?.testCredentials });
+    const identity = await sts.getCallerIdentity({});
+    accountId = identity.Account!;
+  });
+
+  describe("List access points", () => {
+    it("should list access points for the account", async () => {
+      const result = await client.listAccessPoints({ AccountId: accountId });
+
+      expect(result.$metadata?.httpStatusCode).toBe(200);
+      expect(Array.isArray(result.AccessPointList)).toBe(true);
+    });
+  });
+
+  describe("Error types", () => {
+    it("should throw a S3ControlServiceException for non-existent access point", async () => {
+      try {
+        await client.getAccessPoint({
+          AccountId: accountId,
+          Name: "nonexistent-ap-sdk-e2e-test",
+        });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(S3ControlServiceException);
+        expect(e.name).toBe("NoSuchAccessPoint");
+        expect(e.$metadata.httpStatusCode).toBe(404);
+      }
+    });
+
+    it("should throw a base S3ControlServiceException for invalid account ID", async () => {
+      try {
+        await client.listAccessPoints({ AccountId: "invalid-account-id" });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(S3ControlServiceException);
+        expect(Object.getPrototypeOf(e)).toBe(S3ControlServiceException.prototype);
+        expect(e.$metadata.httpStatusCode).toBeGreaterThanOrEqual(400);
+      }
+    });
+
+    it("should throw TooManyTagsException for exceeding tag limit", async () => {
+      const tags = Array.from({ length: 51 }, (_, i) => ({ Key: `k${i}`, Value: `v${i}` }));
+      try {
+        await client.createStorageLensGroup({
+          AccountId: accountId,
+          StorageLensGroup: { Name: "sdk-e2e-test-group", Filter: { MatchAnyPrefix: ["test/"] } },
+          Tags: tags,
+        });
+        expect.fail("expected error");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(S3ControlServiceException);
+        // todo: Service returns "TooManyTags" but modeled class name is "TooManyTagsException"
+        // todo: this is a modeling error. Nothing to do in the SDK.
+        expect(e).not.toBeInstanceOf(TooManyTagsException);
+        expect(e.name).toBe("TooManyTags");
+        expect(e.$metadata.httpStatusCode).toBe(400);
+      }
+    });
+  });
+});

--- a/clients/client-s3-control/vitest.config.e2e.mts
+++ b/clients/client-s3-control/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["../../vitest.nodejs.setup.mts"],
+    exclude: ["**/*.browser.e2e.spec.ts"],
+    include: ["**/*.e2e.spec.ts"],
+    environment: "node",
+  },
+  mode: "development",
+});

--- a/tests/canary/canary-runner.js
+++ b/tests/canary/canary-runner.js
@@ -74,6 +74,8 @@ export default defineConfig({
       "tests/clients/client-kinesis/test/Kinesis.e2e.spec.ts",
       // requires .wav file.
       "tests/clients/client-transcribe-streaming/test/TranscribeStreaming.e2e.spec.ts",
+      // blocked by CORS policy.
+      "tests/clients/client-s3-control/test/s3-control-features.e2e.spec.ts",
     ],
     setupFiles: ["vitest.browser.setup.mts"],
     environment: "happy-dom",

--- a/vitest.config.cross-platform.e2e.mts
+++ b/vitest.config.cross-platform.e2e.mts
@@ -15,6 +15,8 @@ export default defineConfig({
       "node_modules",
       // doesn't support OPTIONS preflight.
       "clients/client-data-pipeline/**/*.e2e.spec.ts",
+      // blocked by CORS policy.
+      "clients/client-s3-control/test/s3-control-features.e2e.spec.ts",
       // is specifically a Node.js HTTP2 test.
       "clients/client-kinesis/test/Kinesis.e2e.spec.ts",
       // S3 has a different browser testing setup.


### PR DESCRIPTION
### Issue
P441667808, ...8057

### Description
Extend e2e error deserialization tests to all protocols, notably to cover DynamoDB's error namespace that differs from the SDK model.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
