### PR TITLE
Fixes #8083 : fix(credential-provider-sso): forward client config to token provider

### DIFF
--- a/packages-internal/credential-provider-sso/src/resolveSSOCredentials.spec.ts
+++ b/packages-internal/credential-provider-sso/src/resolveSSOCredentials.spec.ts
@@ -82,6 +82,44 @@ describe(resolveSSOCredentials.name, () => {
     });
   });
 
+  it("passes client configuration to the SSOTokenProvider if SSO Session name is present", async () => {
+    const mockTokenProvider = vi.fn().mockResolvedValue({
+      token: "mockAccessToken",
+      expiration: new Date(Date.now() + 6_000_000),
+    });
+    vi.mocked(tokenProviders.fromSso).mockReturnValue(mockTokenProvider);
+
+    const requestHandler = vi.fn();
+    const parentLogger = vi.fn();
+    const callerLogger = vi.fn();
+    const clientConfig = { requestHandler };
+    const parentClientConfig = { logger: parentLogger };
+    const callerClientConfig = {
+      logger: callerLogger,
+      region: vi.fn().mockResolvedValue("mock-region"),
+    };
+
+    await resolveSSOCredentials({
+      ...mockOptions,
+      ssoSession: "test-sso-session",
+      clientConfig,
+      parentClientConfig,
+      callerClientConfig,
+    });
+
+    expect(tokenProviders.fromSso).toHaveBeenCalledWith({
+      profile: undefined,
+      filepath: undefined,
+      configFilepath: undefined,
+      ignoreCache: undefined,
+      clientConfig,
+      parentClientConfig,
+    });
+    expect(mockTokenProvider).toHaveBeenCalledWith({
+      callerClientConfig,
+    });
+  });
+
   describe("throws error on expiration", () => {
     afterEach(async () => {
       const expectedError = new CredentialsProviderError(

--- a/packages-internal/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages-internal/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -38,7 +38,9 @@ export const resolveSSOCredentials = async ({
         filepath,
         configFilepath,
         ignoreCache,
-      })();
+        clientConfig,
+        parentClientConfig,
+      })({ callerClientConfig });
       token = {
         accessToken: _token.token,
         expiresAt: new Date(_token.expiration!).toISOString(),


### PR DESCRIPTION
Fixes #8083

This forwards clientConfig, parentClientConfig, and callerClientConfig to the SSO token provider when resolving SSO session credentials, so the refresh path receives the same client configuration as the role credentials path

Added a regression test covering config forwarding to fromSso