### PR TITLE
fix(core): export legacy root symbols from submodules instead of relative paths

### DIFF
--- a/packages-internal/core/src/index.ts
+++ b/packages-internal/core/src/index.ts
@@ -11,7 +11,6 @@
  * No additional exports are allowed.
  */
 
-// --- @aws-sdk/core/client (legacy subset) ---
 export {
   emitWarningIfUnsupportedVersion,
   getLongPollPlugin,
@@ -19,9 +18,8 @@ export {
   setFeature,
   setTokenFeature,
   state,
-} from "./submodules/client/index";
+} from "@aws-sdk/core/client";
 
-// --- @aws-sdk/core/httpAuthSchemes ---
 export {
   AwsSdkSigV4ASigner,
   AwsSdkSigV4Signer,
@@ -33,7 +31,7 @@ export {
   resolveAwsSdkSigV4Config,
   resolveAwsSdkSigV4Config as resolveAWSSDKSigV4Config,
   validateSigningProperties,
-} from "./submodules/httpAuthSchemes/index";
+} from "@aws-sdk/core/httpAuthSchemes";
 export type {
   AwsSdkSigV4AAuthInputConfig,
   AwsSdkSigV4AAuthResolvedConfig,
@@ -45,9 +43,8 @@ export type {
   AwsSdkSigV4Memoized,
   AwsSdkSigV4AuthResolvedConfig as AwsSdkSigV4PreviouslyResolved,
   AwsSdkSigV4AuthResolvedConfig as AWSSDKSigV4PreviouslyResolved,
-} from "./submodules/httpAuthSchemes/index";
+} from "@aws-sdk/core/httpAuthSchemes";
 
-// --- @aws-sdk/core/protocols ---
 export {
   _toBool,
   _toNum,
@@ -75,8 +72,8 @@ export {
   XmlCodec,
   XmlShapeDeserializer,
   XmlShapeSerializer,
-} from "./submodules/protocols/index";
-export type { JsonSettings, QuerySerializerSettings, XmlSettings } from "./submodules/protocols/index";
+} from "@aws-sdk/core/protocols";
+export type { JsonSettings, QuerySerializerSettings, XmlSettings } from "@aws-sdk/core/protocols";
 
 /**
  * WARNING: do not export any additional submodules from the root of this package. See readme.md for


### PR DESCRIPTION
### Issue
V2236964587

### Description
This is a fix for older clients that import from `@aws-sdk/core` root level. The root should export submodules by name so they can re-resolve through the exports mappings rather than directly file-reference a submodule index. 

Using relative paths prevents the conditional browser submodule exports from working.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
