### PR TITLE
chore(codegen): smithy-aws-typescript-codegen 0.51.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Commit logs](https://github.com/aws/aws-sdk-js-v3/commits/main/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen)
 
+## 0.51.0 (2026-07-13)
+
+### Chores
+
+- Upgraded to smithy-typescript 0.51.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0510-2026-07-13))
+
 ## 0.50.0 (2026-05-29)
 
 ### Chores

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -37,7 +37,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.50.0"
+    version = "0.51.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.50.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.51.0")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/c32e88905ba982a9af352ca4b793cee3afc81c90...5fca3a0d37d882fb1836e47f5e75fc53c53b4417
-  SMITHY_TS_COMMIT: "5fca3a0d37d882fb1836e47f5e75fc53c53b4417",
+  // https://github.com/smithy-lang/smithy-typescript/compare/5fca3a0d37d882fb1836e47f5e75fc53c53b4417...6becc8717266e52c5c5a044894db36645553c0a9
+  SMITHY_TS_COMMIT: "6becc8717266e52c5c5a044894db36645553c0a9",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
Bumps `smithy-aws-typescript-codegen` version to `0.51.0`
