### PR TITLE
chore(packages): clean up remaining react-native dist-cjs instructions

### DIFF
--- a/lib/lib-transfer-manager/package.json
+++ b/lib/lib-transfer-manager/package.json
@@ -9,8 +9,7 @@
     "./dist-es/submodules/transfer-manager/index.js": "./dist-es/submodules/transfer-manager/index.browser.js"
   },
   "react-native": {
-    "./dist-es/submodules/transfer-manager/index.js": "./dist-es/submodules/transfer-manager/index.browser.js",
-    "./dist-cjs/submodules/transfer-manager/index.js": "./dist-cjs/submodules/transfer-manager/index.browser.js"
+    "./dist-es/submodules/transfer-manager/index.js": "./dist-es/submodules/transfer-manager/index.browser.js"
   },
   "types": "./dist-types/index.d.ts",
   "exports": {

--- a/packages-internal/core/package.json
+++ b/packages-internal/core/package.json
@@ -78,8 +78,7 @@
     "./dist-es/submodules/client/index.js": "./dist-es/submodules/client/index.browser.js"
   },
   "react-native": {
-    "./dist-es/submodules/client/index.js": "./dist-es/submodules/client/index.native.js",
-    "./dist-cjs/submodules/client/index.js": "./dist-cjs/submodules/client/index.native.js"
+    "./dist-es/submodules/client/index.js": "./dist-es/submodules/client/index.native.js"
   },
   "files": [
     "./account-id-endpoint.d.ts",

--- a/packages-internal/middleware-sdk-s3/package.json
+++ b/packages-internal/middleware-sdk-s3/package.json
@@ -99,11 +99,8 @@
   },
   "react-native": {
     "./dist-es/submodules/s3/index": "./dist-es/submodules/s3/index.browser",
-    "./dist-cjs/submodules/s3/index": "./dist-cjs/submodules/s3/index.browser",
     "./dist-es/submodules/s3/to-stream/toStream": "./dist-es/submodules/s3/to-stream/toStream.browser",
-    "./dist-cjs/submodules/s3/to-stream/toStream": "./dist-cjs/submodules/s3/to-stream/toStream.browser",
-    "./dist-es/submodules/s3/index.js": "./dist-es/submodules/s3/index.browser.js",
-    "./dist-cjs/submodules/s3/index.js": "./dist-cjs/submodules/s3/index.browser.js"
+    "./dist-es/submodules/s3/index.js": "./dist-es/submodules/s3/index.browser.js"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages-internal/middleware-sdk-s3",
   "repository": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -126,7 +126,6 @@
     "./dist-es/submodules/requestHandler/index.js": "./dist-es/submodules/requestHandler/index.browser.js"
   },
   "react-native": {
-    "./dist-es/submodules/requestHandler/index.js": "./dist-es/submodules/requestHandler/index.browser.js",
-    "./dist-cjs/submodules/requestHandler/index.js": "./dist-cjs/submodules/requestHandler/index.browser.js"
+    "./dist-es/submodules/requestHandler/index.js": "./dist-es/submodules/requestHandler/index.browser.js"
   }
 }


### PR DESCRIPTION
### Issue
follows https://github.com/aws/aws-sdk-js-v3/pull/8124

### Description
remove the remaining instances of `dist-cjs` appearing in react-native instructions

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
