### PR TITLE
chore(ci): allow AWS maintained packages in yarn age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,8 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.17.0.cjs
+
+npmPreapprovedPackages:
+  - "@aws/*"
+  - "@aws-crypto/*"
+  - "@smithy/*"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,4 +5,5 @@ yarnPath: .yarn/releases/yarn-4.17.0.cjs
 npmPreapprovedPackages:
   - "@aws/*"
   - "@aws-crypto/*"
+  - "@aws-sdk/*"
   - "@smithy/*"


### PR DESCRIPTION
### Issue

The bump to `yarn@4.17.0` in https://github.com/aws/aws-sdk-js-v3/pull/8137 added default [`npmMinimalAgeGate`](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate) of `1d` which blocked us from updating to new versions of other AWS owned packages, including `@smithy/*`

This PR adds [`npmPreapprovedPackages`](https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages) to preapprove AWS managed package scopes.

### Description
Allows AWS maintained packages in yarn age gate

### Testing
N/A

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
