### PR TITLE
test(bundlers): switch vite canary output format to es

### DIFF
--- a/tests/bundlers/vite.config.mjs
+++ b/tests/bundlers/vite.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 export default defineConfig({
   build: {
-    lib: { entry: "./web-application-sample.ts", formats: ["umd"], name: "AwsSdkCanary" },
+    lib: { entry: "./web-application-sample.ts", formats: ["es"], name: "AwsSdkCanary" },
     outDir: "./dist/vite",
     minify: false,
     sourcemap: false,


### PR DESCRIPTION
### Issue

Refs: https://github.com/aws/aws-sdk-js-v3/pull/8167#issuecomment-4908057721

### Description

Rolldown (rolldown-vite) rejects UMD/IIFE output for code-splitting
builds, and the AWS SDK entry uses dynamic imports that force multiple
chunks. Switch the vite lib format from umd to es, which supports code
splitting, to fix the bundler canary build. Webpack is left on umd
since it supports umd with dynamic imports.

### Testing
* CI
* `make test-bundlers` is successful locally

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
