### PR TITLE
test: add tsup/dts and metro bundler compatibility tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ bundles: build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle
 
 test-bundlers:
 	node ./tests/bundlers/bundler-canary.mjs
+	(cd ./tests/bundler-compat && npm install && node ./run.mjs)
 
 build-s3-browser-bundle:
 	node ./clients/client-s3/test/browser-build/esbuild

--- a/lib/lib-transfer-manager/transfer-manager.d.ts
+++ b/lib/lib-transfer-manager/transfer-manager.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/lib-transfer-manager/transfer-manager" {
-  export * from "@aws-sdk/lib-transfer-manager/dist-types/submodules/transfer-manager/index.d";
-}
+export * from "./dist-types/submodules/transfer-manager/index";

--- a/lib/lib-transfer-manager/worker.d.ts
+++ b/lib/lib-transfer-manager/worker.d.ts
@@ -1,9 +1,5 @@
-
-  /**
-   * Do not edit:
-   * This is a compatibility redirect for contexts that do not understand package.json exports field.
-   */
-  declare module "@aws-sdk/lib-transfer-manager/worker" {
-    export * from "@aws-sdk/lib-transfer-manager/dist-types/submodules/worker/index.d";
-  }
-  
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+export * from "./dist-types/submodules/worker/index";

--- a/lib/lib-transfer-manager/worker.js
+++ b/lib/lib-transfer-manager/worker.js
@@ -1,7 +1,5 @@
-
-  /**
-   * Do not edit:
-   * This is a compatibility redirect for contexts that do not understand package.json exports field.
-   */
-  module.exports = require("./dist-cjs/submodules/worker/index.js");
-  
+/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+module.exports = require("./dist-cjs/submodules/worker/index.js");

--- a/packages-internal/core/account-id-endpoint.d.ts
+++ b/packages-internal/core/account-id-endpoint.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/core/account-id-endpoint" {
-  export * from "@aws-sdk/core/dist-types/submodules/account-id-endpoint/index.d";
-}
+export * from "./dist-types/submodules/account-id-endpoint/index";

--- a/packages-internal/core/client.d.ts
+++ b/packages-internal/core/client.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/core/client" {
-  export * from "@aws-sdk/core/dist-types/submodules/client/index.d";
-}
+export * from "./dist-types/submodules/client/index";

--- a/packages-internal/core/httpAuthSchemes.d.ts
+++ b/packages-internal/core/httpAuthSchemes.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/core/httpAuthSchemes" {
-  export * from "@aws-sdk/core/dist-types/submodules/httpAuthSchemes/index.d";
-}
+export * from "./dist-types/submodules/httpAuthSchemes/index";

--- a/packages-internal/core/protocols.d.ts
+++ b/packages-internal/core/protocols.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/core/protocols" {
-  export * from "@aws-sdk/core/dist-types/submodules/protocols/index.d";
-}
+export * from "./dist-types/submodules/protocols/index";

--- a/packages-internal/core/util.d.ts
+++ b/packages-internal/core/util.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/core/util" {
-  export * from "@aws-sdk/core/dist-types/submodules/util/index.d";
-}
+export * from "./dist-types/submodules/util/index";

--- a/packages-internal/middleware-sdk-s3/s3-control.d.ts
+++ b/packages-internal/middleware-sdk-s3/s3-control.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/middleware-sdk-s3/s3-control" {
-  export * from "@aws-sdk/middleware-sdk-s3/dist-types/submodules/s3-control/index.d";
-}
+export * from "./dist-types/submodules/s3-control/index";

--- a/packages-internal/middleware-sdk-s3/s3.d.ts
+++ b/packages-internal/middleware-sdk-s3/s3.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/middleware-sdk-s3/s3" {
-  export * from "@aws-sdk/middleware-sdk-s3/dist-types/submodules/s3/index.d";
-}
+export * from "./dist-types/submodules/s3/index";

--- a/packages-internal/nested-clients/cognito-identity.d.ts
+++ b/packages-internal/nested-clients/cognito-identity.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/nested-clients/cognito-identity" {
-  export * from "@aws-sdk/nested-clients/dist-types/submodules/cognito-identity/index.d";
-}
+export * from "./dist-types/submodules/cognito-identity/index";

--- a/packages-internal/nested-clients/signin.d.ts
+++ b/packages-internal/nested-clients/signin.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/nested-clients/signin" {
-  export * from "@aws-sdk/nested-clients/dist-types/submodules/signin/index.d";
-}
+export * from "./dist-types/submodules/signin/index";

--- a/packages-internal/nested-clients/sso-oidc.d.ts
+++ b/packages-internal/nested-clients/sso-oidc.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/nested-clients/sso-oidc" {
-  export * from "@aws-sdk/nested-clients/dist-types/submodules/sso-oidc/index.d";
-}
+export * from "./dist-types/submodules/sso-oidc/index";

--- a/packages-internal/nested-clients/sso.d.ts
+++ b/packages-internal/nested-clients/sso.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/nested-clients/sso" {
-  export * from "@aws-sdk/nested-clients/dist-types/submodules/sso/index.d";
-}
+export * from "./dist-types/submodules/sso/index";

--- a/packages-internal/nested-clients/sts.d.ts
+++ b/packages-internal/nested-clients/sts.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/nested-clients/sts" {
-  export * from "@aws-sdk/nested-clients/dist-types/submodules/sts/index.d";
-}
+export * from "./dist-types/submodules/sts/index";

--- a/packages-internal/xml-builder/scripts/benchmark.js
+++ b/packages-internal/xml-builder/scripts/benchmark.js
@@ -1,0 +1,90 @@
+const { XMLParser } = require("fast-xml-parser");
+const { parseXML } = require("../dist-cjs/xml-parser");
+
+const fxpParser = new XMLParser({
+  attributeNamePrefix: "",
+  processEntities: { enabled: true, maxTotalExpansions: Infinity },
+  htmlEntities: true,
+  ignoreAttributes: false,
+  ignoreDeclaration: true,
+  parseTagValue: false,
+  trimValues: false,
+  tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+  maxNestedTags: Infinity,
+});
+
+function generateListBuckets(n) {
+  const bucket = `<Bucket>
+<CreationDate>2023-06-15T12:00:00.000Z</CreationDate>
+<Name>my-example-bucket-name-here</Name>
+<BucketRegion>us-east-1</BucketRegion>
+</Bucket>`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+<Owner><ID>abc123def456</ID><DisplayName>user@example.com</DisplayName></Owner>
+<Buckets>${bucket.repeat(n)}</Buckets>
+</ListAllMyBucketsResult>`;
+}
+
+function generateListObjects(n) {
+  const obj = `<Contents>
+<Key>photos/2024/vacation/IMG_${Math.random().toString(36).slice(2, 10)}.jpg</Key>
+<LastModified>2024-03-15T09:30:00.000Z</LastModified>
+<ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>
+<Size>1048576</Size>
+<StorageClass>STANDARD</StorageClass>
+<Owner><ID>abc123</ID><DisplayName>owner</DisplayName></Owner>
+</Contents>`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+<Name>my-bucket</Name>
+<Prefix>photos/</Prefix>
+<MaxKeys>1000</MaxKeys>
+<IsTruncated>false</IsTruncated>
+${obj.repeat(n)}
+</ListBucketResult>`;
+}
+
+function bench(name, xml, iterations = 100) {
+  // Warmup
+  for (let i = 0; i < 10; i++) {
+    parseXML(xml);
+    fxpParser.parse(xml, true);
+  }
+
+  const t0 = performance.now();
+  for (let i = 0; i < iterations; i++) parseXML(xml);
+  const internalMs = performance.now() - t0;
+
+  const t1 = performance.now();
+  for (let i = 0; i < iterations; i++) fxpParser.parse(xml, true);
+  const fxpMs = performance.now() - t1;
+
+  const ratio = (fxpMs / internalMs).toFixed(2);
+  const sizeKB = (Buffer.byteLength(xml) / 1024).toFixed(1);
+  console.log(
+    `${name.padEnd(30)} ${sizeKB.padStart(7)} KB | internal: ${(internalMs / iterations)
+      .toFixed(3)
+      .padStart(8)} ms | fxp: ${(fxpMs / iterations).toFixed(3).padStart(8)} ms | ratio: ${ratio}x`
+  );
+}
+
+console.log(
+  "Payload".padEnd(30) +
+    "   Size".padStart(7) +
+    "    |" +
+    " internal (avg)".padStart(20) +
+    " | fxp (avg)".padStart(15) +
+    "      | speedup"
+);
+console.log("-".repeat(110));
+
+for (const n of [1, 5, 10, 50, 100, 250, 500, 1000]) {
+  bench(`ListBuckets (${n})`, generateListBuckets(n));
+}
+
+console.log("");
+
+for (const n of [1, 5, 10, 50, 100, 250, 500, 1000]) {
+  bench(`ListObjects (${n})`, generateListObjects(n));
+}

--- a/packages/config/credentials.d.ts
+++ b/packages/config/credentials.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/config/credentials" {
-  export * from "@aws-sdk/config/dist-types/submodules/credentials/index.d";
-}
+export * from "./dist-types/submodules/credentials/index";

--- a/packages/config/logger.d.ts
+++ b/packages/config/logger.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/config/logger" {
-  export * from "@aws-sdk/config/dist-types/submodules/logger/index.d";
-}
+export * from "./dist-types/submodules/logger/index";

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -45,6 +45,14 @@
     },
     "./requestHandler": {
       "types": "./dist-types/submodules/requestHandler/index.d.ts",
+      "react-native": {
+        "import": "./dist-es/submodules/requestHandler/index.browser.js",
+        "require": "./dist-cjs/submodules/requestHandler/index.browser.js"
+      },
+      "browser": {
+        "import": "./dist-es/submodules/requestHandler/index.browser.js",
+        "require": "./dist-cjs/submodules/requestHandler/index.browser.js"
+      },
       "module": "./dist-es/submodules/requestHandler/index.js",
       "node": "./dist-cjs/submodules/requestHandler/index.js",
       "import": "./dist-es/submodules/requestHandler/index.js",
@@ -119,5 +127,12 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/config"
+  },
+  "browser": {
+    "./dist-es/submodules/requestHandler/index.js": "./dist-es/submodules/requestHandler/index.browser.js"
+  },
+  "react-native": {
+    "./dist-es/submodules/requestHandler/index.js": "./dist-es/submodules/requestHandler/index.browser.js",
+    "./dist-cjs/submodules/requestHandler/index.js": "./dist-cjs/submodules/requestHandler/index.browser.js"
   }
 }

--- a/packages/config/protocol.d.ts
+++ b/packages/config/protocol.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/config/protocol" {
-  export * from "@aws-sdk/config/dist-types/submodules/protocol/index.d";
-}
+export * from "./dist-types/submodules/protocol/index";

--- a/packages/config/requestHandler.d.ts
+++ b/packages/config/requestHandler.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/config/requestHandler" {
-  export * from "@aws-sdk/config/dist-types/submodules/requestHandler/index.d";
-}
+export * from "./dist-types/submodules/requestHandler/index";

--- a/packages/config/retryStrategy.d.ts
+++ b/packages/config/retryStrategy.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/config/retryStrategy" {
-  export * from "@aws-sdk/config/dist-types/submodules/retryStrategy/index.d";
-}
+export * from "./dist-types/submodules/retryStrategy/index";

--- a/packages/config/src/submodules/requestHandler/index.browser.ts
+++ b/packages/config/src/submodules/requestHandler/index.browser.ts
@@ -1,0 +1,9 @@
+const no = Symbol.for("node-only");
+
+export { HttpRequest, HttpResponse } from "@smithy/core/protocols";
+
+export { FetchHttpHandler, type FetchHttpHandlerOptions } from "@smithy/fetch-http-handler";
+export { type NodeHttpHandlerOptions, type NodeHttp2HandlerOptions } from "@smithy/node-http-handler";
+
+export const NodeHttpHandler = no;
+export const NodeHttp2Handler = no;

--- a/packages/config/typecheck.d.ts
+++ b/packages/config/typecheck.d.ts
@@ -2,6 +2,4 @@
  * Do not edit:
  * This is a compatibility redirect for contexts that do not understand package.json exports field.
  */
-declare module "@aws-sdk/config/typecheck" {
-  export * from "@aws-sdk/config/dist-types/submodules/typecheck/index.d";
-}
+export * from "./dist-types/submodules/typecheck/index";

--- a/scripts/validation/submodules-linter.js
+++ b/scripts/validation/submodules-linter.js
@@ -112,38 +112,70 @@ const submodulePackages = process.argv.includes("--all")
             fs.writeFileSync(path.join(root, `tsconfig.${kind}.json`), JSON.stringify(tsconfig, null, 2) + "\n");
           }
         }
+        // react-native condition in exports: must point to .native.js if it exists, else .browser.js.
+        const exportEntry = pkgJson.exports[`./${submodule}`];
+        const nativeEs = `./dist-es/submodules/${submodule}/index.native.js`;
+        const browserEs = `./dist-es/submodules/${submodule}/index.browser.js`;
+        const nativeCjs = `./dist-cjs/submodules/${submodule}/index.native.js`;
+        const browserCjs = `./dist-cjs/submodules/${submodule}/index.browser.js`;
+        const hasNative = fs.existsSync(path.join(root, nativeEs));
+        const hasBrowser = fs.existsSync(path.join(root, browserEs));
+        if (hasNative || hasBrowser) {
+          const expectedEs = hasNative ? nativeEs : browserEs;
+          const expectedCjs = hasNative ? nativeCjs : browserCjs;
+          const expected = { import: expectedEs, require: expectedCjs };
+          if (
+            !exportEntry["react-native"] ||
+            exportEntry["react-native"].import !== expectedEs ||
+            exportEntry["react-native"].require !== expectedCjs
+          ) {
+            errors.push(
+              `${submodule} exports "react-native" condition must point to ${hasNative ? ".native.js" : ".browser.js"}`
+            );
+            exportEntry["react-native"] = expected;
+            // reorder so react-native comes after types
+            const reordered = {};
+            if (exportEntry.types) {
+              reordered.types = exportEntry.types;
+            }
+            reordered["react-native"] = exportEntry["react-native"];
+            for (const [k, v] of Object.entries(exportEntry)) {
+              if (k !== "types" && k !== "react-native") {
+                reordered[k] = v;
+              }
+            }
+            pkgJson.exports[`./${submodule}`] = reordered;
+            pushPkgJson();
+          }
+        }
         // compatibility redirect file.
         const compatibilityRedirectFile = path.join(root, `${submodule}.js`);
         if (!fs.existsSync(compatibilityRedirectFile)) {
           errors.push(`${submodule} is missing compatibility redirect file in the package root folder.`);
-          fs.writeFileSync(
-            compatibilityRedirectFile,
-            `
-  /**
-   * Do not edit:
-   * This is a compatibility redirect for contexts that do not understand package.json exports field.
-   */
-  module.exports = require("./dist-cjs/submodules/${submodule}/index.js");
-  `
-          );
         }
+        fs.writeFileSync(
+          compatibilityRedirectFile,
+          `/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+module.exports = require("./dist-cjs/submodules/${submodule}/index.js");
+`
+        );
         // compatibility types file.
         const compatibilityTypesFile = path.join(root, `${submodule}.d.ts`);
         if (!fs.existsSync(compatibilityTypesFile)) {
           errors.push(`${submodule} is missing compatibility types file in the package root folder.`);
-          fs.writeFileSync(
-            compatibilityTypesFile,
-            `
-  /**
-   * Do not edit:
-   * This is a compatibility redirect for contexts that do not understand package.json exports field.
-   */
-  declare module "@aws-sdk/${submodulePackage}/${submodule}" {
-    export * from "@aws-sdk/${submodulePackage}/dist-types/submodules/${submodule}/index.d";
-  }
-  `
-          );
         }
+        fs.writeFileSync(
+          compatibilityTypesFile,
+          `/**
+ * Do not edit:
+ * This is a compatibility redirect for contexts that do not understand package.json exports field.
+ */
+export * from "./dist-types/submodules/${submodule}/index";
+`
+        );
       }
     }
 

--- a/tests/bundler-compat/.gitignore
+++ b/tests/bundler-compat/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+package-lock.json
+yarn.lock

--- a/tests/bundler-compat/babel.config.cjs
+++ b/tests/bundler-compat/babel.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ["@babel/preset-typescript", "@babel/preset-flow"],
+};

--- a/tests/bundler-compat/metro-build.cjs
+++ b/tests/bundler-compat/metro-build.cjs
@@ -1,0 +1,33 @@
+const Metro = require("metro");
+const path = require("node:path");
+
+const root = path.resolve(__dirname);
+
+async function bundle() {
+  const config = await Metro.loadConfig({ cwd: root });
+  config.projectRoot = root;
+  config.watchFolders = [path.resolve(root, "../..")];
+  config.resolver = {
+    ...config.resolver,
+    sourceExts: ["ts", "tsx", "js", "jsx", "json"],
+    resolverMainFields: ["react-native", "browser", "module", "main"],
+    unstable_enablePackageExports: true,
+    unstable_conditionNames: ["react-native", "browser", "import", "require"],
+    nodeModulesPaths: [
+      path.join(root, "node_modules"),
+      path.resolve(root, "../../node_modules"),
+    ],
+  };
+  await Metro.runBuild(config, {
+    entry: "src/sample-app.ts",
+    out: path.join(root, "dist/metro/bundle.js"),
+    platform: "ios",
+    dev: false,
+    minify: false,
+  });
+}
+
+bundle().then(() => process.exit(0)).catch((e) => {
+  console.error(e.message);
+  process.exit(1);
+});

--- a/tests/bundler-compat/package.json
+++ b/tests/bundler-compat/package.json
@@ -1,0 +1,22 @@
+{
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "file:../../clients/client-dynamodb",
+    "@aws-sdk/client-s3": "file:../../clients/client-s3",
+    "@aws-sdk/config": "file:../../packages/config",
+    "@aws-sdk/core": "file:../../packages-internal/core",
+    "@aws-sdk/lib-dynamodb": "file:../../lib/lib-dynamodb",
+    "@aws-sdk/lib-storage": "file:../../lib/lib-storage",
+    "@aws-sdk/middleware-sdk-s3": "file:../../packages-internal/middleware-sdk-s3",
+    "@aws-sdk/nested-clients": "file:../../packages-internal/nested-clients",
+    "@babel/preset-flow": "^7",
+    "@babel/preset-typescript": "^7",
+    "@types/node": "^22",
+    "@smithy/types": "latest",
+    "metro": "^0.82.0",
+    "metro-resolver": "^0.82.0",
+    "tsup": "^8",
+    "typescript": "~5.8.0"
+  }
+}

--- a/tests/bundler-compat/run.mjs
+++ b/tests/bundler-compat/run.mjs
@@ -87,7 +87,7 @@ run("JS bundle (ESM)", () => {
 run("DTS bundle (all types inlined)", () => {
   execSync(
     "npx tsup --config tsup-dts.config.ts --silent",
-    { cwd: root, stdio: "pipe", env: { ...process.env, NODE_OPTIONS: "--max-old-space-size=4096" } }
+    { cwd: root, stdio: "pipe", env: { ...process.env, NODE_OPTIONS: "--max-old-space-size=8192" } }
   );
   const out = path.join(root, "dist/dts/dts-check.d.ts");
   if (!fs.existsSync(out)) {

--- a/tests/bundler-compat/run.mjs
+++ b/tests/bundler-compat/run.mjs
@@ -1,0 +1,141 @@
+/**
+ * Bundler compatibility tests.
+ *
+ * These tests verify that @aws-sdk packages can be successfully processed
+ * by bundlers that are not covered by the primary bundle-size tests
+ * (webpack, esbuild, vite). The focus is on compatibility, not output size.
+ */
+import { execFileSync, execSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = __dirname;
+const require = createRequire(import.meta.url);
+const { findGlobalBufferRefs } = require("../bundlers/bundler-output-analysis.cjs");
+
+let failed = false;
+
+function run(label, fn) {
+  try {
+    fn();
+    console.log(`  ✅ ${label}`);
+  } catch (e) {
+    console.error(`  ❌ ${label}: ${e.message.split("\n").slice(0, 3).join("\n")}`);
+    failed = true;
+  }
+}
+
+function validateBundle(bundler, filePath, { nodeOnlyLimit = 3, checkBuffer = true } = {}) {
+  const content = fs.readFileSync(filePath, "utf-8");
+
+  const nodeImports = content.match(/["']node:[^"']+["']/g) || [];
+  const nodeRequires = content.match(/require\(["']node:[^"']+["']\)/g) || [];
+  const allNodeRefs = [...new Set([...nodeImports, ...nodeRequires])];
+  if (allNodeRefs.length > 0) {
+    console.error(`    ${bundler}: ❌ node: protocol references: ${allNodeRefs.join(", ")}`);
+    failed = true;
+  } else {
+    console.log(`    ${bundler}: ✅ No node: protocol references`);
+  }
+
+  const nodeOnlyMatches = content.match(/\w+\s*=\s*Symbol\.for\(["']node-only["']\)/g) || [];
+  if (nodeOnlyMatches.length > nodeOnlyLimit) {
+    console.error(`    ${bundler}: ❌ ${nodeOnlyMatches.length}/${nodeOnlyLimit} Symbol.for("node-only") — node-only code not fully tree-shaken`);
+    failed = true;
+  } else if (nodeOnlyMatches.length > 0) {
+    console.log(`    ${bundler}: ⚠️ ${nodeOnlyMatches.length}/${nodeOnlyLimit} Symbol.for("node-only") occurrence(s)`);
+  }
+
+  if (checkBuffer) {
+    const globalBufferRefs = findGlobalBufferRefs(content);
+    if (globalBufferRefs.length > 0) {
+      console.error(`    ${bundler}: ❌ ${globalBufferRefs.length} unguarded global Buffer reference(s)`);
+      failed = true;
+    } else {
+      console.log(`    ${bundler}: ✅ No unguarded global Buffer references`);
+    }
+  }
+}
+
+fs.rmSync(path.join(root, "dist"), { recursive: true, force: true });
+
+// ─── tsup ────────────────────────────────────────────────────────────────────
+
+console.log("\n" + "=".repeat(60));
+console.log("tsup");
+console.log("=".repeat(60));
+
+run("JS bundle (ESM)", () => {
+  execSync("npx tsup src/sample-app.ts --format esm --platform browser --outDir dist/js --silent --tsconfig tsconfig.json", {
+    cwd: root,
+    stdio: "pipe",
+    env: { ...process.env, NODE_OPTIONS: "" },
+  });
+  const out = path.join(root, "dist/js/sample-app.js");
+  if (!fs.existsSync(out)) {
+    throw new Error("output file not created");
+  }
+  if (fs.statSync(out).size === 0) {
+    throw new Error("output file is empty");
+  }
+  validateBundle("tsup", out);
+});
+
+run("DTS bundle (all types inlined)", () => {
+  execSync(
+    "npx tsup --config tsup-dts.config.ts --silent",
+    { cwd: root, stdio: "pipe", env: { ...process.env, NODE_OPTIONS: "--max-old-space-size=4096" } }
+  );
+  const out = path.join(root, "dist/dts/dts-check.d.ts");
+  if (!fs.existsSync(out)) {
+    throw new Error("output .d.ts not created");
+  }
+  const content = fs.readFileSync(out, "utf-8");
+  if (content.length < 3000) {
+    throw new Error("output .d.ts too small — types not inlined");
+  }
+  // Verify key types from @aws-sdk/core submodule carriers were inlined (not just re-exported)
+  if (!content.includes("interface AwsSdkSigV4AuthInputConfig")) {
+    throw new Error("AwsSdkSigV4AuthInputConfig not inlined from @aws-sdk/core/httpAuthSchemes");
+  }
+  if (!content.includes("class AwsSmithyRpcV2CborProtocol")) {
+    throw new Error("AwsSmithyRpcV2CborProtocol not inlined from @aws-sdk/core/protocols");
+  }
+});
+
+// ─── metro ───────────────────────────────────────────────────────────────────
+
+console.log("\n" + "=".repeat(60));
+console.log("metro");
+console.log("=".repeat(60));
+
+run("metro resolution", () => {
+  const req = createRequire(path.join(root, "src/sample-app.ts"));
+  const resolved = req.resolve("@aws-sdk/client-s3");
+  if (!resolved) {
+    throw new Error("Failed to resolve @aws-sdk/client-s3");
+  }
+});
+
+run("metro bundle", () => {
+  fs.mkdirSync(path.join(root, "dist/metro"), { recursive: true });
+  execFileSync("node", [path.join(root, "metro-build.cjs")], { cwd: root, stdio: "pipe", timeout: 60_000 });
+  const out = path.join(root, "dist/metro/bundle.js");
+  if (!fs.existsSync(out)) {
+    throw new Error("output file not created");
+  }
+  validateBundle("metro", out, { nodeOnlyLimit: 7, checkBuffer: false });
+});
+
+// ─── Summary ─────────────────────────────────────────────────────────────────
+
+console.log("\n" + "=".repeat(60));
+if (failed) {
+  console.error("❌ Bundler compatibility check FAILED");
+  process.exit(1);
+} else {
+  console.log("✅ Bundler compatibility check PASSED");
+}

--- a/tests/bundler-compat/src/dts-check.ts
+++ b/tests/bundler-compat/src/dts-check.ts
@@ -1,0 +1,39 @@
+/**
+ * DTS inlining test.
+ *
+ * Exercises tsup's rollup-plugin-dts type resolution across
+ * @aws-sdk/core and @aws-sdk/config submodule carriers.
+ * Mimics a library that re-exports SDK infrastructure types.
+ *
+ * This is the regression test for #8112.
+ */
+
+// @aws-sdk/core/client
+export { emitWarningIfUnsupportedVersion, setCredentialFeature, setFeature } from "@aws-sdk/core/client";
+export type { HostHeaderInputConfig } from "@aws-sdk/core/client";
+
+// @aws-sdk/core/httpAuthSchemes — the primary regression target
+export { getBearerTokenEnvKey } from "@aws-sdk/core/httpAuthSchemes";
+export type { AwsSdkSigV4AuthInputConfig, AwsSdkSigV4AAuthInputConfig } from "@aws-sdk/core/httpAuthSchemes";
+
+// @aws-sdk/core/protocols
+export { AwsSmithyRpcV2CborProtocol } from "@aws-sdk/core/protocols";
+
+// @aws-sdk/core/account-id-endpoint
+export {
+  DEFAULT_ACCOUNT_ID_ENDPOINT_MODE,
+  resolveAccountIdEndpointModeConfig,
+} from "@aws-sdk/core/account-id-endpoint";
+export type { AccountIdEndpointMode } from "@aws-sdk/core/account-id-endpoint";
+
+// @aws-sdk/core/util
+export { formatUrl } from "@aws-sdk/core/util";
+export type { ARN } from "@aws-sdk/core/util";
+
+// @aws-sdk/config — one representative from each submodule
+export type { AwsCredentialIdentity } from "@aws-sdk/config/credentials";
+export { NoOpLogger } from "@aws-sdk/config/logger";
+export type { AwsRestJsonProtocol } from "@aws-sdk/config/protocol";
+export { FetchHttpHandler } from "@aws-sdk/config/requestHandler";
+export { RETRY_MODES } from "@aws-sdk/config/retryStrategy";
+export type { AssertiveClient } from "@aws-sdk/config/typecheck";

--- a/tests/bundler-compat/src/sample-app.ts
+++ b/tests/bundler-compat/src/sample-app.ts
@@ -1,0 +1,46 @@
+// @aws-sdk/client-s3, @aws-sdk/client-dynamodb, @aws-sdk/lib-dynamodb, @aws-sdk/lib-storage
+export { S3, S3Client, ListBucketsCommand } from "@aws-sdk/client-s3";
+export { DynamoDB } from "@aws-sdk/client-dynamodb";
+export { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+export { Upload } from "@aws-sdk/lib-storage";
+
+// @smithy/types
+export type { Provider } from "@smithy/types";
+
+// @aws-sdk/config submodules
+export type { AwsCredentialIdentity } from "@aws-sdk/config/credentials";
+export { NoOpLogger, LogLevel } from "@aws-sdk/config/logger";
+export type {
+  AwsRestJsonProtocol,
+  AwsRestXmlProtocol,
+  AwsJson1_0Protocol,
+  AwsJson1_1Protocol,
+  AwsQueryProtocol,
+  AwsSmithyRpcV2CborProtocol,
+} from "@aws-sdk/config/protocol";
+export {
+  FetchHttpHandler,
+  type FetchHttpHandlerOptions,
+  NodeHttpHandler,
+  type NodeHttpHandlerOptions,
+  NodeHttp2Handler,
+  type NodeHttp2HandlerOptions,
+} from "@aws-sdk/config/requestHandler";
+export { RETRY_MODES } from "@aws-sdk/config/retryStrategy";
+export type { AssertiveClient } from "@aws-sdk/config/typecheck";
+
+// @aws-sdk/core submodules
+export { emitWarningIfUnsupportedVersion } from "@aws-sdk/core/client";
+export { DEFAULT_ACCOUNT_ID_ENDPOINT_MODE } from "@aws-sdk/core/account-id-endpoint";
+export { ARN } from "@aws-sdk/core/util";
+
+// @aws-sdk/middleware-sdk-s3 submodules
+export { checkContentLengthHeader } from "@aws-sdk/middleware-sdk-s3/s3";
+export { getProcessArnablesPlugin } from "@aws-sdk/middleware-sdk-s3/s3-control";
+
+// @aws-sdk/nested-clients submodules
+export type { SSOOIDCExtensionConfiguration } from "@aws-sdk/nested-clients/sso-oidc";
+export type { STSExtensionConfiguration } from "@aws-sdk/nested-clients/sts";
+export type { SigninExtensionConfiguration } from "@aws-sdk/nested-clients/signin";
+export type { CognitoIdentityExtensionConfiguration } from "@aws-sdk/nested-clients/cognito-identity";
+export type { SSOExtensionConfiguration } from "@aws-sdk/nested-clients/sso";

--- a/tests/bundler-compat/tsconfig.json
+++ b/tests/bundler-compat/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tests/bundler-compat/tsup-dts.config.ts
+++ b/tests/bundler-compat/tsup-dts.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/dts-check.ts"],
+  outDir: "dist/dts",
+  format: ["esm"],
+  platform: "browser",
+  dts: {
+    resolve: true,
+    compilerOptions: {
+      moduleResolution: "bundler",
+    },
+  },
+  external: [/^node:/, /^@smithy/],
+  tsconfig: "tsconfig.json",
+});

--- a/tests/bundlers/bundler-output-analysis.cjs
+++ b/tests/bundlers/bundler-output-analysis.cjs
@@ -30,12 +30,23 @@ const ARROW_FUNCTION_EXPRESSION = "ArrowFunctionExpression";
  * @internal
  */
 function findGlobalBufferRefs(code) {
-  const ast = parse(code, {
-    ecmaVersion: 2022,
-    sourceType: MODULE,
-    allowHashBang: true,
-    locations: true,
-  });
+  let ast;
+  try {
+    ast = parse(code, {
+      ecmaVersion: 2022,
+      sourceType: MODULE,
+      allowHashBang: true,
+      locations: true,
+    });
+  } catch {
+    ast = parse(code, {
+      ecmaVersion: 2022,
+      sourceType: "script",
+      allowHashBang: true,
+      allowImportExportEverywhere: true,
+      locations: true,
+    });
+  }
 
   const polyfillRanges = collectPolyfillRanges(ast);
   const guardedRanges = collectGuardedRanges(ast);


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8112

### Description
dts type inlining and metro bundler compat tests

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
