### PR TITLE
fix(credential-provider-sso): forward clientConfig to SSO token provider

### DIFF
--- a/packages-internal/credential-provider-node/tests/credential-provider-node.integ.spec.ts
+++ b/packages-internal/credential-provider-node/tests/credential-provider-node.integ.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "@aws-sdk/credential-providers";
 import { assumeRoleArns, MockNodeHttpHandler } from "@aws-sdk/credential-providers/tests/_test-lib";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { HttpResponse } from "@smithy/core/protocols";
 import { externalDataInterceptor } from "@smithy/core/config";
 import type { HttpRequest, MiddlewareStack, ParsedIniData } from "@smithy/types";
 import { AdaptiveRetryStrategy, StandardRetryStrategy } from "@smithy/core/retry";
@@ -16,6 +17,7 @@ import child_process from "node:child_process";
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import { defaultProvider } from "../src/defaultProvider";
@@ -223,7 +225,7 @@ describe("credential-provider-node integration test", () => {
         region: "us-sso-region-2",
         credentials: defaultProvider({
           ssoStartUrl: "SSO_START_URL",
-          ssoAccountId: "1234",
+          ssoAccountId: "123456789012",
           ssoRegion: "us-sso-region-1",
           ssoRoleName: "sso-role",
         }),
@@ -239,6 +241,119 @@ describe("credential-provider-node integration test", () => {
           CREDENTIALS_SSO_LEGACY: "u",
         },
       });
+    });
+
+    it("should use clientConfig.requestHandler for SSO OIDC token refresh", async () => {
+      const seen: string[] = [];
+      const spyHandler = {
+        metadata: { handlerProtocol: "http/1.1" },
+        updateHttpClientConfig() {},
+        httpHandlerConfigs() {
+          return {};
+        },
+        handle: async (request: HttpRequest) => {
+          seen.push(`${request.hostname}${request.path || ""}`);
+          const body = new PassThrough({});
+
+          if (request.path?.includes("/token")) {
+            body.write(
+              JSON.stringify({
+                accessToken: "refreshed_token",
+                expiresIn: 3600,
+                refreshToken: "new_refresh_token",
+              })
+            );
+          } else if (request.path?.includes("/federation/credentials")) {
+            body.write(
+              JSON.stringify({
+                roleCredentials: {
+                  accessKeyId: "SSO_ACCESS_KEY_ID",
+                  secretAccessKey: "SSO_SECRET_ACCESS_KEY",
+                  sessionToken: "SSO_SESSION_TOKEN_us-sso-region-1",
+                  expiration: "3000-01-01T00:00:00.000Z",
+                  accountId: "123456789012",
+                },
+              })
+            );
+          } else if (request.body?.includes("Action=GetCallerIdentity")) {
+            body.write(`
+<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<GetCallerIdentityResult>
+  <Arn>arn:aws:iam::123456789012:user/Alice</Arn>
+  <UserId>AIDACKCEVSQ6C2EXAMPLE</UserId>
+  <Account>123456789012</Account>
+</GetCallerIdentityResult>
+<ResponseMetadata>
+  <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ResponseMetadata>
+</GetCallerIdentityResponse>`);
+          }
+
+          body.end();
+          return {
+            response: new HttpResponse({
+              statusCode: 200,
+              body,
+              headers: {},
+            }),
+          };
+        },
+      };
+
+      // Set up an expired token to force OIDC CreateToken refresh
+      const expiredToken = {
+        accessToken: "expired_token",
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        clientId: "mock_client_id",
+        clientSecret: "mock_client_secret",
+        refreshToken: "mock_refresh_token",
+      };
+      externalDataInterceptor.interceptToken("ssoNew", expiredToken);
+
+      setIniProfileData({
+        "sso-session.ssoNew": {
+          sso_region: "us-sso-region-1",
+          sso_start_url: "SSO_START_URL",
+          sso_registration_scopes: "sso:account:access",
+        },
+        default: {
+          sso_session: "ssoNew",
+          sso_account_id: "1234",
+          sso_region: "us-sso-region-1",
+          sso_role_name: "sso-role",
+        },
+      });
+
+      sts = new STS({
+        region: "us-sso-region-2",
+        credentials: defaultProvider({
+          clientConfig: {
+            requestHandler: spyHandler,
+          },
+        }),
+      });
+
+      await sts.getCallerIdentity({});
+      const credentials = await sts.config.credentials();
+
+      expect(credentials).toEqual({
+        accessKeyId: "SSO_ACCESS_KEY_ID",
+        secretAccessKey: "SSO_SECRET_ACCESS_KEY",
+        sessionToken: "SSO_SESSION_TOKEN_us-sso-region-1",
+        expiration: new Date("3000-01-01T00:00:00.000Z"),
+        $source: {
+          CREDENTIALS_PROFILE_SSO: "r",
+          CREDENTIALS_SSO: "s",
+        },
+      });
+
+      // Verify the custom requestHandler was used for OIDC token refresh
+      expect(seen).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("oidc.us-sso-region-1.amazonaws.com/token"),
+          expect.stringContaining("portal.sso.us-sso-region-1.amazonaws.com/federation/credentials"),
+        ])
+      );
     });
   });
 

--- a/packages-internal/credential-provider-sso/package.json
+++ b/packages-internal/credential-provider-sso/package.json
@@ -13,7 +13,9 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
     "test": "yarn g:vitest run",
-    "test:watch": "yarn g:vitest watch"
+    "test:watch": "yarn g:vitest watch",
+    "test:integration": "yarn g:vitest run -c vitest.config.integ.mts",
+    "test:integration:watch": "yarn g:vitest watch -c vitest.config.integ.mts"
   },
   "keywords": [
     "aws",

--- a/packages-internal/credential-provider-sso/src/fromSSO.integ.spec.ts
+++ b/packages-internal/credential-provider-sso/src/fromSSO.integ.spec.ts
@@ -1,0 +1,203 @@
+import { externalDataInterceptor } from "@smithy/core/config";
+import { HttpResponse } from "@smithy/core/protocols";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import type { HttpRequest, NodeHttpHandlerOptions, ParsedIniData } from "@smithy/types";
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test as it } from "vitest";
+
+import { fromSSO } from "./fromSSO";
+
+let iniProfileData: ParsedIniData = null as any;
+
+function setIniProfileData(data: ParsedIniData) {
+  iniProfileData = data;
+  let buffer = "";
+  for (const profile in data) {
+    if (profile.startsWith("sso-session.")) {
+      buffer += `[sso-session ${profile.split("sso-session.")[1]}]\n`;
+    } else {
+      buffer += `[profile ${profile}]\n`;
+    }
+    for (const [k, v] of Object.entries(data[profile])) {
+      buffer += `${k} = ${v}\n`;
+    }
+    buffer += "\n";
+  }
+  const dir = join(homedir(), ".aws");
+  externalDataInterceptor.interceptFile(join(dir, "config"), buffer);
+}
+
+class MockNodeHttpHandler {
+  static create(instanceOrOptions?: any) {
+    if (typeof instanceOrOptions?.handle === "function") {
+      return instanceOrOptions;
+    }
+    return new MockNodeHttpHandler();
+  }
+
+  async handle(request: HttpRequest) {
+    const body = new PassThrough({});
+    const region = (request.hostname.match(/portal\.sso\.(.*?)\./) || [, "unknown"])[1];
+
+    if (request.path?.includes("/federation/credentials")) {
+      body.write(
+        JSON.stringify({
+          roleCredentials: {
+            accessKeyId: "SSO_ACCESS_KEY_ID",
+            secretAccessKey: "SSO_SECRET_ACCESS_KEY",
+            sessionToken: `SSO_SESSION_TOKEN_${region}`,
+            expiration: "3000-01-01T00:00:00.000Z",
+            accountId: "123456789012",
+          },
+        })
+      );
+    } else {
+      throw new Error("request not supported.");
+    }
+
+    body.end();
+    return {
+      response: new HttpResponse({
+        statusCode: 200,
+        body,
+        headers: {},
+      }),
+    };
+  }
+
+  updateHttpClientConfig(key: keyof NodeHttpHandlerOptions, value: NodeHttpHandlerOptions[typeof key]): void {}
+
+  httpHandlerConfigs(): NodeHttpHandlerOptions {
+    return null as any;
+  }
+}
+
+describe("fromSSO integration", () => {
+  let processSnapshot: typeof process.env;
+  const nodeHttpHandlerCreate = NodeHttpHandler.create;
+
+  const ssoToken = {
+    accessToken: "mock_sso_token",
+    expiresAt: "3000-01-01T00:00:00.000Z",
+  };
+
+  beforeAll(() => {
+    processSnapshot = JSON.parse(JSON.stringify(process.env));
+    NodeHttpHandler.create = MockNodeHttpHandler.create;
+  });
+
+  beforeEach(() => {
+    delete process.env.AWS_PROFILE;
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+
+    const dir = join(homedir(), ".aws");
+    externalDataInterceptor.interceptFile(join(dir, "credentials"), "");
+
+    const hasher = createHash("sha1");
+    const cacheName = hasher.update("SSO_START_URL").digest("hex");
+    const tokenPath = join(homedir(), ".aws", "sso", "cache", `${cacheName}.json`);
+    externalDataInterceptor.interceptFile(tokenPath, JSON.stringify(ssoToken));
+    externalDataInterceptor.interceptToken("SSO_START_URL", ssoToken);
+    externalDataInterceptor.interceptToken("ssoNew", ssoToken);
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, processSnapshot);
+  });
+
+  afterAll(() => {
+    NodeHttpHandler.create = nodeHttpHandlerCreate;
+  });
+
+  describe("SSO with sso-session", () => {
+    it("should use clientConfig.requestHandler for token refresh if provided", async () => {
+      const seen: string[] = [];
+      const spyHandler = {
+        metadata: { handlerProtocol: "http/1.1" },
+        updateHttpClientConfig() {},
+        httpHandlerConfigs() {
+          return {};
+        },
+        handle: async (request: HttpRequest) => {
+          seen.push(`${request.hostname}${request.path || ""}`);
+          const body = new PassThrough({});
+
+          if (request.path?.includes("/token")) {
+            body.write(
+              JSON.stringify({
+                accessToken: "refreshed_token",
+                expiresIn: 3600,
+                refreshToken: "new_refresh_token",
+              })
+            );
+          } else if (request.path?.includes("/federation/credentials")) {
+            body.write(
+              JSON.stringify({
+                roleCredentials: {
+                  accessKeyId: "SSO_ACCESS_KEY_ID",
+                  secretAccessKey: "SSO_SECRET_ACCESS_KEY",
+                  sessionToken: "SSO_SESSION_TOKEN_us-east-1",
+                  expiration: "3000-01-01T00:00:00.000Z",
+                  accountId: "123456789012",
+                },
+              })
+            );
+          }
+
+          body.end();
+          return {
+            response: new HttpResponse({
+              statusCode: 200,
+              body,
+              headers: {},
+            }),
+          };
+        },
+      };
+
+      // Set up an expired token 
+      const expiredToken = {
+        accessToken: "expired_token",
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        clientId: "mock_client_id",
+        clientSecret: "mock_client_secret",
+        refreshToken: "mock_refresh_token",
+      };
+      externalDataInterceptor.interceptToken("ssoNew", expiredToken);
+
+      setIniProfileData({
+        "sso-session.ssoNew": {
+          sso_region: "us-east-1",
+          sso_start_url: "SSO_START_URL",
+          sso_registration_scopes: "sso:account:access",
+        },
+        default: {
+          sso_session: "ssoNew",
+          sso_account_id: "123456789012",
+          sso_role_name: "my-role",
+          sso_region: "us-east-1",
+        },
+      });
+
+      const credentials = await fromSSO({
+        profile: "default",
+        clientConfig: {
+          requestHandler: spyHandler,
+        },
+      })();
+
+      // The spy handler should have been invoked for both the OIDC CreateToken and GetRoleCredentials calls
+      expect(seen).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("oidc.us-east-1.amazonaws.com/token"),
+          expect.stringContaining("portal.sso.us-east-1.amazonaws.com/federation/credentials"),
+        ])
+      );
+    });
+  });
+});

--- a/packages-internal/credential-provider-sso/src/resolveSSOCredentials.spec.ts
+++ b/packages-internal/credential-provider-sso/src/resolveSSOCredentials.spec.ts
@@ -79,7 +79,52 @@ describe(resolveSSOCredentials.name, () => {
     });
     expect(tokenProviders.fromSso).toHaveBeenCalledWith({
       profile: undefined,
+      filepath: undefined,
+      configFilepath: undefined,
+      ignoreCache: undefined,
+      clientConfig: undefined,
+      parentClientConfig: undefined,
+      logger: undefined,
     });
+  });
+
+  it("forwards clientConfig, parentClientConfig, and logger to the token provider", async () => {
+    const mockClientConfig = {
+      requestHandler: { handle: vi.fn() }, 
+      region: "us-west-2" 
+    };
+    const mockParentClientConfig = { logger: console };
+    const mockCallerClientConfig = { region: async () => "us-east-1" };
+    const mockLogger = { 
+      debug: vi.fn(), 
+      info: vi.fn(), 
+      warn: vi.fn(), 
+      error: vi.fn() 
+    };
+
+    const mockTokenProviderFn = vi.fn().mockResolvedValue({
+      token: "mockAccessToken",
+      expiration: new Date(Date.now() + 6_000_000),
+    });
+    vi.mocked(tokenProviders.fromSso).mockReturnValue(mockTokenProviderFn);
+
+    await resolveSSOCredentials({
+      ...mockOptions,
+      ssoSession: "test-sso-session",
+      clientConfig: mockClientConfig,
+      parentClientConfig: mockParentClientConfig,
+      callerClientConfig: mockCallerClientConfig,
+      logger: mockLogger,
+    });
+
+    expect(tokenProviders.fromSso).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientConfig: mockClientConfig,
+        parentClientConfig: mockParentClientConfig,
+        logger: mockLogger,
+      })
+    );
+    expect(mockTokenProviderFn).toHaveBeenCalledWith({ callerClientConfig: mockCallerClientConfig });
   });
 
   describe("throws error on expiration", () => {

--- a/packages-internal/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages-internal/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -38,7 +38,10 @@ export const resolveSSOCredentials = async ({
         filepath,
         configFilepath,
         ignoreCache,
-      })();
+        clientConfig,
+        parentClientConfig,
+        logger,
+      })({ callerClientConfig });
       token = {
         accessToken: _token.token,
         expiresAt: new Date(_token.expiration!).toISOString(),

--- a/packages-internal/credential-provider-sso/vitest.config.integ.mts
+++ b/packages-internal/credential-provider-sso/vitest.config.integ.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.integ.spec.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8083

### Description
Forward `clientConfig` and related options to `SSOOIDCClient` so custom requestHandler is honored during token refresh.

### Testing
```
$yarn test

 ✓ src/isSsoProfile.spec.ts (6 tests) 5ms
 ✓ src/validateSsoProfile.spec.ts (6 tests) 6ms
 ✓ src/fromSSO.spec.ts (9 tests) 11ms
 ✓ src/resolveSSOCredentials.spec.ts (13 tests) 20ms

 Test Files  4 passed (4)
      Tests  34 passed (34)
   Start at  20:19:49
   Duration  346ms (transform 374ms, setup 0ms, import 597ms, tests 42ms, environment 0ms)
```
### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
