### PR TITLE
test(client-kinesis): log connection manager states in e2e test

### DIFF
--- a/clients/client-kinesis/test/Kinesis.e2e.spec.ts
+++ b/clients/client-kinesis/test/Kinesis.e2e.spec.ts
@@ -185,7 +185,7 @@ describe("@aws-sdk/client-kinesis", () => {
        * If debugging this test, get a picture of the connection states
        * at each step by logging this object.
        */
-      // console.log(JSON.stringify(connectionManagerStates, null, 2));
+      console.log(JSON.stringify(connectionManagerStates, null, 2));
       expect(connectionManagerStates.initial).toEqual({});
 
       expect(getSessions(connectionManagerStates.requestsFinished)).not.toEqual([]);


### PR DESCRIPTION
### Issue
Internal P461841445


### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
