### PR TITLE
chore(scripts): apply esm-to-cjs transform to rollup bundles

### DIFF
--- a/packages-internal/credential-provider-ini/src/resolveProcessCredentials.ts
+++ b/packages-internal/credential-provider-ini/src/resolveProcessCredentials.ts
@@ -19,10 +19,11 @@ export const isProcessProfile = (arg: any): arg is ProcessProfile =>
 /**
  * @internal
  */
-export const resolveProcessCredentials = async (options: FromIniInit, profile: string): Promise<Credentials> =>
-  import("@aws-sdk/credential-provider-process").then(({ fromProcess }) =>
-    fromProcess({
-      ...options,
-      profile,
-    })().then((creds) => setCredentialFeature(creds, "CREDENTIALS_PROFILE_PROCESS", "v"))
-  );
+export const resolveProcessCredentials = async (options: FromIniInit, profile: string): Promise<Credentials> => {
+  const { fromProcess } = await import("@aws-sdk/credential-provider-process");
+  const credentials = await fromProcess({
+    ...options,
+    profile,
+  })();
+  return setCredentialFeature(credentials, "CREDENTIALS_PROFILE_PROCESS", "v");
+};

--- a/packages-internal/credential-provider-ini/src/resolveWebIdentityCredentials.ts
+++ b/packages-internal/credential-provider-ini/src/resolveWebIdentityCredentials.ts
@@ -30,16 +30,17 @@ export const resolveWebIdentityCredentials = async (
   profile: WebIdentityProfile,
   options: FromIniInit,
   callerClientConfig?: AwsIdentityProperties["callerClientConfig"]
-): Promise<AwsCredentialIdentity> =>
-  import("@aws-sdk/credential-provider-web-identity").then(({ fromTokenFile }) =>
-    fromTokenFile({
-      webIdentityTokenFile: profile.web_identity_token_file,
-      roleArn: profile.role_arn,
-      roleSessionName: profile.role_session_name,
-      roleAssumerWithWebIdentity: options.roleAssumerWithWebIdentity,
-      logger: options.logger,
-      parentClientConfig: options.parentClientConfig,
-    })({
-      callerClientConfig,
-    }).then((creds) => setCredentialFeature(creds, "CREDENTIALS_PROFILE_STS_WEB_ID_TOKEN", "q"))
-  );
+): Promise<AwsCredentialIdentity> => {
+  const { fromTokenFile } = await import("@aws-sdk/credential-provider-web-identity");
+  const credentials = await fromTokenFile({
+    webIdentityTokenFile: profile.web_identity_token_file,
+    roleArn: profile.role_arn,
+    roleSessionName: profile.role_session_name,
+    roleAssumerWithWebIdentity: options.roleAssumerWithWebIdentity,
+    logger: options.logger,
+    parentClientConfig: options.parentClientConfig,
+  })({
+    callerClientConfig,
+  });
+  return setCredentialFeature(credentials, "CREDENTIALS_PROFILE_STS_WEB_ID_TOKEN", "q");
+};

--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -6,6 +6,7 @@ const { extractImports } = require("./../validation/validation-shared");
 const rollup = require("rollup");
 const { nodeResolve } = require("@rollup/plugin-node-resolve");
 const json = require("@rollup/plugin-json");
+const { transpile } = require("./esm-to-cjs");
 
 const root = path.join(__dirname, "..", "..");
 
@@ -236,17 +237,22 @@ module.exports = class Inliner {
 
     const outputOptions = (dir) => ({
       dir,
-      format: "cjs",
-      exports: "named",
+      format: "es",
       preserveModules: false,
       externalLiveBindings: false,
     });
+
+    const transpileFile = (file) => {
+      const esm = fs.readFileSync(file, "utf-8");
+      fs.writeFileSync(file, transpile(esm));
+    };
 
     // Bundle main index.js (no variants externalized for submodule packages).
     const mainExternals = this.hasSubmodules ? [] : variantExternalsForRollup;
     const bundle = await rollup.rollup(makeInputOptions(entryPoint, mainExternals));
     await bundle.write(outputOptions(path.dirname(this.outfile)));
     await bundle.close();
+    transpileFile(this.outfile);
 
     if (this.hasSubmodules) {
       const submodulesDir = path.join(root, this.subfolder, this.package, "src", "submodules");
@@ -268,6 +274,7 @@ module.exports = class Inliner {
         const nodeBundle = await rollup.rollup(makeInputOptions(path.join(distEsSubmoduleDir, "index.js"), []));
         await nodeBundle.write(outputOptions(submoduleOutDir));
         await nodeBundle.close();
+        transpileFile(path.join(submoduleOutDir, "index.js"));
 
         // Bundle index.browser.js if the source file exists.
         const browserEntry = path.join(distEsSubmoduleDir, "index.browser.js");
@@ -278,6 +285,7 @@ module.exports = class Inliner {
             entryFileNames: "index.browser.js",
           });
           await browserBundle.close();
+          transpileFile(path.join(submoduleOutDir, "index.browser.js"));
         }
 
         // Bundle index.native.js if the source file exists.
@@ -289,6 +297,7 @@ module.exports = class Inliner {
             entryFileNames: "index.native.js",
           });
           await nativeBundle.close();
+          transpileFile(path.join(submoduleOutDir, "index.native.js"));
         }
       }
     }

--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -242,9 +242,16 @@ module.exports = class Inliner {
       externalLiveBindings: false,
     });
 
-    const transpileFile = (file) => {
-      const esm = fs.readFileSync(file, "utf-8");
-      fs.writeFileSync(file, transpile(esm));
+    const transpileDir = (dir) => {
+      for (const file of fs.readdirSync(dir)) {
+        const full = path.join(dir, file);
+        if (fs.statSync(full).isDirectory()) {
+          transpileDir(full);
+        } else if (file.endsWith(".js")) {
+          const esm = fs.readFileSync(full, "utf-8");
+          fs.writeFileSync(full, transpile(esm));
+        }
+      }
     };
 
     // Bundle main index.js (no variants externalized for submodule packages).
@@ -252,7 +259,6 @@ module.exports = class Inliner {
     const bundle = await rollup.rollup(makeInputOptions(entryPoint, mainExternals));
     await bundle.write(outputOptions(path.dirname(this.outfile)));
     await bundle.close();
-    transpileFile(this.outfile);
 
     if (this.hasSubmodules) {
       const submodulesDir = path.join(root, this.subfolder, this.package, "src", "submodules");
@@ -274,7 +280,6 @@ module.exports = class Inliner {
         const nodeBundle = await rollup.rollup(makeInputOptions(path.join(distEsSubmoduleDir, "index.js"), []));
         await nodeBundle.write(outputOptions(submoduleOutDir));
         await nodeBundle.close();
-        transpileFile(path.join(submoduleOutDir, "index.js"));
 
         // Bundle index.browser.js if the source file exists.
         const browserEntry = path.join(distEsSubmoduleDir, "index.browser.js");
@@ -285,7 +290,6 @@ module.exports = class Inliner {
             entryFileNames: "index.browser.js",
           });
           await browserBundle.close();
-          transpileFile(path.join(submoduleOutDir, "index.browser.js"));
         }
 
         // Bundle index.native.js if the source file exists.
@@ -297,10 +301,11 @@ module.exports = class Inliner {
             entryFileNames: "index.native.js",
           });
           await nativeBundle.close();
-          transpileFile(path.join(submoduleOutDir, "index.native.js"));
         }
       }
     }
+
+    transpileDir(path.join(root, this.subfolder, this.package, "dist-cjs"));
 
     return this;
   }
@@ -333,78 +338,7 @@ module.exports = class Inliner {
   }
 
   /**
-   * step 4: delete unreachable dist-cjs files that were not bundled into
-   * index.js and are not variant externals or dynamic import targets.
-   */
-  async deleteUnreachableFiles() {
-    if (this.bailout || this.hasSubmodules) {
-      return this;
-    }
-
-    // Collect files that are targets of dynamic import() from variant externals.
-    const dynamicImportTargets = new Set();
-    for (const external of this.variantExternals) {
-      const externalFile = path.join(this.packageDirectory, "dist-cjs", external);
-      if (fs.existsSync(externalFile)) {
-        const contents = fs.readFileSync(externalFile, "utf-8");
-        for (const specifier of extractImports(contents)) {
-          if (specifier.startsWith(".")) {
-            const resolved = path.normalize(path.join(path.dirname(external), specifier));
-            dynamicImportTargets.add(resolved.endsWith(".js") ? resolved : resolved + ".js");
-          }
-        }
-      }
-    }
-
-    for await (const file of walk(path.join(this.packageDirectory, "dist-cjs"))) {
-      const relativePath = file.replace(path.join(this.packageDirectory, "dist-cjs"), "").slice(1);
-
-      if (relativePath.includes("submodules")) {
-        continue;
-      }
-
-      if (!file.endsWith(".js")) {
-        if (this.verbose) {
-          console.log("Skipping", path.basename(file), "file extension is not .js.");
-        }
-        continue;
-      }
-
-      if (relativePath === "index.js") {
-        if (this.verbose) {
-          console.log("Skipping index.js");
-        }
-        continue;
-      }
-
-      if (this.variantExternals.find((external) => relativePath.endsWith(external))) {
-        if (this.verbose) {
-          console.log("Not rewriting.", relativePath, "is variant.");
-        }
-        continue;
-      }
-
-      if (dynamicImportTargets.has(relativePath)) {
-        if (this.verbose) {
-          console.log("Not rewriting.", relativePath, "is a dynamic import target.");
-        }
-        continue;
-      }
-
-      if (fs.readFileSync(file, "utf-8").includes(`Object.defineProperty(exports, "__esModule", { value: true });`)) {
-        fs.rmSync(file);
-      }
-      const files = fs.readdirSync(path.dirname(file));
-      if (files.length === 0) {
-        fs.rmdirSync(path.dirname(file));
-      }
-    }
-
-    return this;
-  }
-
-  /**
-   * step 5: rewrite variant external imports to correct path.
+   * step 4: rewrite variant external imports to correct path.
    * For submodule packages, this is a no-op since all variants are fully inlined.
    */
   async fixVariantImportPaths() {
@@ -438,7 +372,7 @@ module.exports = class Inliner {
   }
 
   /**
-   * step 6: validate the output.
+   * step 5: validate the output.
    * Checks that variant externals are referenced in the bundled index.
    */
   async validate() {

--- a/scripts/compilation/esm-to-cjs.js
+++ b/scripts/compilation/esm-to-cjs.js
@@ -14,7 +14,7 @@
  *   export class/function X    -> class/function X ...; exports.X = X
  *   export const/let/var X = V -> const/let/var X = V; exports.X = X
  *   await import("n")          -> require("n")
- *   import("n") (not awaited)  -> preserved
+ *   import("n") (not awaited)  -> ERROR (not supported)
  *
  * @internal
  */
@@ -24,6 +24,7 @@ const acorn = require("acorn");
 const ERR_DEFAULT_EXPORT = "default exports are not supported";
 const ERR_STRING_EXPORT = "string-literal export names are not supported";
 const ERR_DYNAMIC_IMPORT = "dynamic await import() with non-literal source is not supported";
+const ERR_NON_AWAITED_IMPORT = "non-awaited dynamic import() is not supported";
 
 const ImportDeclaration = "ImportDeclaration";
 const ExportNamedDeclaration = "ExportNamedDeclaration";
@@ -258,8 +259,8 @@ function transformExportNamed(node, src, innerEdits) {
 }
 
 /**
- * Stack-based AST walk. Converts `await import(x)` to `require(x)` while
- * leaving non-awaited dynamic imports untouched.
+ * Stack-based AST walk. Converts `await import(x)` to `require(x)` and
+ * throws on non-awaited dynamic imports.
  */
 function collectAwaitImports(ast, edits, src) {
   const stack = [ast];
@@ -287,6 +288,9 @@ function collectAwaitImports(ast, edits, src) {
       // Don't descend — the import expression is fully consumed.
       continue;
     }
+    if (node.type === ImportExpression) {
+      throw new Error(ERR_NON_AWAITED_IMPORT);
+    }
     for (const key in node) {
       if (SKIP_KEYS.has(key)) {
         continue;
@@ -312,7 +316,6 @@ module.exports = { transpile };
     `export { C } from "reexport";`,
     `export const foo = 1;`,
     `export const run = async () => { const m = await import("dynamic"); return m; };`,
-    `const p = import("lazy");`,
     `export * from "barrel2";`,
     `export const used = () => {};`,
     `const ref = used();`,
@@ -339,7 +342,6 @@ module.exports = { transpile };
   must(`exports.foo = 1;`);
   must(`exports.run = async () =>`);
   must(`require("dynamic")`);
-  must(`import("lazy")`);
   mustNot(`await import`);
   mustNot(`export `);
   mustNot(`const foo`);
@@ -347,4 +349,15 @@ module.exports = { transpile };
   // 'used' is referenced elsewhere -> two-line pattern
   must(`const used = () => {};`);
   must(`exports.used = used;`);
+
+  // Non-awaited dynamic import must throw.
+  let threw = false;
+  try {
+    transpile(`const p = import("lazy");`);
+  } catch (e) {
+    if (e.message === ERR_NON_AWAITED_IMPORT) {
+      threw = true;
+    }
+  }
+  if (!threw) throw new Error("esm-to-cjs self-test: non-awaited import() did not throw");
 })();

--- a/scripts/compilation/esm-to-cjs.js
+++ b/scripts/compilation/esm-to-cjs.js
@@ -40,7 +40,7 @@ const Literal = "Literal";
 
 // Keys that are never AST child nodes — skip during traversal to avoid
 // descending into primitives.
-const SKIP_KEYS = new Set(["type", "start", "end", "raw", "value", "sourceType"]);
+const SKIP_KEYS = new Set(["type", "start", "end", "raw", "sourceType"]);
 
 /**
  * @param {string} esmCode - ESM code.
@@ -55,16 +55,24 @@ function transpile(esmCode) {
 
   const edits = [];
   let hasExportStar = false;
+  const importedSymbols = new Set();
 
   for (let i = 0; i < ast.body.length; i++) {
     const node = ast.body[i];
     switch (node.type) {
       case ImportDeclaration:
         edits.push({ start: node.start, end: node.end, replacement: transformImport(node) });
+        for (const s of node.specifiers) {
+          importedSymbols.add(s.local.name);
+        }
         break;
       case ExportNamedDeclaration: {
         const inner = awaitImportEdits.filter((e) => e.start >= node.start && e.end <= node.end);
-        edits.push({ start: node.start, end: node.end, replacement: transformExportNamed(node, esmCode, inner) });
+        edits.push({
+          start: node.start,
+          end: node.end,
+          replacement: transformExportNamed(node, esmCode, inner, importedSymbols),
+        });
         break;
       }
       case ExportDefaultDeclaration:
@@ -169,7 +177,7 @@ function isNameUsedOutsideDecl(src, name, declStart, declEnd) {
   return false;
 }
 
-function transformExportNamed(node, src, innerEdits) {
+function transformExportNamed(node, src, innerEdits, importedSymbols) {
   for (let i = 0; i < node.specifiers.length; i++) {
     const s = node.specifiers[i];
     if (s.exported.type === Literal) {
@@ -238,13 +246,20 @@ function transformExportNamed(node, src, innerEdits) {
     let assignments = "";
     for (let i = 0; i < node.specifiers.length; i++) {
       const s = node.specifiers[i];
-      if (bindings) {
-        bindings += ", ";
+      if (importedSymbols.has(s.local.name)) {
+        assignments += "\nexports." + s.exported.name + " = " + s.local.name + ";";
+      } else {
+        if (bindings) {
+          bindings += ", ";
+        }
+        bindings += s.local.name === s.exported.name ? s.local.name : `${s.local.name}: ${s.exported.name}`;
+        assignments += "\nexports." + s.exported.name + " = " + s.exported.name + ";";
       }
-      bindings += s.local.name === s.exported.name ? s.local.name : `${s.local.name}: ${s.exported.name}`;
-      assignments += "\nexports." + s.exported.name + " = " + s.exported.name + ";";
     }
-    return `const { ${bindings} } = require(${source});` + assignments;
+    if (bindings) {
+      return `const { ${bindings} } = require(${source});` + assignments;
+    }
+    return assignments.slice(1);
   }
 
   let result = "";
@@ -359,5 +374,42 @@ module.exports = { transpile };
       threw = true;
     }
   }
-  if (!threw) throw new Error("esm-to-cjs self-test: non-awaited import() did not throw");
+  if (!threw) {
+    throw new Error("esm-to-cjs self-test: non-awaited import() must throw ERR_NON_AWAITED_IMPORT.");
+  }
+
+  // await import inside class method must be transformed.
+  const classSource = `import { foo } from "bar";
+class X { async load() { const { Y } = await import("baz"); return Y; } }
+export { X };`;
+  const classOut = transpile(classSource);
+  const classExpected = `const { foo } = require("bar");
+class X { async load() { const { Y } = require("baz"); return Y; } }
+exports.X = X;`;
+  if (classOut !== classExpected) {
+    throw new Error(
+      `esm-to-cjs self-test: class method mismatch
+  expected:
+    ${classExpected}
+  got:
+    ${classOut}`
+    );
+  }
+
+  // export-from must not re-declare already-imported symbols.
+  const dupSource = `import { A, B } from "pkg";\nexport { A, C } from "pkg";`;
+  const dupOut = transpile(dupSource);
+  if (dupOut.includes("const { A")) {
+    // A should only appear once as a const declaration
+    const matches = dupOut.match(/const \{[^}]*A[^}]*\}/g);
+    if (matches.length > 1) {
+      throw new Error(`esm-to-cjs self-test: duplicate declaration of A\nin:\n${dupOut}`);
+    }
+  }
+  if (!dupOut.includes("exports.A = A;")) {
+    throw new Error(`esm-to-cjs self-test: missing exports.A = A\nin:\n${dupOut}`);
+  }
+  if (!dupOut.includes("exports.C = C;")) {
+    throw new Error(`esm-to-cjs self-test: missing exports.C = C\nin:\n${dupOut}`);
+  }
 })();

--- a/scripts/compilation/inline.js
+++ b/scripts/compilation/inline.js
@@ -56,7 +56,6 @@ if (process.argv.includes("--setup")) {
     await inliner.discoverVariants();
     await inliner.bundle();
     await inliner.transformVariants();
-    await inliner.deleteUnreachableFiles();
     await inliner.fixVariantImportPaths();
     await inliner.validate();
   })();

--- a/scripts/validation/banned-imports.js
+++ b/scripts/validation/banned-imports.js
@@ -11,6 +11,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const walk = require("../utils/walk");
 const { extractImports, getPackageDirs, summarizePackages } = require("./validation-shared");
+const { parse } = require("acorn");
 
 const root = path.join(__dirname, "..", "..");
 
@@ -128,6 +129,62 @@ async function validate(packageDir) {
         continue;
       }
       const code = fs.readFileSync(file, "utf-8");
+
+      // dist-cjs must not contain any ESM including dynamic import.
+      if (dist === "dist-cjs") {
+        let ast;
+        try {
+          ast = parse(code, { ecmaVersion: "latest", sourceType: "module", allowHashBang: true, locations: true });
+        } catch {
+          ast = null;
+        }
+        if (ast) {
+          for (const node of ast.body) {
+            if (
+              node.type === "ImportDeclaration" ||
+              node.type === "ExportNamedDeclaration" ||
+              node.type === "ExportAllDeclaration" ||
+              node.type === "ExportDefaultDeclaration"
+            ) {
+              errors.push(
+                `[${pkgJson.name}] ESM including dynamic import is not allowed in dist-cjs (${path.relative(
+                  packageDir,
+                  file
+                )}:${node.loc?.start?.line ?? 1})`
+              );
+              break;
+            }
+          }
+          // Also check for dynamic import() expressions anywhere in the AST.
+          const queue = [ast];
+          let foundDynamic = false;
+          while (queue.length && !foundDynamic) {
+            const n = queue.pop();
+            if (!n || typeof n !== "object") continue;
+            if (Array.isArray(n)) {
+              queue.push(...n);
+              continue;
+            }
+            if (n.type === "ImportExpression") {
+              errors.push(
+                `[${pkgJson.name}] ESM including dynamic import is not allowed in dist-cjs (${path.relative(
+                  packageDir,
+                  file
+                )}:${n.loc?.start?.line ?? 1})`
+              );
+              foundDynamic = true;
+              break;
+            }
+            for (const key of Object.keys(n)) {
+              if (key === "type") continue;
+              const val = n[key];
+              if (Array.isArray(val)) queue.push(...val);
+              else if (val && typeof val === "object" && val.type) queue.push(val);
+            }
+          }
+        }
+      }
+
       for (const specifier of extractImports(code)) {
         if (allowed.has(specifier)) {
           continue;

--- a/scripts/validation/esm-compat.js
+++ b/scripts/validation/esm-compat.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that dist-cjs named exports are visible via ESM import().
+ * This confirms cjs-module-lexer can parse the generated CJS output.
+ *
+ * Usage: node esm-compat.js
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+const { getPackageDirs, summarizePackages } = require("./validation-shared");
+
+async function validateFile(filePath, label, errors) {
+  let cjsExports, esmNamespace;
+  try {
+    cjsExports = Object.keys(require(filePath));
+  } catch (e) {
+    errors.push(`[${label}] require() failed: ${e.message}`);
+    return;
+  }
+
+  try {
+    esmNamespace = await import(pathToFileURL(filePath).href);
+  } catch (e) {
+    errors.push(`[${label}] import() failed: ${e.message}`);
+    return;
+  }
+
+  const esmKeys = Object.keys(esmNamespace).filter((k) => k !== "default" && k !== "__esModule");
+  const missing = cjsExports.filter((k) => !esmKeys.includes(k));
+
+  if (missing.length) {
+    errors.push(
+      `[${label}] ${missing.length} exports not visible via import(): ${missing.slice(0, 5).join(", ")}${
+        missing.length > 5 ? "..." : ""
+      }`
+    );
+  }
+}
+
+const skip = new Set(["@smithy/util-test", "@aws-sdk/aws-util-test", "@aws-sdk/karma-credential-loader"]);
+
+async function main() {
+  const packages = getPackageDirs();
+  const errors = [];
+  const validated = [];
+
+  for (const { dir } of packages) {
+    const indexPath = path.join(dir, "dist-cjs", "index.js");
+    if (!fs.existsSync(indexPath)) {
+      continue;
+    }
+
+    const pkgJson = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf-8"));
+    if (skip.has(pkgJson.name)) {
+      continue;
+    }
+
+    await validateFile(indexPath, pkgJson.name, errors);
+    validated.push({ dir });
+
+    // Validate submodules.
+    const submodulesDir = path.join(dir, "src", "submodules");
+    if (pkgJson.exports && fs.existsSync(submodulesDir)) {
+      for (const sub of fs.readdirSync(submodulesDir)) {
+        const subIndex = path.join(dir, "dist-cjs", "submodules", sub, "index.js");
+        if (fs.existsSync(subIndex)) {
+          await validateFile(subIndex, `${pkgJson.name}/${sub}`, errors);
+        }
+      }
+    }
+  }
+
+  if (errors.length) {
+    console.error(`❌ ${errors.length} ESM compat issue(s):\n  ${errors.join("\n  ")}`);
+    process.exit(1);
+  }
+  console.log(`✅ All dist-cjs exports visible via import(). (${summarizePackages(validated)})`);
+}
+
+main();

--- a/scripts/validation/validate-all.js
+++ b/scripts/validation/validate-all.js
@@ -29,6 +29,7 @@ const VALIDATIONS = [
     script: "static-import-names.js",
   },
   { name: "banned-imports", label: "no banned imports in dist output", script: "banned-imports.js" },
+  { name: "esm-compat", label: "dist-cjs exports visible via ESM import()", script: "esm-compat.js" },
   { name: "export-names", label: "export function names match their keys", script: "export-names.js" },
   { name: "cycles", label: "no cyclical file or package dependencies", script: "cycles.js" },
   { name: "eslint", label: "eslint passes on source", script: "eslint.js" },


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/7420

### Description
Make rollup bundles using ESM configuration, then apply esm-to-cjs custom transform that includes validation.

- added validation that asserts dist-cjs contains no `import/export` statements at all, including dynamic `import()` (disregarding that it is runnable) 
- added validation that asserts dist-cjs imports the same symbol surface in `import()` and `require()` modes. 

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
