### PR TITLE
fix(cloudfront-signer): filename asterisk apostrophe encoding fix

### DIFF
--- a/packages/cloudfront-signer/src/cloudfront-signer.e2e.spec.ts
+++ b/packages/cloudfront-signer/src/cloudfront-signer.e2e.spec.ts
@@ -287,4 +287,25 @@ describe("@aws-sdk/cloudfront-signer e2e", () => {
     const response = await fetch(signedUrl);
     expect(response.status).toBe(403);
   });
+
+  // https://github.com/aws/aws-sdk-js-v3/issues/8113
+  it("should access content when URL contains filename*=UTF-8'' with single quotes", async () => {
+    const encodedFilename = encodeURIComponent("テスト");
+    const signedUrl = getSignedUrl({
+      url: `https://${domain}/${OBJECT_KEY}?response-content-disposition=${encodeURIComponent(
+        `attachment;filename=test;filename*=UTF-8''${encodedFilename}`
+      )}`,
+      keyPairId,
+      privateKey,
+      dateLessThan: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // Single quotes must be percent-encoded as %27 for CloudFront signature verification
+    expect(signedUrl).toContain("%27%27");
+    expect(signedUrl).not.toContain("UTF-8''");
+
+    const response = await fetch(signedUrl);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(OBJECT_BODY);
+  });
 }, 660_000);

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -968,9 +968,43 @@ describe("url component encoding", () => {
     });
 
     const target =
-      "https://d111111abcdef8.cloudfront.net/private-content/private.jpeg?q=!%40%23%24%25%5E&*()=&image-description=aws's%20image&'''=&!()=5";
+      "https://d111111abcdef8.cloudfront.net/private-content/private.jpeg?q=!%40%23%24%25%5E&*()=&image-description=aws%27s%20image&%27%27%27=&!()=5";
 
     expect(signedUrl.slice(0, target.length)).toBe(target);
+  });
+
+  // https://github.com/aws/aws-sdk-js-v3/issues/8113
+  it("should encode single quotes in filename*=UTF-8'' query values", () => {
+    const encodedFilename = encodeURIComponent("文件");
+    const urlWithFilename = `https://d111111abcdef8.cloudfront.net/path?response-content-disposition=attachment;filename=test;filename*=UTF-8''${encodedFilename}`;
+    const signedUrl = getSignedUrl({
+      url: urlWithFilename,
+      keyPairId,
+      privateKey,
+      dateLessThan: "2026-01-01",
+    });
+
+    // Single quotes in the query value must be encoded as %27 so the signature
+    // matches what CloudFront normalizes the URL to before verification.
+    expect(signedUrl).toContain("UTF-8%27%27%E6%96%87%E4%BB%B6");
+    expect(signedUrl).not.toContain("UTF-8''");
+
+    // Verify the signature is valid against the policy containing the encoded URL
+    const parsedUrl = parseUrl(signedUrl);
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: `https://d111111abcdef8.cloudfront.net/path?response-content-disposition=attachment%3Bfilename%3Dtest%3Bfilename*%3DUTF-8%27%27%E6%96%87%E4%BB%B6`,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": Math.round(new Date("2026-01-01").getTime() / 1000),
+            },
+          },
+        },
+      ],
+    });
+    const signatureQueryParam = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    expect(verifySignature(signatureQueryParam, policyStr)).toBeTruthy();
   });
 });
 

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -307,11 +307,16 @@ function encodeUrlPath(url: string): string {
     }
   });
 
-  // Re-encode query parameters if present
+  // Re-encode query parameters if present.
+  // Single quotes must be encoded as %27 because CloudFront normalizes them
+  // before verifying signatures. encodeURIComponent does not encode quotes,
+  // so we replace them explicitly.
   let encodedQuery = "";
   if (rawQuery) {
     for (const [key, value] of new URLSearchParams(rawQuery.slice(1)).entries()) {
-      encodedQuery += `${encodedQuery ? "&" : "?"}${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+      encodedQuery += `${encodedQuery ? "&" : "?"}${encodeURIComponent(key).replace(/'/g, "%27")}=${encodeURIComponent(
+        value
+      ).replace(/'/g, "%27")}`;
     }
   }
 


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8113

### Description
Fix for filename encoding.

### Testing
CI, new e2e tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
