### PR TITLE
fix(lib-transfer-manager): destroy orphaned response streams on abort

### DIFF
--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -28,7 +28,7 @@ import { join, relative, sep } from "node:path";
 import { type RawDataPart, byteLength, getChunk } from "./chunker";
 import { handleFailure, Semaphore, validateDirectory } from "./directory-transfer-utils";
 import type { AddEventListenerOptions, EventListener, RemoveEventListenerOptions } from "./event-listener-types";
-import { joinStreams } from "./join-streams";
+import { destroyStreams, joinStreams } from "./join-streams";
 import { LogLevel } from "./log-level";
 import type {
   CannedFailurePolicy,
@@ -374,30 +374,6 @@ export class S3TransferManager implements IS3TransferManager {
 
     let onStreamConsumed: ((index: number) => void) | undefined;
 
-    if (this.multipartDownloadType === "PART") {
-      const responseMetadata = await this.downloadByPart(
-        request,
-        transferOptions ?? {},
-        streams,
-        requests,
-        metadata,
-        checksumValidationEnabled
-      );
-      totalSize = responseMetadata.totalSize;
-      onStreamConsumed = responseMetadata.onStreamConsumed;
-    } else if (this.multipartDownloadType === "RANGE") {
-      const responseMetadata = await this.downloadByRange(
-        request,
-        transferOptions ?? {},
-        streams,
-        requests,
-        metadata,
-        checksumValidationEnabled
-      );
-      totalSize = responseMetadata.totalSize;
-      onStreamConsumed = responseMetadata.onStreamConsumed;
-    }
-
     const removeLocalEventListeners = () => {
       this.removeEventListeners(transferOptions?.eventListeners);
       if (transferOptions?.abortSignal) {
@@ -405,6 +381,40 @@ export class S3TransferManager implements IS3TransferManager {
         this.abortCleanupFunctions.delete(transferOptions.abortSignal as AbortSignal);
       }
     };
+
+    try {
+      if (this.multipartDownloadType === "PART") {
+        const responseMetadata = await this.downloadByPart(
+          request,
+          transferOptions ?? {},
+          streams,
+          requests,
+          metadata,
+          checksumValidationEnabled
+        );
+        totalSize = responseMetadata.totalSize;
+        onStreamConsumed = responseMetadata.onStreamConsumed;
+      } else if (this.multipartDownloadType === "RANGE") {
+        const responseMetadata = await this.downloadByRange(
+          request,
+          transferOptions ?? {},
+          streams,
+          requests,
+          metadata,
+          checksumValidationEnabled
+        );
+        totalSize = responseMetadata.totalSize;
+        onStreamConsumed = responseMetadata.onStreamConsumed;
+      }
+    } catch (error) {
+      // On failure or abort, response bodies that were already received but not
+      // yet handed to joinStreams are orphaned. Destroy them (attaching a no-op
+      // error handler) so their underlying sockets don't raise an uncaught
+      // "aborted"/ECONNRESET error when torn down.
+      await destroyStreams(streams);
+      removeLocalEventListeners();
+      throw error;
+    }
 
     const response = {
       ...metadata,
@@ -463,7 +473,10 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @alpha
    */
-  public async uploadDirectory(request: UploadDirectoryRequest, transferOptions?: TransferOptions): Promise<UploadDirectoryResponse> {
+  public async uploadDirectory(
+    request: UploadDirectoryRequest,
+    transferOptions?: TransferOptions
+  ): Promise<UploadDirectoryResponse> {
     const absoluteSource = await validateDirectory(request.source);
     const maxConcurrency = request.maxConcurrency ?? 100;
     const failurePolicy = request.failurePolicy ?? ("terminate" as CannedFailurePolicy);
@@ -520,9 +533,10 @@ export class S3TransferManager implements IS3TransferManager {
       discoveredFiles++;
       discoveredBytes += fileStat.size;
 
-      const count = fileStat.size >= this.multipartUploadThresholdBytes
-        ? Math.min(Math.ceil(fileStat.size / this.targetPartSizeBytes), this.maxConcurrentUploads)
-        : 1;
+      const count =
+        fileStat.size >= this.multipartUploadThresholdBytes
+          ? Math.min(Math.ceil(fileStat.size / this.targetPartSizeBytes), this.maxConcurrentUploads)
+          : 1;
 
       await semaphore.acquire(count);
 
@@ -569,7 +583,10 @@ export class S3TransferManager implements IS3TransferManager {
           }
           const context: DirectoryTransferFailureContext = {
             request,
-            objectRequest: { Bucket: request.bucket, Key: this.deriveS3Key(absoluteSource, filePath, request.s3Prefix) },
+            objectRequest: {
+              Bucket: request.bucket,
+              Key: this.deriveS3Key(absoluteSource, filePath, request.s3Prefix),
+            },
             error,
           };
           const result = await handleFailure(failurePolicy, context, abortController);
@@ -627,7 +644,10 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @alpha
    */
-  public downloadDirectory(request: DownloadDirectoryRequest, transferOptions?: TransferOptions): Promise<DownloadDirectoryResponse> {
+  public downloadDirectory(
+    request: DownloadDirectoryRequest,
+    transferOptions?: TransferOptions
+  ): Promise<DownloadDirectoryResponse> {
     throw new Error("Method not implemented.");
   }
 

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/join-streams.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/join-streams.ts
@@ -53,7 +53,7 @@ export async function* iterateStreams(
     try {
       stream = await streamPromise;
     } catch (e) {
-      await destroy(promises);
+      await destroyStreams(promises);
       eventListeners?.onFailure?.(e, index);
       throw e;
     }
@@ -71,7 +71,7 @@ export async function* iterateStreams(
           eventListeners?.onBytes?.(bytesTransferred, index);
         }
       } catch (e) {
-        await destroy(promises);
+        await destroyStreams(promises);
         eventListeners?.onFailure?.(e, index);
         throw e;
       } finally {
@@ -86,12 +86,12 @@ export async function* iterateStreams(
           eventListeners?.onBytes?.(bytesTransferred, index);
         }
       } catch (e) {
-        await destroy(promises);
+        await destroyStreams(promises);
         eventListeners?.onFailure?.(e, index);
         throw e;
       }
     } else {
-      await destroy(promises);
+      await destroyStreams(promises);
       const failure = new Error(`unhandled stream type ${(stream as any)?.constructor?.name}`);
       eventListeners?.onFailure?.(failure, index);
       throw failure;
@@ -104,15 +104,24 @@ export async function* iterateStreams(
 }
 
 /**
+ * Destroys/cancels a set of stream promises, swallowing any errors.
+ *
+ * Used to clean up response bodies that were received but never fully consumed
+ * (for example when a transfer is aborted). A no-op "error" handler is attached
+ * to Node streams before destroying so that a socket-level error raised while
+ * tearing down an unconsumed response body (e.g. "aborted"/ECONNRESET) does not
+ * surface as an uncaught exception.
+ *
  * @internal
  */
-async function destroy(promises: Promise<StreamingBlobPayloadOutputTypes>[]): Promise<void> {
+export async function destroyStreams(promises: Promise<StreamingBlobPayloadOutputTypes>[]): Promise<void> {
   await Promise.all(
     promises.map(async (streamPromise) => {
       if (!streamPromise) return;
       return streamPromise
         .then((stream) => {
           if (stream instanceof Readable) {
+            stream.on("error", () => {});
             stream.destroy();
             return;
           } else if (isReadableStream(stream)) {


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/8161#issuecomment-4906349051

### Description

When a download was aborted, response bodies that had already been
received but not yet handed to joinStreams were left orphaned with an
open socket and no error handler. When the abort tore down the socket,
Node's HTTP client emitted an uncaught "aborted"/ECONNRESET error,
failing the e2e run with an Uncaught Exception.

Wrap the download flow so any already-created streams are destroyed on
failure or abort, and attach a no-op error handler in destroyStreams
before destroying Node streams so socket-level teardown errors are
swallowed instead of surfacing as uncaught exceptions.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
