### PR TITLE
fix(credential-provider-http): fix token and URI path priority resolution

### DIFF
--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.integ.spec.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.integ.spec.ts
@@ -1,5 +1,8 @@
+import fs from "node:fs";
 import http from "node:http";
 import type { AddressInfo, Socket } from "node:net";
+import os from "node:os";
+import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { fromHttp } from "./fromHttp";
@@ -8,6 +11,10 @@ describe("fromHttp socket cleanup", () => {
   let server: http.Server;
   let port: number;
   let activeConnections: Set<Socket>;
+
+  let tokenServer: http.Server;
+  let tmpDir: string;
+
 
   beforeAll(async () => {
     activeConnections = new Set();
@@ -38,6 +45,13 @@ describe("fromHttp socket cleanup", () => {
       socket.destroy();
     }
     await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    if (tokenServer) {
+      await new Promise<void>((resolve) => tokenServer.close(() => resolve()));
+    }
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
   });
 
   it("destroys sockets after each credential fetch", async () => {
@@ -54,6 +68,42 @@ describe("fromHttp socket cleanup", () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(activeConnections.size).toBe(0);
+  });
+
+  it("re-reads token file on each request", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fromHttp-integ-"));
+    const tokenFile = path.join(tmpDir, "token");
+    fs.writeFileSync(tokenFile, "token-v1");
+
+    const receivedAuths: string[] = [];
+    tokenServer = http.createServer((req, res) => {
+      receivedAuths.push(req.headers.authorization ?? "");
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          AccessKeyId: "AKID",
+          SecretAccessKey: "SECRET",
+          Token: "TOKEN",
+          Expiration: new Date(Date.now() + 3600_000).toISOString(),
+        })
+      );
+    });
+
+    await new Promise<void>((resolve) => tokenServer.listen(0, "127.0.0.1", resolve));
+    const tokenPort = (tokenServer.address() as AddressInfo).port;
+
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: `http://127.0.0.1:${tokenPort}/creds`,
+      awsContainerCredentialsRelativeUri: "",
+      awsContainerAuthorizationTokenFile: tokenFile,
+    });
+
+    await provider();
+    fs.writeFileSync(tokenFile, "token-v2");
+    await provider();
+
+    expect(receivedAuths[0]).toBe("token-v1");
+    expect(receivedAuths[1]).toBe("token-v2");
   });
 
   it("destroys sockets even when requests fail", async () => {

--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.spec.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.spec.ts
@@ -1,6 +1,6 @@
 import { HttpResponse } from "@smithy/core/protocols";
 import { Readable } from "node:stream";
-import { afterAll, describe, expect, test as it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import { fromHttp } from "./fromHttp";
 import * as helpers from "./requestHelpers";
@@ -51,6 +51,11 @@ vi.mock("fs/promises", () => ({
 }));
 
 describe(fromHttp.name, () => {
+  beforeEach(() => {
+    mockHandle.mockClear();
+    mockDestroy.mockClear();
+  });
+
   afterAll(() => {
     vi.resetAllMocks();
   });
@@ -81,9 +86,23 @@ describe(fromHttp.name, () => {
     });
   });
 
+  it("relative uri should take precedence over full uri", async () => {
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: "https://u1.aws",
+      awsContainerCredentialsRelativeUri: "/credential-path",
+    });
+
+    await provider();
+
+    expect(mockHandle).toHaveBeenCalledWith(helpers.createGetRequest(new URL("http://169.254.170.2/credential-path")), {
+      requestTimeout: 1000,
+    });
+  });
+
   it("can use the token", async () => {
     const provider = fromHttp({
       awsContainerCredentialsFullUri: "https://t1.aws",
+      awsContainerCredentialsRelativeUri: "",
       awsContainerAuthorizationToken: mockToken,
     });
 
@@ -98,10 +117,11 @@ describe(fromHttp.name, () => {
   it("can use the token file", async () => {
     const provider = fromHttp({
       awsContainerCredentialsFullUri: "https://t2.aws",
+      awsContainerCredentialsRelativeUri: "",
       awsContainerAuthorizationTokenFile: "some-file",
     });
 
-    const request = helpers.createGetRequest(new URL("https://t1.aws"));
+    const request = helpers.createGetRequest(new URL("https://t2.aws"));
     request.headers.Authorization = mockToken;
 
     await provider();
@@ -109,9 +129,36 @@ describe(fromHttp.name, () => {
     expect(mockHandle).toHaveBeenCalledWith(request, { requestTimeout: 1000 });
   });
 
+  it("token file takes precedence over token", async () => {
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: "https://t3.aws",
+      awsContainerCredentialsRelativeUri: "",
+      awsContainerAuthorizationToken: "static-token",
+      awsContainerAuthorizationTokenFile: "some-file",
+    });
+
+    const request = helpers.createGetRequest(new URL("https://t3.aws"));
+    request.headers.Authorization = mockToken;
+
+    await provider();
+
+    expect(mockHandle).toHaveBeenCalledWith(request, { requestTimeout: 1000 });
+  });
+
+  it("rejects token containing \\r\\n", async () => {
+    const provider = fromHttp({
+      awsContainerCredentialsFullUri: "https://t4.aws",
+      awsContainerCredentialsRelativeUri: "",
+      awsContainerAuthorizationToken: "Bearer token\r\nX-Injected: header",
+    });
+
+    await expect(provider()).rejects.toThrow("Authorization token contains invalid \\r\\n sequence.");
+  });
+
   it("passes custom timeout as requestTimeout to handle()", async () => {
     const provider = fromHttp({
       awsContainerCredentialsFullUri: "https://u1.aws",
+      awsContainerCredentialsRelativeUri: "",
       timeout: 5000,
     });
 
@@ -121,10 +168,9 @@ describe(fromHttp.name, () => {
   });
 
   it("destroys the request handler after the provider resolves", async () => {
-    mockDestroy.mockClear();
-
     const provider = fromHttp({
       awsContainerCredentialsFullUri: "https://u1.aws",
+      awsContainerCredentialsRelativeUri: "",
     });
 
     await provider();
@@ -133,7 +179,6 @@ describe(fromHttp.name, () => {
   });
 
   it("destroys the request handler even when the request fails", async () => {
-    mockDestroy.mockClear();
     mockHandle.mockRejectedValueOnce(new Error("network error"));
     mockHandle.mockRejectedValueOnce(new Error("network error"));
     mockHandle.mockRejectedValueOnce(new Error("network error"));
@@ -141,6 +186,7 @@ describe(fromHttp.name, () => {
 
     const provider = fromHttp({
       awsContainerCredentialsFullUri: "https://u1.aws",
+      awsContainerCredentialsRelativeUri: "",
     });
 
     await expect(provider()).rejects.toThrow();

--- a/packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts
+++ b/packages-internal/credential-provider-http/src/fromHttp/fromHttp.ts
@@ -37,7 +37,7 @@ export const fromHttp = (options: FromHttpOptions = {}): AwsCredentialIdentityPr
       "@aws-sdk/credential-provider-http: " +
         "you have set both awsContainerCredentialsRelativeUri and awsContainerCredentialsFullUri."
     );
-    warn("awsContainerCredentialsFullUri will take precedence.");
+    warn("awsContainerCredentialsRelativeUri will take precedence.");
   }
 
   if (token && tokenFile) {
@@ -45,13 +45,13 @@ export const fromHttp = (options: FromHttpOptions = {}): AwsCredentialIdentityPr
       "@aws-sdk/credential-provider-http: " +
         "you have set both awsContainerAuthorizationToken and awsContainerAuthorizationTokenFile."
     );
-    warn("awsContainerAuthorizationToken will take precedence.");
+    warn("awsContainerAuthorizationTokenFile will take precedence.");
   }
 
-  if (full) {
-    host = full;
-  } else if (relative) {
+  if (relative) {
     host = `${DEFAULT_LINK_LOCAL_HOST}${relative}`;
+  } else if (full) {
+    host = full;
   } else {
     throw new CredentialsProviderError(
       `No HTTP credential provider host provided.
@@ -73,12 +73,12 @@ Set AWS_CONTAINER_CREDENTIALS_FULL_URI or AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
     async (): Promise<AwsCredentialIdentity> => {
       const request = createGetRequest(url);
 
-      if (token) {
-        request.headers.Authorization = token;
-      } else if (tokenFile) {
+      if (tokenFile) {
         // Note: specification requires a file read on each request
         // to allow for updates to the file contents.
-        request.headers.Authorization = (await fs.readFile(tokenFile)).toString();
+        request.headers.Authorization = validateToken((await fs.readFile(tokenFile)).toString());
+      } else if (token) {
+        request.headers.Authorization = validateToken(token);
       }
       try {
         const result = await requestHandler.handle(request, { requestTimeout });
@@ -98,4 +98,16 @@ Set AWS_CONTAINER_CREDENTIALS_FULL_URI or AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
       requestHandler.destroy?.();
     }
   };
+};
+
+/**
+ * Validates that the token does not contain the \r\n sequence
+ * that would otherwise break the HTTP request.
+ * @internal
+ */
+const validateToken = (token: string): string => {
+  if (token.includes("\r\n")) {
+    throw new CredentialsProviderError("Authorization token contains invalid \\r\\n sequence.");
+  }
+  return token;
 };


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8101

### Description
This inverts the priority resolution for `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` and `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` according to the specification.

### Testing
```
yarn test
 ✓ src/fromHttp/fromHttp.spec.ts (10 tests) 6024ms
     ✓ rejects token containing \r\n  3006ms
     ✓ destroys the request handler even when the request fails  3004ms

 Test Files  3 passed (3)
      Tests  22 passed (22)
```
### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
