### PR TITLE
feat(core/client): propagate w3c trace headers

### DIFF
--- a/packages-internal/core/src/submodules/client/middleware-recursion-detection/configuration.ts
+++ b/packages-internal/core/src/submodules/client/middleware-recursion-detection/configuration.ts
@@ -1,11 +1,12 @@
 import type { AbsoluteLocation, BuildHandlerOptions } from "@smithy/types";
 
 /**
+ * Used in conjunction with Lambda invoke store.
  * @internal
  */
 export const recursionDetectionMiddlewareOptions: BuildHandlerOptions & AbsoluteLocation = {
   step: "build",
-  tags: ["RECURSION_DETECTION"],
+  tags: ["RECURSION_DETECTION", "TRACE_CONTEXT_PROPAGATION"],
   name: "recursionDetectionMiddleware",
   override: true,
   priority: "low",

--- a/packages-internal/core/src/submodules/client/middleware-recursion-detection/middleware-recursion-detection.integ.spec.ts
+++ b/packages-internal/core/src/submodules/client/middleware-recursion-detection/middleware-recursion-detection.integ.spec.ts
@@ -128,6 +128,91 @@ describe("middleware-recursion-detection", () => {
       expect.hasAssertions();
     });
 
+    it("should NOT overwrite existing traceparent or add tracestate/baggage from InvokeStore when traceparent is already set", async () => {
+      const existingTraceparent = "00-abcdef1234567890abcdef1234567890-1234567890abcdef-01";
+      const mockTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+      const mockTracestate = "congo=t61rcWkgMzE";
+      const mockBaggage = "userId=alice,serverNode=DF%2028";
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => mockTracestate,
+        getBaggage: () => mockBaggage,
+      } as any);
+
+      const client = new Lambda({
+        region: "us-west-2",
+      });
+
+      // Add middleware that sets traceparent before recursion detection runs.
+      // recursionDetectionMiddleware runs at build step with low priority,
+      // so we add at build step with high priority to run first.
+      client.middlewareStack.add(
+        (next) => async (args: any) => {
+          args.request.headers["traceparent"] = existingTraceparent;
+          return next(args);
+        },
+        { step: "build", priority: "high", name: "testSetTraceparent", override: true }
+      );
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          traceparent: new RegExp(`^${existingTraceparent.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+          tracestate: (value: any) => expect(value).toBeUndefined(),
+          baggage: (value: any) => expect(value).toBeUndefined(),
+        },
+      });
+
+      await client.invoke({
+        FunctionName: "my-function",
+      });
+
+      expect.hasAssertions();
+    });
+
+    it("should preserve existing traceparent, tracestate, and baggage without overwriting from InvokeStore", async () => {
+      const existingTraceparent = "00-abcdef1234567890abcdef1234567890-1234567890abcdef-01";
+      const existingTracestate = "vendor1=opaqueValue1";
+      const existingBaggage = "key1=value1";
+      const mockTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+      const mockTracestate = "congo=t61rcWkgMzE";
+      const mockBaggage = "userId=alice,serverNode=DF%2028";
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => mockTracestate,
+        getBaggage: () => mockBaggage,
+      } as any);
+
+      const client = new Lambda({
+        region: "us-west-2",
+      });
+
+      client.middlewareStack.add(
+        (next) => async (args: any) => {
+          args.request.headers["traceparent"] = existingTraceparent;
+          args.request.headers["tracestate"] = existingTracestate;
+          args.request.headers["baggage"] = existingBaggage;
+          return next(args);
+        },
+        { step: "build", priority: "high", name: "testSetTraceHeaders", override: true }
+      );
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          traceparent: new RegExp(`^${existingTraceparent.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+          tracestate: new RegExp(`^${existingTracestate.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+          baggage: new RegExp(`^${existingBaggage.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+        },
+      });
+
+      await client.invoke({
+        FunctionName: "my-function",
+      });
+
+      expect.hasAssertions();
+    });
+
     it("should NOT add W3C headers when InvokeStore has no traceparent", async () => {
       vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
         getXRayTraceId: () => undefined,

--- a/packages-internal/core/src/submodules/client/middleware-recursion-detection/middleware-recursion-detection.integ.spec.ts
+++ b/packages-internal/core/src/submodules/client/middleware-recursion-detection/middleware-recursion-detection.integ.spec.ts
@@ -1,11 +1,23 @@
+import { InvokeStore } from "@aws/lambda-invoke-store";
 import { requireRequestsFrom } from "@aws-sdk/aws-util-test/src";
 import { Lambda } from "@aws-sdk/client-lambda";
-import { describe, expect, test as it } from "vitest";
+import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 const ENV_LAMBDA_FUNCTION_NAME = "AWS_LAMBDA_FUNCTION_NAME";
 const ENV_TRACE_ID = "_X_AMZN_TRACE_ID";
 
 describe("middleware-recursion-detection", () => {
+  const originEnv = process.env;
+
+  beforeEach(() => {
+    vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue(undefined as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = originEnv;
+  });
+
   describe(Lambda.name, () => {
     it("should create recursion detection headers", async () => {
       process.env[ENV_LAMBDA_FUNCTION_NAME] = "MyLambdaFunction";
@@ -18,6 +30,119 @@ describe("middleware-recursion-detection", () => {
       requireRequestsFrom(client).toMatch({
         headers: {
           "X-Amzn-Trace-Id": /^trace-1234$/,
+        },
+      });
+
+      await client.invoke({
+        FunctionName: "my-function",
+      });
+
+      expect.hasAssertions();
+    });
+
+    it("should propagate W3C traceparent header from InvokeStore", async () => {
+      const mockTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => undefined,
+        getBaggage: () => undefined,
+      } as any);
+
+      const client = new Lambda({
+        region: "us-west-2",
+      });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          traceparent: new RegExp(`^${mockTraceparent.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+        },
+      });
+
+      await client.invoke({
+        FunctionName: "my-function",
+      });
+
+      expect.hasAssertions();
+    });
+
+    it("should propagate all W3C trace context headers from InvokeStore", async () => {
+      const mockTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+      const mockTracestate = "congo=t61rcWkgMzE";
+      const mockBaggage = "userId=alice,serverNode=DF%2028";
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => mockTracestate,
+        getBaggage: () => mockBaggage,
+      } as any);
+
+      const client = new Lambda({
+        region: "us-west-2",
+      });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          traceparent: /^00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01$/,
+          tracestate: /^congo=t61rcWkgMzE$/,
+          baggage: /^userId=alice,serverNode=DF%2028$/,
+        },
+      });
+
+      await client.invoke({
+        FunctionName: "my-function",
+      });
+
+      expect.hasAssertions();
+    });
+
+    it("should propagate both X-Amzn-Trace-Id and W3C headers when in Lambda", async () => {
+      const mockXRayTraceId = "Root=1-abc-def;Parent=123;Sampled=1";
+      const mockTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+      const mockTracestate = "congo=t61rcWkgMzE";
+      process.env[ENV_LAMBDA_FUNCTION_NAME] = "MyLambdaFunction";
+
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => mockXRayTraceId,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => mockTracestate,
+        getBaggage: () => undefined,
+      } as any);
+
+      const client = new Lambda({
+        region: "us-west-2",
+      });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          "X-Amzn-Trace-Id": /^Root=1-abc-def;Parent=123;Sampled=1$/,
+          traceparent: /^00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01$/,
+          tracestate: /^congo=t61rcWkgMzE$/,
+        },
+      });
+
+      await client.invoke({
+        FunctionName: "my-function",
+      });
+
+      expect.hasAssertions();
+    });
+
+    it("should NOT add W3C headers when InvokeStore has no traceparent", async () => {
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => undefined,
+        getTracestate: () => "congo=t61rcWkgMzE",
+        getBaggage: () => "userId=alice",
+      } as any);
+
+      const client = new Lambda({
+        region: "us-west-2",
+      });
+
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          traceparent: (value: any) => expect(value).toBeUndefined(),
         },
       });
 

--- a/packages-internal/core/src/submodules/client/middleware-recursion-detection/recursionDetectionMiddleware.spec.ts
+++ b/packages-internal/core/src/submodules/client/middleware-recursion-detection/recursionDetectionMiddleware.spec.ts
@@ -44,6 +44,7 @@ describe(recursionDetectionMiddleware.name, () => {
     it("trace id value is set in InvokeStore", async () => {
       vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
         getXRayTraceId: () => mockTraceIdInvokeStore,
+        getTraceparent: () => undefined,
       } as any);
       process.env = {
         AWS_LAMBDA_FUNCTION_NAME: "some-function",
@@ -62,6 +63,7 @@ describe(recursionDetectionMiddleware.name, () => {
     it("favors trace id value from InvokeStore over that from env variable", async () => {
       vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
         getXRayTraceId: () => mockTraceIdInvokeStore,
+        getTraceparent: () => undefined,
       } as any);
       process.env = {
         AWS_LAMBDA_FUNCTION_NAME: "some-function",
@@ -189,5 +191,343 @@ describe(recursionDetectionMiddleware.name, () => {
     );
     expect(existingTraceHeader).toBeDefined();
     expect(request.headers[existingTraceHeader!]).toBe("some-real-trace-id");
+  });
+
+  describe("W3C trace context propagation", () => {
+    const mockTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    const mockTracestate = "congo=t61rcWkgMzE";
+    const mockBaggage = "userId=alice,serverNode=DF%2028";
+
+    it("should set traceparent from InvokeStore when not already in headers", async () => {
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => undefined,
+        getBaggage: () => undefined,
+      } as any);
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      expect(request.headers["traceparent"]).toBe(mockTraceparent);
+    });
+
+    it("should set traceparent, tracestate, and baggage from InvokeStore", async () => {
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => mockTracestate,
+        getBaggage: () => mockBaggage,
+      } as any);
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      expect(request.headers["traceparent"]).toBe(mockTraceparent);
+      expect(request.headers["tracestate"]).toBe(mockTracestate);
+      expect(request.headers["baggage"]).toBe(mockBaggage);
+    });
+
+    it("should NOT set tracestate or baggage when traceparent is absent", async () => {
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => undefined,
+        getTracestate: () => mockTracestate,
+        getBaggage: () => mockBaggage,
+      } as any);
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      expect(request.headers["traceparent"]).toBeUndefined();
+      expect(request.headers["tracestate"]).toBeUndefined();
+      expect(request.headers["baggage"]).toBeUndefined();
+    });
+
+    it("should preserve existing traceparent header and add tracestate/baggage from InvokeStore", async () => {
+      const existingTraceparent = "00-abcdef1234567890abcdef1234567890-1234567890abcdef-01";
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => mockTracestate,
+        getBaggage: () => mockBaggage,
+      } as any);
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({
+          headers: {
+            traceparent: existingTraceparent,
+          },
+        }),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      expect(request.headers["traceparent"]).toBe(existingTraceparent);
+      expect(request.headers["tracestate"]).toBe(mockTracestate);
+      expect(request.headers["baggage"]).toBe(mockBaggage);
+    });
+
+    it("should not overwrite existing traceparent when InvokeStore also has one", async () => {
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => undefined,
+        getBaggage: () => undefined,
+      } as any);
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({
+          headers: {
+            traceparent: "existing-value",
+          },
+        }),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      expect(request.headers["traceparent"]).toBe("existing-value");
+    });
+
+    it("should normalize non-canonical traceparent casing and not overwrite with InvokeStore value", async () => {
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => undefined,
+        getBaggage: () => undefined,
+      } as any);
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({
+          headers: {
+            TraceParent: "existing-value",
+          },
+        }),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      // rewritten to canonical lowercase, value preserved, not overwritten
+      expect(request.headers["traceparent"]).toBe("existing-value");
+      expect(request.headers["TraceParent"]).toBeUndefined();
+      expect(Object.keys(request.headers).filter((h) => h.toLowerCase() === "traceparent").length).toBe(1);
+    });
+
+    it("should NOT set tracestate when InvokeStore does not provide it", async () => {
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => undefined,
+        getBaggage: () => mockBaggage,
+      } as any);
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      expect(request.headers["traceparent"]).toBe(mockTraceparent);
+      expect(request.headers["tracestate"]).toBeUndefined();
+      expect(request.headers["baggage"]).toBe(mockBaggage);
+    });
+
+    it("should NOT set baggage when InvokeStore does not provide it", async () => {
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => mockTracestate,
+        getBaggage: () => undefined,
+      } as any);
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      expect(request.headers["traceparent"]).toBe(mockTraceparent);
+      expect(request.headers["tracestate"]).toBe(mockTracestate);
+      expect(request.headers["baggage"]).toBeUndefined();
+    });
+
+    describe("sanitizeTraceHeaders", () => {
+      it("should normalize non-canonical casing of traceparent to lowercase", async () => {
+        vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+          getXRayTraceId: () => undefined,
+          getTraceparent: () => undefined,
+          getTracestate: () => undefined,
+          getBaggage: () => undefined,
+        } as any);
+
+        const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+        await handler({
+          input: {},
+          request: new HttpRequest({
+            headers: {
+              Traceparent: mockTraceparent,
+            },
+          }),
+        });
+
+        const { request } = mockNextHandler.mock.calls[0][0];
+        expect(request.headers["traceparent"]).toBe(mockTraceparent);
+        expect(request.headers["Traceparent"]).toBeUndefined();
+      });
+
+      it("should normalize non-canonical casing of tracestate to lowercase", async () => {
+        vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+          getXRayTraceId: () => undefined,
+          getTraceparent: () => mockTraceparent,
+          getTracestate: () => undefined,
+          getBaggage: () => undefined,
+        } as any);
+
+        const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+        await handler({
+          input: {},
+          request: new HttpRequest({
+            headers: {
+              traceparent: mockTraceparent,
+              TraceState: mockTracestate,
+            },
+          }),
+        });
+
+        const { request } = mockNextHandler.mock.calls[0][0];
+        expect(request.headers["tracestate"]).toBe(mockTracestate);
+        expect(request.headers["TraceState"]).toBeUndefined();
+      });
+
+      it("should normalize non-canonical casing of baggage to lowercase", async () => {
+        vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+          getXRayTraceId: () => undefined,
+          getTraceparent: () => mockTraceparent,
+          getTracestate: () => undefined,
+          getBaggage: () => undefined,
+        } as any);
+
+        const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+        await handler({
+          input: {},
+          request: new HttpRequest({
+            headers: {
+              traceparent: mockTraceparent,
+              Baggage: mockBaggage,
+            },
+          }),
+        });
+
+        const { request } = mockNextHandler.mock.calls[0][0];
+        expect(request.headers["baggage"]).toBe(mockBaggage);
+        expect(request.headers["Baggage"]).toBeUndefined();
+      });
+
+      it("should not modify headers that are already lowercase", async () => {
+        vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+          getXRayTraceId: () => undefined,
+          getTraceparent: () => undefined,
+          getTracestate: () => undefined,
+          getBaggage: () => undefined,
+        } as any);
+
+        const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+        await handler({
+          input: {},
+          request: new HttpRequest({
+            headers: {
+              traceparent: mockTraceparent,
+              tracestate: mockTracestate,
+              baggage: mockBaggage,
+            },
+          }),
+        });
+
+        const { request } = mockNextHandler.mock.calls[0][0];
+        expect(request.headers["traceparent"]).toBe(mockTraceparent);
+        expect(request.headers["tracestate"]).toBe(mockTracestate);
+        expect(request.headers["baggage"]).toBe(mockBaggage);
+      });
+    });
+
+    it("should handle InvokeStore where getTracestate and getBaggage are not defined", async () => {
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+      } as any);
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      expect(request.headers["traceparent"]).toBe(mockTraceparent);
+      expect(request.headers["tracestate"]).toBeUndefined();
+      expect(request.headers["baggage"]).toBeUndefined();
+    });
+
+    it("should set both X-Amzn-Trace-Id and W3C headers when in Lambda with InvokeStore", async () => {
+      const mockXRayTraceId = "Root=1-abc-def;Parent=123;Sampled=1";
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => mockXRayTraceId,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => mockTracestate,
+        getBaggage: () => mockBaggage,
+      } as any);
+      process.env = {
+        AWS_LAMBDA_FUNCTION_NAME: "some-function",
+      };
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      expect(request.headers["X-Amzn-Trace-Id"]).toBe(mockXRayTraceId);
+      expect(request.headers["traceparent"]).toBe(mockTraceparent);
+      expect(request.headers["tracestate"]).toBe(mockTracestate);
+      expect(request.headers["baggage"]).toBe(mockBaggage);
+    });
+
+    it("should only call InvokeStore.getInstanceAsync once when both features need it", async () => {
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => "trace-id",
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => undefined,
+        getBaggage: () => undefined,
+      } as any);
+      process.env = {
+        AWS_LAMBDA_FUNCTION_NAME: "some-function",
+      };
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      expect(InvokeStore.getInstanceAsync).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages-internal/core/src/submodules/client/middleware-recursion-detection/recursionDetectionMiddleware.spec.ts
+++ b/packages-internal/core/src/submodules/client/middleware-recursion-detection/recursionDetectionMiddleware.spec.ts
@@ -256,7 +256,7 @@ describe(recursionDetectionMiddleware.name, () => {
       expect(request.headers["baggage"]).toBeUndefined();
     });
 
-    it("should preserve existing traceparent header and add tracestate/baggage from InvokeStore", async () => {
+    it("should preserve existing traceparent header and NOT add tracestate/baggage from InvokeStore", async () => {
       const existingTraceparent = "00-abcdef1234567890abcdef1234567890-1234567890abcdef-01";
       vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
         getXRayTraceId: () => undefined,
@@ -277,8 +277,37 @@ describe(recursionDetectionMiddleware.name, () => {
 
       const { request } = mockNextHandler.mock.calls[0][0];
       expect(request.headers["traceparent"]).toBe(existingTraceparent);
-      expect(request.headers["tracestate"]).toBe(mockTracestate);
-      expect(request.headers["baggage"]).toBe(mockBaggage);
+      expect(request.headers["tracestate"]).toBeUndefined();
+      expect(request.headers["baggage"]).toBeUndefined();
+    });
+
+    it("should preserve existing traceparent, tracestate, and baggage headers without overwriting from InvokeStore", async () => {
+      const existingTraceparent = "00-abcdef1234567890abcdef1234567890-1234567890abcdef-01";
+      const existingTracestate = "vendor1=opaqueValue1";
+      const existingBaggage = "key1=value1";
+      vi.spyOn(InvokeStore, "getInstanceAsync").mockResolvedValue({
+        getXRayTraceId: () => undefined,
+        getTraceparent: () => mockTraceparent,
+        getTracestate: () => mockTracestate,
+        getBaggage: () => mockBaggage,
+      } as any);
+
+      const handler = recursionDetectionMiddleware()(mockNextHandler, {} as any);
+      await handler({
+        input: {},
+        request: new HttpRequest({
+          headers: {
+            traceparent: existingTraceparent,
+            tracestate: existingTracestate,
+            baggage: existingBaggage,
+          },
+        }),
+      });
+
+      const { request } = mockNextHandler.mock.calls[0][0];
+      expect(request.headers["traceparent"]).toBe(existingTraceparent);
+      expect(request.headers["tracestate"]).toBe(existingTracestate);
+      expect(request.headers["baggage"]).toBe(existingBaggage);
     });
 
     it("should not overwrite existing traceparent when InvokeStore also has one", async () => {

--- a/packages-internal/core/src/submodules/client/middleware-recursion-detection/recursionDetectionMiddleware.ts
+++ b/packages-internal/core/src/submodules/client/middleware-recursion-detection/recursionDetectionMiddleware.ts
@@ -1,20 +1,31 @@
 // @ts-ignore
-import { InvokeStore } from "@aws/lambda-invoke-store";
+import { type InvokeStoreBase, InvokeStore } from "@aws/lambda-invoke-store";
 import { HttpRequest } from "@smithy/core/protocols";
 import type {
   BuildHandler,
   BuildHandlerArguments,
   BuildHandlerOutput,
   BuildMiddleware,
+  HeaderBag,
   MetadataBearer,
 } from "@smithy/types";
 
-const TRACE_ID_HEADER_NAME = "X-Amzn-Trace-Id";
-const ENV_LAMBDA_FUNCTION_NAME = "AWS_LAMBDA_FUNCTION_NAME";
-const ENV_TRACE_ID = "_X_AMZN_TRACE_ID";
+// env
+const AWS_LAMBDA_FUNCTION_NAME = "AWS_LAMBDA_FUNCTION_NAME";
+const _X_AMZN_TRACE_ID = "_X_AMZN_TRACE_ID";
+
+// headers
+const X_AMZN_TRACE_ID = "X-Amzn-Trace-Id";
+const TRACEPARENT = "traceparent";
+const TRACESTATE = "tracestate";
+const BAGGAGE = "baggage";
 
 /**
- * Inject to trace ID to request header to detect recursion invocation in Lambda.
+ * Used for two Lambda-related responsibilities:
+ * - Inject to trace ID to request header to detect recursion invocation in Lambda.
+ * - Propagate W3C trace context headers from
+ *   the Lambda InvokeStore onto outbound requests, enabling distributed trace
+ *   context to flow to downstream calls without creating any spans.
  * @internal
  */
 export const recursionDetectionMiddleware =
@@ -25,26 +36,65 @@ export const recursionDetectionMiddleware =
     if (!HttpRequest.isInstance(request)) {
       return next(args);
     }
-    const traceIdHeader =
-      Object.keys(request.headers ?? {}).find((h) => h.toLowerCase() === TRACE_ID_HEADER_NAME.toLowerCase()) ??
-      TRACE_ID_HEADER_NAME;
 
-    if (request.headers.hasOwnProperty(traceIdHeader)) {
-      return next(args);
+    let invokeStore: InvokeStoreBase | undefined;
+
+    {
+      // block: recursion detection
+      const traceIdHeader =
+        Object.keys(request.headers ?? {}).find((h) => h.toLowerCase() === X_AMZN_TRACE_ID.toLowerCase()) ??
+        X_AMZN_TRACE_ID;
+
+      if (!request.headers.hasOwnProperty(traceIdHeader)) {
+        const functionName = process.env[AWS_LAMBDA_FUNCTION_NAME];
+
+        const traceIdFromEnv = process.env[_X_AMZN_TRACE_ID];
+        invokeStore ??= await InvokeStore.getInstanceAsync();
+        const traceIdFromInvokeStore = invokeStore?.getXRayTraceId();
+        const traceId = traceIdFromInvokeStore ?? traceIdFromEnv;
+
+        const nonEmptyString = (str: unknown): str is string => typeof str === "string" && str.length > 0;
+        if (nonEmptyString(functionName) && nonEmptyString(traceId)) {
+          request.headers[X_AMZN_TRACE_ID] = traceId;
+        }
+      }
     }
-    const functionName = process.env[ENV_LAMBDA_FUNCTION_NAME];
 
-    const traceIdFromEnv = process.env[ENV_TRACE_ID];
-    const invokeStore = await InvokeStore.getInstanceAsync();
-    const traceIdFromInvokeStore = invokeStore?.getXRayTraceId();
-    const traceId = traceIdFromInvokeStore ?? traceIdFromEnv;
+    {
+      // block: w3c tracing headers
 
-    const nonEmptyString = (str: unknown): str is string => typeof str === "string" && str.length > 0;
-    if (nonEmptyString(functionName) && nonEmptyString(traceId)) {
-      request.headers[TRACE_ID_HEADER_NAME] = traceId;
+      sanitizeTraceHeaders(request.headers);
+
+      const traceparent =
+        request.headers[TRACEPARENT] ?? (invokeStore ??= await InvokeStore.getInstanceAsync())?.getTraceparent();
+      if (traceparent) {
+        // traceparent is required.
+        request.headers[TRACEPARENT] = traceparent;
+
+        const tracestate = invokeStore?.getTracestate?.();
+        if (tracestate) {
+          request.headers[TRACESTATE] = tracestate;
+        }
+        const baggage = invokeStore?.getBaggage?.();
+        if (baggage) {
+          request.headers[BAGGAGE] = baggage;
+        }
+      }
     }
-    return next({
-      ...args,
-      request,
-    });
+
+    return next(args);
   };
+
+/**
+ * Rewrites any trace context header that is present under a non-canonical casing
+ * (e.g. "TraceParent") to its lowercase canonical name, in place.
+ */
+function sanitizeTraceHeaders(headers: HeaderBag): void {
+  for (const header of Object.keys(headers)) {
+    const lower = header.toLowerCase();
+    if (header !== lower && (lower === TRACEPARENT || lower === TRACESTATE || lower === BAGGAGE)) {
+      headers[lower] = headers[header];
+      delete headers[header];
+    }
+  }
+}

--- a/packages-internal/core/src/submodules/client/middleware-recursion-detection/recursionDetectionMiddleware.ts
+++ b/packages-internal/core/src/submodules/client/middleware-recursion-detection/recursionDetectionMiddleware.ts
@@ -65,19 +65,21 @@ export const recursionDetectionMiddleware =
 
       sanitizeTraceHeaders(request.headers);
 
-      const traceparent =
-        request.headers[TRACEPARENT] ?? (invokeStore ??= await InvokeStore.getInstanceAsync())?.getTraceparent();
-      if (traceparent) {
-        // traceparent is required.
-        request.headers[TRACEPARENT] = traceparent;
+      const existingTraceparent = request.headers[TRACEPARENT];
 
-        const tracestate = invokeStore?.getTracestate?.();
-        if (tracestate) {
-          request.headers[TRACESTATE] = tracestate;
-        }
-        const baggage = invokeStore?.getBaggage?.();
-        if (baggage) {
-          request.headers[BAGGAGE] = baggage;
+      if (!existingTraceparent) {
+        const traceparent = (invokeStore ??= await InvokeStore.getInstanceAsync())?.getTraceparent?.();
+        if (traceparent) {
+          request.headers[TRACEPARENT] = traceparent;
+
+          const tracestate = invokeStore?.getTracestate?.();
+          if (tracestate) {
+            request.headers[TRACESTATE] = tracestate;
+          }
+          const baggage = invokeStore?.getBaggage?.();
+          if (baggage) {
+            request.headers[BAGGAGE] = baggage;
+          }
         }
       }
     }


### PR DESCRIPTION
### Issue
modified from https://github.com/aws/aws-sdk-js-v3/pull/8147

### Description
propagate `traceparent` `tracestate` `baggage` headers from Lambda invoke store.

### Testing
CI, new unit tests

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
