### PR TITLE
fix(util-user-agent-node): use direct process.env access for bundler tree-shaking

### DIFF
--- a/packages-internal/core/src/submodules/client/util-user-agent-node/getTypeScriptUserAgentPair.spec.ts
+++ b/packages-internal/core/src/submodules/client/util-user-agent-node/getTypeScriptUserAgentPair.spec.ts
@@ -1,4 +1,3 @@
-import { booleanSelector } from "@smithy/core/config";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -7,7 +6,6 @@ import { getNodeModulesParentDirs } from "./getNodeModulesParentDirs";
 import { getSanitizedDevTypeScriptVersion } from "./getSanitizedDevTypeScriptVersion";
 import { getSanitizedTypeScriptVersion } from "./getSanitizedTypeScriptVersion";
 
-vi.mock("@smithy/core/config");
 vi.mock("node:fs/promises");
 vi.mock("./getNodeModulesParentDirs");
 vi.mock("./getSanitizedDevTypeScriptVersion");
@@ -275,16 +273,29 @@ describe("getTypeScriptUserAgentPair", () => {
     });
   });
 
-  describe("when booleanSelector is used to read env var", () => {
-    it("returns undefined without reading files when booleanSelector returns true", async () => {
-      vi.mocked(booleanSelector).mockReturnValue(true);
+  describe("when AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED env var is used to disable detection", () => {
+    const ENV_VAR = "AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED";
+
+    afterEach(() => {
+      delete process.env[ENV_VAR];
+    });
+
+    it("returns undefined without reading files when env var is 'true'", async () => {
+      process.env[ENV_VAR] = "true";
       const { getTypeScriptUserAgentPair } = await import("./getTypeScriptUserAgentPair");
       await expect(getTypeScriptUserAgentPair()).resolves.toBeUndefined();
       expect(readFile).not.toHaveBeenCalled();
     });
 
-    it("proceeds with TypeScript detection when booleanSelector returns undefined", async () => {
-      vi.mocked(booleanSelector).mockReturnValue(undefined);
+    it("returns undefined without reading files when env var is '1'", async () => {
+      process.env[ENV_VAR] = "1";
+      const { getTypeScriptUserAgentPair } = await import("./getTypeScriptUserAgentPair");
+      await expect(getTypeScriptUserAgentPair()).resolves.toBeUndefined();
+      expect(readFile).not.toHaveBeenCalled();
+    });
+
+    it("proceeds with TypeScript detection when env var is not set", async () => {
+      delete process.env[ENV_VAR];
       vi.mocked(readFile).mockImplementation(async (path: any) => {
         if (path === mockAppPackageJson1) {
           return JSON.stringify({ devDependencies: { typescript: mockTscVersion } });
@@ -300,10 +311,8 @@ describe("getTypeScriptUserAgentPair", () => {
       expect(readFile).toHaveBeenCalledTimes(2);
     });
 
-    it("proceeds with TypeScript detection when booleanSelector throws error", async () => {
-      vi.mocked(booleanSelector).mockImplementation(() => {
-        throw new Error("Invalid value");
-      });
+    it("proceeds with TypeScript detection when env var is 'false'", async () => {
+      process.env[ENV_VAR] = "false";
       vi.mocked(readFile).mockImplementation(async (path: any) => {
         if (path === mockAppPackageJson1) {
           return JSON.stringify({ devDependencies: { typescript: mockTscVersion } });

--- a/packages-internal/core/src/submodules/client/util-user-agent-node/getTypeScriptUserAgentPair.ts
+++ b/packages-internal/core/src/submodules/client/util-user-agent-node/getTypeScriptUserAgentPair.ts
@@ -25,7 +25,7 @@ export const getTypeScriptUserAgentPair = async (): Promise<UserAgentPair | unde
   // Disable TypeScript detection if environment variable is set.
   // Direct property access (rather than booleanSelector) allows bundlers to statically replace
   // process.env.AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED and tree-shake this entire function.
-  const _tsDetectionDisabledEnv = process.env.AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED;
+  const _tsDetectionDisabledEnv = process.env?.AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED;
   if (_tsDetectionDisabledEnv === "true" || _tsDetectionDisabledEnv === "1") {
     tscVersion = null;
     return undefined;

--- a/packages-internal/core/src/submodules/client/util-user-agent-node/getTypeScriptUserAgentPair.ts
+++ b/packages-internal/core/src/submodules/client/util-user-agent-node/getTypeScriptUserAgentPair.ts
@@ -1,4 +1,3 @@
-import { booleanSelector, SelectorType } from "@smithy/core/config";
 import type { UserAgentPair } from "@smithy/types";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -24,12 +23,10 @@ export const getTypeScriptUserAgentPair = async (): Promise<UserAgentPair | unde
   }
 
   // Disable TypeScript detection if environment variable is set.
-  let isTypeScriptDetectionDisabled = false;
-  try {
-    isTypeScriptDetectionDisabled =
-      booleanSelector(process.env, "AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED", SelectorType.ENV) || false;
-  } catch {}
-  if (isTypeScriptDetectionDisabled) {
+  // Direct property access (rather than booleanSelector) allows bundlers to statically replace
+  // process.env.AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED and tree-shake this entire function.
+  const _tsDetectionDisabledEnv = process.env.AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED;
+  if (_tsDetectionDisabledEnv === "true" || _tsDetectionDisabledEnv === "1") {
     tscVersion = null;
     return undefined;
   }


### PR DESCRIPTION
## Summary

Closes #8149

`getTypeScriptUserAgentPair` calls `booleanSelector(process.env, "AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED", SelectorType.ENV)` to read the disable flag. Because `booleanSelector` receives `process.env` as a dynamic argument, bundlers (esbuild, rolldown, rollup, etc.) cannot statically resolve the value and cannot tree-shake the entire TypeScript-detection block even when the env var is defined in the bundler's `define` / `transform.define` config.

**Root cause:** indirect property access via `booleanSelector(record, key)` is opaque to bundlers. Only a literal `process.env.KEY` access can be inlined at bundle time.

**Fix:** replace the `booleanSelector` call with a direct `process.env.AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED` property read and inline boolean coercion (`=== "true" || === "1"`). This preserves the existing semantics exactly:

| env value | before | after |
|-----------|--------|-------|
| `"true"` | skip TS detection | skip TS detection |
| `"1"` | skip TS detection | skip TS detection |
| `"false"` / `"0"` / unset | proceed | proceed |
| unrecognized value | `booleanSelector` throws → caught → proceed | `=== "true"` false → proceed |

The `@smithy/core/config` import is now unused in this file and has been removed.

## Test changes

- Removed `vi.mock("@smithy/core/config")` (no longer needed)
- Replaced `vi.mocked(booleanSelector).mockReturnValue(...)` stubs with direct `process.env[ENV_VAR]` assignment/deletion
- Added explicit test for `"1"` truthy value and `"false"` non-truthy value

## Verification (manual)

With esbuild `define: { "process.env.AWS_SDK_JS_TYPESCRIPT_DETECTION_DISABLED": JSON.stringify("true") }` the bundled output now contains zero references to `getTypeScriptUserAgentPair`, `getNodeModulesParentDirs`, `getSanitizedTypeScriptVersion`, etc.