### PR TITLE
test: use crypto.randomUUID for resource names in e2e tests

### DIFF
--- a/clients/client-cloudfront/test/cloudfront-features.e2e.spec.ts
+++ b/clients/client-cloudfront/test/cloudfront-features.e2e.spec.ts
@@ -20,7 +20,7 @@ describe(
 
     describe("Create a distribution", () => {
       it("should handle NoSuchOrigin error for invalid origin", async () => {
-        const uniqueRef = `aws-js-sdk-${Date.now()}-${process.pid}-${Math.random().toString(36).substr(2, 9)}`;
+        const uniqueRef = `aws-js-sdk-${crypto.randomUUID()}`;
         const distributionConfig = {
           CallerReference: uniqueRef,
           Aliases: {

--- a/clients/client-cloudwatch-logs/test/cloudwatch-logs-features.e2e.spec.ts
+++ b/clients/client-cloudwatch-logs/test/cloudwatch-logs-features.e2e.spec.ts
@@ -10,9 +10,7 @@ describe(CloudWatchLogs.name, () => {
   });
 
   const generateLogGroupName = (prefix: string) => {
-    const timestamp = Date.now();
-    const random = Math.random().toString(36).substring(7);
-    return prefix ? `${prefix}-${timestamp}-${random}` : "";
+    return prefix ? `${prefix}-${crypto.randomUUID()}` : "";
   };
 
   afterAll(async () => {

--- a/clients/client-cognito-identity/test/e2e/cognitoidentity-features.e2e.spec.ts
+++ b/clients/client-cognito-identity/test/e2e/cognitoidentity-features.e2e.spec.ts
@@ -23,7 +23,7 @@ describe(CognitoIdentity.name, () => {
     it("should create and describe a Cognito identity pool", async () => {
       // Create identity pool
       const createResult = await client.createIdentityPool({
-        IdentityPoolName: `awssdkjs-test-${Date.now()}`,
+        IdentityPoolName: `awssdkjs-test-${crypto.randomUUID()}`,
         AllowUnauthenticatedIdentities: true,
       });
 

--- a/clients/client-data-pipeline/test/datapipeline-features.e2e.spec.ts
+++ b/clients/client-data-pipeline/test/datapipeline-features.e2e.spec.ts
@@ -22,7 +22,7 @@ describe(DataPipeline.name, () => {
       await expect(
         client.createPipeline({
           name: "",
-          uniqueId: "test-unique-id-" + Date.now(),
+          uniqueId: `test-unique-id-${crypto.randomUUID()}`,
         })
       ).rejects.toThrow(
         expect.objectContaining({

--- a/clients/client-dynamodb/test/dynamodb-features.e2e.spec.ts
+++ b/clients/client-dynamodb/test/dynamodb-features.e2e.spec.ts
@@ -8,9 +8,7 @@ describe(DynamoDB.name, () => {
   beforeAll(async () => {
     client = new DynamoDB({ region: "us-west-2", maxAttempts: 10, credentials: aws?.testCredentials });
 
-    const randId = (Math.random() + 1).toString(36).substring(2, 6);
-    const timestamp = (Date.now() / 1000) | 0;
-    TableName = `js-sdk-client-dynamodb-test-${timestamp}-${randId}`;
+    TableName = `js-sdk-client-dynamodb-test-${crypto.randomUUID()}`;
     const start = Date.now();
     const mark = () => `DDB-E2E: ` + ((Date.now() - start) / 1000).toFixed(3) + "s elapsed.";
 

--- a/clients/client-elastic-beanstalk/test/elasticbeanstalk-features.e2e.spec.ts
+++ b/clients/client-elastic-beanstalk/test/elasticbeanstalk-features.e2e.spec.ts
@@ -11,7 +11,7 @@ describe(ElasticBeanstalk.name, () => {
 
   describe("Creating applications and application versions", () => {
     it("should create application, version, and describe them", async () => {
-      applicationName = `aws-js-sdk-${Date.now()}`;
+      applicationName = `aws-js-sdk-${crypto.randomUUID()}`;
 
       // Create Elastic Beanstalk application
       const createAppResult = await client.createApplication({

--- a/clients/client-elasticache/test/elasticache-features.e2e.spec.ts
+++ b/clients/client-elasticache/test/elasticache-features.e2e.spec.ts
@@ -11,7 +11,7 @@ describe(ElastiCache.name, () => {
 
   describe("Creating and deleting cache parameter groups", () => {
     it("should create, describe, and delete cache parameter group", async () => {
-      cacheParameterGroupName = `aws-js-sdk-${Date.now()}`;
+      cacheParameterGroupName = `aws-js-sdk-${crypto.randomUUID()}`;
 
       // Create cache parameter group
       const createResult = await client.createCacheParameterGroup({

--- a/clients/client-iam/test/iam-features.e2e.spec.ts
+++ b/clients/client-iam/test/iam-features.e2e.spec.ts
@@ -32,7 +32,7 @@ describe(IAM.name, () => {
 
   describe("Users", () => {
     it("should create IAM user", async () => {
-      const username = `js-test-${Date.now()}`;
+      const username = `js-test-${crypto.randomUUID()}`;
 
       const result = await client.createUser({
         UserName: username,
@@ -45,7 +45,7 @@ describe(IAM.name, () => {
 
   describe("Roles", () => {
     it("should create IAM role", async () => {
-      const roleName = `aws-sdk-js-${Date.now()}`;
+      const roleName = `aws-sdk-js-${crypto.randomUUID()}`;
 
       const result = await client.createRole({
         RoleName: roleName,
@@ -62,7 +62,7 @@ describe(IAM.name, () => {
 
   describe("Error handling", () => {
     it("should contain entity already exists error for duplicate user", async () => {
-      const username = `js-test-dupe-${Date.now()}`;
+      const username = `js-test-dupe-${crypto.randomUUID()}`;
 
       await client.createUser({ UserName: username });
       createdUsers.push(username);

--- a/clients/client-kinesis/test/Kinesis.e2e.spec.ts
+++ b/clients/client-kinesis/test/Kinesis.e2e.spec.ts
@@ -4,9 +4,7 @@ import { type MetadataBearer } from "@smithy/types";
 import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
 
 describe("@aws-sdk/client-kinesis", () => {
-  const STREAM_NAME = `aws-sdk-js-v3-e2e-test-${Date.now()}-${Array.from({ length: 6 }, () =>
-    String.fromCharCode(97 + Math.floor(Math.random() * 26))
-  ).join("")}`;
+  const STREAM_NAME = `aws-sdk-js-v3-e2e-test-${crypto.randomUUID()}`;
   const SHARD_COUNT = 1;
   const SESSION_CONCURRENCY = 7;
 

--- a/clients/client-rds/test/rds-features.e2e.spec.ts
+++ b/clients/client-rds/test/rds-features.e2e.spec.ts
@@ -30,7 +30,7 @@ describe(RDS.name, () => {
 
   describe("Describe DB security group", () => {
     it("should create security group, describe it, and verify structure", async () => {
-      dbSecurityGroupName = `aws-sdk-js-rds-e2e-${Date.now()}`;
+      dbSecurityGroupName = `aws-sdk-js-rds-e2e-${crypto.randomUUID()}`;
 
       const expectedDescription = "Test security group for e2e tests";
 

--- a/clients/client-s3/test/e2e/S3.browser.e2e.spec.ts
+++ b/clients/client-s3/test/e2e/S3.browser.e2e.spec.ts
@@ -14,7 +14,7 @@ describe("@aws-sdk/client-s3", () => {
   let Bucket: string;
   let region: string;
   let mrapArn: string;
-  let Key = `${Date.now()}`;
+  let Key = `${crypto.randomUUID()}`;
   const errors = [] as any[];
   let testFailed = false;
   const setTestFailed = () => {
@@ -84,7 +84,7 @@ describe("@aws-sdk/client-s3", () => {
 
   describe("PutObject", () => {
     beforeEach(() => {
-      Key = `${Date.now()}`;
+      Key = `${crypto.randomUUID()}`;
     });
 
     afterEach(async () => {
@@ -150,7 +150,7 @@ describe("@aws-sdk/client-s3", () => {
 
   describe("GetObject", function () {
     beforeEach(async () => {
-      Key = `${Date.now()}`;
+      Key = `${crypto.randomUUID()}`;
     });
 
     afterEach(async () => {
@@ -184,7 +184,7 @@ describe("@aws-sdk/client-s3", () => {
 
   describe("ListObjects", () => {
     beforeEach(async () => {
-      Key = `${Date.now()}`;
+      Key = `${crypto.randomUUID()}`;
       await client.putObject({ Bucket, Key, Body: "foo" });
     });
     afterEach(async () => {
@@ -212,7 +212,7 @@ describe("@aws-sdk/client-s3", () => {
     const multipartObjectKey = `${Key}-multipart`;
 
     beforeEach(() => {
-      Key = `${Date.now()}`;
+      Key = `${crypto.randomUUID()}`;
     });
 
     afterEach(async () => {
@@ -317,7 +317,7 @@ describe("@aws-sdk/client-s3", () => {
 
   describe("Multi-region access point", () => {
     beforeEach(async () => {
-      Key = `${Date.now()}`;
+      Key = `${crypto.randomUUID()}`;
     });
 
     it("should throw for aws-crt no available in browser", async () => {

--- a/clients/client-s3/test/e2e/S3.e2e.spec.ts
+++ b/clients/client-s3/test/e2e/S3.e2e.spec.ts
@@ -9,7 +9,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, test as it } from "vi
 
 import { createBuffer } from "./helpers";
 
-let Key = `${Date.now()}`;
+let Key = `${crypto.randomUUID()}`;
 
 describe("@aws-sdk/client-s3", () => {
   let client: S3;
@@ -32,7 +32,7 @@ describe("@aws-sdk/client-s3", () => {
 
   describe("PutObject", () => {
     beforeAll(() => {
-      Key = `${Date.now()}`;
+      Key = `${crypto.randomUUID()}`;
     });
     afterAll(async () => {
       await client.deleteObject({ Bucket, Key });
@@ -97,7 +97,7 @@ describe("@aws-sdk/client-s3", () => {
 
   describe("GetObject", () => {
     beforeAll(async () => {
-      Key = `${Date.now()}`;
+      Key = `${crypto.randomUUID()}`;
     });
 
     afterAll(async () => {
@@ -148,7 +148,7 @@ describe("@aws-sdk/client-s3", () => {
 
   describe("ListObjects", () => {
     beforeAll(async () => {
-      Key = `${Date.now()}`;
+      Key = `${crypto.randomUUID()}`;
       await client.putObject({ Bucket, Key, Body: "foo" });
     });
     afterAll(async () => {
@@ -171,7 +171,7 @@ describe("@aws-sdk/client-s3", () => {
     let Etag: string;
     const multipartObjectKey = `${Key}-multipart`;
     beforeAll(() => {
-      Key = `${Date.now()}`;
+      Key = `${crypto.randomUUID()}`;
     });
     afterEach(async () => {
       if (UploadId) {
@@ -265,7 +265,7 @@ describe("@aws-sdk/client-s3", () => {
 
   describe("Multi-region access point", () => {
     beforeAll(async () => {
-      Key = `${Date.now()}`;
+      Key = `${crypto.randomUUID()}`;
       await client.putObject({ Bucket: mrapArn, Key, Body: "foo" });
     });
     afterAll(async () => {

--- a/clients/client-s3/test/e2e/s3-bucket-features.e2e.spec.ts
+++ b/clients/client-s3/test/e2e/s3-bucket-features.e2e.spec.ts
@@ -1,23 +1,19 @@
 import { S3, waitUntilBucketExists, waitUntilBucketNotExists } from "@aws-sdk/client-s3";
-import { type GetCallerIdentityCommandOutput, STS } from "@aws-sdk/client-sts";
-import { HttpRequest } from "@smithy/types";
+import type { HttpRequest } from "@smithy/types";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 describe("@aws-sdk/client-s3 - Working with Buckets", () => {
   const s3 = new S3({ region: "us-west-2", credentials: aws?.testCredentials });
   const s3East = new S3({ region: "us-east-1", followRegionRedirects: true, credentials: aws?.testCredentials });
   const s3PathStyle = new S3({ region: "us-west-2", forcePathStyle: true, credentials: aws?.testCredentials });
-  const stsClient = new STS({ region: "us-west-2", credentials: aws?.testCredentials });
 
   function getBucketName(id: string, region = "us-west-2") {
-    return `${callerID.Account}-${crypto.randomUUID()}-${id}-${region}`;
+    return `${id}-${region}-${crypto.randomUUID()}`;
   }
 
   let Bucket: string;
-  let callerID: GetCallerIdentityCommandOutput;
 
   beforeAll(async () => {
-    callerID = await stsClient.getCallerIdentity({});
     Bucket = getBucketName(`js-sdk-e2e`);
   });
 

--- a/clients/client-s3/test/e2e/s3-bucket-features.e2e.spec.ts
+++ b/clients/client-s3/test/e2e/s3-bucket-features.e2e.spec.ts
@@ -10,9 +10,7 @@ describe("@aws-sdk/client-s3 - Working with Buckets", () => {
   const stsClient = new STS({ region: "us-west-2", credentials: aws?.testCredentials });
 
   function getBucketName(id: string, region = "us-west-2") {
-    const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
-    const randId = Array.from({ length: 19 }, () => alphabet[(Math.random() * alphabet.length) | 0]).join("");
-    return `${callerID.Account}-${randId}-${id}-${region}`;
+    return `${callerID.Account}-${crypto.randomUUID()}-${id}-${region}`;
   }
 
   let Bucket: string;

--- a/clients/client-sns/test/sns-features.e2e.spec.ts
+++ b/clients/client-sns/test/sns-features.e2e.spec.ts
@@ -12,7 +12,7 @@ describe(SNS.name, () => {
   describe("Topics", () => {
     it("should create and list SNS topics", async () => {
       const createResult = await client.createTopic({
-        Name: `aws-js-sdk-${Date.now()}`,
+        Name: `aws-js-sdk-${crypto.randomUUID()}`,
       });
 
       topicArn = createResult.TopicArn || "";

--- a/clients/client-sqs/test/sqs-messages-features.e2e.spec.ts
+++ b/clients/client-sqs/test/sqs-messages-features.e2e.spec.ts
@@ -27,7 +27,7 @@ describe(SQS.name, () => {
     it("should send message with correct MD5 and receive it", async () => {
       // Create queue
       const createResult = await client.createQueue({
-        QueueName: `aws-js-sdk-${Date.now()}`,
+        QueueName: `aws-js-sdk-${crypto.randomUUID()}`,
       });
 
       const queueUrl = createResult.QueueUrl || "";
@@ -57,7 +57,7 @@ describe(SQS.name, () => {
     it("should send message with binary attribute", async () => {
       // Create queue
       const createResult = await client.createQueue({
-        QueueName: `aws-js-sdk-${Date.now()}`,
+        QueueName: `aws-js-sdk-${crypto.randomUUID()}`,
       });
 
       const queueUrl = createResult.QueueUrl || "";

--- a/clients/client-sqs/test/sqs-queues-features.e2e.spec.ts
+++ b/clients/client-sqs/test/sqs-queues-features.e2e.spec.ts
@@ -49,7 +49,7 @@ describe("SQS Queues", () => {
   });
 
   describe("Creating and deleting queues", () => {
-    const prefix = `aws-sdk-${Date.now()}-`;
+    const prefix = `aws-sdk-${crypto.randomUUID()}-`;
 
     it("should create queues and eventually list them", async () => {
       // Create first queue

--- a/clients/client-storage-gateway/test/storagegateway-features.e2e.spec.ts
+++ b/clients/client-storage-gateway/test/storagegateway-features.e2e.spec.ts
@@ -22,7 +22,7 @@ describe(StorageGateway.name, () => {
       await expect(
         client.activateGateway({
           ActivationKey: "INVALIDKEY",
-          GatewayName: `aws-sdk-js-${Date.now()}`,
+          GatewayName: `aws-sdk-js-${crypto.randomUUID()}`,
           GatewayTimezone: "GMT-5:00",
           GatewayRegion: "us-east-1",
         })

--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -125,9 +125,8 @@ describe(
       }
     }
 
-    const randId = (Math.random() + 1).toString(36).substring(2, 6);
-    const timestamp = (Date.now() / 1000) | 0;
-    const TableName = `js-sdk-lib-dynamodb-test-${timestamp}-${randId}`;
+    const randId = crypto.randomUUID();
+    const TableName = `js-sdk-lib-dynamodb-test-${randId}`;
     const start = Date.now();
     const mark = () => `DDB-E2E: ` + ((Date.now() - start) / 1000).toFixed(3) + "s elapsed.";
 

--- a/packages-internal/checksums/src/flexible-checksums/middleware-md5-fallback.e2e.spec.ts
+++ b/packages-internal/checksums/src/flexible-checksums/middleware-md5-fallback.e2e.spec.ts
@@ -24,7 +24,7 @@ describe("S3 MD5 Fallback for DeleteObjects", () => {
 
   beforeAll(async () => {
     s3 = new S3({ region: "us-west-2" });
-    Bucket = `md5-fallback-test-${Date.now()}`;
+    Bucket = `md5-fallback-test-${crypto.randomUUID()}`;
 
     try {
       await s3.send(new CreateBucketCommand({ Bucket }));

--- a/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-s3-expires/s3-expires-middleware.e2e.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-s3-expires/s3-expires-middleware.e2e.spec.ts
@@ -1,6 +1,4 @@
 import { S3 } from "@aws-sdk/client-s3";
-import type { GetCallerIdentityCommandOutput } from "@aws-sdk/client-sts";
-import { STS } from "@aws-sdk/client-sts";
 import { afterAll, beforeAll, describe, expect, test as it, vi } from "vitest";
 
 describe("S3 Expires e2e test", () => {
@@ -14,16 +12,11 @@ describe("S3 Expires e2e test", () => {
       error() {},
     },
   });
-  const stsClient = new STS({ region: "us-west-2" });
 
-  let callerID = null as unknown as GetCallerIdentityCommandOutput;
   let Bucket: string;
 
-  const randId = crypto.randomUUID();
-
   beforeAll(async () => {
-    callerID = await stsClient.getCallerIdentity({});
-    Bucket = `${callerID.Account}-s3-expires-${randId}`;
+    Bucket = `s3-expires-${crypto.randomUUID()}`;
 
     await s3
       .createBucket({

--- a/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-s3-expires/s3-expires-middleware.e2e.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-s3-expires/s3-expires-middleware.e2e.spec.ts
@@ -19,9 +19,7 @@ describe("S3 Expires e2e test", () => {
   let callerID = null as unknown as GetCallerIdentityCommandOutput;
   let Bucket: string;
 
-  const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
-  const char = () => alphabet[(Math.random() * alphabet.length) | 0];
-  const randId = char() + char() + char() + char() + (Date.now() % 1000);
+  const randId = crypto.randomUUID();
 
   beforeAll(async () => {
     callerID = await stsClient.getCallerIdentity({});

--- a/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-s3-express/middleware-s3-express.e2e.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-s3-express/middleware-s3-express.e2e.spec.ts
@@ -192,7 +192,7 @@ async function createClientAndRecorder() {
   const sts = new STS({ region });
   const accountId = (await sts.getCallerIdentity({})).Account;
 
-  const bucketName = `${accountId}-js-test-bucket-${(Math.random() + 1).toString(36).substring(2)}--${suffix}`;
+  const bucketName = `${accountId}-js-test-bucket-${crypto.randomUUID()}--${suffix}`;
 
   const s3 = new S3({
     region,

--- a/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-s3-express/middleware-s3-express.e2e.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-s3-express/middleware-s3-express.e2e.spec.ts
@@ -1,5 +1,4 @@
 import { GetObjectCommand, PutObjectCommand, S3, waitUntilBucketExists } from "@aws-sdk/client-s3";
-import { STS } from "@aws-sdk/client-sts";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import type http from "node:http";
 import https from "node:https";
@@ -189,10 +188,7 @@ describe("s3 express CRUD test suite", () => {
 }, 120_000);
 
 async function createClientAndRecorder() {
-  const sts = new STS({ region });
-  const accountId = (await sts.getCallerIdentity({})).Account;
-
-  const bucketName = `${accountId}-js-test-bucket-${crypto.randomUUID()}--${suffix}`;
+  const bucketName = `js-test-${crypto.randomUUID()}--${suffix}`;
 
   const s3 = new S3({
     region,

--- a/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-throw-200-exceptions/throw-200-exceptions.e2e.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-throw-200-exceptions/throw-200-exceptions.e2e.spec.ts
@@ -1,5 +1,4 @@
 import { S3 } from "@aws-sdk/client-s3";
-import { type GetCallerIdentityCommandOutput, STS } from "@aws-sdk/client-sts";
 import { NodeHttpHandler } from "@aws-sdk/config/requestHandler";
 import { HttpResponse } from "@smithy/core/protocols";
 import { Readable } from "node:stream";
@@ -10,15 +9,12 @@ describe("S3 throw 200 exceptions", () => {
     region: "us-west-2",
   };
   const s3 = new S3(config);
-  const stsClient = new STS(config);
 
   const randId = crypto.randomUUID();
   let Bucket: string;
-  let callerID: GetCallerIdentityCommandOutput;
 
   beforeAll(async () => {
-    callerID = await stsClient.getCallerIdentity({});
-    Bucket = `${callerID.Account}-${randId}-js-sdk-e2e-${config.region}`;
+    Bucket = `js-sdk-e2e-${config.region}-${randId}`;
 
     await s3.createBucket({
       Bucket,

--- a/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-throw-200-exceptions/throw-200-exceptions.e2e.spec.ts
+++ b/packages-internal/middleware-sdk-s3/src/submodules/s3/middleware-throw-200-exceptions/throw-200-exceptions.e2e.spec.ts
@@ -12,14 +12,13 @@ describe("S3 throw 200 exceptions", () => {
   const s3 = new S3(config);
   const stsClient = new STS(config);
 
-  const alphabet = "abcdefghijklmnopqrstuvwxyz";
-  const randId = Array.from({ length: 8 }, () => alphabet[(Math.random() * alphabet.length) | 0]).join("");
+  const randId = crypto.randomUUID();
   let Bucket: string;
   let callerID: GetCallerIdentityCommandOutput;
 
   beforeAll(async () => {
     callerID = await stsClient.getCallerIdentity({});
-    Bucket = `${callerID.Account}-${randId}-js-sdk-e2e-${config.region}-${(Date.now() / 1000) | 0}`;
+    Bucket = `${callerID.Account}-${randId}-js-sdk-e2e-${config.region}`;
 
     await s3.createBucket({
       Bucket,

--- a/packages-internal/signature-v4-multi-region/src/eventbridge-sigv4a-put-api.e2e.spec.ts
+++ b/packages-internal/signature-v4-multi-region/src/eventbridge-sigv4a-put-api.e2e.spec.ts
@@ -93,7 +93,7 @@ describe("EventBridge Client with SignatureV4a", () => {
 
         const healthCheck = await route53Client.send(
           new CreateHealthCheckCommand({
-            CallerReference: `${RESOURCE_PREFIX}-${Date.now()}`,
+            CallerReference: `${RESOURCE_PREFIX}-${crypto.randomUUID()}`,
             HealthCheckConfig: {
               Type: "HTTP",
               FullyQualifiedDomainName: "example.com",


### PR DESCRIPTION
### Issue

https://github.com/aws/aws-sdk-js-v3/pull/8088

### Description

Replace Math.random() and Date.now() based ID generation with
crypto.randomUUID() across all e2e spec files to guarantee uniqueness
and avoid resource name collisions in concurrent test runs.

### Testing

CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
