### PR TITLE
docs(clients): document IMDSv2 region resolution step

### DIFF
--- a/packages-internal/credential-provider-node/tests/credential-provider-node.integ.spec.ts
+++ b/packages-internal/credential-provider-node/tests/credential-provider-node.integ.spec.ts
@@ -15,6 +15,7 @@ import type { HttpRequest, MiddlewareStack, ParsedIniData } from "@smithy/types"
 import { AdaptiveRetryStrategy, StandardRetryStrategy } from "@smithy/core/retry";
 import child_process from "node:child_process";
 import { createHash } from "node:crypto";
+import { createServer, type Server } from "node:http";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
@@ -1502,6 +1503,125 @@ describe("credential-provider-node integration test", () => {
       await expect(async () => sts.getCallerIdentity({})).rejects.toThrow(
         "Could not load credentials from any providers"
       );
+    });
+  });
+
+  describe("IMDSv2 region fallback", () => {
+    let imdsServer: Server;
+    let imdsPort: number;
+
+    beforeEach(async () => {
+      imdsServer = createServer((req, res) => {
+        if (req.method === "PUT" && req.url === "/latest/api/token") {
+          res.writeHead(200);
+          res.end("mock-imds-token");
+        } else if (req.method === "GET" && req.url === "/latest/meta-data/placement/region") {
+          res.writeHead(200);
+          res.end("ap-southeast-1");
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+      await new Promise<void>((resolve) => imdsServer.listen(0, "127.0.0.1", resolve));
+      imdsPort = (imdsServer.address() as any).port;
+      process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT = `http://127.0.0.1:${imdsPort}`;
+    });
+
+    afterEach(() => {
+      imdsServer.close();
+      delete process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT;
+    });
+
+    it("should resolve region from IMDS when env and profile region are unset", async () => {
+      delete process.env.AWS_REGION;
+      delete process.env.AWS_EC2_METADATA_DISABLED;
+      setIniProfileData({
+        default: {
+          aws_access_key_id: "STATIC_ACCESS_KEY",
+          aws_secret_access_key: "STATIC_SECRET_KEY",
+        },
+      });
+
+      sts = new STS({});
+      await sts.getCallerIdentity({});
+      const region = await sts.config.region();
+      expect(region).toBe("ap-southeast-1");
+    });
+
+    it("should prefer env region over IMDS", async () => {
+      process.env.AWS_REGION = "us-west-2";
+      delete process.env.AWS_EC2_METADATA_DISABLED;
+      setIniProfileData({
+        default: {
+          aws_access_key_id: "STATIC_ACCESS_KEY",
+          aws_secret_access_key: "STATIC_SECRET_KEY",
+        },
+      });
+
+      sts = new STS({});
+      await sts.getCallerIdentity({});
+      const region = await sts.config.region();
+      expect(region).toBe("us-west-2");
+    });
+
+    it("should prefer profile region over IMDS", async () => {
+      delete process.env.AWS_REGION;
+      delete process.env.AWS_EC2_METADATA_DISABLED;
+      setIniProfileData({
+        default: {
+          region: "eu-west-1",
+          aws_access_key_id: "STATIC_ACCESS_KEY",
+          aws_secret_access_key: "STATIC_SECRET_KEY",
+        },
+      });
+
+      sts = new STS({});
+      await sts.getCallerIdentity({});
+      const region = await sts.config.region();
+      expect(region).toBe("eu-west-1");
+    });
+
+    it("should not call IMDS when AWS_EC2_METADATA_DISABLED is set", async () => {
+      delete process.env.AWS_REGION;
+      process.env.AWS_EC2_METADATA_DISABLED = "true";
+      setIniProfileData({
+        default: {
+          aws_access_key_id: "STATIC_ACCESS_KEY",
+          aws_secret_access_key: "STATIC_SECRET_KEY",
+        },
+      });
+
+      await expect(async () => {
+        sts = new STS({});
+        await sts.getCallerIdentity({});
+      }).rejects.toThrow("Region is missing");
+    });
+
+    it("should use IMDS region for the nested STS client during credential resolution", async () => {
+      delete process.env.AWS_REGION;
+      delete process.env.AWS_EC2_METADATA_DISABLED;
+      setIniProfileData({
+        assume: {
+          aws_access_key_id: "ASSUME_STATIC_ACCESS_KEY",
+          aws_secret_access_key: "ASSUME_STATIC_SECRET_KEY",
+        },
+        default: {
+          role_arn: "ROLE_ARN",
+          role_session_name: "ROLE_SESSION_NAME",
+          source_profile: "assume",
+        },
+      });
+
+      const provider = defaultProvider({});
+      const credentials = await provider();
+      expect(credentials).toEqual(
+        expect.objectContaining({
+          accessKeyId: "STS_AR_ACCESS_KEY_ID",
+          secretAccessKey: "STS_AR_SECRET_ACCESS_KEY",
+        })
+      );
+      expect(credentials.sessionToken).toContain("ap-southeast-1");
     });
   });
 

--- a/packages/credential-providers/README.md
+++ b/packages/credential-providers/README.md
@@ -164,7 +164,8 @@ const client = new STSClient({
 1. `client-region`
 2. `env-region`
 3. `profile-region` (config file)
-4. thrown error (no us-east-1 fallback)
+4. EC2 IMDSv2 (`/latest/meta-data/placement/region`). Opt out with `AWS_EC2_METADATA_DISABLED=true`.
+5. thrown error (no us-east-1 fallback)
 
 # Credential providers
 

--- a/supplemental-docs/CLIENTS.md
+++ b/supplemental-docs/CLIENTS.md
@@ -100,7 +100,7 @@ new S3Client({
 
 #### Region resolution chain
 
-When `region` is not passed to the client constructor, the SDK resolves it in this order:
+The first priority is any `region` string or region provider function passed directly to the client constructor. When neither is provided, the SDK resolves region in this order:
 
 1. `AWS_REGION` environment variable.
 2. `AWS_DEFAULT_REGION` environment variable.

--- a/supplemental-docs/CLIENTS.md
+++ b/supplemental-docs/CLIENTS.md
@@ -98,6 +98,25 @@ new S3Client({
 });
 ```
 
+#### Region resolution chain
+
+When `region` is not passed to the client constructor, the SDK resolves it in this order:
+
+1. `AWS_REGION` environment variable.
+2. `AWS_DEFAULT_REGION` environment variable.
+3. `region` in the shared config file (`~/.aws/config`), scoped to the active profile.
+4. EC2 IMDSv2 (`/latest/meta-data/placement/region`) — available since `@smithy/core@3.28.0`.
+
+If none of these produce a region, the client throws `Region is missing` on the first request.
+
+To opt out of the IMDS step (e.g. on non-EC2 hosts where you want fast failure), set:
+
+```bash
+AWS_EC2_METADATA_DISABLED=true
+```
+
+The IMDS call has a 1s timeout and negative results are cached in-process for 60s so repeated client construction on a non-EC2 host doesn't re-pay the timeout.
+
 ### Credentials `credentials`
 
 AWS Credentials are needed by the SDK to perform requests against the correct


### PR DESCRIPTION
### Issue
JS-6904

### Description
Adds region resolution chain to `CLIENTS.md` (supplemental docs) and updates the STSClient chain in credential-providers README to include the IMDSv2 fallback.

### Testing
Integration tests that uses a local http server via `AWS_EC2_METADATA_SERVICE_ENDPOINT`

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [ ] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [ ] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
