### PR TITLE
feat(undici-http-handler): re-export '@smithy/undici-http-handler'

### DIFF
--- a/packages-internal/undici-http-handler/README.md
+++ b/packages-internal/undici-http-handler/README.md
@@ -1,0 +1,18 @@
+# @aws-sdk/undici-http-handler
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/undici-http-handler/latest.svg)](https://www.npmjs.com/package/@aws-sdk/undici-http-handler)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/undici-http-handler.svg)](https://www.npmjs.com/package/@aws-sdk/undici-http-handler)
+
+This package re-exports [`@smithy/undici-http-handler`][] which is a smithy-compatible HTTP handler backed by
+modern, high performance Node.js [undici][] client.
+
+## When to use this package
+
+If your project uses AWS SDK for JavaScript v3 clients (packages under `@aws-sdk/*`), you can
+use this package to keep your request handler dependency within the same `@aws-sdk` scope.
+
+Functionally, this package is identical to [`@smithy/undici-http-handler`][] — it simply
+re-exports it. Use whichever scope fits your project's dependency conventions.
+
+[`@smithy/undici-http-handler`]: https://www.npmjs.com/package/@smithy/undici-http-handler
+[undici]: https://undici.nodejs.org/

--- a/packages-internal/undici-http-handler/package.json
+++ b/packages-internal/undici-http-handler/package.json
@@ -11,7 +11,9 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
-    "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo"
+    "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
+    "test": "yarn g:vitest run",
+    "test:watch": "yarn g:vitest watch"
   },
   "dependencies": {
     "@smithy/undici-http-handler": "^2.0.0",

--- a/packages-internal/undici-http-handler/package.json
+++ b/packages-internal/undici-http-handler/package.json
@@ -13,7 +13,9 @@
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo",
     "test": "yarn g:vitest run",
-    "test:watch": "yarn g:vitest watch"
+    "test:watch": "yarn g:vitest watch",
+    "test:e2e": "yarn g:vitest run -c vitest.config.e2e.mts",
+    "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.mts"
   },
   "dependencies": {
     "@smithy/undici-http-handler": "^2.0.0",

--- a/packages-internal/undici-http-handler/package.json
+++ b/packages-internal/undici-http-handler/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@aws-sdk/undici-http-handler",
+  "version": "2.0.0",
+  "description": "AWS SDK for JavaScript reqeust handler backed by modern, high performance Node.js undici client",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
+  "scripts": {
+    "build": "concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",
+    "build:cjs": "node ../../scripts/compilation/inline",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "premove dist-cjs dist-es dist-types tsconfig.cjs.tsbuildinfo tsconfig.es.tsbuildinfo tsconfig.types.tsbuildinfo"
+  },
+  "dependencies": {
+    "@smithy/undici-http-handler": "^2.0.0",
+    "tslib": "^2.6.2"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "premove": "4.0.0",
+    "typescript": "~5.8.3"
+  },
+  "engines": {
+    "node": ">=20.18.1"
+  },
+  "typesVersions": {
+    "<4.5": {
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
+      ]
+    }
+  },
+  "files": [
+    "dist-*/**"
+  ],
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages-internal/undici-http-handler",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages-internal/undici-http-handler"
+  },
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/sdk-for-javascript/"
+  }
+}

--- a/packages-internal/undici-http-handler/src/index.ts
+++ b/packages-internal/undici-http-handler/src/index.ts
@@ -1,0 +1,1 @@
+export * from "@smithy/undici-http-handler";

--- a/packages-internal/undici-http-handler/src/undici-http-handler.bedrock-runtime.e2e.spec.ts
+++ b/packages-internal/undici-http-handler/src/undici-http-handler.bedrock-runtime.e2e.spec.ts
@@ -1,0 +1,116 @@
+import { BedrockRuntime } from "@aws-sdk/client-bedrock-runtime";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { UndiciHttpHandler } from "./index";
+
+describe("BedrockRuntime", () => {
+  const client = new BedrockRuntime({
+    region: "us-east-1",
+    requestHandler: new UndiciHttpHandler(),
+  });
+
+  afterAll(() => {
+    client.destroy();
+  });
+
+  it("invokeModelWithBidirectionalStream", async () => {
+    const promptName = "p";
+    const jsonBytes = (data: unknown) => Buffer.from(JSON.stringify(data));
+    const chunk = (event: unknown) => ({
+      chunk: { bytes: jsonBytes({ event }) },
+    });
+
+    const response = await client.invokeModelWithBidirectionalStream({
+      modelId: "amazon.nova-sonic-v1:0",
+      body: {
+        async *[Symbol.asyncIterator]() {
+          yield chunk({ sessionStart: {} });
+          yield chunk({
+            promptStart: {
+              promptName,
+              audioOutputConfiguration: {
+                mediaType: "audio/lpcm",
+                sampleRateHertz: 8000,
+                sampleSizeBits: 16,
+                channelCount: 1,
+                voiceId: "matthew",
+                encoding: "base64",
+                audioType: "SPEECH",
+              },
+            },
+          });
+          yield chunk({
+            contentStart: {
+              promptName,
+              contentName: "c1",
+              type: "TEXT",
+              role: "SYSTEM",
+              textInputConfiguration: { mediaType: "text/plain" },
+            },
+          });
+          yield chunk({
+            textInput: {
+              promptName,
+              contentName: "c1",
+              content: "Hi",
+            },
+          });
+          yield chunk({
+            contentEnd: { promptName, contentName: "c1" },
+          });
+          yield chunk({
+            contentStart: {
+              promptName,
+              contentName: "c2",
+              type: "AUDIO",
+              role: "USER",
+              audioInputConfiguration: {
+                mediaType: "audio/lpcm",
+                sampleRateHertz: 16000,
+                sampleSizeBits: 16,
+                channelCount: 1,
+                audioType: "SPEECH",
+                encoding: "base64",
+              },
+            },
+          });
+          yield chunk({
+            audioInput: {
+              promptName,
+              contentName: "c2",
+              content: Buffer.from(new Uint8Array(3200)).toString("base64"),
+            },
+          });
+          yield chunk({
+            contentEnd: { promptName, contentName: "c2" },
+          });
+          yield chunk({ promptEnd: { promptName } });
+          yield chunk({ sessionEnd: {} });
+        },
+      },
+    });
+
+    expect(response.$metadata.httpStatusCode).toBe(200);
+    expect(response.body).toBeDefined();
+
+    let receivedUsageEvent = false;
+    const receivedEventTypes: string[] = [];
+
+    for await (const event of response.body!) {
+      if (event?.chunk?.bytes?.byteLength) {
+        const parsed = JSON.parse(new TextDecoder().decode(event.chunk.bytes));
+        expect(parsed).toHaveProperty("event");
+
+        const eventType = Object.keys(parsed["event"])[0];
+        receivedEventTypes.push(eventType);
+
+        if (eventType === "usageEvent") {
+          receivedUsageEvent = true;
+        }
+      }
+    }
+
+    expect(receivedEventTypes.length).toBeGreaterThan(0);
+    expect(receivedUsageEvent).toBe(true);
+  });
+});

--- a/packages-internal/undici-http-handler/src/undici-http-handler.cloudwatch-logs.e2e.spec.ts
+++ b/packages-internal/undici-http-handler/src/undici-http-handler.cloudwatch-logs.e2e.spec.ts
@@ -1,0 +1,69 @@
+import { CloudWatchLogs } from "@aws-sdk/client-cloudwatch-logs";
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { UndiciHttpHandler } from "./index";
+
+describe("CloudWatchLogs", () => {
+  const logGroupName = `/test/undici-http-handler/${randomUUID()}`;
+  const logStreamName = "test-stream";
+  const client = new CloudWatchLogs({ requestHandler: new UndiciHttpHandler() });
+  let logGroupArn: string;
+
+  beforeAll(async () => {
+    await client.createLogGroup({ logGroupName });
+    await client.createLogStream({ logGroupName, logStreamName });
+
+    const { logGroups } = await client.describeLogGroups({
+      logGroupNamePrefix: logGroupName,
+    });
+    // The ARN from describeLogGroups ends with ":*", which startLiveTail doesn't accept.
+    logGroupArn = logGroups![0].arn!.replace(/:?\*$/, "");
+  });
+
+  afterAll(async () => {
+    await client.deleteLogStream({ logGroupName, logStreamName }).catch(() => {});
+    await client.deleteLogGroup({ logGroupName }).catch(() => {});
+    client.destroy();
+  });
+
+  it("startLiveTail", { timeout: 60_000 }, async () => {
+    expect.assertions(4);
+    const testMessage = "test message";
+
+    const response = await client.startLiveTail({
+      logGroupIdentifiers: [logGroupArn],
+    });
+
+    expect(response.$metadata.httpStatusCode).toBe(200);
+    expect(response.responseStream).toBeDefined();
+
+    // Put log events AFTER starting the live tail so they appear in the stream
+    const putEventsPromise = async () => {
+      // Wait for the live tail session to establish before putting events
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await client.putLogEvents({
+        logGroupName,
+        logStreamName,
+        logEvents: [{ timestamp: Date.now(), message: testMessage }],
+      });
+    };
+
+    const consumeStreamPromise = async () => {
+      for await (const event of response.responseStream!) {
+        if (event.sessionStart) {
+          expect(event.sessionStart.logGroupIdentifiers).toContain(logGroupArn);
+        }
+        if (event.sessionUpdate) {
+          const messages = event.sessionUpdate.sessionResults?.map((r) => r.message) ?? [];
+          if (messages.includes(testMessage)) {
+            expect(messages).toContain(testMessage);
+            break;
+          }
+        }
+      }
+    };
+
+    await Promise.all([putEventsPromise(), consumeStreamPromise()]);
+  });
+});

--- a/packages-internal/undici-http-handler/src/undici-http-handler.s3.e2e.spec.ts
+++ b/packages-internal/undici-http-handler/src/undici-http-handler.s3.e2e.spec.ts
@@ -1,0 +1,80 @@
+import { S3 } from "@aws-sdk/client-s3";
+import { randomBytes, randomUUID } from "node:crypto";
+import { Readable } from "node:stream";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { UndiciHttpHandler } from "./index";
+
+describe("S3", () => {
+  const bucketName = `test-undici-http-handler-${randomUUID()}`;
+  const client = new S3({ requestHandler: new UndiciHttpHandler() });
+
+  beforeAll(async () => {
+    await client.createBucket({ Bucket: bucketName });
+    await client.waitUntilBucketExists({ Bucket: bucketName }, { maxWaitTime: 60 });
+  });
+
+  afterAll(async () => {
+    // Empty the bucket in case of test failure
+    const { Contents } = await client.listObjectsV2({ Bucket: bucketName });
+    if (Contents) {
+      for (const { Key } of Contents) {
+        await client.deleteObject({ Bucket: bucketName, Key });
+      }
+    }
+
+    // Delete the bucket
+    await client.deleteBucket({ Bucket: bucketName });
+
+    client.destroy();
+  });
+
+  const data = randomBytes(16 * 1024); // 16 KB of random data
+
+  it.each([
+    {
+      type: "string",
+      body: data.toString("base64"),
+      expected: Buffer.from(data.toString("base64")),
+    },
+    { type: "Uint8Array", body: new Uint8Array(data), expected: data },
+    { type: "Buffer", body: data, expected: data },
+    { type: "Readable", body: Readable.from(data), expected: data },
+  ])("put/get/delete with body as $type", async ({ body, expected }) => {
+    const key = `test-object-${randomUUID()}`;
+
+    // headObject should fail before put
+    await expect(client.headObject({ Bucket: bucketName, Key: key })).rejects.toThrow();
+
+    // Put the object
+    const putResponse = await client.putObject({
+      Bucket: bucketName,
+      Key: key,
+      Body: body,
+      // ContentLength is required for streaming bodies (Readable) because handler cannot
+      // determine the content length of a stream on its own, unlike string or Buffer bodies.
+      ...(body instanceof Readable && { ContentLength: expected.length }),
+    });
+    expect(putResponse.$metadata.httpStatusCode).toBe(200);
+
+    // Get the object
+    const getResponse = await client.getObject({
+      Bucket: bucketName,
+      Key: key,
+    });
+    expect(getResponse.$metadata.httpStatusCode).toBe(200);
+
+    const receivedBody = await getResponse.Body!.transformToByteArray();
+    expect(Buffer.from(receivedBody)).toEqual(expected);
+
+    // Delete the object
+    const deleteResponse = await client.deleteObject({
+      Bucket: bucketName,
+      Key: key,
+    });
+    expect(deleteResponse.$metadata.httpStatusCode).toBe(204);
+
+    // headObject should fail after delete
+    await expect(client.headObject({ Bucket: bucketName, Key: key })).rejects.toThrow();
+  });
+});

--- a/packages-internal/undici-http-handler/src/undici-http-handler.version.spec.ts
+++ b/packages-internal/undici-http-handler/src/undici-http-handler.version.spec.ts
@@ -1,0 +1,24 @@
+import { engines as smithyEngines, version as smithyVersion } from "@smithy/undici-http-handler/package.json";
+import { describe, expect, it } from "vitest";
+
+import { engines, version } from "../package.json";
+
+describe("undici-http-handler version", () => {
+  it("engines.node should be same as @smithy/undici-http-handler engines.node", () => {
+    expect(
+      engines.node,
+      "Note: engines.node should be the same as @smithy/undici-http-handler's engines.node." +
+        " If @smithy/undici-http-handler updated its engines requirement, update this package to match."
+    ).toEqual(smithyEngines.node);
+  });
+
+  it("major version should be same as @smithy/undici-http-handler major version", () => {
+    const localMajor = version.split(".")[0];
+    const smithyMajor = smithyVersion.split(".")[0];
+    expect(
+      localMajor,
+      "Note: The major version should be the same as @smithy/undici-http-handler's major version." +
+        " If @smithy/undici-http-handler released a new major version, update this package to match."
+    ).toEqual(smithyMajor);
+  });
+});

--- a/packages-internal/undici-http-handler/tsconfig.cjs.json
+++ b/packages-internal/undici-http-handler/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noUnusedLocals": true,
+    "outDir": "dist-cjs",
+    "rootDir": "src",
+    "noCheck": true
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages-internal/undici-http-handler/tsconfig.es.json
+++ b/packages-internal/undici-http-handler/tsconfig.es.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": [],
+    "noUnusedLocals": true,
+    "outDir": "dist-es",
+    "rootDir": "src",
+    "noCheck": true
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages-internal/undici-http-handler/tsconfig.types.json
+++ b/packages-internal/undici-http-handler/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/packages-internal/undici-http-handler/vitest.config.e2e.mts
+++ b/packages-internal/undici-http-handler/vitest.config.e2e.mts
@@ -2,8 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    exclude: ["**/*.e2e.spec.ts"],
-    include: ["**/*.spec.ts"],
+    include: ["**/*.e2e.spec.ts"],
     environment: "node",
   },
 });

--- a/packages-internal/undici-http-handler/vitest.config.mts
+++ b/packages-internal/undici-http-handler/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.spec.ts"],
+    environment: "node",
+  },
+});

--- a/scripts/validation/api.json
+++ b/scripts/validation/api.json
@@ -1539,6 +1539,10 @@
     "WaiterConfiguration": "type(interface)",
     "WithSdkStreamMixin": "type(object)"
   },
+  "@aws-sdk/undici-http-handler": {
+    "UndiciHttpHandler": "function",
+    "UndiciHttpHandlerOptions": "type(interface)"
+  },
   "@aws-sdk/util-arn-parser": {
     "ARN": "type(interface)",
     "build": "function",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11935,6 +11935,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@aws-sdk/undici-http-handler@workspace:packages-internal/undici-http-handler":
+  version: 0.0.0-use.local
+  resolution: "@aws-sdk/undici-http-handler@workspace:packages-internal/undici-http-handler"
+  dependencies:
+    "@smithy/undici-http-handler": "npm:^2.0.0"
+    "@tsconfig/recommended": "npm:1.0.1"
+    concurrently: "npm:7.0.0"
+    downlevel-dts: "npm:0.10.1"
+    premove: "npm:4.0.0"
+    tslib: "npm:^2.6.2"
+    typescript: "npm:~5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "@aws-sdk/util-arn-parser@workspace:packages-internal/util-arn-parser":
   version: 0.0.0-use.local
   resolution: "@aws-sdk/util-arn-parser@workspace:packages-internal/util-arn-parser"
@@ -16158,6 +16172,20 @@ __metadata:
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/c80244d5ca88992e5609e372eaf2441497d36063688af44e9f0e81ab0ee8d5a4cbdb644822243e4cdfad2dd6484c6274e618dc2a9e91b3b9befe7c7b55e09ddc
+  languageName: node
+  linkType: hard
+
+"@smithy/undici-http-handler@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "@smithy/undici-http-handler@npm:2.0.2"
+  dependencies:
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+    undici: "npm:^7.0.0"
+  peerDependencies:
+    undici: ">=7.0.0"
+  checksum: 10c0/740792abcfb888c421c84b6f577c937fa092da75c958acd505d9375d32e8d27fa4df2a0ea315ff329b272c6155c4d6000f58d13b307716970fa4524bc897e56c
   languageName: node
   linkType: hard
 
@@ -28218,6 +28246,13 @@ __metadata:
   version: 7.18.2
   resolution: "undici-types@npm:7.18.2"
   checksum: 10c0/85a79189113a238959d7a647368e4f7c5559c3a404ebdb8fc4488145ce9426fcd82252a844a302798dfc0e37e6fb178ff481ed03bc4caf634c5757d9ef43521d
+  languageName: node
+  linkType: hard
+
+"undici@npm:^7.0.0":
+  version: 7.27.2
+  resolution: "undici@npm:7.27.2"
+  checksum: 10c0/714632147c80eb8eda8a52df51b481d346df5e035ccc1d87eb3bbcb8f92ec25d7cbbe81abdeae5db4e37a93e490c8d2fa2359ecdca4b2c5c6c513dcd2626ad47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/8092#discussion_r3382550195

### Description
Re-export '@smithy/undici-http-handler' as '@aws-sdk/undici-http-handler'

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
