### PR TITLE
chore(deps): bump @aws/lambda-invoke-store to ^0.3.0

### DIFF
--- a/packages-internal/core/package.json
+++ b/packages-internal/core/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "@aws-sdk/types": "workspace:^3.973.15",
     "@aws-sdk/xml-builder": "workspace:^3.972.33",
-    "@aws/lambda-invoke-store": "^0.2.2",
+    "@aws/lambda-invoke-store": "^0.3.0",
     "@smithy/core": "^3.29.0",
     "@smithy/signature-v4": "^5.6.1",
     "@smithy/types": "^4.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9812,7 +9812,7 @@ __metadata:
   dependencies:
     "@aws-sdk/types": "workspace:^3.973.15"
     "@aws-sdk/xml-builder": "workspace:^3.972.33"
-    "@aws/lambda-invoke-store": "npm:^0.2.2"
+    "@aws/lambda-invoke-store": "npm:^0.3.0"
     "@smithy/core": "npm:^3.29.0"
     "@smithy/signature-v4": "npm:^5.6.1"
     "@smithy/types": "npm:^4.15.1"
@@ -11131,10 +11131,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws/lambda-invoke-store@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "@aws/lambda-invoke-store@npm:0.2.2"
-  checksum: 10c0/0ce2f527e2ab6b07372a08a137991163b99bf646b8dbbb01dbc5370f4e578aa6ddf7f09a63ecead576f04ce54e52cb927c12683f4d97e322dcb76ddfc5843784
+"@aws/lambda-invoke-store@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@aws/lambda-invoke-store@npm:0.3.0"
+  checksum: 10c0/b4a2e6b3b5397bc606053e64270d26dc5c886336f88a98cad587b1592eec17058f8fb172f1827a9f0e591f3595cf8f01575c8c9b36cde38c06456f8a65204046
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue
https://github.com/awslabs/aws-lambda-invoke-store/releases/tag/v0.3.0

### Description
Bump @aws/lambda-invoke-store to ^0.3.0

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
