### PR TITLE
feat: introducing w3c tracing headers propagation

### DIFF
--- a/packages-internal/core/src/submodules/client/index.browser.ts
+++ b/packages-internal/core/src/submodules/client/index.browser.ts
@@ -25,6 +25,11 @@ export { recursionDetectionMiddlewareOptions } from "./middleware-recursion-dete
 export { getRecursionDetectionPlugin } from "./middleware-recursion-detection/getRecursionDetectionPlugin.browser";
 export { recursionDetectionMiddleware } from "./middleware-recursion-detection/recursionDetectionMiddleware.browser";
 
+// middleware-trace-context-propagation
+export { traceContextPropagationMiddlewareOptions } from "./middleware-trace-context-propagation/configuration";
+export { getTraceContextPropagationPlugin } from "./middleware-trace-context-propagation/getTraceContextPropagationPlugin.browser";
+export { traceContextPropagationMiddleware } from "./middleware-trace-context-propagation/traceContextPropagationMiddleware.browser";
+
 // middleware-user-agent
 export { DEFAULT_UA_APP_ID, resolveUserAgentConfig } from "./middleware-user-agent/configurations";
 export type { UserAgentInputConfig, UserAgentResolvedConfig } from "./middleware-user-agent/configurations";

--- a/packages-internal/core/src/submodules/client/index.native.ts
+++ b/packages-internal/core/src/submodules/client/index.native.ts
@@ -25,6 +25,11 @@ export { recursionDetectionMiddlewareOptions } from "./middleware-recursion-dete
 export { getRecursionDetectionPlugin } from "./middleware-recursion-detection/getRecursionDetectionPlugin.browser";
 export { recursionDetectionMiddleware } from "./middleware-recursion-detection/recursionDetectionMiddleware.native";
 
+// middleware-trace-context-propagation
+export { traceContextPropagationMiddlewareOptions } from "./middleware-trace-context-propagation/configuration";
+export { getTraceContextPropagationPlugin } from "./middleware-trace-context-propagation/getTraceContextPropagationPlugin.browser";
+export { traceContextPropagationMiddleware } from "./middleware-trace-context-propagation/traceContextPropagationMiddleware.native";
+
 // middleware-user-agent
 export { DEFAULT_UA_APP_ID, resolveUserAgentConfig } from "./middleware-user-agent/configurations";
 export type { UserAgentInputConfig, UserAgentResolvedConfig } from "./middleware-user-agent/configurations";

--- a/packages-internal/core/src/submodules/client/index.ts
+++ b/packages-internal/core/src/submodules/client/index.ts
@@ -22,6 +22,11 @@ export { recursionDetectionMiddlewareOptions } from "./middleware-recursion-dete
 export { getRecursionDetectionPlugin } from "./middleware-recursion-detection/getRecursionDetectionPlugin";
 export { recursionDetectionMiddleware } from "./middleware-recursion-detection/recursionDetectionMiddleware";
 
+// middleware-trace-context-propagation
+export { traceContextPropagationMiddlewareOptions } from "./middleware-trace-context-propagation/configuration";
+export { getTraceContextPropagationPlugin } from "./middleware-trace-context-propagation/getTraceContextPropagationPlugin";
+export { traceContextPropagationMiddleware } from "./middleware-trace-context-propagation/traceContextPropagationMiddleware";
+
 // middleware-user-agent
 export { DEFAULT_UA_APP_ID, resolveUserAgentConfig } from "./middleware-user-agent/configurations";
 export type { UserAgentInputConfig, UserAgentResolvedConfig } from "./middleware-user-agent/configurations";

--- a/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/configuration.ts
+++ b/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/configuration.ts
@@ -1,0 +1,12 @@
+import type { AbsoluteLocation, BuildHandlerOptions } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export const traceContextPropagationMiddlewareOptions: BuildHandlerOptions & AbsoluteLocation = {
+  step: "build",
+  tags: ["TRACE_CONTEXT_PROPAGATION"],
+  name: "traceContextPropagationMiddleware",
+  override: true,
+  priority: "low",
+};

--- a/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/getTraceContextPropagationPlugin.browser.ts
+++ b/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/getTraceContextPropagationPlugin.browser.ts
@@ -1,0 +1,8 @@
+import type { Pluggable } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export const getTraceContextPropagationPlugin = (options: any): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {},
+});

--- a/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/getTraceContextPropagationPlugin.ts
+++ b/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/getTraceContextPropagationPlugin.ts
@@ -1,0 +1,13 @@
+import type { Pluggable } from "@smithy/types";
+
+import { traceContextPropagationMiddlewareOptions } from "./configuration";
+import { traceContextPropagationMiddleware } from "./traceContextPropagationMiddleware";
+
+/**
+ * @internal
+ */
+export const getTraceContextPropagationPlugin = (options: any): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.add(traceContextPropagationMiddleware(), traceContextPropagationMiddlewareOptions);
+  },
+});

--- a/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/traceContextPropagationMiddleware.browser.ts
+++ b/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/traceContextPropagationMiddleware.browser.ts
@@ -1,0 +1,17 @@
+import type {
+  BuildHandler,
+  BuildHandlerArguments,
+  BuildHandlerOutput,
+  BuildMiddleware,
+  MetadataBearer,
+} from "@smithy/types";
+
+/**
+ * No-op middleware for runtimes outside of Node.js
+ * @internal
+ */
+export const traceContextPropagationMiddleware =
+  (): BuildMiddleware<any, any> =>
+  <Output extends MetadataBearer>(next: BuildHandler<any, Output>): BuildHandler<any, Output> =>
+  async (args: BuildHandlerArguments<any>): Promise<BuildHandlerOutput<Output>> =>
+    next(args);

--- a/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/traceContextPropagationMiddleware.integ.spec.ts
+++ b/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/traceContextPropagationMiddleware.integ.spec.ts
@@ -1,0 +1,47 @@
+// @ts-ignore
+import { InvokeStore, InvokeStoreBase } from "@aws/lambda-invoke-store";
+import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
+import { S3 } from "@aws-sdk/client-s3";
+import { describe, expect, test as it } from "vitest";
+
+import { getTraceContextPropagationPlugin } from "./getTraceContextPropagationPlugin";
+
+const TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+const TRACESTATE = "rojo=00f067aa0ba902b7";
+const BAGGAGE = "userId=alice,serverNode=DF%2028";
+
+describe("middleware-trace-context-propagation", () => {
+  describe(S3.name, () => {
+    it("propagates W3C trace context from the InvokeStore onto an outbound request", async () => {
+      const client = new S3({ region: "us-west-2" });
+      // The plugin is not registered on generated clients by default, so add it
+      // explicitly to exercise the build-step middleware on a real client stack.
+      client.middlewareStack.use(getTraceContextPropagationPlugin({}));
+
+      // Intercept the outbound request before it leaves the client (no network).
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          traceparent: TRACEPARENT,
+          tracestate: TRACESTATE,
+          baggage: BAGGAGE,
+        },
+      });
+
+      // Run the call inside an InvokeStore context that carries trace context,
+      // the same way a Lambda invoke would.
+      const store = await InvokeStore.getInstanceAsync();
+      await store.run(
+        {
+          [InvokeStoreBase.PROTECTED_KEYS.TRACEPARENT]: TRACEPARENT,
+          [InvokeStoreBase.PROTECTED_KEYS.TRACESTATE]: TRACESTATE,
+          [InvokeStoreBase.PROTECTED_KEYS.BAGGAGE]: BAGGAGE,
+        },
+        async () => {
+          await client.listBuckets({});
+        }
+      );
+
+      expect.hasAssertions();
+    });
+  });
+});

--- a/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/traceContextPropagationMiddleware.native.ts
+++ b/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/traceContextPropagationMiddleware.native.ts
@@ -1,0 +1,17 @@
+import type {
+  BuildHandler,
+  BuildHandlerArguments,
+  BuildHandlerOutput,
+  BuildMiddleware,
+  MetadataBearer,
+} from "@smithy/types";
+
+/**
+ * No-op middleware for runtimes outside of Node.js
+ * @internal
+ */
+export const traceContextPropagationMiddleware =
+  (): BuildMiddleware<any, any> =>
+  <Output extends MetadataBearer>(next: BuildHandler<any, Output>): BuildHandler<any, Output> =>
+  async (args: BuildHandlerArguments<any>): Promise<BuildHandlerOutput<Output>> =>
+    next(args);

--- a/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/traceContextPropagationMiddleware.spec.ts
+++ b/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/traceContextPropagationMiddleware.spec.ts
@@ -1,0 +1,156 @@
+// @ts-ignore
+import { InvokeStore } from "@aws/lambda-invoke-store";
+import { HttpRequest } from "@smithy/core/protocols";
+import { afterAll, beforeEach, describe, expect, test as it, vi } from "vitest";
+
+import { traceContextPropagationMiddleware } from "./traceContextPropagationMiddleware";
+
+describe(traceContextPropagationMiddleware.name, () => {
+  const mockNextHandler = vi.fn();
+
+  const TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+  const TRACESTATE = "rojo=00f067aa0ba902b7";
+  const BAGGAGE = "userId=alice,serverNode=DF%2028";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue(undefined as any);
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockInvokeStore = (overrides: Record<string, () => string | undefined>) => {
+    vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+      getTraceparent: () => undefined,
+      getTracestate: () => undefined,
+      getBaggage: () => undefined,
+      ...overrides,
+    } as any);
+  };
+
+  it("propagates traceparent, tracestate, and baggage from InvokeStore", async () => {
+    mockInvokeStore({
+      getTraceparent: () => TRACEPARENT,
+      getTracestate: () => TRACESTATE,
+      getBaggage: () => BAGGAGE,
+    });
+
+    const handler = traceContextPropagationMiddleware()(mockNextHandler, {} as any);
+    await handler({
+      input: {},
+      request: new HttpRequest({}),
+    });
+
+    expect(mockNextHandler.mock.calls.length).toBe(1);
+    const { request } = mockNextHandler.mock.calls[0][0];
+    expect(request.headers.traceparent).toBe(TRACEPARENT);
+    expect(request.headers.tracestate).toBe(TRACESTATE);
+    expect(request.headers.baggage).toBe(BAGGAGE);
+  });
+
+  it("only sets headers for values present in InvokeStore", async () => {
+    mockInvokeStore({
+      getTraceparent: () => TRACEPARENT,
+    });
+
+    const handler = traceContextPropagationMiddleware()(mockNextHandler, {} as any);
+    await handler({
+      input: {},
+      request: new HttpRequest({}),
+    });
+
+    const { request } = mockNextHandler.mock.calls[0][0];
+    expect(request.headers.traceparent).toBe(TRACEPARENT);
+    expect(request.headers.tracestate).not.toBeDefined();
+    expect(request.headers.baggage).not.toBeDefined();
+  });
+
+  it("does not propagate tracestate or baggage when traceparent is absent", async () => {
+    mockInvokeStore({
+      getTracestate: () => TRACESTATE,
+      getBaggage: () => BAGGAGE,
+    });
+
+    const handler = traceContextPropagationMiddleware()(mockNextHandler, {} as any);
+    await handler({
+      input: {},
+      request: new HttpRequest({}),
+    });
+
+    const { request } = mockNextHandler.mock.calls[0][0];
+    expect(request.headers.traceparent).not.toBeDefined();
+    expect(request.headers.tracestate).not.toBeDefined();
+    expect(request.headers.baggage).not.toBeDefined();
+  });
+
+  it("is a no-op when there is no InvokeStore context", async () => {
+    const handler = traceContextPropagationMiddleware()(mockNextHandler, {} as any);
+    await handler({
+      input: {},
+      request: new HttpRequest({}),
+    });
+
+    const { request } = mockNextHandler.mock.calls[0][0];
+    expect(request.headers.traceparent).not.toBeDefined();
+    expect(request.headers.tracestate).not.toBeDefined();
+    expect(request.headers.baggage).not.toBeDefined();
+  });
+
+  it("does not overwrite an existing traceparent header", async () => {
+    mockInvokeStore({
+      getTraceparent: () => TRACEPARENT,
+    });
+
+    const handler = traceContextPropagationMiddleware()(mockNextHandler, {} as any);
+    await handler({
+      input: {},
+      request: new HttpRequest({
+        headers: {
+          traceparent: "existing-value",
+        },
+      }),
+    });
+
+    const { request } = mockNextHandler.mock.calls[0][0];
+    expect(request.headers.traceparent).toBe("existing-value");
+  });
+
+  it("normalizes an existing differently-cased traceparent and does not overwrite it", async () => {
+    mockInvokeStore({
+      getTraceparent: () => TRACEPARENT,
+    });
+
+    const handler = traceContextPropagationMiddleware()(mockNextHandler, {} as any);
+    await handler({
+      input: {},
+      request: new HttpRequest({
+        headers: {
+          TraceParent: "existing-value",
+        },
+      }),
+    });
+
+    const { request } = mockNextHandler.mock.calls[0][0];
+    // rewritten to canonical lowercase, value preserved, not overwritten, not duplicated
+    expect(request.headers.traceparent).toBe("existing-value");
+    expect(request.headers.TraceParent).not.toBeDefined();
+    expect(Object.keys(request.headers).filter((h) => h.toLowerCase() === "traceparent").length).toBe(1);
+  });
+
+  it("does not modify non-HttpRequest requests", async () => {
+    mockInvokeStore({
+      getTraceparent: () => TRACEPARENT,
+    });
+
+    const nonHttpRequest = { foo: "bar" };
+    const handler = traceContextPropagationMiddleware()(mockNextHandler, {} as any);
+    await handler({
+      input: {},
+      request: nonHttpRequest as any,
+    });
+
+    expect(mockNextHandler.mock.calls[0][0].request).toBe(nonHttpRequest);
+  });
+});

--- a/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/traceContextPropagationMiddleware.ts
+++ b/packages-internal/core/src/submodules/client/middleware-trace-context-propagation/traceContextPropagationMiddleware.ts
@@ -1,0 +1,97 @@
+// @ts-ignore
+import { InvokeStore } from "@aws/lambda-invoke-store";
+import { HttpRequest } from "@smithy/core/protocols";
+import type {
+  BuildHandler,
+  BuildHandlerArguments,
+  BuildHandlerOutput,
+  BuildMiddleware,
+  HeaderBag,
+  MetadataBearer,
+} from "@smithy/types";
+
+const TRACEPARENT_HEADER_NAME = "traceparent";
+const TRACESTATE_HEADER_NAME = "tracestate";
+const BAGGAGE_HEADER_NAME = "baggage";
+
+/**
+ * Propagates W3C trace context headers (traceparent, tracestate, baggage) from
+ * the Lambda InvokeStore onto outbound requests, enabling distributed trace
+ * context to flow to downstream calls without creating any spans.
+ *
+ * Any already-present trace headers are first normalized to their canonical
+ * lowercase name. If the request then already carries a `traceparent`, its
+ * existing trace context is respected and nothing is injected. Otherwise the
+ * trace context from the InvokeStore is injected: `traceparent` is required,
+ * while `tracestate` and `baggage` are optional and only propagated when present.
+ * @internal
+ */
+export const traceContextPropagationMiddleware =
+  (): BuildMiddleware<any, any> =>
+  <Output extends MetadataBearer>(next: BuildHandler<any, Output>): BuildHandler<any, Output> =>
+  async (args: BuildHandlerArguments<any>): Promise<BuildHandlerOutput<Output>> => {
+    const { request } = args;
+    if (!HttpRequest.isInstance(request)) {
+      return next(args);
+    }
+
+    // Normalize any already-present trace headers to their canonical lowercase
+    // name. This runs regardless of whether we inject, since downstream
+    // consumers rely on the canonical casing, and it makes the presence check
+    // below a direct lookup.
+    sanitizeTraceHeaders(request.headers);
+
+    // If the request already carries trace context, respect it and do nothing.
+    // traceparent is the anchor of W3C trace context (tracestate and baggage are
+    // meaningless without it).
+    if (request.headers[TRACEPARENT_HEADER_NAME]) {
+      return next(args);
+    }
+
+    // Read the trace context from the InvokeStore. getInstanceAsync memoizes the
+    // store as a module-level promise: the first call in the process pays the
+    // small setup cost, and every later call (here or in any other middleware)
+    // just awaits the cached promise.
+    const invokeStore = await InvokeStore.getInstanceAsync();
+    const traceparent = invokeStore?.getTraceparent();
+
+    // traceparent is required; without it there is nothing to propagate.
+    if (!traceparent) {
+      return next(args);
+    }
+
+    request.headers[TRACEPARENT_HEADER_NAME] = traceparent;
+
+    // tracestate and baggage are optional, and only propagated when present.
+    const tracestate = invokeStore?.getTracestate();
+    if (tracestate) {
+      request.headers[TRACESTATE_HEADER_NAME] = tracestate;
+    }
+
+    const baggage = invokeStore?.getBaggage();
+    if (baggage) {
+      request.headers[BAGGAGE_HEADER_NAME] = baggage;
+    }
+
+    return next({
+      ...args,
+      request,
+    });
+  };
+
+/**
+ * Rewrites any trace context header that is present under a non-canonical casing
+ * (e.g. "TraceParent") to its lowercase canonical name, in place.
+ */
+function sanitizeTraceHeaders(headers: HeaderBag): void {
+  for (const header of Object.keys(headers)) {
+    const lower = header.toLowerCase();
+    if (
+      header !== lower &&
+      (lower === TRACEPARENT_HEADER_NAME || lower === TRACESTATE_HEADER_NAME || lower === BAGGAGE_HEADER_NAME)
+    ) {
+      headers[lower] = headers[header];
+      delete headers[header];
+    }
+  }
+}

--- a/packages-internal/core/tsconfig.json
+++ b/packages-internal/core/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "./src",
+    "noEmit": true,
+    "strict": true,
+    "paths": {
+      "@smithy/core/*": ["../../node_modules/@smithy/core/dist-types/submodules/*/index.d.ts"],
+      "@aws-sdk/core/client": ["./src/submodules/client/index.ts"],
+      "@aws-sdk/core/httpAuthSchemes": ["./src/submodules/httpAuthSchemes/index.ts"],
+      "@aws-sdk/core/protocols": ["./src/submodules/protocols/index.ts"],
+      "@aws-sdk/core/account-id-endpoint": ["./src/submodules/account-id-endpoint/index.ts"],
+      "@aws-sdk/core/util": ["./src/submodules/util/index.ts"]
+    }
+  },
+  "include": ["src/"],
+  "exclude": ["node_modules", "dist-cjs", "dist-es", "dist-types"]
+}


### PR DESCRIPTION
### Issue

N/A — W3C trace context propagation

### Description

Adds a build-step middleware that propagates W3C trace context headers (`traceparent`, `tracestate`, `baggage`) from the Lambda `InvokeStore` onto outbound AWS SDK requests.

**Why:** When a Lambda function receives a request with trace context, downstream calls made via the AWS SDK should carry that context forward. This enables distributed tracing across service boundaries on the AWS SDK.

**How it works:**
- The middleware reads trace context from `@aws/lambda-invoke-store` (which the Lambda runtime populates per-invocation from inbound headers)
- If `traceparent` is present and the outgoing request doesn't already have one, it injects `traceparent`, `tracestate`, and `baggage` headers
- Existing trace headers are respected (never overwritten) and normalized to lowercase
- Browser and React Native get no-op implementations (InvokeStore is Node-only)

**Design decisions:**
- Registered as a plugin (`getTraceContextPropagationPlugin`) — not auto-added to generated clients.
- `traceparent` is the gate: `tracestate` and `baggage` are only propagated when `traceparent` is present (per W3C spec).
- `InvokeStore.getInstanceAsync()` is memoized at module level — subsequent calls on the hot path just await a resolved promise.

### Testing

- 7 unit tests covering: full propagation, partial headers, missing traceparent, no InvokeStore context, existing headers preserved, case normalization, non-HTTP request no-op
- 1 integration test exercising a real S3 client middleware stack with `requireRequestsFrom` (no network calls)
- All tests pass locally. Fork CI cannot authenticate with upstream's AWS OIDC role (expected for fork PRs).

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.