### PR TITLE
chore(lib-transfer-manager): sort scripts alphabetically

### DIFF
--- a/lib/lib-transfer-manager/package.json
+++ b/lib/lib-transfer-manager/package.json
@@ -39,7 +39,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
-    "lint": "node ../../scripts/validation/submodules-linter.js --pkg lib-transfer-manager",
+    "lint": "node ../../scripts/validation/submodules-linter",
     "test": "yarn g:vitest run",
     "test:watch": "yarn g:vitest watch",
     "test:e2e": "yarn g:vitest run -c vitest.config.e2e.mts --mode development",

--- a/lib/lib-transfer-manager/package.json
+++ b/lib/lib-transfer-manager/package.json
@@ -32,20 +32,20 @@
     }
   },
   "scripts": {
-    "build": "concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",
-    "lint": "node ../../scripts/validation/submodules-linter.js --pkg lib-transfer-manager",
+    "build": "yarn lint && concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",
     "build:cjs": "node ../../scripts/compilation/inline lib-transfer-manager",
     "build:es": "tsc -p tsconfig.es.json",
     "build:include:deps": "yarn g:turbo run build -F=\"$npm_package_name\"",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
+    "lint": "node ../../scripts/validation/submodules-linter.js --pkg lib-transfer-manager",
     "test": "yarn g:vitest run",
     "test:watch": "yarn g:vitest watch",
-    "test:browser": "yarn g:vitest run -c vitest.config.browser.mts",
-    "test:browser:watch": "yarn g:vitest watch -c vitest.config.browser.mts",
     "test:e2e": "yarn g:vitest run -c vitest.config.e2e.mts --mode development",
-    "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.mts"
+    "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.mts",
+    "test:browser": "yarn g:vitest run -c vitest.config.browser.mts",
+    "test:browser:watch": "yarn g:vitest watch -c vitest.config.browser.mts"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/actions/runs/27156466760/job/80160519079

### Description
Sort scripts alphabetically for lib-transfer-manager.
This was missed as https://github.com/aws/aws-sdk-js-v3/pull/8074 wasn't rebased before merging

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
