### PR TITLE
chore(scripts): drop bundler support in dist-cjs (use dist-es instead)

### DIFF
--- a/clients/client-lambda-core/tsconfig.json
+++ b/clients/client-lambda-core/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,
-    "incremental": true,
     "removeComments": true,
     "resolveJsonModule": true,
     "rootDir": "src",

--- a/clients/client-lambda-microvms/tsconfig.json
+++ b/clients/client-lambda-microvms/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "downlevelIteration": true,
     "importHelpers": true,
-    "incremental": true,
     "removeComments": true,
     "resolveJsonModule": true,
     "rootDir": "src",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -63,8 +63,7 @@
     "stream": "stream-browserify"
   },
   "react-native": {
-    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.native",
-    "./dist-cjs/runtimeConfig": "./dist-cjs/runtimeConfig.native"
+    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.native"
   },
   "files": [
     "dist-*/**"

--- a/lib/lib-transfer-manager/package.json
+++ b/lib/lib-transfer-manager/package.json
@@ -30,14 +30,8 @@
     },
     "./transfer-manager": {
       "types": "./dist-types/submodules/transfer-manager/index.d.ts",
-      "react-native": {
-        "import": "./dist-es/submodules/transfer-manager/index.browser.js",
-        "require": "./dist-cjs/submodules/transfer-manager/index.browser.js"
-      },
-      "browser": {
-        "import": "./dist-es/submodules/transfer-manager/index.browser.js",
-        "require": "./dist-cjs/submodules/transfer-manager/index.browser.js"
-      },
+      "react-native": "./dist-es/submodules/transfer-manager/index.browser.js",
+      "browser": "./dist-es/submodules/transfer-manager/index.browser.js",
       "module": "./dist-es/submodules/transfer-manager/index.js",
       "node": "./dist-cjs/submodules/transfer-manager/index.js",
       "import": "./dist-es/submodules/transfer-manager/index.js",

--- a/packages-internal/checksums/package.json
+++ b/packages-internal/checksums/package.json
@@ -61,8 +61,7 @@
     "./dist-es/flexible-checksums/getCrc32ChecksumAlgorithmFunction": "./dist-es/flexible-checksums/getCrc32ChecksumAlgorithmFunction.browser"
   },
   "react-native": {
-    "./dist-es/flexible-checksums/getCrc32ChecksumAlgorithmFunction": "./dist-es/flexible-checksums/getCrc32ChecksumAlgorithmFunction.browser",
-    "./dist-cjs/flexible-checksums/getCrc32ChecksumAlgorithmFunction": "./dist-cjs/flexible-checksums/getCrc32ChecksumAlgorithmFunction.browser"
+    "./dist-es/flexible-checksums/getCrc32ChecksumAlgorithmFunction": "./dist-es/flexible-checksums/getCrc32ChecksumAlgorithmFunction.browser"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages-internal/checksums",
   "repository": {

--- a/packages-internal/core/package.json
+++ b/packages-internal/core/package.json
@@ -38,14 +38,8 @@
     },
     "./client": {
       "types": "./dist-types/submodules/client/index.d.ts",
-      "react-native": {
-        "import": "./dist-es/submodules/client/index.native.js",
-        "require": "./dist-cjs/submodules/client/index.native.js"
-      },
-      "browser": {
-        "import": "./dist-es/submodules/client/index.browser.js",
-        "require": "./dist-cjs/submodules/client/index.browser.js"
-      },
+      "react-native": "./dist-es/submodules/client/index.native.js",
+      "browser": "./dist-es/submodules/client/index.browser.js",
       "module": "./dist-es/submodules/client/index.js",
       "node": "./dist-cjs/submodules/client/index.js",
       "import": "./dist-es/submodules/client/index.js",

--- a/packages-internal/credential-provider-http/package.json
+++ b/packages-internal/credential-provider-http/package.json
@@ -10,9 +10,7 @@
   },
   "react-native": {
     "./dist-es/index": "./dist-es/index.browser",
-    "./dist-cjs/index": "./dist-cjs/index.browser",
-    "./dist-es/fromHttp/fromHttp": "./dist-es/fromHttp/fromHttp.browser",
-    "./dist-cjs/fromHttp/fromHttp": "./dist-cjs/fromHttp/fromHttp.browser"
+    "./dist-es/fromHttp/fromHttp": "./dist-es/fromHttp/fromHttp.browser"
   },
   "scripts": {
     "build": "concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",

--- a/packages-internal/credential-provider-web-identity/package.json
+++ b/packages-internal/credential-provider-web-identity/package.json
@@ -20,8 +20,7 @@
     "./dist-es/fromTokenFile": false
   },
   "react-native": {
-    "./dist-es/fromTokenFile": false,
-    "./dist-cjs/fromTokenFile": false
+    "./dist-es/fromTokenFile": false
   },
   "keywords": [
     "aws",

--- a/packages-internal/middleware-sdk-s3/package.json
+++ b/packages-internal/middleware-sdk-s3/package.json
@@ -39,14 +39,8 @@
     },
     "./s3": {
       "types": "./dist-types/submodules/s3/index.d.ts",
-      "react-native": {
-        "import": "./dist-es/submodules/s3/index.browser.js",
-        "require": "./dist-cjs/submodules/s3/index.browser.js"
-      },
-      "browser": {
-        "import": "./dist-es/submodules/s3/index.browser.js",
-        "require": "./dist-cjs/submodules/s3/index.browser.js"
-      },
+      "react-native": "./dist-es/submodules/s3/index.browser.js",
+      "browser": "./dist-es/submodules/s3/index.browser.js",
       "module": "./dist-es/submodules/s3/index.js",
       "node": "./dist-cjs/submodules/s3/index.js",
       "import": "./dist-es/submodules/s3/index.js",

--- a/packages-internal/middleware-token/package.json
+++ b/packages-internal/middleware-token/package.json
@@ -62,8 +62,7 @@
     "./dist-es/tokenDefaultProvider": "./dist-es/tokenDefaultProvider.browser"
   },
   "react-native": {
-    "./dist-es/tokenDefaultProvider": "./dist-es/tokenDefaultProvider.browser",
-    "./dist-cjs/tokenDefaultProvider": "./dist-cjs/tokenDefaultProvider.browser"
+    "./dist-es/tokenDefaultProvider": "./dist-es/tokenDefaultProvider.browser"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages-internal/middleware-token",
   "repository": {

--- a/packages-internal/util-dns/package.json
+++ b/packages-internal/util-dns/package.json
@@ -66,9 +66,6 @@
   "react-native": {
     "./dist-es/index": "./dist-es/index.browser",
     "./dist-es/HostResolver": "./dist-es/HostResolver.browser",
-    "./dist-es/NodeDnsLookupHostResolver": false,
-    "./dist-cjs/index": "./dist-cjs/index.browser",
-    "./dist-cjs/HostResolver": "./dist-cjs/HostResolver.browser",
-    "./dist-cjs/NodeDnsLookupHostResolver": false
+    "./dist-es/NodeDnsLookupHostResolver": false
   }
 }

--- a/packages-internal/xml-builder/package.json
+++ b/packages-internal/xml-builder/package.json
@@ -45,8 +45,7 @@
     "./dist-es/xml-parser": "./dist-es/xml-parser.browser"
   },
   "react-native": {
-    "./dist-es/xml-parser": "./dist-es/xml-parser.browser",
-    "./dist-cjs/xml-parser": "./dist-cjs/xml-parser.browser"
+    "./dist-es/xml-parser": "./dist-es/xml-parser.browser"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages-internal/xml-builder",
   "repository": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -45,14 +45,8 @@
     },
     "./requestHandler": {
       "types": "./dist-types/submodules/requestHandler/index.d.ts",
-      "react-native": {
-        "import": "./dist-es/submodules/requestHandler/index.browser.js",
-        "require": "./dist-cjs/submodules/requestHandler/index.browser.js"
-      },
-      "browser": {
-        "import": "./dist-es/submodules/requestHandler/index.browser.js",
-        "require": "./dist-cjs/submodules/requestHandler/index.browser.js"
-      },
+      "react-native": "./dist-es/submodules/requestHandler/index.browser.js",
+      "browser": "./dist-es/submodules/requestHandler/index.browser.js",
       "module": "./dist-es/submodules/requestHandler/index.js",
       "node": "./dist-cjs/submodules/requestHandler/index.js",
       "import": "./dist-es/submodules/requestHandler/index.js",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -10,9 +10,7 @@
   },
   "react-native": {
     "./dist-es/fromTemporaryCredentials": "./dist-es/fromTemporaryCredentials.browser",
-    "./dist-cjs/fromTemporaryCredentials": "./dist-cjs/fromTemporaryCredentials.browser",
-    "./dist-es/index": "./dist-es/index.browser",
-    "./dist-cjs/index": "./dist-cjs/index.browser"
+    "./dist-es/index": "./dist-es/index.browser"
   },
   "scripts": {
     "build": "concurrently 'yarn:build:types' 'yarn:build:es' && yarn build:cjs",

--- a/packages/dsql-signer/package.json
+++ b/packages/dsql-signer/package.json
@@ -59,8 +59,7 @@
     "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.browser"
   },
   "react-native": {
-    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.native",
-    "./dist-cjs/runtimeConfig": "./dist-cjs/runtimeConfig.native"
+    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.native"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/dsql-signer",
   "repository": {

--- a/packages/rds-signer/package.json
+++ b/packages/rds-signer/package.json
@@ -60,8 +60,7 @@
     "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.browser"
   },
   "react-native": {
-    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.native",
-    "./dist-cjs/runtimeConfig": "./dist-cjs/runtimeConfig.native"
+    "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.native"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/rds-signer",
   "repository": {

--- a/scripts/compilation/Inliner.js
+++ b/scripts/compilation/Inliner.js
@@ -1,8 +1,6 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { spawnProcess } = require("./../utils/spawn-process");
-const walk = require("./../utils/walk");
-const { extractImports } = require("./../validation/validation-shared");
 const rollup = require("rollup");
 const { nodeResolve } = require("@rollup/plugin-node-resolve");
 const json = require("@rollup/plugin-json");
@@ -12,46 +10,33 @@ const root = path.join(__dirname, "..", "..");
 
 /**
  *
- * Inline a package as one dist file, preserves other files as re-export stubs,
- * preserves files with react-native variants as externals.
+ * Inline a package as one dist file.
+ * Normal packages produce a single dist-cjs/index.js.
+ * Submodule packages produce dist-cjs/index.js plus one
+ * dist-cjs/submodules/<name>/index.js per submodule.
  *
  */
 module.exports = class Inliner {
   constructor(pkg) {
     this.package = pkg;
-    this.platform = "node";
     this.isInternalPackage = fs.existsSync(path.join(root, "packages-internal", pkg));
     this.isPackage = !this.isInternalPackage && fs.existsSync(path.join(root, "packages", pkg));
     this.isLib = fs.existsSync(path.join(root, "lib", pkg));
     this.isPrivate = fs.existsSync(path.join(root, "private", pkg));
     this.subfolder = (() => {
-      if (this.isInternalPackage) {
-        return "packages-internal";
-      }
-      if (this.isPackage) {
-        return "packages";
-      }
-      if (this.isLib) {
-        return "lib";
-      }
-      if (this.isPrivate) {
-        return "private";
-      }
+      if (this.isInternalPackage) return "packages-internal";
+      if (this.isPackage) return "packages";
+      if (this.isLib) return "lib";
+      if (this.isPrivate) return "private";
       return "clients";
     })();
     this.hasSubmodules =
       fs.existsSync(path.join(root, this.subfolder, pkg, "src", "submodules")) &&
       "exports" in require(path.join(root, this.subfolder, pkg, "package.json"));
     this.verbose = process.env.DEBUG || process.argv.includes("--debug");
-
     this.packageDirectory = path.join(root, this.subfolder, pkg);
-
     this.outfile = path.join(root, this.subfolder, pkg, "dist-cjs", "index.js");
-
     this.pkgJson = require(path.join(root, this.subfolder, this.package, "package.json"));
-    /**
-     * If the react entrypoint is another file entirely, then bail out of inlining.
-     */
     this.bailout = typeof this.pkgJson["react-native"] === "string";
   }
 
@@ -59,7 +44,7 @@ module.exports = class Inliner {
    * step 0: delete the dist-cjs folder.
    */
   async clean() {
-    await spawnProcess("yarn", ["premove", "./dist-cjs", "tsconfig.cjs.tsbuildinfo"], { cwd: this.packageDirectory });
+    await spawnProcess("yarn", ["premove", "./dist-cjs"], { cwd: this.packageDirectory });
     if (this.verbose) {
       console.log("Deleted ./dist-cjs in " + this.package);
     }
@@ -67,131 +52,22 @@ module.exports = class Inliner {
   }
 
   /**
-   * step 1: detect all variant files.
-   * For submodule packages, we collect variant mappings per submodule to produce
-   * fully-inlined browser/native bundles.
-   * For non-submodule packages, we collect variant externals as before.
-   *
-   * Walks dist-es to discover variant files (.native.js, .browser.js).
+   * step 1: bundle the package index into dist-cjs/index.js.
+   * For submodule packages, also produces one index.js per submodule.
    */
-  async discoverVariants() {
+  async bundle() {
     if (this.bailout) {
       console.log("Inliner bailout.");
       return this;
     }
 
-    if (this.hasSubmodules) {
-      this.variantExternals = [];
-      this.variantMap = {};
-      return this;
-    }
-
-    this.variantEntries = Object.entries(this.pkgJson["react-native"] ?? {}).map(([k, v]) => [
-      k.replace("dist-cjs/", "dist-es/"),
-      String(v).replace("dist-cjs/", "dist-es/"),
-    ]);
-
-    for await (const file of walk(path.join(this.packageDirectory, "dist-es"))) {
-      if (file.endsWith(".js") && fs.existsSync(file.replace(/\.js$/, ".native.js"))) {
-        console.log("detected undeclared auto-variant", file);
-        const canonical = file.replace(/(.*?)dist-es\//, "./dist-es/").replace(/\.js$/, "");
-        const variant = canonical.replace(/(.*?)(\.js)?$/, "$1.native$2");
-        this.variantEntries.push([canonical, variant]);
-      }
-      if (
-        file.endsWith(".js") &&
-        !file.endsWith(".browser.js") &&
-        fs.existsSync(file.replace(/\.js$/, ".browser.js"))
-      ) {
-        const canonical = file.replace(/(.*?)dist-es\//, "./dist-es/").replace(/\.js$/, "");
-        const variant = canonical.replace(/(.*?)(\.js)?$/, "$1.browser$2");
-        this.variantEntries.push([canonical, variant]);
-      }
-    }
-
-    this.transitiveVariants = [];
-
-    for (const [k, v] of this.variantEntries) {
-      for (const variantFile of [k, String(v)]) {
-        if (!variantFile.includes("dist-es/")) {
-          continue;
-        }
-        const keyFile = path.join(
-          this.packageDirectory,
-          "dist-es",
-          variantFile.replace(/(.*?)dist-es\//, "") + (variantFile.endsWith(".js") ? "" : ".js")
-        );
-        if (!fs.existsSync(keyFile)) continue;
-        const keyFileContents = fs.readFileSync(keyFile, "utf-8");
-        const relativeImports = extractImports(keyFileContents).filter((s) => s.startsWith("."));
-        for (const dep of relativeImports) {
-          const key = path.normalize(path.join(path.dirname(keyFile), dep)).replace(/(.*?)dist-es\//, "./dist-es/");
-          if (this.verbose) {
-            console.log("Transitive variant file:", key);
-          }
-
-          const transitiveVariant = key.replace(/(.*?)dist-es\//, "").replace(/(\.js)?$/, "");
-
-          if (!this.transitiveVariants.includes(transitiveVariant)) {
-            this.variantEntries.push([key, key]);
-            this.transitiveVariants.push(transitiveVariant);
-          }
-        }
-      }
-    }
-
-    this.variantExternals = [];
-    this.variantMap = {};
-
-    for (const [k, v] of this.variantEntries) {
-      const prefix = "dist-es/";
-      const keyPrefixIndex = k.indexOf(prefix);
-      if (keyPrefixIndex === -1) {
-        continue;
-      }
-      const keyRelativePath = k.slice(keyPrefixIndex + prefix.length);
-      const valuePrefixIndex = String(v).indexOf(prefix);
-
-      const addJsExtension = (file) => (file.endsWith(".js") ? file : file + ".js");
-
-      if (valuePrefixIndex !== -1) {
-        const valueRelativePath = String(v).slice(valuePrefixIndex + prefix.length);
-        this.variantExternals.push(...[keyRelativePath, valueRelativePath].map(addJsExtension));
-        this.variantMap[keyRelativePath] = valueRelativePath;
-      } else {
-        this.variantExternals.push(addJsExtension(keyRelativePath));
-        this.variantMap[keyRelativePath] = v;
-      }
-    }
-
-    this.variantExternals = [...new Set(this.variantExternals)];
-
-    return this;
-  }
-
-  /**
-   * step 2: bundle the package index into dist-cjs/index.js except for node_modules
-   * and also excluding any local files that have variants for react-native.
-   *
-   * For submodule packages, produces fully-inlined bundles per submodule:
-   * - index.js (node/default)
-   * - index.browser.js (with browser variants resolved)
-   * - index.native.js (with native variants resolved, only if native variants exist)
-   */
-  async bundle() {
-    if (this.bailout) {
-      return this;
-    }
-
-    const variantExternalsForRollup = this.variantExternals.map((variant) => variant.replace(/.js$/, ""));
-
     const entryPoint = path.join(root, this.subfolder, this.package, "dist-es", "index.js");
 
-    const makeInputOptions = (entry, externals, plugins = []) => {
+    const makeInputOptions = (entry) => {
       const externalityAssessments = {};
       return {
         input: [entry],
-        plugins: [...plugins, nodeResolve(), json()],
+        plugins: [nodeResolve(), json()],
         onwarn(warning) {
           if (warning.code === "CIRCULAR_DEPENDENCY") {
             throw Error(warning.message);
@@ -221,15 +97,6 @@ module.exports = class Inliner {
             return (externalityAssessments[id] = true);
           }
 
-          for (const file of externals) {
-            const idWithoutExtension = id.replace(/\.[tj]s$/, "");
-            const idBasename = path.basename(idWithoutExtension);
-            if (idBasename === path.basename(file)) {
-              this.verbose && console.log("EXTERN (variant)", id);
-              return (externalityAssessments[id] = true);
-            }
-          }
-
           return (externalityAssessments[id] = false);
         },
       };
@@ -254,9 +121,8 @@ module.exports = class Inliner {
       }
     };
 
-    // Bundle main index.js (no variants externalized for submodule packages).
-    const mainExternals = this.hasSubmodules ? [] : variantExternalsForRollup;
-    const bundle = await rollup.rollup(makeInputOptions(entryPoint, mainExternals));
+    // Bundle main index.js.
+    const bundle = await rollup.rollup(makeInputOptions(entryPoint));
     await bundle.write(outputOptions(path.dirname(this.outfile)));
     await bundle.close();
 
@@ -270,147 +136,18 @@ module.exports = class Inliner {
         const distEsSubmoduleDir = path.join(root, this.subfolder, this.package, "dist-es", "submodules", submodule);
         const submoduleOutDir = path.join(root, this.subfolder, this.package, "dist-cjs", "submodules", submodule);
 
-        // Remove all tsc-generated files in this submodule's dist-cjs folder.
         if (fs.existsSync(submoduleOutDir)) {
           fs.rmSync(submoduleOutDir, { recursive: true });
         }
         fs.mkdirSync(submoduleOutDir, { recursive: true });
 
-        // Bundle index.js (node/default).
-        const nodeBundle = await rollup.rollup(makeInputOptions(path.join(distEsSubmoduleDir, "index.js"), []));
-        await nodeBundle.write(outputOptions(submoduleOutDir));
-        await nodeBundle.close();
-
-        // Bundle index.browser.js if the source file exists.
-        const browserEntry = path.join(distEsSubmoduleDir, "index.browser.js");
-        if (fs.existsSync(browserEntry)) {
-          const browserBundle = await rollup.rollup(makeInputOptions(browserEntry, []));
-          await browserBundle.write({
-            ...outputOptions(submoduleOutDir),
-            entryFileNames: "index.browser.js",
-          });
-          await browserBundle.close();
-        }
-
-        // Bundle index.native.js if the source file exists.
-        const nativeEntry = path.join(distEsSubmoduleDir, "index.native.js");
-        if (fs.existsSync(nativeEntry)) {
-          const nativeBundle = await rollup.rollup(makeInputOptions(nativeEntry, []));
-          await nativeBundle.write({
-            ...outputOptions(submoduleOutDir),
-            entryFileNames: "index.native.js",
-          });
-          await nativeBundle.close();
-        }
+        const subBundle = await rollup.rollup(makeInputOptions(path.join(distEsSubmoduleDir, "index.js")));
+        await subBundle.write(outputOptions(submoduleOutDir));
+        await subBundle.close();
       }
     }
 
     transpileDir(path.join(root, this.subfolder, this.package, "dist-cjs"));
-
-    return this;
-  }
-
-  /**
-   * step 3: transform retained variant files from dist-es to dist-cjs.
-   */
-  async transformVariants() {
-    if (this.bailout || this.hasSubmodules) {
-      return this;
-    }
-
-    const { transpile } = require("./esm-to-cjs");
-
-    for (const variantFile of this.variantExternals) {
-      const srcFile = path.join(this.packageDirectory, "dist-es", variantFile);
-      if (!fs.existsSync(srcFile)) continue;
-
-      const esmCode = fs.readFileSync(srcFile, "utf-8");
-      const outFile = path.join(this.packageDirectory, "dist-cjs", variantFile);
-      fs.mkdirSync(path.dirname(outFile), { recursive: true });
-      fs.writeFileSync(outFile, transpile(esmCode));
-
-      if (this.verbose) {
-        console.log("Transformed variant:", variantFile);
-      }
-    }
-
-    return this;
-  }
-
-  /**
-   * step 4: rewrite variant external imports to correct path.
-   * For submodule packages, this is a no-op since all variants are fully inlined.
-   */
-  async fixVariantImportPaths() {
-    if (this.bailout || this.hasSubmodules) {
-      return this;
-    }
-    this.indexContents = fs.readFileSync(this.outfile, "utf-8");
-    const fixImportsForFile = (contents, remove = "") => {
-      for (const variant of Object.keys(this.variantMap)) {
-        const basename = path.basename(variant).replace(/.js$/, "");
-        const dirname = path.dirname(variant);
-
-        const find = new RegExp(`require\\("\\.(.*?)/${basename}"\\)`, "g");
-        const rel = path.join(dirname, basename);
-        const replace = `require("${rel.startsWith(".") ? rel : "./" + rel}")`.replace(remove, "");
-
-        contents = contents.replace(find, replace);
-
-        if (this.verbose) {
-          console.log("Replacing", find, "with", replace, "removed=", remove);
-        }
-      }
-      return contents;
-    };
-    if (this.verbose) {
-      console.log("Fixing imports for main file", path.dirname(this.outfile));
-    }
-    this.indexContents = fixImportsForFile(this.indexContents);
-    fs.writeFileSync(this.outfile, this.indexContents, "utf-8");
-    return this;
-  }
-
-  /**
-   * step 5: validate the output.
-   * Checks that variant externals are referenced in the bundled index.
-   */
-  async validate() {
-    if (this.bailout || this.hasSubmodules) {
-      return this;
-    }
-
-    this.indexContents = fs.readFileSync(this.outfile, "utf-8");
-
-    const externalsToCheck = new Set(
-      Object.keys(this.variantMap)
-        .filter(
-          (variant) => !this.transitiveVariants.includes(variant.replace(/\.js$/, "")) && !variant.endsWith("index")
-        )
-        .map((variant) => path.basename(variant).replace(/.js$/, ""))
-    );
-
-    for (const line of this.indexContents.split("\n")) {
-      if (line.includes("require(")) {
-        const checkOrder = [...externalsToCheck].sort().reverse();
-        for (const external of checkOrder) {
-          if (line.includes(external)) {
-            if (this.verbose) {
-              console.log("Inline index confirmed require() for variant external:", external);
-            }
-            externalsToCheck.delete(external);
-          }
-        }
-      }
-    }
-
-    if (externalsToCheck.size) {
-      throw new Error(
-        "require() statements for the following variant externals: " +
-          [...externalsToCheck].join(", ") +
-          " were not found in the index."
-      );
-    }
 
     return this;
   }

--- a/scripts/compilation/inline.js
+++ b/scripts/compilation/inline.js
@@ -53,10 +53,6 @@ if (process.argv.includes("--setup")) {
   (async () => {
     const inliner = new Inliner(_package);
     await inliner.clean();
-    await inliner.discoverVariants();
     await inliner.bundle();
-    await inliner.transformVariants();
-    await inliner.fixVariantImportPaths();
-    await inliner.validate();
   })();
 }

--- a/scripts/runtime-dependency-version-check/package-json-enforcement.js
+++ b/scripts/runtime-dependency-version-check/package-json-enforcement.js
@@ -109,24 +109,16 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
         }
       }
 
-      const reactNativeCanonical = [
-        ...new Set([
-          ...Object.entries(pkgJson["react-native"]).map(([k, v]) => [
-            k.replace("dist-cjs", "dist-es"),
-            typeof v === "string" ? v.replace("dist-cjs", "dist-es") : v,
-          ]),
-          ...Object.entries(pkgJson["react-native"]).map(([k, v]) => [
-            k.replace("dist-es", "dist-cjs"),
-            typeof v === "string" ? v.replace("dist-es", "dist-cjs") : v,
-          ]),
-        ]),
-      ].reduce((acc, [k, v]) => {
-        acc[k] = v;
+      const reactNativeCanonical = Object.entries(pkgJson["react-native"]).reduce((acc, [k, v]) => {
+        // react-native must point to dist-es for bundling in all cases.
+        const esKey = k.replace("dist-cjs", "dist-es");
+        const esValue = typeof v === "string" ? v.replace("dist-cjs", "dist-es") : v;
+        acc[esKey] = esValue;
         return acc;
       }, {});
 
-      if (Object.keys(reactNativeCanonical).length !== Object.keys(pkgJson["react-native"]).length) {
-        errors.push(`${pkgJson.name} react-native field is incomplete.`);
+      if (JSON.stringify(pkgJson["react-native"]) !== JSON.stringify(reactNativeCanonical)) {
+        errors.push(`${pkgJson.name} react-native field must point to dist-es only.`);
         if (overwrite) {
           pkgJson["react-native"] = reactNativeCanonical;
         }
@@ -145,7 +137,6 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
         }
 
         const esIndex = `./dist-es/submodules/${sub}/index.js`;
-        const cjsIndex = `./dist-cjs/submodules/${sub}/index.js`;
 
         if (fs.existsSync(path.join(subPath, "index.browser.ts"))) {
           const esBrowserExpected = `./dist-es/submodules/${sub}/index.browser.js`;
@@ -162,26 +153,19 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
           // Conditional exports must have "browser" condition pointing to dist-es.
           const exportEntry = pkgJson.exports?.[`./${sub}`];
           if (exportEntry) {
-            const esBrowser = esBrowserExpected;
-            const cjsBrowser = esBrowser.replace("dist-es", "dist-cjs");
-            const expectedBrowser = { import: esBrowser, require: cjsBrowser };
-            if (JSON.stringify(exportEntry.browser) !== JSON.stringify(expectedBrowser)) {
-              errors.push(`${pkgJson.name} exports["./${sub}"].browser should be ${JSON.stringify(expectedBrowser)}`);
+            if (exportEntry.browser !== esBrowserExpected) {
+              errors.push(`${pkgJson.name} exports["./${sub}"].browser should be "${esBrowserExpected}"`);
               if (overwrite) {
-                exportEntry.browser = expectedBrowser;
+                exportEntry.browser = esBrowserExpected;
               }
             }
-            // react-native condition: native variant if exists, otherwise browser fallback.
+            // react-native condition: native variant if exists, otherwise browser fallback. Points to dist-es only.
             const hasNative = fs.existsSync(path.join(subPath, "index.native.ts"));
-            const esRn = hasNative ? `./dist-es/submodules/${sub}/index.native.js` : esBrowser;
-            const cjsRn = esRn.replace("dist-es", "dist-cjs");
-            const expectedRn = { import: esRn, require: cjsRn };
-            if (JSON.stringify(exportEntry["react-native"]) !== JSON.stringify(expectedRn)) {
-              errors.push(
-                `${pkgJson.name} exports["./${sub}"]["react-native"] should be ${JSON.stringify(expectedRn)}`
-              );
+            const esRn = hasNative ? `./dist-es/submodules/${sub}/index.native.js` : esBrowserExpected;
+            if (exportEntry["react-native"] !== esRn) {
+              errors.push(`${pkgJson.name} exports["./${sub}"]["react-native"] should be "${esRn}"`);
               if (overwrite) {
-                exportEntry["react-native"] = expectedRn;
+                exportEntry["react-native"] = esRn;
               }
             }
           }
@@ -189,9 +173,8 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
 
         if (fs.existsSync(path.join(subPath, "index.native.ts"))) {
           const esNativeExpected = `./dist-es/submodules/${sub}/index.native.js`;
-          const cjsNativeExpected = `./dist-cjs/submodules/${sub}/index.native.js`;
 
-          // react-native field: re-path both dist-es and dist-cjs.
+          // react-native field: re-path dist-es only (bundlers resolve from dist-es).
           if (reactNativeField[esIndex] !== esNativeExpected) {
             errors.push(`${pkgJson.name} react-native["${esIndex}"] should be "${esNativeExpected}"`);
             if (overwrite) {
@@ -199,17 +182,9 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
               didModify = true;
             }
           }
-          if (reactNativeField[cjsIndex] !== cjsNativeExpected) {
-            errors.push(`${pkgJson.name} react-native["${cjsIndex}"] should be "${cjsNativeExpected}"`);
-            if (overwrite) {
-              reactNativeField[cjsIndex] = cjsNativeExpected;
-              didModify = true;
-            }
-          }
         } else if (fs.existsSync(path.join(subPath, "index.browser.ts"))) {
-          // No native variant — react-native falls back to browser for both dist-es and dist-cjs.
+          // No native variant — react-native falls back to browser for dist-es.
           const esBrowserExpected = `./dist-es/submodules/${sub}/index.browser.js`;
-          const cjsBrowserExpected = `./dist-cjs/submodules/${sub}/index.browser.js`;
 
           if (reactNativeField[esIndex] !== esBrowserExpected) {
             errors.push(
@@ -217,15 +192,6 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
             );
             if (overwrite) {
               reactNativeField[esIndex] = esBrowserExpected;
-              didModify = true;
-            }
-          }
-          if (reactNativeField[cjsIndex] !== cjsBrowserExpected) {
-            errors.push(
-              `${pkgJson.name} react-native["${cjsIndex}"] should be "${cjsBrowserExpected}" (fallback to browser)`
-            );
-            if (overwrite) {
-              reactNativeField[cjsIndex] = cjsBrowserExpected;
               didModify = true;
             }
           }
@@ -295,8 +261,6 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
 
         const esCanonical = `./dist-es${canonicalPath}`;
         const esVariant = `./dist-es${relativePath}`;
-        const cjsCanonical = `./dist-cjs${canonicalPath}`;
-        const cjsVariant = `./dist-cjs${relativePath}`;
 
         // For react-native, .native takes precedence over .browser.
         const hasNativeVariant = variant === "browser" && fs.existsSync(file.replace(/\.browser\.ts$/, ".native.ts"));
@@ -317,26 +281,12 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
                 didModify = true;
               }
             }
-            if (reactNativeField[cjsCanonical] !== cjsVariant) {
-              errors.push(`${pkgJson.name} react-native["${cjsCanonical}"] should be "${cjsVariant}"`);
-              if (overwrite) {
-                reactNativeField[cjsCanonical] = cjsVariant;
-                didModify = true;
-              }
-            }
           }
         } else if (variant === "native") {
           if (reactNativeField[esCanonical] !== esVariant) {
             errors.push(`${pkgJson.name} react-native["${esCanonical}"] should be "${esVariant}"`);
             if (overwrite) {
               reactNativeField[esCanonical] = esVariant;
-              didModify = true;
-            }
-          }
-          if (reactNativeField[cjsCanonical] !== cjsVariant) {
-            errors.push(`${pkgJson.name} react-native["${cjsCanonical}"] should be "${cjsVariant}"`);
-            if (overwrite) {
-              reactNativeField[cjsCanonical] = cjsVariant;
               didModify = true;
             }
           }

--- a/scripts/validation/submodules-linter.js
+++ b/scripts/validation/submodules-linter.js
@@ -112,27 +112,17 @@ const submodulePackages = process.argv.includes("--all")
             fs.writeFileSync(path.join(root, `tsconfig.${kind}.json`), JSON.stringify(tsconfig, null, 2) + "\n");
           }
         }
-        // react-native condition in exports: must point to .native.js if it exists, else .browser.js.
+        // react-native condition in exports: must point to dist-es (.native.js if it exists, else .browser.js).
         const exportEntry = pkgJson.exports[`./${submodule}`];
         const nativeEs = `./dist-es/submodules/${submodule}/index.native.js`;
         const browserEs = `./dist-es/submodules/${submodule}/index.browser.js`;
-        const nativeCjs = `./dist-cjs/submodules/${submodule}/index.native.js`;
-        const browserCjs = `./dist-cjs/submodules/${submodule}/index.browser.js`;
         const hasNative = fs.existsSync(path.join(root, nativeEs));
         const hasBrowser = fs.existsSync(path.join(root, browserEs));
         if (hasNative || hasBrowser) {
           const expectedEs = hasNative ? nativeEs : browserEs;
-          const expectedCjs = hasNative ? nativeCjs : browserCjs;
-          const expected = { import: expectedEs, require: expectedCjs };
-          if (
-            !exportEntry["react-native"] ||
-            exportEntry["react-native"].import !== expectedEs ||
-            exportEntry["react-native"].require !== expectedCjs
-          ) {
-            errors.push(
-              `${submodule} exports "react-native" condition must point to ${hasNative ? ".native.js" : ".browser.js"}`
-            );
-            exportEntry["react-native"] = expected;
+          if (!exportEntry["react-native"] || exportEntry["react-native"] !== expectedEs) {
+            errors.push(`${submodule} exports "react-native" condition must point to ${expectedEs}`);
+            exportEntry["react-native"] = expectedEs;
             // reorder so react-native comes after types
             const reordered = {};
             if (exportEntry.types) {


### PR DESCRIPTION
### Issue
n/a

### Description
As you may know, each `@aws-sdk` package distributes `dist-es`, `dist-cjs`, and `dist-types` on NPM. The ES and CJS dists are identical copies (api-wise), except that CJS uses the `require()` and `exports.X = ...` syntax.

The CJS dist is only meant to be run in Node.js (module mode or otherwise), whereas the ES dist has alternate files ("variants") for browser and react-native bundling. 

Because all bundlers (tsup, esbuild, rollup/down, webpack, metro, etc.) support bundling out of the `dist-es` artifact, the `dist-cjs` artifact is now going to be inlined into a single file that is only compatible with Node.js. There's no reason to maintain separate files in `dist-cjs` for bundlers when that artifact is only run by Node.js. 

For the secondary issue of readability, you can give us the line number and the stack trace as usual. We know what source code it all corresponds to.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
