### PR TITLE
docs: suggest UndiciHttpHandler as an alternative request handler

### DIFF
--- a/supplemental-docs/CLIENTS.md
+++ b/supplemental-docs/CLIENTS.md
@@ -391,17 +391,17 @@ const __error__ = await bodyStream.transformToString();
 
 #### Alternative: `UndiciHttpHandler`
 
-We also provide [`@smithy/undici-http-handler`][] - a compatible request handler backed by
+We also provide [`@aws-sdk/undici-http-handler`][] - a compatible request handler backed by
 modern, high performance Node.js [undici][] client.
 
 ```bash
-npm i @smithy/undici-http-handler
+npm i @aws-sdk/undici-http-handler
 ```
 
 ```ts
 // Example: using UndiciHttpHandler.
 import { S3 } from "@aws-sdk/client-s3";
-import { UndiciHttpHandler } from "@smithy/undici-http-handler";
+import { UndiciHttpHandler } from "@aws-sdk/undici-http-handler";
 
 const s3 = new S3({
   requestHandler: new UndiciHttpHandler({
@@ -1012,5 +1012,5 @@ try {
 }
 ```
 
-[`@smithy/undici-http-handler`]: https://www.npmjs.com/package/@smithy/undici-http-handler
+[`@aws-sdk/undici-http-handler`]: https://www.npmjs.com/package/@aws-sdk/undici-http-handler
 [undici]: https://undici.nodejs.org/

--- a/supplemental-docs/CLIENTS.md
+++ b/supplemental-docs/CLIENTS.md
@@ -389,6 +389,31 @@ const bodyAsString = await bodyStream.transformToString();
 const __error__ = await bodyStream.transformToString();
 ```
 
+#### Alternative: `UndiciHttpHandler`
+
+We also provide [`@smithy/undici-http-handler`][] - a compatible request handler backed by
+modern, high performance Node.js [undici][] client.
+
+```bash
+npm i @smithy/undici-http-handler
+```
+
+```ts
+// Example: using UndiciHttpHandler.
+import { S3 } from "@aws-sdk/client-s3";
+import { UndiciHttpHandler } from "@smithy/undici-http-handler";
+
+const s3 = new S3({
+  requestHandler: new UndiciHttpHandler({
+    dispatcher: {
+      connections: 50, // analogous to maxSockets
+      headersTimeout: 3_000,
+      connect: { timeout: 3_000 },
+    },
+  }),
+});
+```
+
 #### Browsers' `requestHandler`
 
 The default browser requestHandler is `@aws-sdk/fetch-http-handler` and uses
@@ -986,3 +1011,6 @@ try {
   console.log("SendMessage Failure", error);
 }
 ```
+
+[`@smithy/undici-http-handler`]: https://www.npmjs.com/package/@smithy/undici-http-handler
+[undici]: https://undici.nodejs.org/

--- a/supplemental-docs/performance/README.md
+++ b/supplemental-docs/performance/README.md
@@ -15,4 +15,4 @@ Topics:
 - [Dynamic Imports](./dynamic-imports.md)
 - [Dependency File Count Reduction](./dependency-file-count-reduction.md)
 - [Parallel workloads in Node.js](./parallel-workloads-node-js.md)
-- [Request Handler backed by high-performance undici client](https://www.npmjs.com/package/@smithy/undici-http-handler)
+- [Request Handler backed by high-performance undici client](https://www.npmjs.com/package/@aws-sdk/undici-http-handler)

--- a/supplemental-docs/performance/README.md
+++ b/supplemental-docs/performance/README.md
@@ -15,3 +15,4 @@ Topics:
 - [Dynamic Imports](./dynamic-imports.md)
 - [Dependency File Count Reduction](./dependency-file-count-reduction.md)
 - [Parallel workloads in Node.js](./parallel-workloads-node-js.md)
+- [Request Handler backed by high-performance undici client](https://www.npmjs.com/package/@smithy/undici-http-handler)

--- a/supplemental-docs/performance/parallel-workloads-node-js.md
+++ b/supplemental-docs/performance/parallel-workloads-node-js.md
@@ -240,8 +240,8 @@ In this example we've adhered to the best practices mentioned in this section:
 
 ## Alternative: UndiciHttpHandler
 
-If you need even higher throughput, consider trying [`@smithy/undici-http-handler`][] - a compatible request handler
+If you need even higher throughput, consider trying [`@aws-sdk/undici-http-handler`][] - a compatible request handler
 backed by modern, high performance Node.js [undici][] client instead of `node:https`.
 
-[`@smithy/undici-http-handler`]: https://www.npmjs.com/package/@smithy/undici-http-handler
+[`@aws-sdk/undici-http-handler`]: https://www.npmjs.com/package/@aws-sdk/undici-http-handler
 [undici]: https://undici.nodejs.org/

--- a/supplemental-docs/performance/parallel-workloads-node-js.md
+++ b/supplemental-docs/performance/parallel-workloads-node-js.md
@@ -237,3 +237,11 @@ In this example we've adhered to the best practices mentioned in this section:
 
 - use one client instance for repeated requests
 - set a `maxSockets` value that is a factor of the batch size
+
+## Alternative: UndiciHttpHandler
+
+If you need even higher throughput, consider trying [`@smithy/undici-http-handler`][] - a compatible request handler
+backed by modern, high performance Node.js [undici][] client instead of `node:https`.
+
+[`@smithy/undici-http-handler`]: https://www.npmjs.com/package/@smithy/undici-http-handler
+[undici]: https://undici.nodejs.org/


### PR DESCRIPTION
### Issue
N/A

### Description

Document @smithy/undici-http-handler in CLIENTS.md with usage example
showing dispatcher configuration options. Add a note in the parallel
workloads guide pointing to it as a higher-throughput alternative to
the default node:https handler. Share link in performance README too.

### Testing
N/A

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
