### PR TITLE
test(core): prebuild before integration and e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,29 @@ login:
 sync:
 	make -f Makefile.private.mk sync
 
-bundles: build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle
-	node ./packages-internal/core/scripts/browser-build/esbuild.js
-
-test-unit: bundles
-	yarn workspace @aws-sdk/core run prebuild
+test-unit: bundles core-prebuild
 	yarn g:vitest run -c vitest.config.mts
 	yarn g:vitest run -c vitest.config.browser.mts
 	yarn g:vitest run -c vitest.config.clients.unit.mts
 	npx jest -c jest.config.js
+
+# run public API tests (no network requests).
+test-integration: bundles core-prebuild
+	rm -rf ./clients/client-sso/node_modules/\@smithy # todo(yarn) incompatible redundant nesting.
+	make static-analysis
+	node ./scripts/compilation/Inliner.spec.js
+	yarn g:vitest run -c vitest.config.integ.mts
+	make test-protocols
+	make test-types
+	make snapshot-compare
+	make test-indices
+	make test-endpoints
+
+# run all e2e tests (real services).
+test-e2e: bundles core-prebuild
+	yarn g:vitest run -c vitest.config.e2e.mts --retry.count=4 --retry.delay=20000 --test-timeout=60000 --hook-timeout=60000
+	make test-browser-cross-platform
+	make test-canary
 
 test-codegen:
 	cp ./private/aws-protocoltests-restjson-schema/package.json ./tmp/pkg.json.bak
@@ -55,18 +69,6 @@ snapshot-write:
 test-schema: bundles
 	yarn g:vitest run -c vitest.config.protocols-schema.integ.mts
 
-# run public API tests (no network requests).
-test-integration: bundles
-	rm -rf ./clients/client-sso/node_modules/\@smithy # todo(yarn) incompatible redundant nesting.
-	make static-analysis
-	node ./scripts/compilation/Inliner.spec.js
-	yarn g:vitest run -c vitest.config.integ.mts
-	make test-protocols
-	make test-types
-	make snapshot-compare
-	make test-indices
-	make test-endpoints
-
 api-snapshot:
 	node ./scripts/validation/api-snapshot.js
 	git diff --exit-code scripts/validation/api.json
@@ -76,12 +78,6 @@ update-lib-dynamodb-snapshot:
 
 test-endpoints:
 	npx vitest run -c ./tests/endpoints-2.0/vitest.config.mts
-
-# run all e2e tests (real services).
-test-e2e: bundles
-	yarn g:vitest run -c vitest.config.e2e.mts --retry.count=4 --retry.delay=20000 --test-timeout=60000 --hook-timeout=60000
-	make test-browser-cross-platform
-	make test-canary
 
 test-x: test-browser-cross-platform
 
@@ -99,6 +95,9 @@ reset-test-credentials:
 test-canary:
 	make test-bundlers;
 	node ./tests/canary/canary-runner.js
+
+bundles: build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle
+	node ./packages-internal/core/scripts/browser-build/esbuild.js
 
 test-bundlers:
 	node ./tests/bundlers/bundler-canary.mjs
@@ -163,3 +162,6 @@ clients:
 
 nested-clients:
 	node scripts/generate-clients/nested-clients/generate-nested-clients.js --exec
+
+core-prebuild:
+	yarn workspace @aws-sdk/core run prebuild

--- a/packages-internal/core/scripts/copy-partitions.js
+++ b/packages-internal/core/scripts/copy-partitions.js
@@ -6,5 +6,5 @@ const partitionsInfo = require(resolve(root, "..", "util-endpoints", "src", "lib
 
 writeFileSync(
   resolve(root, "src", "submodules", "client", "util-endpoints", "lib", "aws", "partitions.ts"),
-  "export const partitionsInfo = " + JSON.stringify(partitionsInfo) + ";\n"
+  "export const partitionsInfo = " + JSON.stringify(partitionsInfo, null, 2) + ";\n"
 );


### PR DESCRIPTION
### Issue
n/a

### Description
the core prebuild script isn't compatible with turbo because it isn't versioned, and has an input dependency on another package.

Manually add prebuild to the unit, integ, and e2e test targets.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
