### PR TITLE
test: add TypeScript version compatibility suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This is the public Makefile containing some build commands.
 # You can implement some additional personal commands such as login and sync in Makefile.private.mk (unversioned).
 
-.PHONY: login sync bundles test-unit test-types test-indices test-protocols test-schema test-integration test-endpoints test-e2e build build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle clean-nested link-smithy unlink-smithy copy-smithy gen-auth b-auth tpk unbuilt turbo-clean server-protocols nested-clients clients static-analysis
+.PHONY: login sync bundles test-unit test-typescript test-indices test-protocols test-schema test-integration test-endpoints test-e2e build build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle clean-nested link-smithy unlink-smithy copy-smithy gen-auth b-auth tpk unbuilt turbo-clean server-protocols nested-clients clients static-analysis
 
 # fetch AWS testing credentials
 login:
@@ -27,7 +27,7 @@ test-integration: bundles core-prebuild
 	node ./scripts/compilation/Inliner.spec.js
 	yarn g:vitest run -c vitest.config.integ.mts
 	make test-protocols
-	make test-types
+	make test-typescript
 	make snapshot-compare
 	make test-indices
 	make test-endpoints
@@ -47,10 +47,12 @@ test-codegen:
 	cp ./tmp/changelog.bak ./private/aws-protocoltests-restjson-schema/CHANGELOG.md
 	git diff --exit-code ./
 
-# typecheck for test code.
-test-types: reset-test-credentials
+# run all TypeScript checks: typecheck test code, then verify clients compile
+# across supported TypeScript versions (see tests/ts-compat/README.md).
+test-typescript: reset-test-credentials
 	npx tsc -p tsconfig.test.json
 	npx tsc -p tsconfig.test.index-types.json
+	(cd ./tests/ts-compat && npm install --no-audit --no-fund && node ./run.mjs)
 
 test-indices:
 	node ./scripts/validation/client-indexes.mjs

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This is the public Makefile containing some build commands.
 # You can implement some additional personal commands such as login and sync in Makefile.private.mk (unversioned).
 
-.PHONY: login sync bundles test-unit test-typescript test-indices test-protocols test-schema test-integration test-endpoints test-e2e build build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle clean-nested link-smithy unlink-smithy copy-smithy gen-auth b-auth tpk unbuilt turbo-clean server-protocols nested-clients clients static-analysis
+.PHONY: login sync bundles test-unit test-types test-typescript-versions test-indices test-protocols test-schema test-integration test-endpoints test-e2e build build-s3-browser-bundle build-signature-v4-multi-region-browser-bundle clean-nested link-smithy unlink-smithy copy-smithy gen-auth b-auth tpk unbuilt turbo-clean server-protocols nested-clients clients static-analysis
 
 # fetch AWS testing credentials
 login:
@@ -27,7 +27,8 @@ test-integration: bundles core-prebuild
 	node ./scripts/compilation/Inliner.spec.js
 	yarn g:vitest run -c vitest.config.integ.mts
 	make test-protocols
-	make test-typescript
+	make test-types
+	make test-typescript-versions
 	make snapshot-compare
 	make test-indices
 	make test-endpoints
@@ -47,11 +48,13 @@ test-codegen:
 	cp ./tmp/changelog.bak ./private/aws-protocoltests-restjson-schema/CHANGELOG.md
 	git diff --exit-code ./
 
-# run all TypeScript checks: typecheck test code, then verify clients compile
-# across supported TypeScript versions (see tests/ts-compat/README.md).
-test-typescript: reset-test-credentials
+# typecheck for test code.
+test-types: reset-test-credentials
 	npx tsc -p tsconfig.test.json
 	npx tsc -p tsconfig.test.index-types.json
+
+# verify clients compile across supported TypeScript versions (see tests/ts-compat/README.md).
+test-typescript-versions:
 	(cd ./tests/ts-compat && npm install --no-audit --no-fund && node ./run.mjs)
 
 test-indices:

--- a/tests/ts-compat/.gitignore
+++ b/tests/ts-compat/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+yarn.lock
+.tmp/

--- a/tests/ts-compat/README.md
+++ b/tests/ts-compat/README.md
@@ -1,0 +1,62 @@
+# ts-compat
+
+Verifies that one client per protocol compiles on every TypeScript version
+listed in [`typescript-versions.json`](./typescript-versions.json).
+
+The clients in this repository support a range of TypeScript versions (types are
+downleveled for older releases). This test guards that support by type-checking a
+small fixture that imports and uses one client per wire protocol against each
+version.
+
+## What it does
+
+For every version in `typescript-versions.json`, the runner:
+
+1. Installs that TypeScript version in isolation (under `.tmp/`).
+2. Type-checks [`fixtures/index.ts`](./fixtures/index.ts) against it.
+
+The clients' published `.d.ts` are parsed (so downlevel _syntax_ incompatibilities
+surface), while `skipLibCheck` avoids failing on their internal Node references
+(see [`tsconfig.json`](./tsconfig.json)). Work is parallelized across a pool of
+worker threads sized to the number of available processors.
+
+## Running
+
+This suite runs as part of the `test-typescript` Make target:
+
+```bash
+make test-typescript
+```
+
+You can also run it directly:
+
+```bash
+cd tests/ts-compat && npm install && node ./run.mjs
+```
+
+Either way assumes the referenced clients are already built (their `dist-types`
+are present). `run.mjs` errors with guidance if they are not. It runs in
+isolation with its own dependency installs.
+
+## Protocol coverage
+
+| Protocol   | Client                            |
+| ---------- | --------------------------------- |
+| awsJson1_0 | `@aws-sdk/client-dynamodb`        |
+| awsJson1_1 | `@aws-sdk/client-cloudwatch-logs` |
+| awsQuery   | `@aws-sdk/client-sts`             |
+| ec2Query   | `@aws-sdk/client-ec2`             |
+| restJson1  | `@aws-sdk/client-lambda`          |
+| restXml    | `@aws-sdk/client-s3`              |
+
+No shipping client currently uses the smithy `rpcv2Cbor` protocol; add one to the
+fixture once such a client is published.
+
+## Updating the supported versions
+
+Edit `typescript-versions.json`. Each entry is `{ version, tscArgs? }`:
+
+- `version` — any spec npm accepts (a bare minor like `"5.4"` installs its latest patch).
+- `tscArgs` — optional compiler flags for that version, passed on the command line
+  to override `tsconfig.json` when an option changed. For example, `moduleResolution:
+node` (node10) became a deprecation error in TS 6.0 and was removed in TS 7.0.

--- a/tests/ts-compat/fixtures/index.ts
+++ b/tests/ts-compat/fixtures/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Type-compatibility fixture.
+ *
+ * One AWS client per wire protocol is imported, instantiated, and used to send
+ * a command. Nothing here is executed - the file exists purely so that `tsc`
+ * type-checks the clients' published `.d.ts` surface (and their transitive
+ * `@smithy` / `@aws-sdk` type dependencies) against each TypeScript version.
+ *
+ * Protocol coverage:
+ *   - awsJson1_0  -> @aws-sdk/client-dynamodb
+ *   - awsJson1_1  -> @aws-sdk/client-cloudwatch-logs
+ *   - awsQuery    -> @aws-sdk/client-sts
+ *   - ec2Query    -> @aws-sdk/client-ec2
+ *   - restJson1   -> @aws-sdk/client-lambda
+ *   - restXml     -> @aws-sdk/client-s3
+ *
+ * Note: no shipping client currently uses the smithy rpcv2Cbor protocol. Add
+ * one here (with its command) once such a client is published.
+ */
+import { CloudWatchLogsClient, DescribeLogGroupsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { DynamoDBClient, ListTablesCommand } from "@aws-sdk/client-dynamodb";
+import { DescribeRegionsCommand, EC2Client } from "@aws-sdk/client-ec2";
+import { LambdaClient, ListFunctionsCommand } from "@aws-sdk/client-lambda";
+import { ListBucketsCommand, S3Client } from "@aws-sdk/client-s3";
+import { GetCallerIdentityCommand, STSClient } from "@aws-sdk/client-sts";
+
+// awsJson1_0
+export async function dynamodb(): Promise<void> {
+  const client = new DynamoDBClient({});
+  const output = await client.send(new ListTablesCommand({}));
+  const names: string[] | undefined = output.TableNames;
+  void names;
+}
+
+// awsJson1_1
+export async function cloudwatchLogs(): Promise<void> {
+  const client = new CloudWatchLogsClient({});
+  const output = await client.send(new DescribeLogGroupsCommand({}));
+  void output.logGroups;
+}
+
+// awsQuery
+export async function sts(): Promise<void> {
+  const client = new STSClient({});
+  const output = await client.send(new GetCallerIdentityCommand({}));
+  const account: string | undefined = output.Account;
+  void account;
+}
+
+// ec2Query
+export async function ec2(): Promise<void> {
+  const client = new EC2Client({});
+  const output = await client.send(new DescribeRegionsCommand({}));
+  void output.Regions;
+}
+
+// restJson1
+export async function lambda(): Promise<void> {
+  const client = new LambdaClient({});
+  const output = await client.send(new ListFunctionsCommand({}));
+  void output.Functions;
+}
+
+// restXml
+export async function s3(): Promise<void> {
+  const client = new S3Client({});
+  const output = await client.send(new ListBucketsCommand({}));
+  void output.Buckets;
+}

--- a/tests/ts-compat/package.json
+++ b/tests/ts-compat/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "name": "@aws-sdk/ts-compat-test",
+  "description": "Verifies that one client per protocol compiles against every supported TypeScript minor version.",
+  "type": "module",
+  "scripts": {
+    "test": "node ./run.mjs"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "file:../../clients/client-cloudwatch-logs",
+    "@aws-sdk/client-dynamodb": "file:../../clients/client-dynamodb",
+    "@aws-sdk/client-ec2": "file:../../clients/client-ec2",
+    "@aws-sdk/client-lambda": "file:../../clients/client-lambda",
+    "@aws-sdk/client-s3": "file:../../clients/client-s3",
+    "@aws-sdk/client-sts": "file:../../clients/client-sts"
+  }
+}

--- a/tests/ts-compat/run.mjs
+++ b/tests/ts-compat/run.mjs
@@ -1,0 +1,147 @@
+/**
+ * TypeScript compatibility test runner.
+ *
+ * For every TypeScript version listed in typescript-versions.json, this script:
+ *   1. Installs that TypeScript version in isolation (under .tmp/).
+ *   2. Type-checks fixtures/index.ts - which imports and uses one client per
+ *      protocol - against it. The clients' published .d.ts are parsed (so
+ *      downlevel *syntax* incompatibilities surface), while skipLibCheck avoids
+ *      failing on their internal Node references (see tsconfig.json).
+ *
+ * Work is parallelized across a pool of worker threads sized to the number of
+ * available processors (os.cpus().length).
+ *
+ * Usage: node ./run.mjs
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Worker } from "node:worker_threads";
+
+const root = import.meta.dirname;
+
+// The versions under test live in typescript-versions.json (oldest -> newest)
+// so the support range can be updated without touching runner logic. Each entry
+// is { version: string, tscArgs?: string[] } where `version` is any spec npm
+// accepts (a bare minor like "5.4" installs its latest patch) and `tscArgs`
+// holds compiler options that CHANGED for that version and must be passed on
+// the command line (overriding tsconfig.json) so the shared base config stays
+// valid everywhere. Past examples of why an entry needed tscArgs:
+//   - `moduleResolution: node` (node10) became a deprecation *error* in TS 6.0.
+//   - `moduleResolution: node` (node10) was removed in TS 7.0; `bundler`
+//     resolution requires `module: preserve` (or esnext).
+const VERSIONS_FILE = path.join(root, "typescript-versions.json");
+
+/**
+ * Load the version specs under test.
+ * @returns {{ version: string, tscArgs: string[] }[]}
+ */
+function loadVersions() {
+  /** @type {{ version: string, tscArgs?: string[] }[]} */
+  const specs = JSON.parse(readFileSync(VERSIONS_FILE, "utf8"));
+  return specs.map(({ version, tscArgs = [] }) => ({ version, tscArgs }));
+}
+
+/**
+ * Ensure the workspace clients are installed and built (dist-types present).
+ * The clients are consumed via file: links, so their .d.ts must exist on disk.
+ */
+function ensureClientsReady() {
+  if (!existsSync(path.join(root, "node_modules"))) {
+    console.log("Installing fixture dependencies (clients) ...");
+    execFileSync("npm", ["install", "--no-audit", "--no-fund"], { cwd: root, stdio: "inherit" });
+  }
+
+  const clients = [
+    "@aws-sdk/client-dynamodb",
+    "@aws-sdk/client-cloudwatch-logs",
+    "@aws-sdk/client-sts",
+    "@aws-sdk/client-ec2",
+    "@aws-sdk/client-lambda",
+    "@aws-sdk/client-s3",
+  ];
+  const missing = clients.filter(
+    (name) => !existsSync(path.join(root, "node_modules", ...name.split("/"), "dist-types", "index.d.ts"))
+  );
+  if (missing.length > 0) {
+    console.error(
+      `\nThe following clients are not built (dist-types missing): ${missing.join(", ")}.\n` +
+        `Build them first, e.g.:\n` +
+        `  node ./scripts/turbo build -F=@aws-sdk/client-dynamodb -F=@aws-sdk/client-cloudwatch-logs \\\n` +
+        `    -F=@aws-sdk/client-sts -F=@aws-sdk/client-ec2 -F=@aws-sdk/client-lambda -F=@aws-sdk/client-s3\n`
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * Run all compile jobs across a worker pool.
+ * @param {{ minor: string, version: string }[]} versions
+ */
+async function runPool(versions) {
+  const poolSize = Math.max(1, Math.min(os.cpus().length, versions.length));
+
+  const queue = [...versions];
+  /** @type {{ version: string, ok: boolean, output: string }[]} */
+  const results = [];
+
+  await new Promise((resolve, reject) => {
+    let active = 0;
+
+    const workerPath = path.join(root, "worker.mjs");
+
+    const spawnWorker = () => {
+      const job = queue.shift();
+      if (!job) {
+        return;
+      }
+      active++;
+      const worker = new Worker(workerPath, { workerData: { root, job } });
+
+      worker.once("message", (res) => {
+        results.push(res);
+        worker.terminate();
+      });
+      worker.once("error", reject);
+      worker.once("exit", () => {
+        active--;
+        if (queue.length > 0) {
+          spawnWorker();
+        } else if (active === 0) {
+          resolve(undefined);
+        }
+      });
+    };
+
+    for (let i = 0; i < poolSize; i++) {
+      spawnWorker();
+    }
+  });
+
+  return results;
+}
+
+ensureClientsReady();
+const versions = loadVersions();
+const results = await runPool(versions);
+
+results.sort(
+  (a, b) => versions.findIndex((v) => v.version === a.version) - versions.findIndex((v) => v.version === b.version)
+);
+
+const failures = results.filter((r) => !r.ok);
+
+console.log("\n" + "=".repeat(60));
+console.log("TypeScript compatibility summary");
+console.log("=".repeat(60));
+for (const r of results) {
+  console.log(`  ${r.ok ? "PASS" : "FAIL"}  typescript@${r.version}`);
+}
+
+if (failures.length > 0) {
+  for (const f of failures) {
+    console.error(`\nFAIL typescript@${f.version}:\n${f.output.trim()}`);
+  }
+  process.exit(1);
+}

--- a/tests/ts-compat/tsconfig.json
+++ b/tests/ts-compat/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  // Base config. Options here must be valid across every TypeScript version
+  // listed in typescript-versions.json. Options that changed between versions
+  // (e.g. moduleResolution handling in newer releases) are supplied per-version
+  // by run.mjs.
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["es2020", "dom"],
+    // types:[] keeps @types/node out of the program. The fixture uses no Node
+    // APIs, and no single @types/node version parses across all the TypeScript
+    // versions under test.
+    "types": [],
+    "strict": true,
+    "esModuleInterop": true,
+    // skipLibCheck lets the clients' internal Node references pass without
+    // @types/node; the .d.ts are still parsed, so downlevel *syntax*
+    // incompatibilities are still caught.
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["fixtures/**/*.ts"]
+}

--- a/tests/ts-compat/typescript-versions.json
+++ b/tests/ts-compat/typescript-versions.json
@@ -1,0 +1,19 @@
+[
+  { "version": "4.5" },
+  { "version": "4.6" },
+  { "version": "4.7" },
+  { "version": "4.8" },
+  { "version": "4.9" },
+  { "version": "5.0" },
+  { "version": "5.1" },
+  { "version": "5.2" },
+  { "version": "5.3" },
+  { "version": "5.4" },
+  { "version": "5.5" },
+  { "version": "5.6" },
+  { "version": "5.7" },
+  { "version": "5.8" },
+  { "version": "5.9" },
+  { "version": "6.0", "tscArgs": ["--ignoreDeprecations", "6.0"] },
+  { "version": "7.0", "tscArgs": ["--moduleResolution", "bundler", "--module", "preserve"] }
+]

--- a/tests/ts-compat/worker.mjs
+++ b/tests/ts-compat/worker.mjs
@@ -1,0 +1,70 @@
+/**
+ * Worker thread for the TypeScript compatibility runner.
+ *
+ * Installs a single TypeScript version into an isolated directory and runs it
+ * against the fixture tsconfig, then reports the result back to the main thread.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { parentPort, workerData } from "node:worker_threads";
+
+const { root, job } = workerData;
+const { version, tscArgs = [] } = job;
+
+/**
+ * Locate the tsc executable inside an isolated TypeScript install.
+ * @param {string} installDir
+ * @returns {string | undefined}
+ */
+function findTsc(installDir) {
+  const candidates = [
+    path.join(installDir, "node_modules", ".bin", process.platform === "win32" ? "tsc.cmd" : "tsc"),
+    path.join(installDir, "node_modules", "typescript", "bin", "tsc"),
+  ];
+  return candidates.find((c) => existsSync(c));
+}
+
+function run() {
+  const installDir = path.join(root, ".tmp", `ts-${version}`);
+  mkdirSync(installDir, { recursive: true });
+  // A minimal manifest keeps npm from walking up to the workspace root.
+  writeFileSync(path.join(installDir, "package.json"), JSON.stringify({ private: true, name: `ts-${version}` }));
+
+  const install = spawnSync(
+    "npm",
+    ["install", `typescript@${version}`, "--no-save", "--no-package-lock", "--no-audit", "--no-fund"],
+    { cwd: installDir, encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }
+  );
+  if (install.status !== 0) {
+    return {
+      version,
+      ok: false,
+      output: `Failed to install typescript@${version}:\n${install.stdout || ""}${install.stderr || ""}`,
+    };
+  }
+
+  const tsc = findTsc(installDir);
+  if (!tsc) {
+    return { version, ok: false, output: `Could not locate tsc binary for typescript@${version}.` };
+  }
+
+  // Run from the fixture root so module resolution finds the installed clients
+  // in ./node_modules, while the compiler itself is the isolated version.
+  // Per-version tscArgs override tsconfig.json for options that changed.
+  const compile = spawnSync(process.execPath, [tsc, "-p", "tsconfig.json", "--pretty", "false", ...tscArgs], {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 300000,
+  });
+
+  const output = `${compile.stdout || ""}${compile.stderr || ""}`;
+  return { version, ok: compile.status === 0, output };
+}
+
+try {
+  parentPort.postMessage(run());
+} catch (e) {
+  parentPort.postMessage({ version, ok: false, output: String(e && e.stack ? e.stack : e) });
+}


### PR DESCRIPTION
### Issue

Internal JS-7050

### Description

Add `tests/ts-compat`, which verifies that one client per wire protocol
(`awsJson1_0`, `awsJson1_1`, `awsQuery`, `ec2Query`, `restJson1`, `restXml`)
compiles against every TypeScript version listed in `typescript-versions.json`.

The runner type-checks a small fixture that imports and uses each client,
installing each TypeScript version in isolation and compiling in parallel
across a pool of worker threads. Per-version compiler option overrides live
in the version data file so the supported range can change without touching
runner logic.

Wire the suite into the new test-typescript Make target alongside the
existing test-code typecheck, and run it from test-integration.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
