### PR TITLE
chore(lib-dynamodb): enable isolatedModules

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
@@ -158,8 +158,8 @@ public class AddDocumentClientPlugin implements TypeScriptIntegration {
                 writer.write(
                     """
                     export { NumberValueImpl as NumberValue } from "@aws-sdk/util-dynamodb";
-                    export { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
-                    export { NativeAttributeValue, NativeAttributeBinary, NativeScalarAttributeValue } from "@aws-sdk/util-dynamodb";
+                    export type { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
+                    export type { NativeAttributeValue, NativeAttributeBinary, NativeScalarAttributeValue } from "@aws-sdk/util-dynamodb";
                                     """
                 );
             });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -79,7 +79,7 @@ final class DocumentClientPaginationGenerator implements Runnable {
         );
 
         writer.writeDocs("@public");
-        writer.write("export { Paginator };");
+        writer.write("export type { Paginator };");
 
         writePager();
     }
@@ -117,7 +117,7 @@ final class DocumentClientPaginationGenerator implements Runnable {
         );
 
         writer.writeDocs("@public");
-        writer.write("export { PaginationConfiguration };");
+        writer.write("export type { PaginationConfiguration };");
         writer.write("");
 
         writer.writeDocs("@public");

--- a/lib/lib-dynamodb/src/index.ts
+++ b/lib/lib-dynamodb/src/index.ts
@@ -5,5 +5,5 @@ export * from "./DynamoDBDocumentClient";
 export * from "./DynamoDBDocument";
 
 export { NumberValueImpl as NumberValue } from "@aws-sdk/util-dynamodb";
-export { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
-export { NativeAttributeValue, NativeAttributeBinary, NativeScalarAttributeValue } from "@aws-sdk/util-dynamodb";
+export type { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
+export type { NativeAttributeValue, NativeAttributeBinary, NativeScalarAttributeValue } from "@aws-sdk/util-dynamodb";

--- a/lib/lib-dynamodb/src/pagination/Interfaces.ts
+++ b/lib/lib-dynamodb/src/pagination/Interfaces.ts
@@ -7,7 +7,7 @@ import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
 /**
  * @public
  */
-export { PaginationConfiguration };
+export type { PaginationConfiguration };
 
 /**
  * @public

--- a/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
@@ -9,7 +9,7 @@ import type { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
 /**
  * @public
  */
-export { Paginator };
+export type { Paginator };
 /**
  * @public
  */

--- a/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
@@ -9,7 +9,7 @@ import type { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
 /**
  * @public
  */
-export { Paginator };
+export type { Paginator };
 /**
  * @public
  */

--- a/lib/lib-dynamodb/tsconfig.types.json
+++ b/lib/lib-dynamodb/tsconfig.types.json
@@ -6,7 +6,7 @@
     "paths": {
       "@smithy/core/*": ["../../node_modules/@smithy/core/dist-types/submodules/*/index.d.ts"]
     },
-    "isolatedModules": false
+    "isolatedModules": true
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]


### PR DESCRIPTION
### Issue
JS-7014

### Description
enable isolated modules for lib-dynamodb, which had a codegen component to it.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
