### PR TITLE
fix(util-dynamodb): throw on heterogeneous sets instead of corrupting data

### DIFF
--- a/packages-internal/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages-internal/util-dynamodb/src/convertToAttr.spec.ts
@@ -317,6 +317,25 @@ describe("convertToAttr", () => {
         }).toThrowError(`Only Number Set (NS), Binary Set (BS) or String Set (SS) are allowed.`);
       });
     });
+
+    describe("mixed set", () => {
+      [
+        new Set([1, "a"]),
+        new Set(["a", 1]),
+        new Set(["a", new Uint8Array([1])]),
+        new Set([1, new Uint8Array([1])]),
+      ].forEach((set) => {
+        it(`throws error for a set with values of different types`, () => {
+          expect(() => {
+            convertToAttr(set);
+          }).toThrowError(`All values in a set must be of the same type.`);
+        });
+      });
+
+      it("allows a set mixing number, bigint, and NumberValue as a number set", () => {
+        expect(convertToAttr(new Set([1, 2n, NumberValue.from("3")]))).toEqual({ NS: ["1", "2", "3"] });
+      });
+    });
   });
 
   describe("map", () => {

--- a/packages-internal/util-dynamodb/src/convertToAttr.ts
+++ b/packages-internal/util-dynamodb/src/convertToAttr.ts
@@ -84,6 +84,13 @@ const convertToSetAttr = (
 
   const item = setToOperate.values().next().value;
 
+  const setType = getSetType(item);
+  for (const value of setToOperate) {
+    if (getSetType(value) !== setType) {
+      throw new Error(`All values in a set must be of the same type. Received a mix of ${setType} and other types.`);
+    }
+  }
+
   if (item instanceof NumberValue) {
     return {
       NS: Array.from(setToOperate).map((_) => _.toString()),
@@ -202,4 +209,15 @@ const isBinary = (data: any): boolean => {
     return binaryTypes.includes(data.constructor.name);
   }
   return false;
+};
+
+const getSetType = (data: any): "NS" | "SS" | "BS" | null => {
+  if (data instanceof NumberValue || typeof data === "number" || typeof data === "bigint") {
+    return "NS";
+  } else if (typeof data === "string") {
+    return "SS";
+  } else if (isBinary(data)) {
+    return "BS";
+  }
+  return null;
 };


### PR DESCRIPTION
## Description

`marshall()` silently corrupts a heterogeneous `Set` instead of rejecting it. `convertToSetAttr` (in `@aws-sdk/util-dynamodb`) picks the DynamoDB set type (`NS` / `SS` / `BS`) from the first element only, then coerces every other element through that branch's converter. A `Set` whose elements are not all the same category is marshalled into invalid or corrupted data, with no error:

```js
marshall(new Set([1, "a"]))                       // { NS: ["1", "a"] }  invalid Number Set
marshall(new Set(["a", 1]))                        // { SS: ["a", "1"] }  number silently stringified
marshall(new Set(["a", new Uint8Array([1])]))      // { SS: ["a", "1"] }  binary data destroyed
marshall(new Set([1, new Uint8Array([1])]))        // { NS: ["1", "1"] }  binary data destroyed
```

The `String(Uint8Array([1]))` coercion produces `"1"`, so binary values are lost entirely. The code already throws for fully unsupported sets (for example a `Set` of booleans); heterogeneous sets were simply never guarded.

## Fix

Add a `getSetType` helper and an up-front homogeneity check that throws when a set mixes categories, while still allowing the intended number-like mixing (`number`, `bigint`, and `NumberValue` all share `NS`). The existing empty-set and unsupported-type behavior is unchanged.

## Test

Added cases to `convertToAttr.spec.ts` for the heterogeneous sets above. They fail before the change (silent corruption) and throw after; the full `util-dynamodb` suite stays green.
