### PR TITLE
fix(xml-builder): decode astral numeric character references with fromCodePoint

### DIFF
--- a/packages-internal/xml-builder/src/xml-parser.spec.ts
+++ b/packages-internal/xml-builder/src/xml-parser.spec.ts
@@ -347,6 +347,18 @@ describe("xml parsing", () => {
     });
   });
 
+  it("should resolve supplementary-plane numeric character references", () => {
+    const xml = `<Response><Hex>&#x1F600;</Hex><Dec>&#128512;</Dec><CJK>&#x20000;</CJK></Response>`;
+    const object = parseXML(xml);
+    expect(object).toEqual({
+      Response: {
+        Hex: "\u{1F600}",
+        Dec: "\u{1F600}",
+        CJK: "\u{20000}",
+      },
+    });
+  });
+
   it("should preserve control characters like \\x15 in text content despite xml 1.0 decl", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response><Key>prefix&#x15;suffix</Key></Response>`;

--- a/packages-internal/xml-builder/src/xml-parser.ts
+++ b/packages-internal/xml-builder/src/xml-parser.ts
@@ -291,10 +291,10 @@ class AwsXmlParser {
   private decodeEntities(s: string): string {
     return s.replace(/&(?:#x([0-9a-fA-F]{1,6})|#(\d{1,7})|([a-zA-Z][a-zA-Z0-9]{0,30}));/g, (_, hex, dec, named) => {
       if (hex) {
-        return String.fromCharCode(parseInt(hex, 16));
+        return String.fromCodePoint(parseInt(hex, 16));
       }
       if (dec) {
-        return String.fromCharCode(parseInt(dec, 10));
+        return String.fromCodePoint(parseInt(dec, 10));
       }
       return AwsXmlParser.ENTITIES[named] ?? "";
     });


### PR DESCRIPTION
The Node XML parser decodes numeric character references with
String.fromCharCode, which only uses the low 16 bits of its argument. Any
reference above U+FFFF (emoji, CJK Extension B, and other supplementary-plane
characters) is truncated to a wrong BMP code unit instead of the correct
character.

The reference regex accepts hex values of 1 to 6 digits and decimal values of 1
to 7 digits, so supplementary-plane code points reach the decoder and get
mangled. For example, `<r>&#x1F600;</r>` decodes to U+F600 instead of U+1F600
(GRINNING FACE), and `<r>&#x20000;</r>` decodes to U+0000 instead of U+20000.

XML 1.0 section 4.1 allows character references up to U+10FFFF, so these are
valid inputs. The browser parser in this package uses native DOMParser, which
decodes them correctly, so the Node and browser parsers currently disagree for
the same document.

Fix: use String.fromCodePoint instead of String.fromCharCode for both the hex
and decimal branches.

Existing tests did not catch this because the special-character test uses astral
characters only as literal UTF-8 bytes, never as numeric references, and the only
numeric references it tests are within the BMP.

Added a test that parses hex and decimal supplementary-plane references and
asserts the correct decoded characters. It fails on the current code and passes
with the fix.
