### PR TITLE
test(checksums): pass buffer in flexible checksums integ test

### DIFF
--- a/packages-internal/checksums/src/submodules/flexible-checksums/middleware-flexible-checksums.integ.spec.ts
+++ b/packages-internal/checksums/src/submodules/flexible-checksums/middleware-flexible-checksums.integ.spec.ts
@@ -151,7 +151,7 @@ describe("middleware-flexible-checksums", () => {
                           "content-length": body.length.toString(),
                           [checksumHeader]: checksumValue,
                         },
-                        body: Readable.from([body]),
+                        body: Readable.from([Buffer.from(body)]),
                       }),
                     };
                   }


### PR DESCRIPTION
### Issue
Internal JS-7042

### Description

The mocked `HttpHandler` was constructing its response stream with `Readable.from([body])`, where body is a plain string. `Readable.from()` preserves the type of the items you hand it, so this produced a stream that emits **string** chunks.

That does not match real runtime behavior. In Node.js, a `Readable` stream backed by a network/HTTP response operates on binary data and, by default, emits **Buffer** chunks (unless an encoding is explicitly set). So the mock was feeding downstream checksum/stream-collection logic a data shape it would never actually receive in production.

Wrapping the payload with `Buffer.from(body)` makes the mock emit Buffer chunks, so the integration test exercises the same code paths (buffer concatenation, checksum computation over bytes, `transformToString` decoding) that run against a live S3 response.

From Node.js docs: https://nodejs.org/api/stream.html#readablesetencodingencoding
> By default, no encoding is assigned and stream data will be returned as `Buffer` objects

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
