### PR TITLE
fix(tests): use ES format for rollup bundle-size benchmark

### DIFF
--- a/tests/performance-tests/runner/BundlerSizeBenchmarker.mjs
+++ b/tests/performance-tests/runner/BundlerSizeBenchmarker.mjs
@@ -1,9 +1,9 @@
-import path from "node:path";
-import fs from "node:fs";
-import webpack from "webpack";
-import { build } from "vite";
 import esbuild from "esbuild";
+import fs from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { build } from "vite";
+import webpack from "webpack";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const APPLICATIONS_DIR = path.join(__dirname, "..", "applications");
@@ -23,7 +23,13 @@ export class BundlerSizeBenchmarker {
           entry: path.resolve(APPLICATIONS_DIR, this.application),
           target: "web",
           output: { path: DIST_DIR, filename: path.basename(outfile), library: "dist" },
-          optimization: { minimize: true, splitChunks: false, runtimeChunk: false, sideEffects: true, usedExports: true },
+          optimization: {
+            minimize: true,
+            splitChunks: false,
+            runtimeChunk: false,
+            sideEffects: true,
+            usedExports: true,
+          },
           stats: "none",
         },
         (err, stats) => {
@@ -31,7 +37,7 @@ export class BundlerSizeBenchmarker {
           if (stats?.hasErrors()) return reject(new Error(stats.toString("errors-only")));
           const totalBytes = Object.values(stats.compilation.assets).reduce((sum, a) => sum + a.size(), 0);
           resolve({ bundler: "webpack", bytes: totalBytes });
-        }
+        },
       );
     });
   }
@@ -49,11 +55,11 @@ export class BundlerSizeBenchmarker {
           entry: path.resolve(APPLICATIONS_DIR, this.application),
           name: "dist",
           fileName: () => `rollup-${this.application}.js`,
-          formats: ["umd"],
+          formats: ["es"],
         },
         minify: true,
         emptyOutDir: false,
-        rollupOptions: { external: [], output: { inlineDynamicImports: true } },
+        rollupOptions: { external: [], output: { codeSplitting: false } },
       },
     });
     return { bundler: "rollup", bytes: fs.statSync(outfile).size };


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/8161#issuecomment-4900763280

### Description

The rollup benchmark ran through Vite lib mode with `formats: ["umd"]`
and `inlineDynamicImports: true`. Newer Rollup (4.53.x, via vite@8)
deprecates `inlineDynamicImports` in favor of `output.codeSplitting`
and rejects UMD/IIFE for code-splitting builds, causing every rollup
build to fail with INVALID_OPTION and all rollup results to be skipped.

Switch to `formats: ["es"]` with `output.codeSplitting: false`, which
produces a single self-contained output file so the size measurement
stays accurate. Output filename is unchanged, so spec.mjs still passes.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
