### PR TITLE
test(client-kinesis): resolve e2e endpoint from client config

### DIFF
--- a/clients/client-kinesis/test/Kinesis.e2e.spec.ts
+++ b/clients/client-kinesis/test/Kinesis.e2e.spec.ts
@@ -1,5 +1,6 @@
-import { Kinesis } from "@aws-sdk/client-kinesis";
+import { CreateStreamCommand, Kinesis } from "@aws-sdk/client-kinesis";
 import { NodeHttp2Handler } from "@aws-sdk/config/requestHandler";
+import { getEndpointFromInstructions } from "@smithy/core/endpoints";
 import { type MetadataBearer } from "@smithy/types";
 import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
 
@@ -124,11 +125,8 @@ describe("@aws-sdk/client-kinesis", () => {
   }
 
   beforeAll(async () => {
-    const { url } = client.config.endpointProvider({
-      Region: await client.config.region(),
-      UseFIPS: await client.config.useFipsEndpoint(),
-      UseDualStack: await client.config.useDualstackEndpoint(),
-    });
+    // Resolve the endpoint the same way the SDK does at request time.
+    const { url } = await getEndpointFromInstructions({}, CreateStreamCommand, client.config);
     endpoint = url.toString();
 
     connectionManagerStates.initial = debug();

--- a/clients/client-kinesis/test/Kinesis.e2e.spec.ts
+++ b/clients/client-kinesis/test/Kinesis.e2e.spec.ts
@@ -22,6 +22,13 @@ describe("@aws-sdk/client-kinesis", () => {
     return (client.config.requestHandler as any).connectionManager?.debug?.();
   };
 
+  /**
+   * The endpoint the client resolves to, used as the connection pool key.
+   * Resolved from the client config instead of being hardcoded, so the test
+   * follows the client's configured region/endpoint.
+   */
+  let endpoint: string;
+
   async function setup() {
     await client.createStream({ StreamName: STREAM_NAME, ShardCount: SHARD_COUNT });
     let status = "";
@@ -113,10 +120,17 @@ describe("@aws-sdk/client-kinesis", () => {
    * ```
    */
   function getSessions(state: any) {
-    return state?.["https://kinesis.us-west-2.amazonaws.com/"]?.sessions ?? [];
+    return state?.[endpoint]?.sessions ?? [];
   }
 
   beforeAll(async () => {
+    const { url } = client.config.endpointProvider({
+      Region: await client.config.region(),
+      UseFIPS: await client.config.useFipsEndpoint(),
+      UseDualStack: await client.config.useDualstackEndpoint(),
+    });
+    endpoint = url.toString();
+
     connectionManagerStates.initial = debug();
     await setup();
 
@@ -161,7 +175,6 @@ describe("@aws-sdk/client-kinesis", () => {
   });
 
   describe("Node.js HTTP2 session concurrency", () => {
-    const usWest2Endpoint = "https://kinesis.us-west-2.amazonaws.com/";
     const sessionType = {
       id: expect.any(Number),
       active: expect.any(Number),
@@ -179,20 +192,20 @@ describe("@aws-sdk/client-kinesis", () => {
 
       expect(getSessions(connectionManagerStates.requestsFinished)).not.toEqual([]);
       expect(connectionManagerStates.requestsFinished).toMatchObject({
-        [usWest2Endpoint]: {
+        [endpoint]: {
           sessions: getSessions(connectionManagerStates.requestsFinished).map(() => sessionType),
         },
       });
 
       expect(getSessions(connectionManagerStates.secondBatchRequestsFinished)).not.toEqual([]);
       expect(connectionManagerStates.secondBatchRequestsFinished).toMatchObject({
-        [usWest2Endpoint]: {
+        [endpoint]: {
           sessions: getSessions(connectionManagerStates.secondBatchRequestsFinished).map(() => sessionType),
         },
       });
 
       expect(connectionManagerStates.idle).toEqual({
-        "https://kinesis.us-west-2.amazonaws.com/": {
+        [endpoint]: {
           sessions: [],
         },
       });


### PR DESCRIPTION
### Issue
* Internal JS-6993
* Internal JS-7000

### Description

Replace the hardcoded `kinesis.us-west-2.amazonaws.com` endpoint in the
HTTP2 session concurrency test with the endpoint resolved from the
getEndpointFromInstructions. The connection pool is keyed by the resolved
endpoint URL, so the test now tracks the client's configured region/endpoint
instead of a fixed host.

### Testing
* CI
* `yarn test:e2e` is successful locally in `client-kinesis` folder

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
