### PR TITLE
feat(lib-transfer-manager): add uploadDirectory functionality

### DIFF
--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.e2e.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.e2e.spec.ts
@@ -2,10 +2,13 @@ import { getE2eTestResources } from "@aws-sdk/aws-util-test/src";
 import type { GetObjectCommandOutput } from "@aws-sdk/client-s3";
 import { S3 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeAll, describe, expect, test as it } from "vitest";
 
 import { internalEventHandler, S3TransferManager } from "./S3TransferManager";
-import type { S3TransferManagerConfig } from "./types";
+import { type S3TransferManagerConfig,CannedFailurePolicy } from "./types";
 
 describe(S3TransferManager.name, () => {
   const chunk = "01234567";
@@ -571,5 +574,227 @@ describe(S3TransferManager.name, () => {
 
       await client.deleteObject({ Bucket, Key });
     }, 60_000);
+  });
+
+  describe("uploadDirectory tests", () => {
+    const prefix = `upload-dir-e2e-${Date.now()}`;
+
+    async function cleanupS3Objects(s3Prefix: string) {
+      const listed = await client.listObjectsV2({ Bucket, Prefix: s3Prefix });
+      if (listed.Contents?.length) {
+        await Promise.all(
+          listed.Contents.map((obj) => client.deleteObject({ Bucket, Key: obj.Key! }))
+        );
+      }
+    }
+
+    it("should upload directory recursively", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
+      await writeFile(join(tmpDir, "photo1.jpg"), data(2048576));
+      await mkdir(join(tmpDir, "2023", "jan"), { recursive: true });
+      await writeFile(join(tmpDir, "2023", "jan", "photo2.jpg"), data(1048576));
+      await writeFile(join(tmpDir, "readme.txt"), data(1024));
+
+      const s3Prefix = `${prefix}/recursive`;
+      const tm = new S3TransferManager({ s3: client });
+
+      try {
+        const result = await tm.uploadDirectory({
+          bucket: Bucket,
+          source: tmpDir,
+          recursive: true,
+          s3Prefix,
+        });
+
+        expect(result.objectsUploaded).toBe(3);
+        expect(result.objectsFailed).toBe(0);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+        await cleanupS3Objects(s3Prefix);
+      }
+    });
+
+    it("should upload directory with s3Prefix", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
+      await writeFile(join(tmpDir, "file1.txt"), data(1024));
+      await mkdir(join(tmpDir, "sub"));
+      await writeFile(join(tmpDir, "sub", "file2.txt"), data(1024));
+
+      const s3Prefix = `${prefix}/backup`;
+      const tm = new S3TransferManager({ s3: client });
+
+      try {
+        const result = await tm.uploadDirectory({
+          bucket: Bucket,
+          source: tmpDir,
+          recursive: true,
+          s3Prefix,
+        });
+
+        expect(result.objectsUploaded).toBe(2);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+        await cleanupS3Objects(s3Prefix);
+      }
+    });
+
+    it("should upload only root-level files when non-recursive", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
+      await writeFile(join(tmpDir, "file1.txt"), data(1048576));
+      await mkdir(join(tmpDir, "subdir"));
+      await writeFile(join(tmpDir, "subdir", "file2.txt"), data(2048576));
+
+      const s3Prefix = `${prefix}/nonrecursive`;
+      const tm = new S3TransferManager({ s3: client });
+
+      try {
+        const result = await tm.uploadDirectory({
+          bucket: Bucket,
+          source: tmpDir,
+          recursive: false,
+          s3Prefix,
+        });
+
+        expect(result.objectsUploaded).toBe(1);
+        expect(result.objectsFailed).toBe(0);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+        await cleanupS3Objects(s3Prefix);
+      }
+    });
+
+    it("should apply filter to only upload the files that match.", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
+      await writeFile(join(tmpDir, "image.jpg"), data(2048576));
+      await writeFile(join(tmpDir, "document.txt"), data(2048576));
+
+      const s3Prefix = `${prefix}/filtered`;
+      const tm = new S3TransferManager({ s3: client });
+
+      try {
+        const result = await tm.uploadDirectory({
+          bucket: Bucket,
+          source: tmpDir,
+          recursive: true,
+          s3Prefix,
+          filter: (filePath) => filePath.endsWith(".jpg"),
+        });
+
+        expect(result.objectsUploaded).toBe(1);
+        expect(result.objectsFailed).toBe(0);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+        await cleanupS3Objects(s3Prefix);
+      }
+    });
+
+    it("test upload directory - failure handling with continue policy", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
+      await writeFile(join(tmpDir, "good.txt"), data(1024));
+      await writeFile(join(tmpDir, "bad.txt"), data(1024));
+
+      const s3Prefix = `${prefix}/continue-policy`;
+      const tm = new S3TransferManager({ s3: client });
+
+      try {
+        const result = await tm.uploadDirectory({
+          bucket: Bucket,
+          source: tmpDir,
+          recursive: true,
+          s3Prefix,
+          failurePolicy: CannedFailurePolicy.Continue,
+          uploadObjectRequestModifier: (req) => {
+            if (req.Key?.endsWith("bad.txt")) {
+              return { ...req, Bucket: "nonexistent-bucket-xyz-12345" };
+            }
+            return req;
+          },
+        });
+
+        expect(result.objectsUploaded).toBe(1);
+        expect(result.objectsFailed).toBe(1);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+        await cleanupS3Objects(s3Prefix);
+      }
+    });
+
+    // waiting on some information form sep author
+    it.skip("should terminate on first failure with default policy", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
+      await writeFile(join(tmpDir, "file1.txt"), data(1024));
+      await writeFile(join(tmpDir, "file2.txt"), data(1024));
+
+      const s3Prefix = `${prefix}/terminate-policy`;
+      const tm = new S3TransferManager({ s3: client });
+
+      try {
+        await expect(
+          tm.uploadDirectory({
+            bucket: "nonexistent-bucket-xyz-12345",
+            source: tmpDir,
+            recursive: true,
+            s3Prefix,
+          })
+        ).rejects.toThrow();
+      } finally {
+        await rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should handle empty directory", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
+
+      const tm = new S3TransferManager({ s3: client });
+
+      try {
+        const result = await tm.uploadDirectory({
+          bucket: Bucket,
+          source: tmpDir,
+          recursive: true,
+        });
+
+        expect(result.objectsUploaded).toBe(0);
+        expect(result.objectsFailed).toBe(0);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should throw when source directory does not exist", async () => {
+      const tm = new S3TransferManager({ s3: client });
+
+      await expect(
+        tm.uploadDirectory({
+          bucket: Bucket,
+          source: "/nonexistent/path/e2e-test",
+          recursive: true,
+        })
+      ).rejects.toThrow("Directory does not exist");
+    });
+
+    it("should use multipart upload for large files in directory", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
+      await writeFile(join(tmpDir, "large-video.mp4"), data(20 * 1024 * 1024));
+      await writeFile(join(tmpDir, "metadata.txt"), data(2048));
+
+      const s3Prefix = `${prefix}/multipart`;
+      const tm = new S3TransferManager({ s3: client });
+
+      try {
+        const result = await tm.uploadDirectory({
+          bucket: Bucket,
+          source: tmpDir,
+          recursive: false,
+          s3Prefix,
+        });
+
+        expect(result.objectsUploaded).toBe(2);
+        expect(result.objectsFailed).toBe(0);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+        await cleanupS3Objects(s3Prefix);
+      }
+    });
   });
 });

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.e2e.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.e2e.spec.ts
@@ -8,7 +8,7 @@ import { join } from "node:path";
 import { afterEach, beforeAll, describe, expect, test as it } from "vitest";
 
 import { internalEventHandler, S3TransferManager } from "./S3TransferManager";
-import { type DirectoryProgressSnapshot, type S3TransferManagerConfig, CannedFailurePolicy } from "./types";
+import { type CannedFailurePolicy,type DirectoryProgressSnapshot, type S3TransferManagerConfig } from "./types";
 
 describe(S3TransferManager.name, () => {
   const chunk = "01234567";
@@ -702,7 +702,7 @@ describe(S3TransferManager.name, () => {
           source: tmpDir,
           recursive: true,
           s3Prefix,
-          failurePolicy: CannedFailurePolicy.Continue,
+          failurePolicy: "continue" as CannedFailurePolicy,
           uploadObjectRequestModifier: (req) => {
             if (req.Key?.endsWith("bad.txt")) {
               return { ...req, Bucket: "nonexistent-bucket-xyz-12345" };
@@ -875,7 +875,7 @@ describe(S3TransferManager.name, () => {
           source: "/nonexistent/path/e2e-test",
           recursive: true,
         })
-      ).rejects.toThrow("Directory does not exist");
+      ).rejects.toThrow("Cannot access directory at");
     });
 
     it("should use multipart upload for large files in directory", async () => {

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.e2e.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.e2e.spec.ts
@@ -8,7 +8,7 @@ import { join } from "node:path";
 import { afterEach, beforeAll, describe, expect, test as it } from "vitest";
 
 import { internalEventHandler, S3TransferManager } from "./S3TransferManager";
-import { type S3TransferManagerConfig,CannedFailurePolicy } from "./types";
+import { type DirectoryProgressSnapshot, type S3TransferManagerConfig, CannedFailurePolicy } from "./types";
 
 describe(S3TransferManager.name, () => {
   const chunk = "01234567";
@@ -719,8 +719,7 @@ describe(S3TransferManager.name, () => {
       }
     });
 
-    // waiting on some information form sep author
-    it.skip("should terminate on first failure with default policy", async () => {
+    it("should terminate on first failure with default policy", async () => {
       const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
       await writeFile(join(tmpDir, "file1.txt"), data(1024));
       await writeFile(join(tmpDir, "file2.txt"), data(1024));
@@ -760,6 +759,112 @@ describe(S3TransferManager.name, () => {
         await rm(tmpDir, { recursive: true });
       }
     });
+
+    it("should report directory upload transfer progress via event listeners", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
+      await writeFile(join(tmpDir, "file1.txt"), data(1024));
+      await writeFile(join(tmpDir, "file2.txt"), data(2048));
+      await mkdir(join(tmpDir, "sub"));
+      await writeFile(join(tmpDir, "sub", "file3.txt"), data(4096));
+
+      const s3Prefix = `${prefix}/progress`;
+      const tm = new S3TransferManager({ s3: client });
+
+      let initiated = false;
+      let completed = false;
+      const progressSnapshots: DirectoryProgressSnapshot[] = [];
+
+      try {
+        const result = await tm.uploadDirectory(
+          {
+            bucket: Bucket,
+            source: tmpDir,
+            recursive: true,
+            s3Prefix,
+          },
+          {
+            eventListeners: {
+              transferInitiated: [
+                (event) => {
+                  const snapshot = event.snapshot as DirectoryProgressSnapshot;
+                  if ("transferredFiles" in event.snapshot) {
+                    initiated = true;
+                    expect(snapshot.transferredBytes).toBe(0);
+                    expect(snapshot.transferredFiles).toBe(0);
+                    expect(snapshot.totalFiles).toBeUndefined();
+                  }
+                },
+              ],
+              bytesTransferred: [
+                (event) => {
+                  if ("transferredFiles" in event.snapshot) {
+                    progressSnapshots.push({ ...(event.snapshot as DirectoryProgressSnapshot) });
+                  }
+                },
+              ],
+              transferComplete: [
+                (event) => {
+                  if ("transferredFiles" in event.snapshot) {
+                    completed = true;
+                    const snapshot = event.snapshot as DirectoryProgressSnapshot;
+                    expect(snapshot.transferredFiles).toBe(3);
+                    expect(snapshot.totalFiles).toBe(3);
+                    expect(snapshot.transferredBytes).toBe(1024 + 2048 + 4096);
+                  }
+                },
+              ],
+            },
+          }
+        );
+
+        expect(initiated).toBe(true);
+        expect(completed).toBe(true);
+        expect(progressSnapshots.length).toBe(3);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+        await cleanupS3Objects(s3Prefix);
+      }
+    }, 60_000);
+
+    it("should report transferFailed event on terminate policy", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-uploaddir-"));
+      await writeFile(join(tmpDir, "file1.txt"), data(1024));
+
+      const s3Prefix = `${prefix}/progress-fail`;
+      const tm = new S3TransferManager({ s3: client });
+
+      let failedEvent = false;
+
+      try {
+        await tm.uploadDirectory(
+          {
+            bucket: "nonexistent-bucket-xyz-12345",
+            source: tmpDir,
+            recursive: true,
+            s3Prefix,
+          },
+          {
+            eventListeners: {
+              transferFailed: [
+                (event) => {
+                  if ("transferredFiles" in event.snapshot) {
+                    failedEvent = true;
+                    const snapshot = event.snapshot as DirectoryProgressSnapshot;
+                    expect(snapshot.transferredFiles).toBe(0);
+                    expect(snapshot.totalFiles).toBe(1);
+                  }
+                },
+              ],
+            },
+          }
+        );
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect(failedEvent).toBe(true);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+      }
+    }, 60_000);
 
     it("should throw when source directory does not exist", async () => {
       const tm = new S3TransferManager({ s3: client });

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
@@ -1,9 +1,13 @@
 import { S3, S3Client } from "@aws-sdk/client-s3";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { Readable } from "node:stream";
 import { beforeAll, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import { S3TransferManager } from "./S3TransferManager";
 import type { TransferCompleteEvent, TransferEvent } from "./types";
+import { CannedFailurePolicy } from "./types";
 import { WorkerHttpHandler } from "./worker-http-handler";
 
 describe("S3TransferManager Unit Tests", () => {
@@ -1318,4 +1322,393 @@ describe("S3TransferManager Unit Tests", () => {
       expect(createCalls[0].input.ChecksumAlgorithm).toBe("CRC32");
     });
   });
+
+  describe("uploadDirectory", () => {
+    let mockSend: any;
+    let sendCalls: any[];
+
+    function createMockClient() {
+      sendCalls = [];
+      mockSend = vi.fn().mockImplementation((command: any) => {
+        sendCalls.push(command);
+        return Promise.resolve({ ETag: '"mock-etag"', $metadata: {} });
+      });
+      return { send: mockSend, config: {} } as any;
+    }
+
+    it("should upload only root-level files when recursive is false", async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      await fs.writeFile(path.join(tmpDir, "file1.txt"), "hello");
+      await fs.writeFile(path.join(tmpDir, "file2.txt"), "world");
+      await fs.mkdir(path.join(tmpDir, "subdir"));
+      await fs.writeFile(path.join(tmpDir, "subdir", "nested1.txt"), "nested1");
+      await fs.writeFile(path.join(tmpDir, "subdir", "nested2.txt"), "nested2");
+
+      try {
+        const mockClient = createMockClient();
+        const tm = new S3TransferManager({ s3: mockClient});
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          recursive: false,
+        });
+
+        expect(result.objectsUploaded).toBe(2);
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should upload all files including nested directories when recursive is true", async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      await fs.writeFile(path.join(tmpDir, "file1.txt"), "hello");
+      await fs.writeFile(path.join(tmpDir, "file2.txt"), "world");
+      await fs.mkdir(path.join(tmpDir, "subdir"));
+      await fs.writeFile(path.join(tmpDir, "subdir", "nested1.txt"), "nested1");
+      await fs.writeFile(path.join(tmpDir, "subdir", "nested2.txt"), "nested2");
+
+      try {
+        const mockClient = createMockClient();
+        const tm = new S3TransferManager({ s3: mockClient});
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          recursive: true,
+        });
+
+        expect(result.objectsUploaded).toBe(4);
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should apply filter to skip files", async () => {
+
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      await fs.writeFile(path.join(tmpDir, "file1.txt"), "file to include 1");
+      await fs.writeFile(path.join(tmpDir, "file2.log"), "don't include this file");
+      await fs.writeFile(path.join(tmpDir, "file3.txt"), "file to include 2"); 
+      try {
+        const mockClient = createMockClient();
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          filter: (filePath: string) => filePath.endsWith(".txt"),
+        });
+
+        expect(result.objectsUploaded).toBe(2);
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should prepend s3Prefix to keys", async () => {
+
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      await fs.writeFile(path.join(tmpDir, "root.txt"), "root content");
+      await fs.mkdir(path.join(tmpDir, "subdir"));
+      await fs.writeFile(path.join(tmpDir, "subdir", "nested.txt"), "nested content");
+
+      try {
+        const mockClient = createMockClient();
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          s3Prefix: "uploadAll-prefix",
+          recursive: true,
+        });
+
+        expect(result.objectsUploaded).toBe(2);
+        const keys = sendCalls.map((c: any) => c.input.Key);
+        expect(keys).toContain("uploadAll-prefix/root.txt");
+        expect(keys).toContain("uploadAll-prefix/subdir/nested.txt");
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should terminate on failure with terminate policy", async () => {
+
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
+      await fs.writeFile(path.join(tmpDir, "file2.txt"), "content2");
+      await fs.writeFile(path.join(tmpDir, "file3.txt"), "content3");
+      await fs.writeFile(path.join(tmpDir, "file3.txt"), "content4");
+
+      try {
+        const mockClient = {
+          send: vi.fn().mockRejectedValue(new Error("S3 error")),
+          config: {},
+        } as any;
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          failurePolicy: CannedFailurePolicy.Terminate,
+          maxConcurrency: 2,
+        });
+
+        expect(result.objectsUploaded).toBe(0);
+        expect(result.objectsFailed).toBeGreaterThanOrEqual(1);
+        // With maxConcurrency=2, at most 2 files are dispatched before terminate stops picking up new files.
+        expect(mockClient.send.mock.calls.length).toBeLessThanOrEqual(2);
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should continue on failure with continue policy", async () => {
+
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-test-"));
+      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
+      await fs.writeFile(path.join(tmpDir, "file2.txt"), "content2");
+
+      try {
+        let callCount = 0;
+        const mockClient = {
+          send: vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) return Promise.reject(new Error("S3 error"));
+            return Promise.resolve({ ETag: '"mock-etag"', $metadata: {} });
+          }),
+          config: {},
+        } as any;
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          failurePolicy: CannedFailurePolicy.Continue,
+        });
+
+        expect(result.objectsFailed).toBe(1);
+        expect(result.objectsUploaded).toBe(1);
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should continue on transient errors and terminate on non-retryable errors with custom policy", async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
+      await fs.writeFile(path.join(tmpDir, "file2.txt"), "content2");
+      await fs.writeFile(path.join(tmpDir, "file3.txt"), "content3");
+      await fs.writeFile(path.join(tmpDir, "file4.txt"), "content4");
+
+      try {
+        let callCount = 0;
+        const mockClient = {
+          send: vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) {
+              const err = new Error("Request timed out");
+              err.name = "TimeoutError";
+              return Promise.reject(err);
+            }
+            if (callCount === 2) {
+              return Promise.resolve({ ETag: '"mock-etag"', $metadata: {} });
+            }
+            if (callCount === 3) {
+              const err = new Error("Service unavailable");
+              err.name = "ServiceUnavailable";
+              return Promise.reject(err);
+            }
+            return Promise.resolve({ ETag: '"mock-etag"', $metadata: {} });
+          }),
+          config: {},
+        } as any;
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        const customPolicy = async (context: any) => {
+          const errorName = context.error?.name;
+          if (errorName === "TimeoutError" || errorName === "ServiceUnavailable" || errorName === "ThrottlingException") {
+            return "continue" as const;
+          }
+          return "terminate" as const;
+        };
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          failurePolicy: customPolicy,
+          maxConcurrency: 1,
+        });
+
+        expect(result.objectsFailed).toBe(2);
+        expect(result.objectsUploaded).toBe(2);
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should terminate when custom policy encounters non-retryable error", async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
+      await fs.writeFile(path.join(tmpDir, "file2.txt"), "content2");
+      await fs.writeFile(path.join(tmpDir, "file3.txt"), "content3");
+      await fs.writeFile(path.join(tmpDir, "file4.txt"), "content4");
+      await fs.writeFile(path.join(tmpDir, "file5.txt"), "content5");
+
+      try {
+        let callCount = 0;
+        const mockClient = {
+          send: vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) {
+              return Promise.resolve({ ETag: '"mock-etag"', $metadata: {} });
+            }
+            if (callCount === 2) {
+              return Promise.resolve({ ETag: '"mock-etag"', $metadata: {} });
+            }
+            if (callCount === 3) {
+              const err = new Error("Access Denied");
+              err.name = "AccessDenied";
+              return Promise.reject(err);
+            }
+            return Promise.resolve({ ETag: '"mock-etag"', $metadata: {} });
+          }),
+          config: {},
+        } as any;
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        const customPolicy = async (context: any) => {
+          const errorName = context.error?.name;
+          if (errorName === "TimeoutError" || errorName === "ServiceUnavailable" || errorName === "ThrottlingException") {
+            return "continue" as const;
+          }
+          return "terminate" as const;
+        };
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          failurePolicy: customPolicy,
+          maxConcurrency: 1,
+        });
+
+        expect(result.objectsUploaded).toBe(2);
+        expect(result.objectsFailed).toBe(1);
+        // file1 and file2 succeeded, file3 failed with AccessDenied → terminate
+        // file4 and file5 should not have been attempted
+        expect(mockClient.send.mock.calls.length).toBeLessThanOrEqual(3);
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should apply uploadObjectRequestModifier to override request fields", async () => {
+
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
+      await fs.writeFile(path.join(tmpDir, "file2.txt"), "content2");
+
+      try {
+        const mockClient = createMockClient();
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          uploadObjectRequestModifier: (req) => ({
+            ...req,
+            Bucket: "override-bucket"
+          }),
+        });
+
+        for (const call of sendCalls) {
+          expect(call.input.Bucket).toBe("override-bucket");
+        }
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should propagate exceptions thrown in uploadObjectRequestModifier", async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
+
+      try {
+        const mockClient = createMockClient();
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          uploadObjectRequestModifier: () => {
+            throw new Error("uploadObjectRequestModifier failed");
+          },
+        });
+
+        expect(result.objectsUploaded).toBe(0);
+        expect(result.objectsFailed).toBe(1);
+        expect(mockClient.send).not.toHaveBeenCalled();
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should throw when source directory does not exist", async () => {
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({ s3: mockClient });
+
+      await expect(
+        tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: "/nonexistent/path/abc123",
+        })
+      ).rejects.toThrow("Directory does not exist");
+    });
+
+    it("should abort when transferOptions.abortSignal is triggered", async () => {
+
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      await fs.writeFile(path.join(tmpDir, "file.txt"), "content");
+
+      try {
+        const ac = new AbortController();
+        ac.abort();
+
+        const mockClient = createMockClient();
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        await expect(
+          tm.uploadDirectory({
+            bucket: "test-bucket",
+            source: tmpDir,
+          }, { abortSignal: ac.signal })
+        ).rejects.toThrow("Transfer aborted");
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+
+    it("should return zero counts for empty directory", async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+
+      try {
+        const mockClient = createMockClient();
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          recursive: true,
+        });
+
+        expect(result.objectsUploaded).toBe(0);
+        expect(result.objectsFailed).toBe(0);
+        expect(mockClient.send).not.toHaveBeenCalled();
+      } finally {
+        await fs.rm(tmpDir, { recursive: true });
+      }
+    });
+  });
+
 });

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
@@ -1,7 +1,7 @@
 import { S3, S3Client } from "@aws-sdk/client-s3";
-import * as fs from "node:fs/promises";
-import * as os from "node:os";
-import * as path from "node:path";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Readable } from "node:stream";
 import { beforeAll, beforeEach, describe, expect, test as it, vi } from "vitest";
 
@@ -1337,12 +1337,12 @@ describe("S3TransferManager Unit Tests", () => {
     }
 
     it("should upload only root-level files when recursive is false", async () => {
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
-      await fs.writeFile(path.join(tmpDir, "file1.txt"), "hello");
-      await fs.writeFile(path.join(tmpDir, "file2.txt"), "world");
-      await fs.mkdir(path.join(tmpDir, "subdir"));
-      await fs.writeFile(path.join(tmpDir, "subdir", "nested1.txt"), "nested1");
-      await fs.writeFile(path.join(tmpDir, "subdir", "nested2.txt"), "nested2");
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "file1.txt"), "hello");
+      await writeFile(join(tmpDir, "file2.txt"), "world");
+      await mkdir(join(tmpDir, "subdir"));
+      await writeFile(join(tmpDir, "subdir", "nested1.txt"), "nested1");
+      await writeFile(join(tmpDir, "subdir", "nested2.txt"), "nested2");
 
       try {
         const mockClient = createMockClient();
@@ -1356,17 +1356,17 @@ describe("S3TransferManager Unit Tests", () => {
 
         expect(result.objectsUploaded).toBe(2);
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
     it("should upload all files including nested directories when recursive is true", async () => {
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
-      await fs.writeFile(path.join(tmpDir, "file1.txt"), "hello");
-      await fs.writeFile(path.join(tmpDir, "file2.txt"), "world");
-      await fs.mkdir(path.join(tmpDir, "subdir"));
-      await fs.writeFile(path.join(tmpDir, "subdir", "nested1.txt"), "nested1");
-      await fs.writeFile(path.join(tmpDir, "subdir", "nested2.txt"), "nested2");
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "file1.txt"), "hello");
+      await writeFile(join(tmpDir, "file2.txt"), "world");
+      await mkdir(join(tmpDir, "subdir"));
+      await writeFile(join(tmpDir, "subdir", "nested1.txt"), "nested1");
+      await writeFile(join(tmpDir, "subdir", "nested2.txt"), "nested2");
 
       try {
         const mockClient = createMockClient();
@@ -1380,16 +1380,16 @@ describe("S3TransferManager Unit Tests", () => {
 
         expect(result.objectsUploaded).toBe(4);
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
     it("should apply filter to skip files", async () => {
 
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
-      await fs.writeFile(path.join(tmpDir, "file1.txt"), "file to include 1");
-      await fs.writeFile(path.join(tmpDir, "file2.log"), "don't include this file");
-      await fs.writeFile(path.join(tmpDir, "file3.txt"), "file to include 2"); 
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "file1.txt"), "file to include 1");
+      await writeFile(join(tmpDir, "file2.log"), "don't include this file");
+      await writeFile(join(tmpDir, "file3.txt"), "file to include 2"); 
       try {
         const mockClient = createMockClient();
         const tm = new S3TransferManager({ s3: mockClient });
@@ -1402,16 +1402,16 @@ describe("S3TransferManager Unit Tests", () => {
 
         expect(result.objectsUploaded).toBe(2);
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
     it("should prepend s3Prefix to keys", async () => {
 
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
-      await fs.writeFile(path.join(tmpDir, "root.txt"), "root content");
-      await fs.mkdir(path.join(tmpDir, "subdir"));
-      await fs.writeFile(path.join(tmpDir, "subdir", "nested.txt"), "nested content");
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "root.txt"), "root content");
+      await mkdir(join(tmpDir, "subdir"));
+      await writeFile(join(tmpDir, "subdir", "nested.txt"), "nested content");
 
       try {
         const mockClient = createMockClient();
@@ -1429,17 +1429,17 @@ describe("S3TransferManager Unit Tests", () => {
         expect(keys).toContain("uploadAll-prefix/root.txt");
         expect(keys).toContain("uploadAll-prefix/subdir/nested.txt");
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
     it("should terminate on failure with terminate policy", async () => {
 
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
-      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
-      await fs.writeFile(path.join(tmpDir, "file2.txt"), "content2");
-      await fs.writeFile(path.join(tmpDir, "file3.txt"), "content3");
-      await fs.writeFile(path.join(tmpDir, "file3.txt"), "content4");
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "file1.txt"), "content1");
+      await writeFile(join(tmpDir, "file2.txt"), "content2");
+      await writeFile(join(tmpDir, "file3.txt"), "content3");
+      await writeFile(join(tmpDir, "file3.txt"), "content4");
 
       try {
         const mockClient = {
@@ -1448,27 +1448,27 @@ describe("S3TransferManager Unit Tests", () => {
         } as any;
         const tm = new S3TransferManager({ s3: mockClient });
 
-        const result = await tm.uploadDirectory({
-          bucket: "test-bucket",
-          source: tmpDir,
-          failurePolicy: CannedFailurePolicy.Terminate,
-          maxConcurrency: 2,
-        });
+        await expect(
+          tm.uploadDirectory({
+            bucket: "test-bucket",
+            source: tmpDir,
+            failurePolicy: CannedFailurePolicy.Terminate,
+            maxConcurrency: 2,
+          })
+        ).rejects.toThrow("S3 error");
 
-        expect(result.objectsUploaded).toBe(0);
-        expect(result.objectsFailed).toBeGreaterThanOrEqual(1);
         // With maxConcurrency=2, at most 2 files are dispatched before terminate stops picking up new files.
         expect(mockClient.send.mock.calls.length).toBeLessThanOrEqual(2);
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
     it("should continue on failure with continue policy", async () => {
 
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-test-"));
-      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
-      await fs.writeFile(path.join(tmpDir, "file2.txt"), "content2");
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-test-"));
+      await writeFile(join(tmpDir, "file1.txt"), "content1");
+      await writeFile(join(tmpDir, "file2.txt"), "content2");
 
       try {
         let callCount = 0;
@@ -1491,16 +1491,16 @@ describe("S3TransferManager Unit Tests", () => {
         expect(result.objectsFailed).toBe(1);
         expect(result.objectsUploaded).toBe(1);
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
     it("should continue on transient errors and terminate on non-retryable errors with custom policy", async () => {
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
-      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
-      await fs.writeFile(path.join(tmpDir, "file2.txt"), "content2");
-      await fs.writeFile(path.join(tmpDir, "file3.txt"), "content3");
-      await fs.writeFile(path.join(tmpDir, "file4.txt"), "content4");
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "file1.txt"), "content1");
+      await writeFile(join(tmpDir, "file2.txt"), "content2");
+      await writeFile(join(tmpDir, "file3.txt"), "content3");
+      await writeFile(join(tmpDir, "file4.txt"), "content4");
 
       try {
         let callCount = 0;
@@ -1544,17 +1544,17 @@ describe("S3TransferManager Unit Tests", () => {
         expect(result.objectsFailed).toBe(2);
         expect(result.objectsUploaded).toBe(2);
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
     it("should terminate when custom policy encounters non-retryable error", async () => {
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
-      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
-      await fs.writeFile(path.join(tmpDir, "file2.txt"), "content2");
-      await fs.writeFile(path.join(tmpDir, "file3.txt"), "content3");
-      await fs.writeFile(path.join(tmpDir, "file4.txt"), "content4");
-      await fs.writeFile(path.join(tmpDir, "file5.txt"), "content5");
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "file1.txt"), "content1");
+      await writeFile(join(tmpDir, "file2.txt"), "content2");
+      await writeFile(join(tmpDir, "file3.txt"), "content3");
+      await writeFile(join(tmpDir, "file4.txt"), "content4");
+      await writeFile(join(tmpDir, "file5.txt"), "content5");
 
       try {
         let callCount = 0;
@@ -1586,28 +1586,28 @@ describe("S3TransferManager Unit Tests", () => {
           return "terminate" as const;
         };
 
-        const result = await tm.uploadDirectory({
-          bucket: "test-bucket",
-          source: tmpDir,
-          failurePolicy: customPolicy,
-          maxConcurrency: 1,
-        });
+        await expect(
+          tm.uploadDirectory({
+            bucket: "test-bucket",
+            source: tmpDir,
+            failurePolicy: customPolicy,
+            maxConcurrency: 1,
+          })
+        ).rejects.toThrow("Access Denied");
 
-        expect(result.objectsUploaded).toBe(2);
-        expect(result.objectsFailed).toBe(1);
         // file1 and file2 succeeded, file3 failed with AccessDenied → terminate
         // file4 and file5 should not have been attempted
         expect(mockClient.send.mock.calls.length).toBeLessThanOrEqual(3);
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
     it("should apply uploadObjectRequestModifier to override request fields", async () => {
 
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
-      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
-      await fs.writeFile(path.join(tmpDir, "file2.txt"), "content2");
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "file1.txt"), "content1");
+      await writeFile(join(tmpDir, "file2.txt"), "content2");
 
       try {
         const mockClient = createMockClient();
@@ -1626,31 +1626,31 @@ describe("S3TransferManager Unit Tests", () => {
           expect(call.input.Bucket).toBe("override-bucket");
         }
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
     it("should propagate exceptions thrown in uploadObjectRequestModifier", async () => {
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
-      await fs.writeFile(path.join(tmpDir, "file1.txt"), "content1");
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "file1.txt"), "content1");
 
       try {
         const mockClient = createMockClient();
         const tm = new S3TransferManager({ s3: mockClient });
 
-        const result = await tm.uploadDirectory({
-          bucket: "test-bucket",
-          source: tmpDir,
-          uploadObjectRequestModifier: () => {
-            throw new Error("uploadObjectRequestModifier failed");
-          },
-        });
+        await expect(
+          tm.uploadDirectory({
+            bucket: "test-bucket",
+            source: tmpDir,
+            uploadObjectRequestModifier: () => {
+              throw new Error("uploadObjectRequestModifier failed");
+            },
+          })
+        ).rejects.toThrow("uploadObjectRequestModifier failed");
 
-        expect(result.objectsUploaded).toBe(0);
-        expect(result.objectsFailed).toBe(1);
         expect(mockClient.send).not.toHaveBeenCalled();
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
@@ -1668,8 +1668,8 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("should abort when transferOptions.abortSignal is triggered", async () => {
 
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
-      await fs.writeFile(path.join(tmpDir, "file.txt"), "content");
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "file.txt"), "content");
 
       try {
         const ac = new AbortController();
@@ -1685,12 +1685,12 @@ describe("S3TransferManager Unit Tests", () => {
           }, { abortSignal: ac.signal })
         ).rejects.toThrow("Transfer aborted");
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
 
     it("should return zero counts for empty directory", async () => {
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tm-uploadDir-test-"));
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
 
       try {
         const mockClient = createMockClient();
@@ -1706,9 +1706,10 @@ describe("S3TransferManager Unit Tests", () => {
         expect(result.objectsFailed).toBe(0);
         expect(mockClient.send).not.toHaveBeenCalled();
       } finally {
-        await fs.rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
     });
+
   });
 
 });

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
@@ -1453,12 +1453,10 @@ describe("S3TransferManager Unit Tests", () => {
             bucket: "test-bucket",
             source: tmpDir,
             failurePolicy: CannedFailurePolicy.Terminate,
-            maxConcurrency: 2,
           })
         ).rejects.toThrow("S3 error");
 
-        // With maxConcurrency=2, at most 2 files are dispatched before terminate stops picking up new files.
-        expect(mockClient.send.mock.calls.length).toBeLessThanOrEqual(2);
+        expect(mockClient.send.mock.calls.length).toBeLessThanOrEqual(1);
       } finally {
         await rm(tmpDir, { recursive: true });
       }

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
@@ -7,7 +7,7 @@ import { beforeAll, beforeEach, describe, expect, test as it, vi } from "vitest"
 
 import { S3TransferManager } from "./S3TransferManager";
 import type { TransferCompleteEvent, TransferEvent } from "./types";
-import { CannedFailurePolicy } from "./types";
+import type { CannedFailurePolicy } from "./types";
 import { WorkerHttpHandler } from "./worker-http-handler";
 
 describe("S3TransferManager Unit Tests", () => {
@@ -1406,6 +1406,29 @@ describe("S3TransferManager Unit Tests", () => {
       }
     });
 
+    it("should apply RegExp filter to skip files", async () => {
+
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
+      await writeFile(join(tmpDir, "hello.txt"), "hello");
+      await writeFile(join(tmpDir, "world.txt"), "world");
+      await writeFile(join(tmpDir, "file123.txt"), "this is file123");
+      await writeFile(join(tmpDir, "data-file.txt"), "this is a data file");
+      try {
+        const mockClient = createMockClient();
+        const tm = new S3TransferManager({ s3: mockClient });
+
+        const result = await tm.uploadDirectory({
+          bucket: "test-bucket",
+          source: tmpDir,
+          filter: /\/[a-zA-Z]+\.txt$/,
+        });
+
+        expect(result.objectsUploaded).toBe(2);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+      }
+    });
+
     it("should prepend s3Prefix to keys", async () => {
 
       const tmpDir = await mkdtemp(join(tmpdir(), "tm-uploadDir-test-"));
@@ -1452,7 +1475,7 @@ describe("S3TransferManager Unit Tests", () => {
           tm.uploadDirectory({
             bucket: "test-bucket",
             source: tmpDir,
-            failurePolicy: CannedFailurePolicy.Terminate,
+            failurePolicy: "terminate" as CannedFailurePolicy,
           })
         ).rejects.toThrow("S3 error");
 
@@ -1483,7 +1506,7 @@ describe("S3TransferManager Unit Tests", () => {
         const result = await tm.uploadDirectory({
           bucket: "test-bucket",
           source: tmpDir,
-          failurePolicy: CannedFailurePolicy.Continue,
+          failurePolicy: "continue" as CannedFailurePolicy,
         });
 
         expect(result.objectsFailed).toBe(1);
@@ -1661,7 +1684,7 @@ describe("S3TransferManager Unit Tests", () => {
           bucket: "test-bucket",
           source: "/nonexistent/path/abc123",
         })
-      ).rejects.toThrow("Directory does not exist");
+      ).rejects.toThrow("Cannot access directory at");
     });
 
     it("should abort when transferOptions.abortSignal is triggered", async () => {

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -520,10 +520,14 @@ export class S3TransferManager implements IS3TransferManager {
       discoveredFiles++;
       discoveredBytes += fileStat.size;
 
-      await semaphore.acquire();
+      const count = fileStat.size >= this.multipartUploadThresholdBytes
+        ? Math.min(Math.ceil(fileStat.size / this.targetPartSizeBytes), this.maxConcurrentUploads)
+        : 1;
+
+      await semaphore.acquire(count);
 
       if (terminated || abortController.signal.aborted) {
-        semaphore.release();
+        semaphore.release(count);
         break;
       }
 
@@ -577,7 +581,7 @@ export class S3TransferManager implements IS3TransferManager {
           }
           objectsFailed++;
         } finally {
-          semaphore.release();
+          semaphore.release(count);
         }
       })();
 

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -478,6 +478,11 @@ export class S3TransferManager implements IS3TransferManager {
 
     this.checkAborted(transferOptions);
 
+    const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
+    if (userSignal) {
+      userSignal.addEventListener("abort", () => abortController.abort(), { once: true });
+    }
+
     for await (const filePath of this.traverseDirectory(absoluteSource, {
       recursive: request.recursive ?? false,
       followSymbolicLinks: request.followSymbolicLinks ?? false,
@@ -510,9 +515,13 @@ export class S3TransferManager implements IS3TransferManager {
             putRequest = request.uploadObjectRequestModifier(putRequest);
           }
 
-          await this.upload(putRequest, transferOptions);
+          await this.upload(putRequest, { ...transferOptions, abortSignal: abortController.signal });
           objectsUploaded++;
         } catch (error) {
+          if (terminated || abortController.signal.aborted) {
+            objectsFailed++;
+            return;
+          }
           const context: DirectoryTransferFailureContext = {
             request,
             objectRequest: { Bucket: request.bucket, Key: this.deriveS3Key(absoluteSource, filePath, request.s3Prefix) },
@@ -521,10 +530,11 @@ export class S3TransferManager implements IS3TransferManager {
           const result = await handleFailure(failurePolicy, context, abortController);
           if (result === "terminate") {
             terminated = true;
-            terminationError = error;
-          } else {
-            objectsFailed++;
+            if (!terminationError) {
+              terminationError = error;
+            }
           }
+          objectsFailed++;
         } finally {
           semaphore.release();
         }

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -477,11 +477,32 @@ export class S3TransferManager implements IS3TransferManager {
     let terminationError: unknown;
 
     this.checkAborted(transferOptions);
+    this.addEventListeners(transferOptions?.eventListeners);
+
+    let transferredBytes = 0;
+    let transferredFiles = 0;
+    let totalFiles: number | undefined = undefined;
+    let totalBytes: number | undefined = undefined;
+    let traversalComplete = false;
+
+    const removeLocalEventListeners = () => {
+      this.removeEventListeners(transferOptions?.eventListeners);
+    };
+
+    this.dispatchEvent(
+      Object.assign(new Event("transferInitiated"), {
+        request,
+        snapshot: { transferredBytes: 0, totalBytes: undefined, transferredFiles: 0, totalFiles: undefined },
+      })
+    );
 
     const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
     if (userSignal) {
       userSignal.addEventListener("abort", () => abortController.abort(), { once: true });
     }
+
+    let discoveredFiles = 0;
+    let discoveredBytes = 0;
 
     for await (const filePath of this.traverseDirectory(absoluteSource, {
       recursive: request.recursive ?? false,
@@ -492,6 +513,10 @@ export class S3TransferManager implements IS3TransferManager {
 
       if (request.filter && !request.filter(filePath)) continue;
 
+      const fileStat = await stat(filePath);
+      discoveredFiles++;
+      discoveredBytes += fileStat.size;
+
       await semaphore.acquire();
 
       if (terminated || abortController.signal.aborted) {
@@ -501,7 +526,6 @@ export class S3TransferManager implements IS3TransferManager {
 
       const task = (async () => {
         try {
-          const fileStat = await stat(filePath);
           const key = this.deriveS3Key(absoluteSource, filePath, request.s3Prefix);
 
           let putRequest: PutObjectCommandInput = {
@@ -515,8 +539,22 @@ export class S3TransferManager implements IS3TransferManager {
             putRequest = request.uploadObjectRequestModifier(putRequest);
           }
 
-          await this.upload(putRequest, { ...transferOptions, abortSignal: abortController.signal });
+          await this.upload(putRequest, { abortSignal: abortController.signal });
           objectsUploaded++;
+          transferredFiles++;
+          transferredBytes += fileStat.size;
+
+          this.dispatchEvent(
+            Object.assign(new Event("bytesTransferred"), {
+              request,
+              snapshot: {
+                transferredBytes,
+                totalBytes: traversalComplete ? totalBytes : undefined,
+                transferredFiles,
+                totalFiles: traversalComplete ? totalFiles : undefined,
+              },
+            })
+          );
         } catch (error) {
           if (terminated || abortController.signal.aborted) {
             objectsFailed++;
@@ -544,12 +582,31 @@ export class S3TransferManager implements IS3TransferManager {
       task.finally(() => inFlight.delete(task));
     }
 
+    traversalComplete = true;
+    totalFiles = discoveredFiles;
+    totalBytes = discoveredBytes;
+
     await Promise.allSettled([...inFlight]);
 
     if (terminated && terminationError) {
+      this.dispatchEvent(
+        Object.assign(new Event("transferFailed"), {
+          request,
+          snapshot: { transferredBytes, totalBytes, transferredFiles, totalFiles },
+        })
+      );
+      removeLocalEventListeners();
       throw terminationError;
     }
 
+    this.dispatchEvent(
+      Object.assign(new Event("transferComplete"), {
+        request,
+        response: { objectsUploaded, objectsFailed },
+        snapshot: { transferredBytes, totalBytes, transferredFiles, totalFiles },
+      })
+    );
+    removeLocalEventListeners();
     return { objectsUploaded, objectsFailed };
   }
 

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -1,5 +1,4 @@
 import type {
-  _Object as S3Object,
   AbortMultipartUploadCommandInput,
   CompletedPart,
   CompleteMultipartUploadCommandInput,
@@ -22,12 +21,20 @@ import {
 } from "@aws-sdk/client-s3";
 import type { Logger } from "@smithy/types";
 import { type StreamingBlobPayloadOutputTypes } from "@smithy/types";
+import { createReadStream } from "node:fs";
+import { opendir, realpath, stat } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
 
 import { type RawDataPart, byteLength, getChunk } from "./chunker";
+import { handleFailure, Semaphore, validateDirectory } from "./directory-transfer-utils";
 import type { AddEventListenerOptions, EventListener, RemoveEventListenerOptions } from "./event-listener-types";
 import { joinStreams } from "./join-streams";
 import { LogLevel } from "./log-level";
 import type {
+  CannedFailurePolicy,
+  DirectoryTransferFailureContext,
+  DownloadDirectoryRequest,
+  DownloadDirectoryResponse,
   DownloadRequest,
   DownloadResponse,
   IS3TransferManager,
@@ -36,6 +43,8 @@ import type {
   TransferEvent,
   TransferEventListeners,
   TransferOptions,
+  UploadDirectoryRequest,
+  UploadDirectoryResponse,
   UploadRequest,
   UploadResponse,
 } from "./types";
@@ -444,28 +453,94 @@ export class S3TransferManager implements IS3TransferManager {
   }
 
   /**
-   * Uploads all files in a directory recursively to an S3 bucket.
-   * Automatically maps local file paths to S3 object keys using prefix and delimiter configuration.
+   * Uploads files in a directory to an S3 bucket.
+   * By default, it does not recurse into subdirectories. To upload recursively, set recursive: true.
    *
-   * @param options - Configuration including bucket, source directory, filtering, failure handling, and transfer settings.
+   * @param request - Configuration including bucket, source directory, filtering, failure handling, and transfer settings.
+   * @param transferOptions - Allows users to specify cancel functions for the request and a collection of callbacks for monitoring transfer lifecycle events.
    *
    * @returns the number of objects that have been uploaded and the number of objects that have failed.
    *
    * @alpha
    */
-  public uploadAll(options: {
-    bucket: string;
-    source: string;
-    followSymbolicLinks?: boolean;
-    recursive?: boolean;
-    s3Prefix?: string;
-    filter?: (filepath: string) => boolean;
-    s3Delimiter?: string;
-    putObjectRequestCallback?: (putObjectRequest: PutObjectCommandInput) => Promise<void>;
-    failurePolicy?: (error?: unknown) => Promise<void>;
-    transferOptions?: TransferOptions;
-  }): Promise<{ objectsUploaded: number; objectsFailed: number }> {
-    throw new Error("Method not implemented.");
+  public async uploadDirectory(request: UploadDirectoryRequest, transferOptions?: TransferOptions): Promise<UploadDirectoryResponse> {
+    const absoluteSource = await validateDirectory(request.source);
+    const maxConcurrency = request.maxConcurrency ?? 100;
+    const failurePolicy = request.failurePolicy ?? ("terminate" as CannedFailurePolicy);
+    const semaphore = new Semaphore(maxConcurrency);
+    const abortController = new AbortController();
+    const inFlight = new Set<Promise<void>>();
+
+    let objectsUploaded = 0;
+    let objectsFailed = 0;
+    let terminated = false;
+    let terminationError: unknown;
+
+    this.checkAborted(transferOptions);
+
+    for await (const filePath of this.traverseDirectory(absoluteSource, {
+      recursive: request.recursive ?? false,
+      followSymbolicLinks: request.followSymbolicLinks ?? false,
+    })) {
+      if (terminated || abortController.signal.aborted) break;
+      this.checkAborted(transferOptions);
+
+      if (request.filter && !request.filter(filePath)) continue;
+
+      await semaphore.acquire();
+
+      if (terminated || abortController.signal.aborted) {
+        semaphore.release();
+        break;
+      }
+
+      const task = (async () => {
+        try {
+          const fileStat = await stat(filePath);
+          const key = this.deriveS3Key(absoluteSource, filePath, request.s3Prefix);
+
+          let putRequest: PutObjectCommandInput = {
+            Bucket: request.bucket,
+            Key: key,
+            Body: createReadStream(filePath),
+            ContentLength: fileStat.size,
+          };
+
+          if (request.uploadObjectRequestModifier) {
+            putRequest = request.uploadObjectRequestModifier(putRequest);
+          }
+
+          await this.upload(putRequest, transferOptions);
+          objectsUploaded++;
+        } catch (error) {
+          const context: DirectoryTransferFailureContext = {
+            request,
+            objectRequest: { Bucket: request.bucket, Key: this.deriveS3Key(absoluteSource, filePath, request.s3Prefix) },
+            error,
+          };
+          const result = await handleFailure(failurePolicy, context, abortController);
+          if (result === "terminate") {
+            terminated = true;
+            terminationError = error;
+          } else {
+            objectsFailed++;
+          }
+        } finally {
+          semaphore.release();
+        }
+      })();
+
+      inFlight.add(task);
+      task.finally(() => inFlight.delete(task));
+    }
+
+    await Promise.allSettled([...inFlight]);
+
+    if (terminated && terminationError) {
+      throw terminationError;
+    }
+
+    return { objectsUploaded, objectsFailed };
   }
 
   /**
@@ -478,17 +553,7 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @alpha
    */
-  public downloadAll(options: {
-    bucket: string;
-    destination: string;
-    s3Prefix?: string;
-    s3Delimiter?: string;
-    recursive?: boolean;
-    filter?: (object?: S3Object) => boolean;
-    getObjectRequestCallback?: (getObjectRequest: GetObjectCommandInput) => Promise<void>;
-    failurePolicy?: (error?: unknown) => Promise<void>;
-    transferOptions?: TransferOptions;
-  }): Promise<{ objectsDownloaded: number; objectsFailed: number }> {
+  public downloadDirectory(request: DownloadDirectoryRequest, transferOptions?: TransferOptions): Promise<DownloadDirectoryResponse> {
     throw new Error("Method not implemented.");
   }
 
@@ -1520,6 +1585,60 @@ export class S3TransferManager implements IS3TransferManager {
       }
       throw error;
     }
+  }
+
+  /**
+   * Async generator that yields file paths from the source directory.
+   * Uses fs.opendir with recursive option (Node 20+).
+   * Handles symlink cycle detection when followSymbolicLinks is true.
+   *
+   * @internal
+   */
+  private async *traverseDirectory(
+    source: string,
+    options: { recursive: boolean; followSymbolicLinks: boolean }
+  ): AsyncGenerator<string> {
+    const visited = new Set<string>();
+    const dir = await opendir(source, { recursive: options.recursive });
+    for await (const entry of dir) {
+      const fullPath = join((entry as any).parentPath ?? (entry as any).path ?? source, entry.name);
+
+      if (entry.isSymbolicLink()) {
+        if (!options.followSymbolicLinks) continue;
+        const realPath = await realpath(fullPath);
+        const linkStat = await stat(realPath);
+        if (linkStat.isDirectory()) {
+          if (visited.has(realPath)) {
+            throw new Error(`Circular symbolic link detected: ${fullPath} -> ${realPath}`);
+          }
+          visited.add(realPath);
+          yield* this.traverseDirectory(realPath, options);
+          continue;
+        }
+        if (!linkStat.isFile()) continue;
+      } else if (!entry.isFile()) {
+        continue;
+      }
+
+      yield fullPath;
+    }
+  }
+
+  /**
+   * Derives the S3 object key from local file path.
+   * Computes relative path from source, normalizes separators to "/",
+   * and prepends s3Prefix if provided.
+   *
+   * @internal
+   */
+  private deriveS3Key(source: string, filePath: string, s3Prefix?: string): string {
+    let relativePath = relative(source, filePath);
+    if (sep !== "/") {
+      relativePath = relativePath.split(sep).join("/");
+    }
+    if (!s3Prefix) return relativePath;
+    const normalizedPrefix = s3Prefix.endsWith("/") ? s3Prefix : s3Prefix + "/";
+    return normalizedPrefix + relativePath;
   }
 
   /**

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -511,7 +511,10 @@ export class S3TransferManager implements IS3TransferManager {
       if (terminated || abortController.signal.aborted) break;
       this.checkAborted(transferOptions);
 
-      if (request.filter && !request.filter(filePath)) continue;
+      if (request.filter) {
+        const include = request.filter instanceof RegExp ? request.filter.test(filePath) : request.filter(filePath);
+        if (!include) continue;
+      }
 
       const fileStat = await stat(filePath);
       discoveredFiles++;

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/directory-transfer-utils.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/directory-transfer-utils.ts
@@ -5,28 +5,34 @@ import { resolve } from "node:path";
 import type { CannedFailurePolicy, DirectoryTransferFailureContext, FailurePolicy } from "./types";
 
 /**
- * Simple counting semaphore for bounding concurrency.
+ * Weighted semaphore with a soft concurrency limit.
+ * Allows a job to start if in-flight weight is below the limit, even if
+ * that job pushes the total over. New jobs are paused until it drops back.
+ *
  * @internal
  */
 export class Semaphore {
-  private queue: Array<() => void> = [];
+  private inFlightRequests = 0;
+  private waiters: Array<() => void> = [];
 
-  public constructor(private slots: number) {}
+  public constructor(private readonly limit: number) {}
 
-  public async acquire(): Promise<void> {
-    if (this.slots > 0) {
-      this.slots--;
+  public async acquire(count = 1): Promise<void> {
+    if (this.inFlightRequests < this.limit) {
+      this.inFlightRequests += count;
       return;
     }
-    return new Promise((resolve) => this.queue.push(resolve));
+    await new Promise<void>((resolve) => this.waiters.push(resolve));
+    this.inFlightRequests += count;
   }
 
-  public release(): void {
-    const next = this.queue.shift();
-    if (next) {
-      next();
-    } else {
-      this.slots++;
+  public release(count = 1): void {
+    this.inFlightRequests -= count;
+    while (this.waiters.length > 0 && this.inFlightRequests < this.limit) {
+      const next = this.waiters.shift();
+      if (next) {
+        next();
+      }
     }
   }
 }

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/directory-transfer-utils.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/directory-transfer-utils.ts
@@ -1,0 +1,93 @@
+import { type Stats } from "node:fs";
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import type {  DirectoryTransferFailureContext, FailurePolicy } from "./types";
+
+/**
+ * Simple counting semaphore for bounding concurrency.
+ * @internal
+ */
+export class Semaphore {
+  private slots: number;
+  private queue: Array<() => void> = [];
+
+  constructor(slots: number) {
+    this.slots = slots;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.slots > 0) {
+      this.slots--;
+      return;
+    }
+    return new Promise((resolve) => this.queue.push(resolve));
+  }
+
+  release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next();
+    } else {
+      this.slots++;
+    }
+  }
+}
+
+/**
+ * Validates that a path exists and is a directory.
+ * Resolves to absolute path.
+ *
+ * @param dirPath - The directory path to validate.
+ *
+ * @throws Error - If the path does not exist.
+ * @throws Error - If the path is not a directory.
+ *
+ * @internal
+ */
+export async function validateDirectory(dirPath: string): Promise<string> {
+  const absolutePath = resolve(dirPath);
+  let stats: Stats;
+  try {
+    stats = await stat(absolutePath);
+  } catch (error: any) {
+    throw new Error(`Directory does not exist at: ${absolutePath}`);
+  }
+  if (!stats.isDirectory()) {
+    throw new Error(`Path is not a directory: ${absolutePath}`);
+  }
+  return absolutePath;
+}
+
+/**
+ * Executes the failure policy for a failed transfer (upload or download).
+ *
+ * @param policy - The failure policy to execute (canned or custom callback).
+ * @param context - The failure context containing the directory request, failed object request, and error.
+ * @param abortController - Controller to signal abort to all in-flight operations on terminate.
+ *
+ * @internal
+ */
+export async function handleFailure(
+  policy: FailurePolicy,
+  context: DirectoryTransferFailureContext,
+  abortController: AbortController
+): Promise<"continue" | "terminate"> {
+  if (policy === "terminate") {
+    abortController.abort();
+    return "terminate";
+  }
+  if (policy === "continue") {
+    return "continue";
+  }
+  try {
+    const result = await policy(context);
+    if (result === "terminate") {
+      abortController.abort();
+    }
+    return result;
+  } catch {
+    abortController.abort();
+    return "terminate";
+  }
+}

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/directory-transfer-utils.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/directory-transfer-utils.ts
@@ -2,21 +2,18 @@ import { type Stats } from "node:fs";
 import { stat } from "node:fs/promises";
 import { resolve } from "node:path";
 
-import type {  DirectoryTransferFailureContext, FailurePolicy } from "./types";
+import type { CannedFailurePolicy, DirectoryTransferFailureContext, FailurePolicy } from "./types";
 
 /**
  * Simple counting semaphore for bounding concurrency.
  * @internal
  */
 export class Semaphore {
-  private slots: number;
   private queue: Array<() => void> = [];
 
-  constructor(slots: number) {
-    this.slots = slots;
-  }
+  public constructor(private slots: number) {}
 
-  async acquire(): Promise<void> {
+  public async acquire(): Promise<void> {
     if (this.slots > 0) {
       this.slots--;
       return;
@@ -24,7 +21,7 @@ export class Semaphore {
     return new Promise((resolve) => this.queue.push(resolve));
   }
 
-  release(): void {
+  public release(): void {
     const next = this.queue.shift();
     if (next) {
       next();
@@ -51,7 +48,7 @@ export async function validateDirectory(dirPath: string): Promise<string> {
   try {
     stats = await stat(absolutePath);
   } catch (error: any) {
-    throw new Error(`Directory does not exist at: ${absolutePath}`);
+    throw new Error(`Cannot access directory at: ${absolutePath}, ${error.message}`);
   }
   if (!stats.isDirectory()) {
     throw new Error(`Path is not a directory: ${absolutePath}`);
@@ -72,7 +69,7 @@ export async function handleFailure(
   policy: FailurePolicy,
   context: DirectoryTransferFailureContext,
   abortController: AbortController
-): Promise<"continue" | "terminate"> {
+): Promise<CannedFailurePolicy> {
   if (policy === "terminate") {
     abortController.abort();
     return "terminate";

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/types.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/types.ts
@@ -149,66 +149,25 @@ export interface IS3TransferManager {
   download(request: DownloadRequest, transferOptions?: TransferOptions): Promise<DownloadResponse>;
 
   /**
-   * Represents an API to upload all files under the given directory to the provided S3 bucket.
+   * Uploads files in a directory to the provided S3 bucket.
+   * By default, it does not recurse into subdirectories. To upload recursively, set recursive: true.
    *
-   * @param options.bucket - The name of the bucket to upload objects to.
-   * @param options.source - The source directory to upload.
-   * @param options.followSymbolicLinks - Whether to follow symbolic links when traversing the file tree.
-   * @param options.recursive - Whether to upload directories recursively.
-   * @param options.s3Prefix - The S3 key prefix to use for each object. If not provided, files will be uploaded to the root of the bucket todo().
-   * @param options.filter - A callback to allow users to filter out unwanted S3 object. It is invoked for each S3 object. An example implementation is a predicate that takes an S3Object and returns a boolean indicating whether this S3Object should be uploaded.
-   * @param options.s3Delimiter - Default "/". The S3 delimiter. A delimiter causes a list operation to roll up all the keys that share a common prefix into a single summary list result.
-   * @param options.putObjectRequestCallback - A callback mechanism to allow customers to update individual putObjectRequest that the S3 Transfer Manager generates.
-   * @param options.failurePolicy - The failure policy to handle failed requests.
-   * @param options.transferOptions - Allows supplying an AbortSignal and/or transfer event listeners.
+   * @param request - Configuration for the directory upload operation.
+   * @param transferOptions - Allows users to specify cancel functions for the request and a collection of callbacks for monitoring transfer lifecycle events.
    *
    * @returns the number of objects that have been uploaded and the number of objects that have failed
    */
-  uploadAll(options: {
-    bucket: string;
-    source: string;
-    followSymbolicLinks?: boolean;
-    recursive?: boolean;
-    s3Prefix?: string;
-    filter?: (filepath: string) => boolean;
-    s3Delimiter?: string;
-    putObjectRequestCallback?: (putObjectRequest: PutObjectCommandInput) => Promise<void>;
-    failurePolicy?: (error?: unknown) => Promise<void>;
-    transferOptions?: TransferOptions;
-  }): Promise<{
-    objectsUploaded: number;
-    objectsFailed: number;
-  }>;
+  uploadDirectory(request: UploadDirectoryRequest, transferOptions?: TransferOptions): Promise<UploadDirectoryResponse>;
 
   /**
-   * Represents an API to download all objects under a bucket to the provided local directory.
+   * Downloads objects under a bucket to the provided local directory.
    *
-   * @param options.bucket - The name of the bucket.
-   * @param options.destination - The destination directory.
-   * @param options.s3Prefix - Specify the S3 prefix that limits the response to keys that begin with the specified prefix.
-   * @param options.s3Delimiter - Specify the S3 delimiter.
-   * @param options.recursive - Whether to upload directories recursively.
-   * @param options.filter - A callback to allow users to filter out unwanted S3 object. It is invoked for each S3 object. An example implementation is a predicate that takes an S3Object and returns a boolean indicating whether this S3Object should be downloaded.
-   * @param options.getObjectRequestCallback - A callback mechanism to allow customers to update individual getObjectRequest that the S3 Transfer Manager generates.
-   * @param options.failurePolicy - The failure policy to handle failed requests.
-   * @param options.transferOptions - Allows supplying an AbortSignal and/or transfer event listeners.
+   * @param request - Configuration for the directory download operation.
+   * @param transferOptions - Allows users to specify cancel functions for the request and a collection of callbacks for monitoring transfer lifecycle events.
    *
-   * @returns The number of objects that have been uploaded and the number of objects that have failed
+   * @returns the number of objects that have been downloaded and the number of objects that have failed
    */
-  downloadAll(options: {
-    bucket: string;
-    destination: string;
-    s3Prefix?: string;
-    s3Delimiter?: string;
-    recursive?: boolean;
-    filter?: (object?: S3Object) => boolean;
-    getObjectRequestCallback?: (getObjectRequest: GetObjectCommandInput) => Promise<void>;
-    failurePolicy?: (error?: unknown) => Promise<void>;
-    transferOptions?: TransferOptions;
-  }): Promise<{
-    objectsDownloaded: number;
-    objectsFailed: number;
-  }>;
+  downloadDirectory(request: DownloadDirectoryRequest, transferOptions?: TransferOptions): Promise<DownloadDirectoryResponse>;
 
   /**
    * Registers a callback function to be executed when a specific transfer event occurs.
@@ -362,4 +321,180 @@ export interface JoinStreamIterationEvents {
   onCompletion?: (byteLength: number, index: number) => void;
   onFailure?: (error: unknown, index: number) => void;
   onStreamConsumed?: (index: number) => void;
+}
+
+/**
+ * Canned failure policies for directory transfers.
+ * Used to control behavior when an individual object fails during a multi-object transfer.
+ *
+ * @alpha
+ */
+export enum CannedFailurePolicy {
+  /**
+   * Cancel all ongoing requests, terminate the directory transfer, and throw the error. (Default)
+   */
+  Terminate = "terminate",
+  /**
+   * Ignore the failure, increment failed count, and continue transferring remaining objects.
+   */
+  Continue = "continue",
+}
+
+/**
+ * Context provided to a custom failure policy callback when an individual object transfer fails.
+ * Contains the directory transfer request, the specific failed object request, and the error.
+ *
+ * @alpha
+ */
+export interface DirectoryTransferFailureContext {
+  /**
+   * The original directory transfer request.
+   */
+  request: UploadDirectoryRequest | DownloadDirectoryRequest;
+  /**
+   * The individual object request that failed.
+   */
+  objectRequest: PutObjectCommandInput | GetObjectCommandInput;
+  /**
+   * The error that caused the failure.
+   */
+  error: unknown;
+}
+
+/**
+ * Failure policy for directory transfers.
+ * Either a canned policy enum value, or a custom callback invoked per failure.
+ * Custom callbacks return "continue" to skip the failure, or "terminate" to abort.
+ *
+ * @alpha
+ */
+export type FailurePolicy =
+  | CannedFailurePolicy
+  | ((context: DirectoryTransferFailureContext) => Promise<"continue" | "terminate">);
+
+/**
+ * Request parameters for uploadDirectory operation.
+ *
+ * @alpha
+ */
+export interface UploadDirectoryRequest {
+  /**
+   * The name of the bucket to upload objects to.
+   */
+  bucket: string;
+  /**
+   * The source directory to upload.
+   */
+  source: string;
+  /**
+   * Whether to follow symbolic links when traversing.
+   * Default: false.
+   */
+  followSymbolicLinks?: boolean;
+  /**
+   * Whether to upload directories recursively.
+   * Default: false.
+   */
+  recursive?: boolean;
+  /**
+   * S3 key prefix prepended to each object key.
+   * By default, if no prefix is specified, objects are uploaded to the root of the bucket.
+   */
+  s3Prefix?: string;
+  /**
+   * A callback to allow users to filter out unwanted files.
+   * Return true to include the file for upload, false to skip.
+   * By default, if no filter is specified, all files will be uploaded.
+   */
+  filter?: (filePath: string) => boolean;
+  /**
+   * Modifier invoked per upload request.
+   * MUST return a new copy.
+   * By default, if no modifier is specified, requests are passed as-is.
+   */
+  uploadObjectRequestModifier?: (request: PutObjectCommandInput) => PutObjectCommandInput;
+  /**
+   * Failure policy for handling individual upload failures.
+   * Default: Terminate.
+   */
+  failurePolicy?: FailurePolicy;
+  /**
+   * Max concurrent file uploads for this directory operation.
+   * Default: 100.
+   */
+  maxConcurrency?: number;
+}
+
+/**
+ * Response from uploadDirectory operation.
+ *
+ * @alpha
+ */
+export interface UploadDirectoryResponse {
+  /**
+   * Number of objects successfully uploaded.
+   */
+  objectsUploaded: number;
+  /**
+   * Number of objects that failed to upload.
+   */
+  objectsFailed: number;
+}
+
+/**
+ * Request parameters for downloadDirectory operation.
+ *
+ * @alpha
+ */
+export interface DownloadDirectoryRequest {
+  /**
+   * The name of the bucket.
+   */
+  bucket: string;
+  /**
+   * The destination local directory.
+   */
+  destination: string;
+  /**
+   * S3 prefix to filter listed objects.
+   */
+  s3Prefix?: string;
+  /**
+   * A callback to allow users to filter out unwanted S3 objects.
+   * Return true to include the object for download, false to skip.
+   * By default, if no filter is specified, all objects will be downloaded.
+   */
+  filter?: (object: S3Object) => boolean;
+  /**
+   * Modifier invoked per download request.
+   * MUST return a new copy.
+   * By default, if no modifier is specified, requests are passed through as-is.
+   */
+  downloadObjectRequestModifier?: (request: GetObjectCommandInput) => GetObjectCommandInput;
+  /**
+   * Failure policy for handling individual download failures.
+   * Default: Terminate.
+   */
+  failurePolicy?: FailurePolicy;
+  /**
+   * Max concurrent file downloads for this directory operation.
+   * Default: 100.
+   */
+  maxConcurrency?: number;
+}
+
+/**
+ * Response from downloadDirectory operation.
+ *
+ * @alpha
+ */
+export interface DownloadDirectoryResponse {
+  /**
+   * Number of objects successfully downloaded.
+   */
+  objectsDownloaded: number;
+  /**
+   * Number of objects that failed to download.
+   */
+  objectsFailed: number;
 }

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/types.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/types.ts
@@ -327,18 +327,12 @@ export interface JoinStreamIterationEvents {
  * Canned failure policies for directory transfers.
  * Used to control behavior when an individual object fails during a multi-object transfer.
  *
+ * "terminate" - Cancel all ongoing requests, terminate the directory transfer, and throw the error. (Default)
+ * "continue" - Ignore the failure, increment failed count, and continue transferring remaining objects.
+ *
  * @alpha
  */
-export enum CannedFailurePolicy {
-  /**
-   * Cancel all ongoing requests, terminate the directory transfer, and throw the error. (Default)
-   */
-  Terminate = "terminate",
-  /**
-   * Ignore the failure, increment failed count, and continue transferring remaining objects.
-   */
-  Continue = "continue",
-}
+export type CannedFailurePolicy = "terminate" | "continue";
 
 /**
  * Context provided to a custom failure policy callback when an individual object transfer fails.
@@ -370,7 +364,7 @@ export interface DirectoryTransferFailureContext {
  */
 export type FailurePolicy =
   | CannedFailurePolicy
-  | ((context: DirectoryTransferFailureContext) => Promise<"continue" | "terminate">);
+  | ((context: DirectoryTransferFailureContext) => Promise<CannedFailurePolicy>);
 
 /**
  * Request parameters for uploadDirectory operation.
@@ -402,11 +396,11 @@ export interface UploadDirectoryRequest {
    */
   s3Prefix?: string;
   /**
-   * A callback to allow users to filter out unwanted files.
-   * Return true to include the file for upload, false to skip.
+   * Filter to control which files are uploaded.
+   * Can be a callback (return true to include, false to skip) or a RegExp (matches are included).
    * By default, if no filter is specified, all files will be uploaded.
    */
-  filter?: (filePath: string) => boolean;
+  filter?: ((filePath: string) => boolean) | RegExp;
   /**
    * Modifier invoked per upload request.
    * MUST return a new copy.


### PR DESCRIPTION
### Issue
Internal JS-6110

### Description
Adds `uploadDirectory` functionality to S3TransferManager for uploading files from a local directory to an S3 bucket.

### Testing
```
yarn test:e2e

Test Files  1 passed (1)
      Tests  37 passed (37)
   Start at  18:36:24
   Duration  273.35s (transform 256ms, setup 0ms, import 448ms, tests 272.77s, environment 0ms)
```

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [x] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [ ] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
