### PR TITLE
fix(scripts): publish unreleased X.0.0 baseline versions as-is

### DIFF
--- a/scripts/update-versions/lib/generateChangelog.mjs
+++ b/scripts/update-versions/lib/generateChangelog.mjs
@@ -111,16 +111,30 @@ async function generateChangelog(packagePath, since) {
   const changelog = JSON.parse(`[${processedRows.slice(0, -1)}]`);
   changelog.forEach(parseMessage);
 
+  // Publish a fresh baseline version (minor === 0 && patch === 0, e.g. 2.0.0 or 3.0.0) as-is
+  // instead of applying a conventional-commit bump, as long as that exact version has not
+  // been released yet. This lets us intentionally introduce a new major/initial version
+  // without it being incremented (e.g. a "feat" commit bumping 2.0.0 -> 2.1.0). Once that
+  // baseline version has a CHANGELOG.md entry, normal minor/patch bumping resumes.
+  const isNewBaselineVersion = semver.minor(pkgJson.version) === 0 && semver.patch(pkgJson.version) === 0;
+  const escapedVersion = pkgJson.version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const isVersionAlreadyReleased =
+    fs.existsSync(changelog_md) &&
+    new RegExp(`^#\\s+${escapedVersion}(?![\\d.])`, "m").test(fs.readFileSync(changelog_md, "utf-8"));
+  const isUnreleasedBaselineVersion = isNewBaselineVersion && !isVersionAlreadyReleased;
+
   let newVersion;
   const minorBump = changelog.some((e) => e.type === "feat");
-  if (minorBump) {
-    newVersion = writeNewVersion("minor", pkg_json);
-  }
   const patchBump = !minorBump && changelog.length > 0;
-  if (patchBump) {
+  if (changelog.length > 0 && isUnreleasedBaselineVersion) {
+    // Keep the current X.0.0 version as-is for its first release.
+    newVersion = pkgJson.version;
+  } else if (minorBump) {
+    newVersion = writeNewVersion("minor", pkg_json);
+  } else if (patchBump) {
     newVersion = writeNewVersion("patch", pkg_json);
   }
-  if (minorBump || patchBump) {
+  if (newVersion) {
     const md = createChangelogEntryMarkdown(changelog, newVersion);
     if (!fs.existsSync(changelog_md)) {
       fs.writeFileSync(changelog_md, `# Change Log\n\n`, "utf-8");

--- a/scripts/update-versions/lib/generateChangelog.mjs
+++ b/scripts/update-versions/lib/generateChangelog.mjs
@@ -126,7 +126,7 @@ async function generateChangelog(packagePath, since) {
   let newVersion;
   const minorBump = changelog.some((e) => e.type === "feat");
   const patchBump = !minorBump && changelog.length > 0;
-  if (changelog.length > 0 && isUnreleasedBaselineVersion) {
+  if (isUnreleasedBaselineVersion) {
     // Keep the current X.0.0 version as-is for its first release.
     newVersion = pkgJson.version;
   } else if (minorBump) {


### PR DESCRIPTION
### Issue

Internal JS-6966

### Description

The internal-package changelog generator applied a conventional-commit
bump on top of the version in package.json. A package intentionally set
to a fresh baseline like 2.0.0 with a "feat" commit was published as
2.1.0 instead of 2.0.0.

Example: We wanted to publish `@aws-sdk/undici-http-handler@2.0.0`
in #8093, but it published [2.1.0][] instead.

This PR keeps the declared version when it is a baseline (minor === 0
and patch === 0) and that exact version has no CHANGELOG.md entry yet.
Once the baseline is released, normal minor/patch bumping resumes, so a
later 3.0.0 baseline is also published as-is while 2.x keeps bumping.

[2.1.0]: https://github.com/aws/aws-sdk-js-v3/blob/main/packages-internal/undici-http-handler/CHANGELOG.md#210-2026-06-10

### Testing
Will be tested with `@aws-sdk/undici-http-handler@3.0.0` publish when https://github.com/smithy-lang/smithy-typescript/pull/2123 is re-exported.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
