### PR TITLE
fix(scripts): add typesVersions entries for submodules

### DIFF
--- a/lib/lib-transfer-manager/package.json
+++ b/lib/lib-transfer-manager/package.json
@@ -81,9 +81,12 @@
     "typescript": "~5.8.3"
   },
   "typesVersions": {
-    "<4.0": {
+    "<4.5": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
+      ],
+      "*": [
+        "dist-types/ts3.4/submodules/*/index.d.ts"
       ]
     }
   },

--- a/packages-internal/checksums/package.json
+++ b/packages-internal/checksums/package.json
@@ -98,6 +98,9 @@
     "<4.5": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
+      ],
+      "*": [
+        "dist-types/ts3.4/submodules/*/index.d.ts"
       ]
     }
   },

--- a/packages-internal/core/package.json
+++ b/packages-internal/core/package.json
@@ -126,6 +126,9 @@
     "<4.5": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
+      ],
+      "*": [
+        "dist-types/ts3.4/submodules/*/index.d.ts"
       ]
     }
   },

--- a/packages-internal/middleware-sdk-s3/package.json
+++ b/packages-internal/middleware-sdk-s3/package.json
@@ -82,6 +82,9 @@
     "<4.5": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
+      ],
+      "*": [
+        "dist-types/ts3.4/submodules/*/index.d.ts"
       ]
     }
   },

--- a/packages-internal/nested-clients/package.json
+++ b/packages-internal/nested-clients/package.json
@@ -47,6 +47,9 @@
     "<4.5": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
+      ],
+      "*": [
+        "dist-types/ts3.4/submodules/*/index.d.ts"
       ]
     }
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -113,6 +113,9 @@
     "<4.5": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
+      ],
+      "*": [
+        "dist-types/ts3.4/submodules/*/index.d.ts"
       ]
     }
   },

--- a/scripts/validation/submodules-linter.js
+++ b/scripts/validation/submodules-linter.js
@@ -170,6 +170,23 @@ export * from "./dist-types/submodules/${submodule}/index";
     }
 
     /**
+     * typesVersions metadata for downlevel (TypeScript <4.5) resolution.
+     * A single wildcard entry covers all submodules instead of one entry per submodule.
+     */
+    if (submodules.length > 0) {
+      const expectedTypesVersions = {
+        "dist-types/*": ["dist-types/ts3.4/*"],
+        "*": ["dist-types/ts3.4/submodules/*/index.d.ts"],
+      };
+      pkgJson.typesVersions = pkgJson.typesVersions ?? {};
+      if (JSON.stringify(pkgJson.typesVersions["<4.5"]) !== JSON.stringify(expectedTypesVersions)) {
+        errors.push(`package.json typesVersions is missing the wildcard submodules entry`);
+        pkgJson.typesVersions["<4.5"] = expectedTypesVersions;
+        fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(pkgJson, null, 2) + "\n");
+      }
+    }
+
+    /**
      * Root index.ts must not use relative imports — use canonical submodule paths instead.
      * Relative imports bypass conditional exports (browser/react-native resolution).
      */


### PR DESCRIPTION
### Issue

* Internal JS-7055
* Similar to https://github.com/smithy-lang/smithy-typescript/pull/2142

### Description
Add typesVersions entries for submodules

### Testing
Validated by editing local workspace in https://github.com/aws/aws-sdk-js-v3/pull/8182

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
