### PR TITLE
feat(undici-http-handler): bump version to 3.0.0

### DIFF
--- a/packages-internal/undici-http-handler/package.json
+++ b/packages-internal/undici-http-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-sdk/undici-http-handler",
-  "version": "2.1.4",
+  "version": "3.0.0",
   "description": "AWS SDK for JavaScript reqeust handler backed by modern, high performance Node.js undici client",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
@@ -18,7 +18,7 @@
     "test:e2e:watch": "yarn g:vitest watch -c vitest.config.e2e.mts"
   },
   "dependencies": {
-    "@smithy/undici-http-handler": "^2.2.5",
+    "@smithy/undici-http-handler": "^3.0.0",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages-internal/undici-http-handler/src/undici-http-handler.bedrock-runtime.e2e.spec.ts
+++ b/packages-internal/undici-http-handler/src/undici-http-handler.bedrock-runtime.e2e.spec.ts
@@ -6,7 +6,7 @@ import { UndiciHttpHandler } from "./index";
 describe("BedrockRuntime", () => {
   const client = new BedrockRuntime({
     region: "us-east-1",
-    requestHandler: new UndiciHttpHandler(),
+    requestHandler: new UndiciHttpHandler({ dispatcher: { allowH2: true } }),
   });
 
   afterAll(() => {

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/9e76e52a04da3929c18e5930a2246a8de2099a62...29ad40ae33b8e2e242b33fcd6e6dfeda7fcec2c6
-  SMITHY_TS_COMMIT: "29ad40ae33b8e2e242b33fcd6e6dfeda7fcec2c6",
+  // https://github.com/smithy-lang/smithy-typescript/compare/29ad40ae33b8e2e242b33fcd6e6dfeda7fcec2c6...3c14866b08c9527b6262000f4194b84ce35a3e80
+  SMITHY_TS_COMMIT: "3c14866b08c9527b6262000f4194b84ce35a3e80",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10926,7 +10926,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk/undici-http-handler@workspace:packages-internal/undici-http-handler"
   dependencies:
-    "@smithy/undici-http-handler": "npm:^2.2.5"
+    "@smithy/undici-http-handler": "npm:^3.0.0"
     "@tsconfig/recommended": "npm:1.0.1"
     concurrently: "npm:7.0.0"
     downlevel-dts: "npm:0.10.1"
@@ -15928,9 +15928,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/undici-http-handler@npm:^2.2.5":
-  version: 2.2.5
-  resolution: "@smithy/undici-http-handler@npm:2.2.5"
+"@smithy/undici-http-handler@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@smithy/undici-http-handler@npm:3.0.0"
   dependencies:
     "@smithy/core": "npm:^3.29.1"
     "@smithy/types": "npm:^4.15.1"
@@ -15938,7 +15938,7 @@ __metadata:
     undici: "npm:^7.0.0"
   peerDependencies:
     undici: ">=7.0.0"
-  checksum: 10c0/5023f0da12cd569a23a8755421dad5c608c05cdf48ec8360001d2479e948b9d056f78b8170d05cd038f93b51c3ffb181971763c8fab195c8b7ad164548778138
+  checksum: 10c0/8e7831398bd38ef62a764cbaed57f173a3e7859869aae56b240d4dbd904818f6f81dcbbd1c7b6e30d8610101cd19b1ec3997db4c29c28fbe2e9b62d80b987c5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Version bump to include `@smithy/undici-http-handler@^3.0.0` from https://github.com/smithy-lang/smithy-typescript/blob/main/packages/undici-http-handler/CHANGELOG.md#300

### Description

Bumps `@aws-sdk/undici-http-handler` version to 3.0.0

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
