### PR TITLE
fix(util-dynamodb): null empty ArrayBuffer and DataView with convertEmptyValues

### DIFF
--- a/packages-internal/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages-internal/util-dynamodb/src/convertToAttr.spec.ts
@@ -162,6 +162,17 @@ describe("convertToAttr", () => {
           NULL: true,
         });
       });
+
+      it("returns null for an empty ArrayBuffer or DataView when options.convertEmptyValues=true", () => {
+        expect(convertToAttr(new ArrayBuffer(0), { convertClassInstanceToMap, convertEmptyValues: true })).toEqual({
+          NULL: true,
+        });
+        expect(
+          convertToAttr(new DataView(new ArrayBuffer(0)), { convertClassInstanceToMap, convertEmptyValues: true })
+        ).toEqual({
+          NULL: true,
+        });
+      });
     });
   });
 

--- a/packages-internal/util-dynamodb/src/convertToAttr.ts
+++ b/packages-internal/util-dynamodb/src/convertToAttr.ts
@@ -28,7 +28,7 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
   ) {
     return convertToMapAttrFromEnumerableProps(data as Record<string, NativeAttributeValue>, options);
   } else if (isBinary(data)) {
-    if (data.byteLength === 0 && options?.convertEmptyValues) {
+    if (options?.convertEmptyValues && isEmptyBinary(data)) {
       return convertToNullAttr();
     }
     // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
@@ -176,6 +176,19 @@ const convertToNumberAttr = (num: number | Number, options?: marshallOptions): {
     }
   }
   return { N: num.toString() };
+};
+
+const isEmptyBinary = (data: any): boolean => {
+  if (data && typeof data === "object") {
+    if (
+      (typeof data.length === "number" && data.length === 0) ||
+      (typeof data.byteLength === "number" && data.byteLength === 0) ||
+      (typeof data.size === "number" && data.size === 0)
+    ) {
+      return true;
+    }
+  }
+  return false;
 };
 
 const isBinary = (data: any): boolean => {

--- a/packages-internal/util-dynamodb/src/convertToAttr.ts
+++ b/packages-internal/util-dynamodb/src/convertToAttr.ts
@@ -28,7 +28,7 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
   ) {
     return convertToMapAttrFromEnumerableProps(data as Record<string, NativeAttributeValue>, options);
   } else if (isBinary(data)) {
-    if (data.length === 0 && options?.convertEmptyValues) {
+    if (data.byteLength === 0 && options?.convertEmptyValues) {
       return convertToNullAttr();
     }
     // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530


### PR DESCRIPTION
With `marshallOptions.convertEmptyValues` set to true, an empty binary value is
meant to be converted to a NULL attribute. This works for a typed array such as
`Uint8Array`, but not for an empty `ArrayBuffer` or `DataView`.

`convertToAttr` checks `data.length === 0` inside the binary branch, but
`ArrayBuffer` and `DataView` do not have a `length` property (they use
`byteLength`), so `data.length` is `undefined`, the check is false, and the empty
value is marshalled as `{ B: ... }` instead of `{ NULL: true }`. `isBinary`
already recognizes `ArrayBuffer` and `DataView` as binary, so both reach this
branch.

The fix uses `byteLength`, which is defined for every binary type including typed
arrays, so the empty check is correct for all of them. Added a test for an empty
`ArrayBuffer` and `DataView`.
