### PR TITLE
test(core): prebuild core before unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ bundles: build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle
 	node ./packages-internal/core/scripts/browser-build/esbuild.js
 
 test-unit: bundles
+	yarn workspace @aws-sdk/core run prebuild
 	yarn g:vitest run -c vitest.config.mts
 	yarn g:vitest run -c vitest.config.browser.mts
 	yarn g:vitest run -c vitest.config.clients.unit.mts


### PR DESCRIPTION
Adds `yarn workspace @aws-sdk/core run prebuild` as the first step of `make test-unit` to ensure core's partitions data is up to date before tests run.