### PR TITLE
chore(scripts): reorganize static analysis validations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,8 @@ unbuilt:
 static-analysis:
 	node ./scripts/validation/generic-byte-arrays.js
 	node ./scripts/validation/validate-all.js;
+	yarn lint:versions
+	yarn lint:dependencies
 	make api-snapshot
 
 # Clears the Turborepo local build cache

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && yarn lint:versions && yarn lint:dependencies",
+      "pre-commit": "lint-staged",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },

--- a/scripts/validation/ast-bus.js
+++ b/scripts/validation/ast-bus.js
@@ -1,0 +1,562 @@
+#!/usr/bin/env node
+
+/**
+ * AST Bus — single-pass file walker and parser that dispatches to registered
+ * validators. Each file is read once, parsed once, and all registered
+ * callbacks fire against the shared parse result.
+ *
+ * Validators register which file sets (targets) they need and which callbacks
+ * they implement. The bus only walks targets that at least one validator requested,
+ * and only enables expensive AST features when a validator needs them.
+ *
+ * @example
+ * const { createBus } = require("./ast-bus");
+ * const bus = createBus({ packages });
+ * bus.register(myValidator);
+ * await bus.run();
+ * const errors = bus.getErrors();
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { parse } = require("acorn");
+
+/**
+ * Targets:
+ *   "dist-cjs" — walk dist-cjs/*.js
+ *   "dist-es"  — walk dist-es/*.js
+ *   "src"      — walk src/*.ts (regex scan only)
+ *   "dist-types" — walk dist-types/*.d.ts (regex scan only)
+ *
+ * Features:
+ *   "esm-detection" — full AST tree walk to find ESM nodes (ImportDeclaration,
+ *                     ExportNamedDeclaration, ExportAllDeclaration,
+ *                     ExportDefaultDeclaration, ImportExpression) in dist-cjs files
+ *
+ * Callbacks:
+ *   onImport(specifier, file, context)       — static import/require with literal specifier
+ *   onNonLiteralImportSpecifier(node, file, context) — import()/require() with non-literal argument
+ *   onExportAll(node, file, context)         — ExportAllDeclaration
+ *   onESMNode(node, file, context)           — ESM syntax node (feature-gated)
+ *   onDtsImport(specifier, file, context)    — import in .d.ts file (regex-extracted)
+ *   onFile(file, context)                    — fires for every file visited (before parse)
+ *   onWalkComplete(graph)                    — fires after all files walked
+ *   getErrors()                              — returns array of error strings
+ *   getWarnings()                            — returns array of warning strings
+ *
+ * Context object passed to callbacks:
+ *   { packageDir, packageJson, target, generated }
+ */
+
+const DTS_IMPORT_RE = /from\s+["']([^"']+)["']/g;
+
+/**
+ * @param {{ packages: Array<{dir: string, generated: boolean}> }} options
+ */
+function createBus(options) {
+  const { packages } = options;
+  const validators = [];
+
+  // Collected state.
+  let needTargets = new Set();
+  let needEsmDetection = false;
+  let visitedPackages = [];
+  let hasOnImport = false;
+  let hasOnNonLiteralImportSpecifier = false;
+  let hasOnExportAll = false;
+  let hasOnESMNode = false;
+  let hasOnDtsImport = false;
+  let hasOnFile = false;
+  let hasOnWalkComplete = false;
+
+  function register(validator) {
+    validators.push(validator);
+
+    if (validator.targets) {
+      for (let i = 0; i < validator.targets.length; ++i) {
+        needTargets.add(validator.targets[i]);
+      }
+    }
+    if (validator.features) {
+      for (let i = 0; i < validator.features.length; ++i) {
+        if (validator.features[i] === "esm-detection") {
+          needEsmDetection = true;
+        }
+      }
+    }
+    if (validator.onImport) {
+      hasOnImport = true;
+    }
+    if (validator.onNonLiteralImportSpecifier) {
+      hasOnNonLiteralImportSpecifier = true;
+    }
+    if (validator.onExportAll) {
+      hasOnExportAll = true;
+    }
+    if (validator.onESMNode) {
+      hasOnESMNode = true;
+    }
+    if (validator.onDtsImport) {
+      hasOnDtsImport = true;
+    }
+    if (validator.onFile) {
+      hasOnFile = true;
+    }
+    if (validator.onWalkComplete) {
+      hasOnWalkComplete = true;
+    }
+  }
+
+  /**
+   * Parse a JS file with acorn. Returns AST or null.
+   */
+  function parseJS(code) {
+    try {
+      return parse(code, { ecmaVersion: "latest", sourceType: "module", allowHashBang: true, locations: true });
+    } catch {
+      return parse(code, { ecmaVersion: "latest", sourceType: "script", allowHashBang: true, locations: true });
+    }
+  }
+
+  /**
+   * Single-pass extraction from a JS AST. Extracts imports, dynamic imports,
+   * export-all declarations, and optionally ESM nodes — all in one walk.
+   */
+  function extractFromAST(ast, needDynamic, needExportAll, needEsm) {
+    const imports = [];
+    const nonLiteralImports = [];
+    const exportAlls = [];
+    const esmNodes = [];
+
+    // Top-level statements.
+    for (let i = 0; i < ast.body.length; ++i) {
+      const node = ast.body[i];
+      const type = node.type;
+
+      if (type === "ImportDeclaration" && node.source) {
+        imports.push(node.source.value);
+        if (needEsm) {
+          esmNodes.push(node);
+        }
+      } else if (type === "ExportNamedDeclaration" && node.source) {
+        imports.push(node.source.value);
+        if (needEsm) {
+          esmNodes.push(node);
+        }
+      } else if (type === "ExportAllDeclaration") {
+        if (node.source) {
+          imports.push(node.source.value);
+        }
+        if (needExportAll) {
+          exportAlls.push(node);
+        }
+        if (needEsm) {
+          esmNodes.push(node);
+        }
+      } else if (type === "ExportDefaultDeclaration") {
+        if (needEsm) {
+          esmNodes.push(node);
+        }
+      } else if (type === "ExportNamedDeclaration" && !node.source) {
+        if (needEsm) {
+          esmNodes.push(node);
+        }
+      }
+    }
+
+    // Deep walk for require(), dynamic import(), and ImportExpression in ESM detection.
+    if (needDynamic || needEsm) {
+      const stack = [ast];
+      while (stack.length) {
+        const n = stack.pop();
+        if (!n || typeof n !== "object") {
+          continue;
+        }
+
+        if (n.type === "CallExpression" && n.callee && n.callee.name === "require" && n.arguments.length) {
+          if (n.arguments[0].type === "Literal") {
+            imports.push(n.arguments[0].value);
+          } else if (needDynamic) {
+            nonLiteralImports.push({ line: n.loc?.start?.line ?? 0, type: "require()" });
+          }
+        } else if (n.type === "ImportExpression") {
+          if (n.source && n.source.type === "Literal") {
+            imports.push(n.source.value);
+          } else if (needDynamic) {
+            nonLiteralImports.push({ line: n.loc?.start?.line ?? 0, type: "import()" });
+          }
+          if (needEsm) {
+            esmNodes.push(n);
+          }
+        }
+
+        for (const key of Object.keys(n)) {
+          if (key === "type") {
+            continue;
+          }
+          const val = n[key];
+          if (Array.isArray(val)) {
+            for (let i = 0; i < val.length; ++i) {
+              if (val[i] && typeof val[i] === "object" && val[i].type) {
+                stack.push(val[i]);
+              }
+            }
+          } else if (val && typeof val === "object" && val.type) {
+            stack.push(val);
+          }
+        }
+      }
+    } else {
+      // Still need require() for imports, but no dynamic import tracking.
+      const stack = [ast];
+      while (stack.length) {
+        const n = stack.pop();
+        if (!n || typeof n !== "object") {
+          continue;
+        }
+
+        if (n.type === "CallExpression" && n.callee && n.callee.name === "require" && n.arguments.length) {
+          if (n.arguments[0].type === "Literal") {
+            imports.push(n.arguments[0].value);
+          }
+        } else if (n.type === "ImportExpression" && n.source && n.source.type === "Literal") {
+          imports.push(n.source.value);
+        }
+
+        for (const key of Object.keys(n)) {
+          if (key === "type") {
+            continue;
+          }
+          const val = n[key];
+          if (Array.isArray(val)) {
+            for (let i = 0; i < val.length; ++i) {
+              if (val[i] && typeof val[i] === "object" && val[i].type) {
+                stack.push(val[i]);
+              }
+            }
+          } else if (val && typeof val === "object" && val.type) {
+            stack.push(val);
+          }
+        }
+      }
+    }
+
+    return { imports, nonLiteralImports, exportAlls, esmNodes };
+  }
+
+  /**
+   * Regex fallback for TypeScript files acorn can't parse.
+   * Extracts export * declarations.
+   */
+  function extractExportStarRegex(code) {
+    const hits = [];
+    const lines = code.split("\n");
+    for (let i = 0; i < lines.length; ++i) {
+      const line = lines[i];
+      if (/^\s*export\s*\*\s*from\s/.test(line) || /^\s*export\s*\*\s*;/.test(line)) {
+        hits.push({ line: i + 1, loc: { start: { line: i + 1 } } });
+      }
+    }
+    return hits;
+  }
+
+  /**
+   * Walk a directory recursively, yielding file paths.
+   */
+  async function* walkDir(dir) {
+    let entries;
+    try {
+      entries = await fs.promises.opendir(dir);
+    } catch {
+      return;
+    }
+    for await (const d of entries) {
+      const entry = path.join(dir, d.name);
+      if (d.name === "node_modules") {
+        continue;
+      }
+      if (d.isDirectory()) {
+        yield* walkDir(entry);
+      } else if (d.isFile()) {
+        yield entry;
+      }
+    }
+  }
+
+  /**
+   * Dispatch onImport to all validators that have the callback and
+   * whose targets include the current target.
+   */
+  function dispatchImport(specifier, file, context) {
+    for (let i = 0; i < validators.length; ++i) {
+      const v = validators[i];
+      if (v.onImport && v.targets.includes(context.target)) {
+        v.onImport(specifier, file, context);
+      }
+    }
+  }
+
+  function dispatchNonLiteralImportSpecifier(node, file, context) {
+    for (let i = 0; i < validators.length; ++i) {
+      const v = validators[i];
+      if (v.onNonLiteralImportSpecifier && v.targets.includes(context.target)) {
+        v.onNonLiteralImportSpecifier(node, file, context);
+      }
+    }
+  }
+
+  function dispatchExportAll(node, file, context) {
+    for (let i = 0; i < validators.length; ++i) {
+      const v = validators[i];
+      if (v.onExportAll && v.targets.includes(context.target)) {
+        v.onExportAll(node, file, context);
+      }
+    }
+  }
+
+  function dispatchESMNode(node, file, context) {
+    for (let i = 0; i < validators.length; ++i) {
+      const v = validators[i];
+      if (v.onESMNode && v.targets.includes(context.target)) {
+        v.onESMNode(node, file, context);
+      }
+    }
+  }
+
+  function dispatchDtsImport(specifier, file, context) {
+    for (let i = 0; i < validators.length; ++i) {
+      const v = validators[i];
+      if (v.onDtsImport && v.targets.includes(context.target)) {
+        v.onDtsImport(specifier, file, context);
+      }
+    }
+  }
+
+  function dispatchFile(file, context) {
+    for (let i = 0; i < validators.length; ++i) {
+      const v = validators[i];
+      if (v.onFile && v.targets.includes(context.target)) {
+        v.onFile(file, context);
+      }
+    }
+  }
+
+  function dispatchWalkComplete(graph) {
+    for (let i = 0; i < validators.length; ++i) {
+      const v = validators[i];
+      if (v.onWalkComplete) {
+        v.onWalkComplete(graph);
+      }
+    }
+  }
+
+  /**
+   * Process a single .js file from dist-cjs or dist-es.
+   */
+  function processJSFile(file, code, context, graph) {
+    const isDistCjs = context.target === "dist-cjs";
+    const needDynamic = hasOnNonLiteralImportSpecifier;
+    const needExportAll = hasOnExportAll;
+    const needEsm = needEsmDetection && isDistCjs && hasOnESMNode;
+
+    const ast = parseJS(code);
+
+    const result = extractFromAST(ast, needDynamic, needExportAll, needEsm);
+
+    // Record imports in graph for onWalkComplete consumers.
+    if (hasOnWalkComplete) {
+      graph.set(file, result.imports);
+    }
+
+    // Dispatch imports.
+    if (hasOnImport) {
+      for (let i = 0; i < result.imports.length; ++i) {
+        dispatchImport(result.imports[i], file, context);
+      }
+    }
+
+    // Dispatch dynamic imports.
+    if (needDynamic && result.nonLiteralImports.length) {
+      for (let i = 0; i < result.nonLiteralImports.length; ++i) {
+        dispatchNonLiteralImportSpecifier(result.nonLiteralImports[i], file, context);
+      }
+    }
+
+    // Dispatch export-all.
+    if (needExportAll && result.exportAlls.length) {
+      for (let i = 0; i < result.exportAlls.length; ++i) {
+        dispatchExportAll(result.exportAlls[i], file, context);
+      }
+    }
+
+    // Dispatch ESM nodes.
+    if (needEsm && result.esmNodes.length) {
+      for (let i = 0; i < result.esmNodes.length; ++i) {
+        dispatchESMNode(result.esmNodes[i], file, context);
+      }
+    }
+  }
+
+  /**
+   * Process a single .ts file from src (regex-based extraction).
+   */
+  function processTSFile(file, code, context) {
+    if (hasOnExportAll) {
+      const hits = extractExportStarRegex(code);
+      for (let i = 0; i < hits.length; ++i) {
+        dispatchExportAll(hits[i], file, context);
+      }
+    }
+  }
+
+  /**
+   * Process a single .d.ts file from dist-types.
+   */
+  function processDtsFile(file, code, context) {
+    DTS_IMPORT_RE.lastIndex = 0;
+    let m;
+    while ((m = DTS_IMPORT_RE.exec(code)) !== null) {
+      dispatchDtsImport(m[1], file, context);
+    }
+  }
+
+  /**
+   * Run the bus — walk all requested targets for all packages, parse files,
+   * dispatch to validators.
+   */
+  async function run() {
+    // Import graph: file → array of import specifiers.
+    const graph = new Map();
+    // Track which packages were visited per target for coverage reporting.
+    visitedPackages = [];
+
+    for (let p = 0; p < packages.length; ++p) {
+      const pkg = packages[p];
+      const pkgJsonPath = path.join(pkg.dir, "package.json");
+      if (!fs.existsSync(pkgJsonPath)) {
+        continue;
+      }
+      const packageJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+      let visited = false;
+
+      // Walk dist-cjs and dist-es (.js files).
+      for (const target of ["dist-cjs", "dist-es"]) {
+        if (!needTargets.has(target)) {
+          continue;
+        }
+        const distDir = path.join(pkg.dir, target);
+        if (!fs.existsSync(distDir)) {
+          continue;
+        }
+        visited = true;
+
+        const context = { packageDir: pkg.dir, packageJson, target, generated: pkg.generated };
+
+        for await (const file of walkDir(distDir)) {
+          if (!file.endsWith(".js")) {
+            continue;
+          }
+          if (hasOnFile) {
+            dispatchFile(file, context);
+          }
+          const code = fs.readFileSync(file, "utf-8");
+          processJSFile(file, code, context, graph);
+        }
+      }
+
+      // Walk src (.ts files).
+      if (needTargets.has("src")) {
+        const srcDir = path.join(pkg.dir, "src");
+        if (fs.existsSync(srcDir)) {
+          visited = true;
+          const context = { packageDir: pkg.dir, packageJson, target: "src", generated: pkg.generated };
+          for await (const file of walkDir(srcDir)) {
+            if (!file.endsWith(".ts") || file.endsWith(".d.ts") || file.endsWith(".spec.ts")) {
+              continue;
+            }
+            if (hasOnFile) {
+              dispatchFile(file, context);
+            }
+            if (hasOnExportAll) {
+              const code = fs.readFileSync(file, "utf-8");
+              processTSFile(file, code, context);
+            }
+          }
+        }
+      }
+
+      // Walk dist-types (.d.ts files).
+      if (needTargets.has("dist-types") && hasOnDtsImport) {
+        const distTypes = path.join(pkg.dir, "dist-types");
+        if (fs.existsSync(distTypes)) {
+          visited = true;
+          const context = { packageDir: pkg.dir, packageJson, target: "dist-types", generated: pkg.generated };
+          for await (const file of walkDir(distTypes)) {
+            if (!file.endsWith(".d.ts")) {
+              continue;
+            }
+            if (hasOnFile) {
+              dispatchFile(file, context);
+            }
+            const code = fs.readFileSync(file, "utf-8");
+            processDtsFile(file, code, context);
+          }
+        }
+      }
+
+      if (visited) {
+        visitedPackages.push(pkg);
+      }
+    }
+
+    // Fire onWalkComplete with the collected graph.
+    if (hasOnWalkComplete) {
+      dispatchWalkComplete(graph);
+    }
+  }
+
+  function getErrors() {
+    const errors = [];
+    for (let i = 0; i < validators.length; ++i) {
+      if (validators[i].getErrors) {
+        errors.push(...validators[i].getErrors());
+      }
+    }
+    return errors;
+  }
+
+  function getWarnings() {
+    const warnings = [];
+    for (let i = 0; i < validators.length; ++i) {
+      if (validators[i].getWarnings) {
+        warnings.push(...validators[i].getWarnings());
+      }
+    }
+    return warnings;
+  }
+
+  /**
+   * Returns a coverage summary string, e.g. "427 clients, 14 packages, 3 lib".
+   */
+  function getSummary() {
+    const counts = {};
+    for (let i = 0; i < visitedPackages.length; ++i) {
+      const folder = path.basename(path.dirname(visitedPackages[i].dir));
+      counts[folder] = (counts[folder] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([folder, count]) => `${count} ${folder}`)
+      .join(", ");
+  }
+
+  /**
+   * Returns the list of targets that were actually walked.
+   */
+  function getTargets() {
+    return [...needTargets];
+  }
+
+  return { register, run, getErrors, getWarnings, getSummary, getTargets };
+}
+
+module.exports = { createBus };

--- a/scripts/validation/banned-imports.js
+++ b/scripts/validation/banned-imports.js
@@ -3,17 +3,14 @@
 /**
  * AST-based banned import checker for dist-cjs and dist-es output.
  * Enforces no-restricted-imports rules via direct AST parsing.
+ * Also enforces: dist-cjs must not contain ESM syntax.
  *
  * Usage: node banned-imports.js
  */
 
-const fs = require("node:fs");
 const path = require("node:path");
-const walk = require("../utils/walk");
-const { extractImports, getPackageDirs, summarizePackages } = require("./validation-shared");
-const { parse } = require("acorn");
-
-const root = path.join(__dirname, "..", "..");
+const { createBus } = require("./ast-bus");
+const { getPackageDirs } = require("./validation-shared");
 
 // Banned exact-match packages (consolidated into @smithy/core/* or @aws-sdk/core/*).
 const BANNED_PACKAGES = new Set([
@@ -80,41 +77,41 @@ const BANNED_PACKAGES = new Set([
   "@aws-sdk/middleware-sdk-s3-control",
 ]);
 
+// Packages that intentionally re-export a banned package (compatibility shims).
+const REEXPORT_ALLOWLIST = {
+  "@aws-sdk/smithy-client": new Set(["@smithy/smithy-client"]),
+};
+
 /**
  * Checks if a specifier is banned.
- * Rules:
- * 1. Must not contain "src" (unless contains "csrc") or "dist-" in path
- * 2. "@aws-sdk/core" without subpath is banned (must use @aws-sdk/core/submodule)
- * 3. Any import starting with a banned package name is banned
  */
 function checkBanned(specifier) {
   if (specifier.startsWith(".")) {
     return null;
   }
 
-  // Rule: no src or dist- in import paths (except csrc)
+  // Rule: no src or dist- in import paths (except csrc).
   if ((specifier.includes("src") && !specifier.includes("csrc")) || specifier.includes("dist-")) {
     return `"${specifier}" — imports must not contain src or dist- in their path`;
   }
 
-  // Rule: @aws-sdk/core must use submodule
+  // Rule: @aws-sdk/core must use submodule.
   if (specifier === "@aws-sdk/core") {
     return `"${specifier}" — import from a specific submodule like @aws-sdk/core/submodule instead`;
   }
 
-  // Rule: @aws-sdk/checksums must use submodule
+  // Rule: @aws-sdk/checksums must use submodule.
   if (specifier === "@aws-sdk/checksums") {
     return `"${specifier}" — import from a specific submodule like @aws-sdk/checksums/crc, @aws-sdk/checksums/sha, or @aws-sdk/checksums/flexible-checksums instead`;
   }
 
-  // Rule: @aws-sdk/middleware-sdk-s3 must use submodule
+  // Rule: @aws-sdk/middleware-sdk-s3 must use submodule.
   if (specifier === "@aws-sdk/middleware-sdk-s3") {
     return `"${specifier}" — import from a specific submodule like @aws-sdk/middleware-sdk-s3/s3 or @aws-sdk/middleware-sdk-s3/s3-control instead`;
   }
 
-  // Rule: banned consolidated packages
+  // Rule: banned consolidated packages.
   const pkgName = specifier.startsWith("@") ? specifier.split("/").slice(0, 2).join("/") : specifier.split("/")[0];
-
   if (BANNED_PACKAGES.has(pkgName)) {
     return `"${specifier}" — this package has been consolidated`;
   }
@@ -122,111 +119,73 @@ function checkBanned(specifier) {
   return null;
 }
 
-// Packages that intentionally re-export a banned package (compatibility shims).
-const REEXPORT_ALLOWLIST = {
-  "@aws-sdk/smithy-client": ["@smithy/smithy-client"],
-};
-
-async function validate(packageDir) {
-  const pkgJsonPath = path.join(packageDir, "package.json");
-  if (!fs.existsSync(pkgJsonPath)) {
-    return [];
-  }
-  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
-  const allowed = new Set(REEXPORT_ALLOWLIST[pkgJson.name] || []);
-
+/**
+ * Creates the banned-imports validator.
+ */
+function createValidator() {
   const errors = [];
-  for (const dist of ["dist-cjs", "dist-es"]) {
-    const distDir = path.join(packageDir, dist);
-    if (!fs.existsSync(distDir)) {
-      continue;
-    }
-    for await (const file of walk(distDir, ["node_modules"])) {
-      if (!file.endsWith(".js")) {
-        continue;
-      }
-      const code = fs.readFileSync(file, "utf-8");
+  // Deduplicate ESM errors — one per file is enough to avoid noise.
+  const esmReportedFiles = new Set();
 
-      // dist-cjs must not contain any ESM including dynamic import.
-      if (dist === "dist-cjs") {
-        let ast;
-        try {
-          ast = parse(code, { ecmaVersion: "latest", sourceType: "module", allowHashBang: true, locations: true });
-        } catch {
-          ast = null;
-        }
-        if (ast) {
-          for (const node of ast.body) {
-            if (
-              node.type === "ImportDeclaration" ||
-              node.type === "ExportNamedDeclaration" ||
-              node.type === "ExportAllDeclaration" ||
-              node.type === "ExportDefaultDeclaration"
-            ) {
-              errors.push(
-                `[${pkgJson.name}] ESM including dynamic import is not allowed in dist-cjs (${path.relative(
-                  packageDir,
-                  file
-                )}:${node.loc?.start?.line ?? 1})`
-              );
-              break;
-            }
-          }
-          // Also check for dynamic import() expressions anywhere in the AST.
-          const queue = [ast];
-          let foundDynamic = false;
-          while (queue.length && !foundDynamic) {
-            const n = queue.pop();
-            if (!n || typeof n !== "object") continue;
-            if (Array.isArray(n)) {
-              queue.push(...n);
-              continue;
-            }
-            if (n.type === "ImportExpression") {
-              errors.push(
-                `[${pkgJson.name}] ESM including dynamic import is not allowed in dist-cjs (${path.relative(
-                  packageDir,
-                  file
-                )}:${n.loc?.start?.line ?? 1})`
-              );
-              foundDynamic = true;
-              break;
-            }
-            for (const key of Object.keys(n)) {
-              if (key === "type") continue;
-              const val = n[key];
-              if (Array.isArray(val)) queue.push(...val);
-              else if (val && typeof val === "object" && val.type) queue.push(val);
-            }
-          }
-        }
-      }
+  return {
+    name: "banned-imports",
+    targets: ["dist-cjs", "dist-es"],
+    features: ["esm-detection"],
 
-      for (const specifier of extractImports(code)) {
-        if (allowed.has(specifier)) {
-          continue;
-        }
-        const reason = checkBanned(specifier);
-        if (reason) {
-          errors.push(`[${pkgJson.name}] ${reason} (${path.relative(packageDir, file)})`);
-        }
+    onImport(specifier, file, context) {
+      const { packageJson } = context;
+      const allowed = REEXPORT_ALLOWLIST[packageJson.name];
+      if (allowed && allowed.has(specifier)) {
+        return;
       }
-    }
-  }
-  return errors;
+      const reason = checkBanned(specifier);
+      if (reason) {
+        errors.push(`[${packageJson.name}] ${reason} (${path.relative(context.packageDir, file)})`);
+      }
+    },
+
+    onESMNode(node, file, context) {
+      // Only care about ESM in dist-cjs.
+      if (context.target !== "dist-cjs") {
+        return;
+      }
+      if (esmReportedFiles.has(file)) {
+        return;
+      }
+      esmReportedFiles.add(file);
+      const { packageJson, packageDir } = context;
+      errors.push(
+        `[${packageJson.name}] ESM including dynamic import is not allowed in dist-cjs (${path.relative(
+          packageDir,
+          file
+        )}:${node.loc?.start?.line ?? 1})`
+      );
+    },
+
+    getErrors() {
+      return errors;
+    },
+  };
 }
 
 async function main() {
   const packages = getPackageDirs();
-  const errors = [];
-  for (const { dir } of packages) {
-    errors.push(...(await validate(dir)));
-  }
+  const validator = createValidator();
+  const bus = createBus({ packages });
+  bus.register(validator);
+  await bus.run();
+
+  const errors = validator.getErrors();
   if (errors.length) {
     console.error(`❌ ${errors.length} banned import(s):\n  ${[...new Set(errors)].join("\n  ")}`);
     process.exit(1);
   }
-  console.log(`✅ No banned imports. (${summarizePackages(packages)})`);
+  console.log(`✅ No banned imports. (${bus.getSummary()})`);
+  console.log(`    [${(validator.inspects || validator.targets).join(", ")}]`);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { createValidator };

--- a/scripts/validation/built.js
+++ b/scripts/validation/built.js
@@ -24,9 +24,13 @@ function main() {
   const errors = [];
   for (const { dir } of packages) {
     const pkgJsonPath = path.join(dir, "package.json");
-    if (!fs.existsSync(pkgJsonPath)) continue;
+    if (!fs.existsSync(pkgJsonPath)) {
+      continue;
+    }
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
-    if (SKIP.has(pkgJson.name)) continue;
+    if (SKIP.has(pkgJson.name)) {
+      continue;
+    }
     validated.push({ dir });
     for (const file of REQUIRED_FILES) {
       if (!fs.existsSync(path.join(dir, file))) {

--- a/scripts/validation/cycles.js
+++ b/scripts/validation/cycles.js
@@ -8,35 +8,26 @@
  * Usage: node cycles.js
  */
 
-const fs = require("node:fs");
 const path = require("node:path");
-const walk = require("../utils/walk");
-const {
-  extractImports,
-  getPackageName,
-  resolveRelative,
-  getPackageDirs,
-  summarizePackages,
-} = require("./validation-shared");
+const { createBus } = require("./ast-bus");
+const { getPackageName, resolveRelative, getPackageDirs } = require("./validation-shared");
 
 /**
  * Finds all cycles in a directed graph using Tarjan's algorithm.
- *
- * @param graph - adjacency list (Map of node -> Set of neighbors).
- * @returns array of { cycle, sccSize } objects.
+ * Returns one representative cycle per strongly connected component.
  */
 function findAllCycles(graph) {
   const discoveryIndex = new Map();
   const lowlink = new Map();
   const onStack = new Set();
   const stack = [];
-  let i = 0;
+  let idx = 0;
   const connectedComponents = [];
 
   function visit(node) {
-    discoveryIndex.set(node, i);
-    lowlink.set(node, i);
-    i++;
+    discoveryIndex.set(node, idx);
+    lowlink.set(node, idx);
+    ++idx;
     stack.push(node);
     onStack.add(node);
 
@@ -124,65 +115,10 @@ function findAllCycles(graph) {
 }
 
 /**
- * Builds a module-level dependency graph from @aws-sdk/* imports across packages.
- *
- * @param packageDirs - list of package root paths.
- * @returns adjacency list of package name -> Set of @aws-sdk/* dependency names.
- */
-async function buildModuleGraph(packageDirs) {
-  const graph = new Map();
-
-  for (const packageDir of packageDirs) {
-    const pkgJsonPath = path.join(packageDir, "package.json");
-    if (!fs.existsSync(pkgJsonPath)) {
-      continue;
-    }
-    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
-    const name = pkgJson.name;
-    if (!name || !name.startsWith("@aws-sdk/")) {
-      continue;
-    }
-    if (!graph.has(name)) {
-      graph.set(name, new Set());
-    }
-
-    for (const dist of ["dist-cjs", "dist-es"]) {
-      const distDir = path.join(packageDir, dist);
-      if (!fs.existsSync(distDir)) {
-        continue;
-      }
-      for await (const file of walk(distDir, ["node_modules"])) {
-        if (!file.endsWith(".js")) {
-          continue;
-        }
-        const code = fs.readFileSync(file, "utf-8");
-        for (const specifier of extractImports(code)) {
-          if (specifier.startsWith(".") || specifier.startsWith("node:")) {
-            continue;
-          }
-          const pkg = getPackageName(specifier);
-          if (pkg.startsWith("@aws-sdk/") && pkg !== name) {
-            graph.get(name).add(pkg);
-          }
-        }
-      }
-    }
-  }
-
-  return graph;
-}
-
-/**
  * Resolves a self-referencing package import (e.g. "@aws-sdk/core/client")
  * to a file path within the package using the exports map.
- *
- * @param specifier - the import specifier.
- * @param pkgJson - parsed package.json.
- * @param packageDir - package root.
- * @param distName - "dist-cjs" or "dist-es".
- * @returns absolute file path, or null if not a self-reference.
  */
-function resolveSelfImport(specifier, pkgJson, packageDir, distName) {
+function resolveSelfImport(specifier, pkgJson, packageDir, target) {
   const pkg = getPackageName(specifier);
   if (pkg !== pkgJson.name) {
     return null;
@@ -192,10 +128,10 @@ function resolveSelfImport(specifier, pkgJson, packageDir, distName) {
   if (!exportConfig) {
     return null;
   }
-  const conditionKeys = distName === "dist-es" ? ["module", "import"] : ["node", "require"];
+  const conditionKeys = target === "dist-es" ? ["module", "import"] : ["node", "require"];
   for (const key of conditionKeys) {
     const val = typeof exportConfig === "string" ? exportConfig : exportConfig[key];
-    if (typeof val === "string" && val.includes(distName)) {
+    if (typeof val === "string" && val.includes(target)) {
       return path.resolve(packageDir, val);
     }
   }
@@ -203,87 +139,143 @@ function resolveSelfImport(specifier, pkgJson, packageDir, distName) {
 }
 
 /**
- * Builds a file-level dependency graph within a single dist directory.
- *
- * @param distDir - absolute path to dist-cjs or dist-es.
- * @param pkgJson - parsed package.json.
- * @param packageDir - package root.
- * @param distName - "dist-cjs" or "dist-es".
- * @returns adjacency list of absolute file path -> Set of absolute file paths.
+ * Creates the cycles validator.
  */
-async function buildFileGraph(distDir, pkgJson, packageDir, distName) {
-  const graph = new Map();
+function createValidator() {
+  // Module-level graph: packageName → Set<packageName>
+  const moduleGraph = new Map();
+  // File-level graph: filePath → Set<filePath>
+  const fileGraph = new Map();
+  // Track which package owns which file for error reporting.
+  const filePkgInfo = new Map();
 
-  for await (const file of walk(distDir, ["node_modules"])) {
-    if (!file.endsWith(".js")) {
-      continue;
-    }
-    if (!graph.has(file)) {
-      graph.set(file, new Set());
-    }
-    const code = fs.readFileSync(file, "utf-8");
-    for (const specifier of extractImports(code)) {
-      let target = null;
-      if (specifier.startsWith(".")) {
-        target = resolveRelative(file, specifier);
-      } else {
-        target = resolveSelfImport(specifier, pkgJson, packageDir, distName);
-      }
-      if (target) {
-        graph.get(file).add(target);
-      }
-    }
-  }
-
-  return graph;
-}
-
-async function validate(packageDirs) {
   const errors = [];
 
-  // Module-level cycle detection.
-  const moduleGraph = await buildModuleGraph(packageDirs);
-  const moduleCycles = findAllCycles(moduleGraph);
-  for (const { cycle, sccSize } of moduleCycles) {
-    const sccNote = sccSize > cycle.length - 1 ? ` (${sccSize} packages in cycle group)` : "";
-    errors.push(`module-level cycle${sccNote}:\n    ${cycle.join(" →\n    ")}`);
-  }
+  return {
+    name: "cycles",
+    targets: ["dist-cjs", "dist-es"],
 
-  // File-level cycle detection per package per dist.
-  for (const packageDir of packageDirs) {
-    const pkgJsonPath = path.join(packageDir, "package.json");
-    if (!fs.existsSync(pkgJsonPath)) {
-      continue;
-    }
-    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+    onImport(specifier, file, context) {
+      const { packageJson, packageDir, target } = context;
+      const pkgName = packageJson.name;
 
-    for (const dist of ["dist-cjs", "dist-es"]) {
-      const distDir = path.join(packageDir, dist);
-      if (!fs.existsSync(distDir)) {
-        continue;
+      // Module-level: track @aws-sdk/* cross-package imports.
+      if (!specifier.startsWith(".") && !specifier.startsWith("node:")) {
+        const importedPkg = getPackageName(specifier);
+        if (importedPkg.startsWith("@aws-sdk/") && importedPkg !== pkgName) {
+          if (!moduleGraph.has(pkgName)) {
+            moduleGraph.set(pkgName, new Set());
+          }
+          moduleGraph.get(pkgName).add(importedPkg);
+        }
+
+        // Self-referencing subpath imports create file-level edges.
+        const selfTarget = resolveSelfImport(specifier, packageJson, packageDir, target);
+        if (selfTarget) {
+          if (!fileGraph.has(file)) {
+            fileGraph.set(file, new Set());
+          }
+          fileGraph.get(file).add(selfTarget);
+        }
       }
-      const fileGraph = await buildFileGraph(distDir, pkgJson, packageDir, dist);
-      const fileCycles = findAllCycles(fileGraph);
-      for (const { cycle, sccSize } of fileCycles) {
-        const relCycle = cycle.map((f) => path.relative(packageDir, f));
-        const sccNote = sccSize > cycle.length - 1 ? ` (${sccSize} files in cycle group)` : "";
-        errors.push(`[${pkgJson.name}/${dist}] file-level cycle${sccNote}:\n    ${relCycle.join(" →\n    ")}`);
-      }
-    }
-  }
 
-  return errors;
+      // File-level: track relative imports.
+      if (specifier.startsWith(".")) {
+        const resolved = resolveRelative(file, specifier);
+        if (resolved) {
+          if (!fileGraph.has(file)) {
+            fileGraph.set(file, new Set());
+          }
+          fileGraph.get(file).add(resolved);
+        }
+      }
+    },
+
+    onFile(file, context) {
+      filePkgInfo.set(file, {
+        packageDir: context.packageDir,
+        packageJson: context.packageJson,
+        target: context.target,
+      });
+      if (!fileGraph.has(file)) {
+        fileGraph.set(file, new Set());
+      }
+    },
+
+    onWalkComplete() {
+      // Module-level cycle detection.
+      const moduleCycles = findAllCycles(moduleGraph);
+      for (const { cycle, sccSize } of moduleCycles) {
+        const sccNote = sccSize > cycle.length - 1 ? ` (${sccSize} packages in cycle group)` : "";
+        errors.push(`module-level cycle${sccNote}:\n    ${cycle.join(" →\n    ")}`);
+      }
+
+      // File-level cycle detection — partition file graph by package+target.
+      const partitions = new Map();
+      for (const [file, info] of filePkgInfo) {
+        const key = `${info.packageDir}::${info.target}`;
+        if (!partitions.has(key)) {
+          partitions.set(key, {
+            packageDir: info.packageDir,
+            packageJson: info.packageJson,
+            target: info.target,
+            files: new Set(),
+          });
+        }
+        partitions.get(key).files.add(file);
+      }
+
+      for (const { packageDir, packageJson, target, files } of partitions.values()) {
+        // Build a subgraph restricted to files within this package+target.
+        const subgraph = new Map();
+        for (const file of files) {
+          const edges = fileGraph.get(file);
+          if (edges) {
+            const filtered = new Set();
+            for (const neighbor of edges) {
+              if (files.has(neighbor)) {
+                filtered.add(neighbor);
+              }
+            }
+            if (filtered.size) {
+              subgraph.set(file, filtered);
+            }
+          }
+        }
+
+        const fileCycles = findAllCycles(subgraph);
+        for (const { cycle, sccSize } of fileCycles) {
+          const relCycle = cycle.map((f) => path.relative(packageDir, f));
+          const sccNote = sccSize > cycle.length - 1 ? ` (${sccSize} files in cycle group)` : "";
+          errors.push(`[${packageJson.name}/${target}] file-level cycle${sccNote}:\n    ${relCycle.join(" →\n    ")}`);
+        }
+      }
+    },
+
+    getErrors() {
+      return errors;
+    },
+  };
 }
 
 async function main() {
   const packages = getPackageDirs();
-  const packageDirs = packages.map((p) => p.dir);
-  const errors = await validate(packageDirs);
+  const validator = createValidator();
+  const bus = createBus({ packages });
+  bus.register(validator);
+  await bus.run();
+
+  const errors = validator.getErrors();
   if (errors.length) {
     console.error(`❌ ${errors.length} cycle(s) detected:\n  ${errors.join("\n  ")}`);
     process.exit(1);
   }
-  console.log(`✅ No cyclical file or package dependencies. (${summarizePackages(packages)})`);
+  console.log(`✅ No cyclical file or package dependencies. (${bus.getSummary()})`);
+  console.log(`    [${(validator.inspects || validator.targets).join(", ")}]`);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { createValidator };

--- a/scripts/validation/deps-used.js
+++ b/scripts/validation/deps-used.js
@@ -9,11 +9,10 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
-const walk = require("../utils/walk");
-const { getPackageName, extractImports, getPackageDirs, summarizePackages } = require("./validation-shared");
+const { createBus } = require("./ast-bus");
+const { getPackageName, getPackageDirs } = require("./validation-shared");
 
 const IMPLICIT_DEPS = new Set(["tslib", "@aws-sdk/types", "@smithy/types", "vitest"]);
-const DTS_IMPORT_RE = /from\s+["']([^"']+)["']/g;
 
 /**
  * Browser polyfill packages that are declared as dependencies but imported
@@ -22,88 +21,103 @@ const DTS_IMPORT_RE = /from\s+["']([^"']+)["']/g;
 const BROWSER_POLYFILL_MAP = new Map([["stream-browserify", "stream"]]);
 
 /**
- * @param packageDir - package root.
- * @returns error messages for unused dependencies.
+ * Creates the deps-used validator.
+ * Needs access to packages list to check declared deps at the end.
  */
-async function validate(packageDir) {
-  const pkgJsonPath = path.join(packageDir, "package.json");
-  if (!fs.existsSync(pkgJsonPath)) {
-    return [];
-  }
-  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
-  const declared = new Set(Object.keys(pkgJson.dependencies || {}));
-  const used = new Set();
+function createValidator(packages) {
+  // Need both "what's declared" and "what's actually imported" to diff at the end.
+  const usedByPackage = new Map();
+  const declaredByPackage = new Map();
 
-  // Scan compiled JS.
-  for (const dist of ["dist-cjs", "dist-es"]) {
-    const distDir = path.join(packageDir, dist);
-    if (!fs.existsSync(distDir)) {
+  // Snapshot declared deps up front so we can diff against usage after the walk.
+  for (const { dir } of packages) {
+    if (dir.includes("/private/")) {
       continue;
     }
-    for await (const file of walk(distDir, ["node_modules"])) {
-      if (!file.endsWith(".js")) {
-        continue;
+    const pkgJsonPath = path.join(dir, "package.json");
+    if (!fs.existsSync(pkgJsonPath)) {
+      continue;
+    }
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+    declaredByPackage.set(pkgJson.name, new Set(Object.keys(pkgJson.dependencies || {})));
+    usedByPackage.set(pkgJson.name, new Set());
+  }
+
+  return {
+    name: "deps-used",
+    targets: ["dist-cjs", "dist-es", "dist-types"],
+    inspects: ["dist-cjs", "dist-es", "dist-types", "package.json"],
+
+    onImport(specifier, file, context) {
+      if (specifier.startsWith(".") || specifier.startsWith("node:")) {
+        return;
       }
-      const code = fs.readFileSync(file, "utf-8");
-      for (const specifier of extractImports(code)) {
-        if (specifier.startsWith(".") || specifier.startsWith("node:")) {
-          continue;
-        }
+      if (context.packageDir.includes("/private/")) {
+        return;
+      }
+      const pkgName = context.packageJson.name;
+      const used = usedByPackage.get(pkgName);
+      if (used) {
         used.add(getPackageName(specifier));
       }
-    }
-  }
+    },
 
-  // Scan .d.ts for type-only imports erased from JS.
-  const distTypes = path.join(packageDir, "dist-types");
-  if (fs.existsSync(distTypes)) {
-    for await (const file of walk(distTypes, ["node_modules"])) {
-      if (!file.endsWith(".d.ts")) {
-        continue;
+    onDtsImport(specifier, file, context) {
+      if (specifier.startsWith(".") || specifier.startsWith("node:")) {
+        return;
       }
-      const contents = fs.readFileSync(file, "utf-8");
-      let m;
-      DTS_IMPORT_RE.lastIndex = 0;
-      while ((m = DTS_IMPORT_RE.exec(contents)) !== null) {
-        if (m[1].startsWith(".") || m[1].startsWith("node:")) {
-          continue;
+      if (context.packageDir.includes("/private/")) {
+        return;
+      }
+      const pkgName = context.packageJson.name;
+      const used = usedByPackage.get(pkgName);
+      if (used) {
+        used.add(getPackageName(specifier));
+      }
+    },
+
+    getErrors() {
+      const errors = [];
+      for (const [pkgName, declared] of declaredByPackage) {
+        const used = usedByPackage.get(pkgName) || new Set();
+        for (const dep of declared) {
+          if (IMPLICIT_DEPS.has(dep)) {
+            continue;
+          }
+          if (used.has(dep)) {
+            continue;
+          }
+          // Allow browser polyfill packages imported via core module name.
+          const coreModule = BROWSER_POLYFILL_MAP.get(dep);
+          if (coreModule && used.has(coreModule)) {
+            continue;
+          }
+          errors.push(`${dep} declared but never imported in ${pkgName}`);
         }
-        used.add(getPackageName(m[1]));
       }
-    }
-  }
-
-  const errors = [];
-  for (const dep of declared) {
-    if (IMPLICIT_DEPS.has(dep)) {
-      continue;
-    }
-    if (!used.has(dep)) {
-      // Allow browser polyfill packages that are imported via their core module name.
-      const coreModule = BROWSER_POLYFILL_MAP.get(dep);
-      if (coreModule && used.has(coreModule)) {
-        continue;
-      }
-      errors.push(`${dep} declared but never imported in ${pkgJson.name}`);
-    }
-  }
-  return errors;
+      return errors;
+    },
+  };
 }
 
 async function main() {
   const packages = getPackageDirs();
-  const validated = [];
-  const errors = [];
-  for (const { dir } of packages) {
-    if (dir.includes("/private/")) continue;
-    validated.push({ dir });
-    errors.push(...(await validate(dir)));
-  }
+  const validator = createValidator(packages);
+  const bus = createBus({ packages });
+  bus.register(validator);
+  await bus.run();
+
+  const errors = validator.getErrors();
   if (errors.length) {
     console.error(`❌ ${errors.length} unused dependency declaration(s):\n  ${errors.join("\n  ")}`);
     process.exit(1);
   }
-  console.log(`✅ All declared dependencies are imported. (${summarizePackages(validated)})`);
+  console.log(`✅ All declared dependencies are imported. (${bus.getSummary()})`);
+  console.log(`    [${(validator.inspects || validator.targets).join(", ")}]`);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { createValidator };

--- a/scripts/validation/filenames.js
+++ b/scripts/validation/filenames.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that dist-es and dist-cjs output filenames do not contain
+ * multiple dots, which would indicate that test/fixture files leaked
+ * into the build output.
+ *
+ * Allowed multi-dot patterns: *.native.js, *.browser.js, *.shared.js
+ *
+ * Usage: node filenames.js [package-dir ...]
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { getPackageDirs } = require("./validation-shared");
+
+const ALLOWED_SUFFIXES = [".native.js", ".browser.js", ".shared.js", ".base.js"];
+const IGNORED_PACKAGES = new Set(["@aws-sdk/aws-client-api-test", "@aws-sdk/aws-client-retry-test"]);
+
+function isAllowedMultiDot(fileName) {
+  return ALLOWED_SUFFIXES.some((suffix) => fileName.endsWith(suffix));
+}
+
+function walkDir(dir, callback) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkDir(fullPath, callback);
+    } else {
+      callback(fullPath);
+    }
+  }
+}
+
+function validate(packageDir) {
+  const errors = [];
+
+  for (const distDir of ["dist-es", "dist-cjs"]) {
+    const dir = path.join(packageDir, distDir);
+    if (!fs.existsSync(dir)) continue;
+
+    walkDir(dir, (filePath) => {
+      const fileName = path.basename(filePath);
+      if (!fileName.endsWith(".js")) return;
+
+      // Count dots (excluding the final .js extension).
+      const withoutExt = fileName.slice(0, -3);
+      const dotCount = (withoutExt.match(/\./g) || []).length;
+
+      if (dotCount > 0 && !isAllowedMultiDot(fileName)) {
+        errors.push(filePath);
+      }
+    });
+  }
+
+  return errors;
+}
+
+const packages = getPackageDirs();
+let totalErrors = 0;
+
+for (const { dir } of packages) {
+  const pkgJsonPath = path.join(dir, "package.json");
+  if (!fs.existsSync(pkgJsonPath)) continue;
+  const pkgName = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8")).name;
+  if (IGNORED_PACKAGES.has(pkgName)) continue;
+  const errors = validate(dir);
+  if (errors.length) {
+    for (const file of errors) {
+      console.error(`${pkgName}: suspicious filename "${path.relative(dir, file)}"`);
+    }
+    totalErrors += errors.length;
+  }
+}
+
+if (totalErrors > 0) {
+  console.error(`\n${totalErrors} file(s) with suspicious multi-dot names found in dist output.`);
+  process.exit(1);
+} else {
+  console.log("filenames: OK");
+}

--- a/scripts/validation/imports-declared.js
+++ b/scripts/validation/imports-declared.js
@@ -7,103 +7,92 @@
  * Usage: node imports-declared.js
  */
 
-const fs = require("node:fs");
 const path = require("node:path");
-const walk = require("../utils/walk");
-const {
-  NODE_BUILTINS,
-  getPackageName,
-  extractImports,
-  getPackageDirs,
-  summarizePackages,
-} = require("./validation-shared");
-
-/**
- * @param packageDir - package root.
- * @param pkgJson - parsed package.json.
- * @param distName - "dist-cjs" or "dist-es".
- * @returns error messages for undeclared imports.
- */
-async function validateDist(packageDir, pkgJson, distName) {
-  const distDir = path.join(packageDir, distName);
-  if (!fs.existsSync(distDir)) {
-    return [];
-  }
-
-  const declared = new Set([
-    ...Object.keys(pkgJson.dependencies || {}),
-    ...Object.keys(pkgJson.peerDependencies || {}),
-  ]);
-
-  const useRequireResolve = distName === "dist-cjs";
-  const errors = [];
-  for await (const file of walk(distDir, ["node_modules"])) {
-    if (!file.endsWith(".js")) {
-      continue;
-    }
-    const code = fs.readFileSync(file, "utf-8");
-    for (const specifier of extractImports(code)) {
-      if (specifier.startsWith(".") || specifier.startsWith("node:")) {
-        continue;
-      }
-      if (NODE_BUILTINS.has(specifier)) {
-        continue;
-      }
-      if (specifier === "vitest") {
-        continue;
-      }
-      const pkg = getPackageName(specifier);
-      if (pkg === pkgJson.name) {
-        continue;
-      }
-      if (!declared.has(pkg)) {
-        errors.push(`${pkg} imported but not declared in ${pkgJson.name} (${path.relative(packageDir, file)})`);
-      } else if (useRequireResolve) {
-        try {
-          require.resolve(specifier, { paths: [path.dirname(file)] });
-        } catch {
-          errors.push(`${specifier} does not resolve in ${pkgJson.name} (${path.relative(packageDir, file)})`);
-        }
-      }
-    }
-  }
-  return errors;
-}
+const { createBus } = require("./ast-bus");
+const { NODE_BUILTINS, getPackageName, getPackageDirs } = require("./validation-shared");
 
 // Packages exempt from undeclared import checks.
 const ALLOWLIST = new Set([]);
 
 /**
- * @param packageDir - package root.
- * @returns aggregated errors from both dist directories.
+ * Creates the imports-declared validator.
  */
-async function validate(packageDir) {
-  const pkgJsonPath = path.join(packageDir, "package.json");
-  if (!fs.existsSync(pkgJsonPath)) {
-    return [];
-  }
-  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
-  if (ALLOWLIST.has(pkgJson.name)) {
-    return [];
-  }
+function createValidator() {
   const errors = [];
-  for (const dist of ["dist-cjs", "dist-es"]) {
-    errors.push(...(await validateDist(packageDir, pkgJson, dist)));
+  // Cache declared deps per package — avoids rebuilding Sets on every onImport call.
+  const declaredCache = new Map();
+
+  function getDeclared(packageJson) {
+    let declared = declaredCache.get(packageJson.name);
+    if (!declared) {
+      declared = new Set([
+        ...Object.keys(packageJson.dependencies || {}),
+        ...Object.keys(packageJson.peerDependencies || {}),
+      ]);
+      declaredCache.set(packageJson.name, declared);
+    }
+    return declared;
   }
-  return errors;
+
+  return {
+    name: "imports-declared",
+    targets: ["dist-cjs", "dist-es"],
+    inspects: ["dist-cjs", "dist-es", "package.json"],
+
+    onImport(specifier, file, context) {
+      if (specifier.startsWith(".") || specifier.startsWith("node:")) {
+        return;
+      }
+      if (NODE_BUILTINS.has(specifier)) {
+        return;
+      }
+      if (specifier === "vitest") {
+        return;
+      }
+      const { packageJson, packageDir, target } = context;
+      if (ALLOWLIST.has(packageJson.name)) {
+        return;
+      }
+      const pkg = getPackageName(specifier);
+      if (pkg === packageJson.name) {
+        return;
+      }
+      const declared = getDeclared(packageJson);
+      if (!declared.has(pkg)) {
+        errors.push(`${pkg} imported but not declared in ${packageJson.name} (${path.relative(packageDir, file)})`);
+      } else if (target === "dist-cjs") {
+        try {
+          require.resolve(specifier, { paths: [path.dirname(file)] });
+        } catch {
+          errors.push(`${specifier} does not resolve in ${packageJson.name} (${path.relative(packageDir, file)})`);
+        }
+      }
+    },
+
+    getErrors() {
+      return errors;
+    },
+  };
 }
 
 async function main() {
   const packages = getPackageDirs();
-  const errors = [];
-  for (const { dir } of packages) {
-    errors.push(...(await validate(dir)));
-  }
+  const validator = createValidator();
+  const bus = createBus({ packages });
+  bus.register(validator);
+  await bus.run();
+
+  const errors = validator.getErrors();
   if (errors.length) {
     console.error(`❌ ${errors.length} undeclared import(s):\n  ${[...new Set(errors)].join("\n  ")}`);
     process.exit(1);
   }
-  console.log(`✅ All absolute imports are declared in package.json. (${summarizePackages(packages)})`);
+  console.log(`✅ All absolute imports are declared in package.json. (${bus.getSummary()})`);
+  console.log(`    [${(validator.inspects || validator.targets).join(", ")}]`);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { createValidator };

--- a/scripts/validation/no-export-star.js
+++ b/scripts/validation/no-export-star.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+/**
+ * Bans `export *` (ExportAllDeclaration) in package source files.
+ * Enforces explicit named exports for better tree-shaking and API clarity.
+ *
+ * Usage: node no-export-star.js [<packageDir> ...]
+ */
+
+const path = require("node:path");
+const { createBus } = require("./ast-bus");
+const { getPackageDirs } = require("./validation-shared");
+
+/**
+ * Creates the no-export-star validator.
+ */
+function createValidator() {
+  const errors = [];
+
+  // Packages exempt entirely (generated-like structure with barrel re-exports).
+  const EXEMPT_PACKAGES = new Set(["@aws-sdk/lib-dynamodb", "@aws-sdk/nested-clients"]);
+
+  // Files exempt by relative path (applies to any package).
+  const EXEMPT_FILES = new Set(["src/api-extractor-type-index.ts"]);
+
+  // Package-specific file exemptions.
+  const EXEMPT_PACKAGE_FILES = new Map([
+    ["@aws-sdk/config", new Set(["src/submodules/credentials/index.ts"])],
+    ["@aws-sdk/crt-loader", new Set(["src/index.ts"])],
+    ["@aws-sdk/smithy-client", new Set(["src/index.ts"])],
+    ["@aws-sdk/undici-http-handler", new Set(["src/index.ts"])],
+  ]);
+
+  return {
+    name: "no-export-star",
+    targets: ["src"],
+
+    onExportAll(node, file, context) {
+      // Skip generated packages.
+      if (context.generated) {
+        return;
+      }
+      const { packageJson, packageDir } = context;
+      if (EXEMPT_PACKAGES.has(packageJson.name)) {
+        return;
+      }
+      const rel = path.relative(packageDir, file);
+      if (EXEMPT_FILES.has(rel)) {
+        return;
+      }
+      const pkgExemptions = EXEMPT_PACKAGE_FILES.get(packageJson.name);
+      if (pkgExemptions && pkgExemptions.has(rel)) {
+        return;
+      }
+      const line = node.loc?.start?.line ?? 0;
+      errors.push(`[${packageJson.name}] ${rel}:${line} - Use explicit named exports instead of 'export *'.`);
+    },
+
+    getErrors() {
+      return errors;
+    },
+  };
+}
+
+async function main() {
+  const packages = getPackageDirs();
+  const validator = createValidator();
+  const bus = createBus({ packages });
+  bus.register(validator);
+  await bus.run();
+
+  const errors = validator.getErrors();
+  if (errors.length) {
+    console.error(`❌ ${errors.length} 'export *' usage(s) found:\n  ${errors.join("\n  ")}`);
+    process.exit(1);
+  }
+  console.log(`✅ No 'export *' found. (${bus.getSummary()})`);
+  console.log(`    [${(validator.inspects || validator.targets).join(", ")}]`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { createValidator };

--- a/scripts/validation/relative-imports.js
+++ b/scripts/validation/relative-imports.js
@@ -7,76 +7,62 @@
  * Usage: node relative-imports.js
  */
 
-const fs = require("node:fs");
 const path = require("node:path");
-const walk = require("../utils/walk");
-const { extractImports, resolveRelative, getPackageDirs, summarizePackages } = require("./validation-shared");
+const { createBus } = require("./ast-bus");
+const { resolveRelative, getPackageDirs } = require("./validation-shared");
 
 /**
- * @param packageDir - package root.
- * @param pkgJson - parsed package.json.
- * @param distName - "dist-cjs" or "dist-es".
- * @returns error messages for broken relative imports.
+ * Creates the relative-imports validator.
  */
-async function validateDist(packageDir, pkgJson, distName) {
-  const distDir = path.join(packageDir, distName);
-  if (!fs.existsSync(distDir)) {
-    return [];
-  }
-
-  const useRequireResolve = distName === "dist-cjs";
+function createValidator() {
   const errors = [];
-  for await (const file of walk(distDir, ["node_modules"])) {
-    if (!file.endsWith(".js")) {
-      continue;
-    }
-    const code = fs.readFileSync(file, "utf-8");
-    for (const specifier of extractImports(code)) {
+
+  return {
+    name: "relative-imports",
+    targets: ["dist-cjs", "dist-es"],
+
+    onImport(specifier, file, context) {
       if (!specifier.startsWith(".")) {
-        continue;
+        return;
       }
-      if (useRequireResolve) {
+      const { packageJson, packageDir, target } = context;
+      if (target === "dist-cjs") {
         try {
           require.resolve(specifier, { paths: [path.dirname(file)] });
         } catch {
-          errors.push(`[${pkgJson.name}/${distName}] ${specifier} not found (from ${path.relative(packageDir, file)})`);
+          errors.push(
+            `[${packageJson.name}/${target}] ${specifier} not found (from ${path.relative(packageDir, file)})`
+          );
         }
       } else if (!resolveRelative(file, specifier)) {
-        errors.push(`[${pkgJson.name}/${distName}] ${specifier} not found (from ${path.relative(packageDir, file)})`);
+        errors.push(`[${packageJson.name}/${target}] ${specifier} not found (from ${path.relative(packageDir, file)})`);
       }
-    }
-  }
-  return errors;
-}
+    },
 
-/**
- * @param packageDir - package root.
- * @returns aggregated errors from both dist directories.
- */
-async function validate(packageDir) {
-  const pkgJsonPath = path.join(packageDir, "package.json");
-  if (!fs.existsSync(pkgJsonPath)) {
-    return [];
-  }
-  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
-  const errors = [];
-  for (const dist of ["dist-cjs", "dist-es"]) {
-    errors.push(...(await validateDist(packageDir, pkgJson, dist)));
-  }
-  return errors;
+    getErrors() {
+      return errors;
+    },
+  };
 }
 
 async function main() {
   const packages = getPackageDirs();
-  const errors = [];
-  for (const { dir } of packages) {
-    errors.push(...(await validate(dir)));
-  }
+  const validator = createValidator();
+  const bus = createBus({ packages });
+  bus.register(validator);
+  await bus.run();
+
+  const errors = validator.getErrors();
   if (errors.length) {
     console.error(`❌ ${errors.length} broken relative import(s):\n  ${errors.join("\n  ")}`);
     process.exit(1);
   }
-  console.log(`✅ All relative imports resolve to existing files. (${summarizePackages(packages)})`);
+  console.log(`✅ All relative imports resolve to existing files. (${bus.getSummary()})`);
+  console.log(`    [${(validator.inspects || validator.targets).join(", ")}]`);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { createValidator };

--- a/scripts/validation/static-import-names.js
+++ b/scripts/validation/static-import-names.js
@@ -7,65 +7,53 @@
  * Usage: node static-import-names.js
  */
 
-const fs = require("node:fs");
 const path = require("node:path");
-const walk = require("../utils/walk");
-const { analyzeImports, getPackageDirs, summarizePackages } = require("./validation-shared");
+const { createBus } = require("./ast-bus");
+const { getPackageDirs } = require("./validation-shared");
 
 /**
- * @param packageDir - package root.
- * @param pkgJson - parsed package.json.
- * @param distName - "dist-cjs" or "dist-es".
- * @returns error messages with file and line.
+ * Creates the static-import-names validator.
  */
-async function validateDist(packageDir, pkgJson, distName) {
-  const distDir = path.join(packageDir, distName);
-  if (!fs.existsSync(distDir)) {
-    return [];
-  }
-
+function createValidator() {
   const errors = [];
-  for await (const file of walk(distDir, ["node_modules"])) {
-    if (!file.endsWith(".js")) {
-      continue;
-    }
-    const code = fs.readFileSync(file, "utf-8");
-    const { dynamicImports } = analyzeImports(code);
-    for (const { line, type } of dynamicImports) {
-      errors.push(`${type} with non-literal argument at ${path.relative(packageDir, file)}:${line}`);
-    }
-  }
-  return errors;
-}
 
-/**
- * @param packageDir - package root.
- * @returns formatted error messages.
- */
-async function validate(packageDir) {
-  const pkgJsonPath = path.join(packageDir, "package.json");
-  if (!fs.existsSync(pkgJsonPath)) {
-    return [];
-  }
-  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
-  const errors = [];
-  for (const dist of ["dist-cjs", "dist-es"]) {
-    errors.push(...(await validateDist(packageDir, pkgJson, dist)));
-  }
-  return errors.map((e) => `[${pkgJson.name}] ${e}`);
+  return {
+    name: "static-import-names",
+    targets: ["dist-cjs", "dist-es"],
+
+    onNonLiteralImportSpecifier(node, file, context) {
+      const { packageJson, packageDir } = context;
+      errors.push(
+        `[${packageJson.name}] ${node.type} with non-literal argument at ${path.relative(packageDir, file)}:${
+          node.line
+        }`
+      );
+    },
+
+    getErrors() {
+      return errors;
+    },
+  };
 }
 
 async function main() {
   const packages = getPackageDirs();
-  const errors = [];
-  for (const { dir } of packages) {
-    errors.push(...(await validate(dir)));
-  }
+  const validator = createValidator();
+  const bus = createBus({ packages });
+  bus.register(validator);
+  await bus.run();
+
+  const errors = validator.getErrors();
   if (errors.length) {
     console.error(`❌ ${errors.length} dynamic import(s) with non-literal specifier:\n  ${errors.join("\n  ")}`);
     process.exit(1);
   }
-  console.log(`✅ No dynamic imports with non-literal specifiers. (${summarizePackages(packages)})`);
+  console.log(`✅ No dynamic imports with non-literal specifiers. (${bus.getSummary()})`);
+  console.log(`    [${(validator.inspects || validator.targets).join(", ")}]`);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { createValidator };

--- a/scripts/validation/unreachable-files.js
+++ b/scripts/validation/unreachable-files.js
@@ -9,53 +9,12 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
-const walk = require("../utils/walk");
-const { extractImports, resolveRelative, getPackageDirs, summarizePackages } = require("./validation-shared");
-
-/**
- * @param code - JS file contents.
- * @returns only the relative specifiers.
- */
-function extractRelativeImports(code) {
-  return extractImports(code).filter((s) => s.startsWith("."));
-}
-
-/**
- * BFS from entry points, following relative imports.
- *
- * @param entryPoints - absolute paths to start from.
- * @returns set of all reachable absolute file paths.
- */
-function collectReachable(entryPoints) {
-  const visited = new Set();
-  const queue = [...entryPoints];
-
-  while (queue.length) {
-    const file = queue.shift();
-    if (visited.has(file) || !fs.existsSync(file)) {
-      continue;
-    }
-    visited.add(file);
-
-    const code = fs.readFileSync(file, "utf-8");
-    for (const specifier of extractRelativeImports(code)) {
-      const target = resolveRelative(file, specifier);
-      if (target && !visited.has(target)) {
-        queue.push(target);
-      }
-    }
-  }
-  return visited;
-}
+const { createBus } = require("./ast-bus");
+const { resolveRelative, getPackageDirs } = require("./validation-shared");
 
 /**
  * Collects entry point paths for a dist directory from package.json fields:
  * main, module, exports, browser, react-native.
- *
- * @param pkgJson - parsed package.json.
- * @param packageDir - package root.
- * @param distName - "dist-cjs" or "dist-es".
- * @returns deduplicated absolute paths.
  */
 function getEntryPoints(pkgJson, packageDir, distName) {
   const entries = [];
@@ -107,72 +66,162 @@ function getEntryPoints(pkgJson, packageDir, distName) {
 }
 
 /**
- * @param packageDir - package root.
- * @param pkgJson - parsed package.json.
- * @param distName - "dist-cjs" or "dist-es".
- * @returns relative paths of unreachable files.
+ * BFS from entry points, following relative imports using the graph.
  */
-async function validateDist(packageDir, pkgJson, distName) {
-  const distDir = path.join(packageDir, distName);
-  if (!fs.existsSync(distDir)) {
-    return [];
-  }
+function collectReachable(entryPoints, graph) {
+  const visited = new Set();
+  const queue = [...entryPoints];
 
-  const entryPoints = getEntryPoints(pkgJson, packageDir, distName);
-  if (!entryPoints.length) {
-    return [];
-  }
-
-  const reachable = collectReachable(entryPoints);
-
-  const allFiles = [];
-  for await (const file of walk(distDir, ["node_modules"])) {
-    if (!file.endsWith(".js")) {
+  while (queue.length) {
+    const file = queue.shift();
+    if (visited.has(file) || !fs.existsSync(file)) {
       continue;
     }
-    // Type-only files compile to just "export {};".
-    const content = fs.readFileSync(file, "utf-8").trim();
-    if (content === "export {};" || content === '"use strict";') {
+    visited.add(file);
+
+    const imports = graph.get(file);
+    if (!imports) {
       continue;
     }
-    allFiles.push(file);
+    for (let i = 0; i < imports.length; ++i) {
+      const specifier = imports[i];
+      if (!specifier.startsWith(".")) {
+        continue;
+      }
+      const target = resolveRelative(file, specifier);
+      if (target && !visited.has(target)) {
+        queue.push(target);
+      }
+    }
   }
-
-  return allFiles
-    .filter((f) => !reachable.has(f))
-    .map((f) => path.relative(packageDir, f))
-    .filter((f) => f !== `${distName}/runtimeConfig.browser.js` && f !== `${distName}/runtimeConfig.native.js`);
+  return visited;
 }
 
 /**
- * @param packageDir - package root.
- * @returns formatted warning messages.
+ * Creates the unreachable-files validator.
  */
-async function validate(packageDir) {
-  const pkgJsonPath = path.join(packageDir, "package.json");
-  if (!fs.existsSync(pkgJsonPath)) {
-    return [];
-  }
-  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+function createValidator() {
+  // Collect file lists during the walk so we can diff against reachability in onWalkComplete.
+  // Key format: `${packageDir}::${target}` → Set<filePath>
+  const filesByPkgTarget = new Map();
+  const pkgJsonByDir = new Map();
   const errors = [];
-  for (const dist of ["dist-cjs", "dist-es"]) {
-    const unreachable = await validateDist(packageDir, pkgJson, dist);
-    errors.push(...unreachable.map((f) => `[${pkgJson.name}] unreachable file: ${f}`));
-  }
-  return errors;
+
+  // Packages exempt entirely.
+  const EXEMPT_PACKAGES = new Set(["@aws-sdk/aws-client-api-test", "@aws-sdk/aws-client-retry-test"]);
+
+  // Package-specific file exemptions (relative paths from package root).
+  const EXEMPT_FILES = new Map([
+    [
+      "@aws-sdk/core",
+      new Set([
+        "dist-es/submodules/client/util-user-agent-browser/defaultUserAgent.browser.js",
+        "dist-es/submodules/protocols/json/experimental/SinglePassJsonShapeSerializer.js",
+        "dist-es/submodules/protocols/xml/simpleFormatXml.js",
+      ]),
+    ],
+    [
+      "@aws-sdk/nested-clients",
+      new Set([
+        "dist-es/submodules/cognito-identity/runtimeConfig.native.js",
+        "dist-es/submodules/signin/runtimeConfig.native.js",
+        "dist-es/submodules/sso/runtimeConfig.native.js",
+        "dist-es/submodules/sso-oidc/runtimeConfig.native.js",
+        "dist-es/submodules/sts/runtimeConfig.native.js",
+      ]),
+    ],
+    ["@aws-sdk/util-dns", new Set(["dist-es/archive/NodeDnsResolveHostResolver.js"])],
+    [
+      "@aws-sdk/lib-transfer-manager",
+      new Set([
+        "dist-es/submodules/transfer-manager/join-streams.browser.js",
+        "dist-es/submodules/transfer-manager/worker-http-handler.browser.js",
+      ]),
+    ],
+  ]);
+
+  return {
+    name: "unreachable-files",
+    targets: ["dist-cjs", "dist-es"],
+
+    onFile(file, context) {
+      if (!file.endsWith(".js")) {
+        return;
+      }
+      const key = `${context.packageDir}::${context.target}`;
+      if (!filesByPkgTarget.has(key)) {
+        filesByPkgTarget.set(key, new Set());
+        pkgJsonByDir.set(context.packageDir, context.packageJson);
+      }
+      filesByPkgTarget.get(key).add(file);
+    },
+
+    onWalkComplete(graph) {
+      for (const [key, files] of filesByPkgTarget) {
+        const [packageDir, target] = key.split("::");
+        const pkgJson = pkgJsonByDir.get(packageDir);
+        if (!pkgJson) {
+          continue;
+        }
+        if (EXEMPT_PACKAGES.has(pkgJson.name)) {
+          continue;
+        }
+
+        const entryPoints = getEntryPoints(pkgJson, packageDir, target);
+        if (!entryPoints.length) {
+          continue;
+        }
+
+        const reachable = collectReachable(entryPoints, graph);
+        const pkgExemptions = EXEMPT_FILES.get(pkgJson.name);
+
+        for (const file of files) {
+          if (reachable.has(file)) {
+            continue;
+          }
+          // Type-only files compile to just "export {};".
+          const content = fs.readFileSync(file, "utf-8").trim();
+          if (content === "export {};" || content === '"use strict";') {
+            continue;
+          }
+          const rel = path.relative(packageDir, file);
+          // Skip known browser/native runtimeConfig alternates.
+          if (rel === `${target}/runtimeConfig.browser.js` || rel === `${target}/runtimeConfig.native.js`) {
+            continue;
+          }
+          // Skip package-specific exemptions.
+          if (pkgExemptions && pkgExemptions.has(rel)) {
+            continue;
+          }
+          errors.push(`[${pkgJson.name}] unreachable file: ${rel}`);
+        }
+      }
+    },
+
+    getErrors() {
+      return errors;
+    },
+  };
 }
 
 async function main() {
   const packages = getPackageDirs();
-  const errors = [];
-  for (const { dir } of packages) {
-    errors.push(...(await validate(dir)));
-  }
+  const validator = createValidator();
+  const bus = createBus({ packages });
+  bus.register(validator);
+  await bus.run();
+
+  const errors = validator.getErrors();
   if (errors.length) {
-    console.log(`⚠️  ${errors.length} unreachable file(s):\n  ${errors.join("\n  ")}`);
-  } else {
-    console.log(`✅ All dist files are reachable from entry points. (${summarizePackages(packages)})`);
+    console.error(`❌ ${errors.length} unreachable file(s):\n  ${errors.join("\n  ")}`);
+    process.exit(1);
   }
+  console.log(`✅ All dist files are reachable from entry points. (${bus.getSummary()})`);
+  console.log(`    [${(validator.inspects || validator.targets).join(", ")}]`);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { createValidator };

--- a/scripts/validation/validate-all.js
+++ b/scripts/validation/validate-all.js
@@ -2,6 +2,8 @@
 
 /**
  * Orchestrator: runs all validation scripts against all packages.
+ * Bus-compatible validators (7) ride a single AST bus for one-pass parsing.
+ * Non-bus validators run as subprocesses.
  *
  * Usage:
  *   node validate-all.js
@@ -11,35 +13,68 @@
 const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
+const { createBus } = require("./ast-bus");
+const { getPackageDirs } = require("./validation-shared");
 
 const root = path.join(__dirname, "..", "..");
 const validationDir = __dirname;
 
 const PACKAGE_ROOTS = ["clients", "packages", "packages-internal", "lib", "private"];
 
-const VALIDATIONS = [
-  { name: "built", label: "all packages have build artifacts", script: "built.js" },
-  { name: "imports-declared", label: "all imports are declared in package.json", script: "imports-declared.js" },
-  { name: "relative-imports", label: "all relative imports resolve to existing files", script: "relative-imports.js" },
-  { name: "deps-used", label: "all declared dependencies are actually imported", script: "deps-used.js" },
-  { name: "unreachable-files", label: "no unreachable files in dist bundles", script: "unreachable-files.js" },
+// Bus-compatible validators — these ride one bus together.
+const BUS_VALIDATIONS = [
+  { name: "imports-declared", label: "all imports are declared in package.json", module: "./imports-declared.js" },
+  {
+    name: "relative-imports",
+    label: "all relative imports resolve to existing files",
+    module: "./relative-imports.js",
+  },
+  { name: "deps-used", label: "all declared dependencies are actually imported", module: "./deps-used.js" },
+  { name: "unreachable-files", label: "no unreachable files in dist bundles", module: "./unreachable-files.js" },
   {
     name: "static-import-names",
     label: "no dynamic imports with non-literal specifiers",
-    script: "static-import-names.js",
+    module: "./static-import-names.js",
   },
-  { name: "banned-imports", label: "no banned imports in dist output", script: "banned-imports.js" },
-  { name: "esm-compat", label: "dist-cjs exports visible via ESM import()", script: "esm-compat.js" },
-  { name: "export-names", label: "export function names match their keys", script: "export-names.js" },
-  { name: "cycles", label: "no cyclical file or package dependencies", script: "cycles.js" },
-  { name: "eslint", label: "eslint passes on source", script: "eslint.js" },
+  { name: "banned-imports", label: "no banned imports in dist output", module: "./banned-imports.js" },
+  { name: "no-export-star", label: "no export * in source", module: "./no-export-star.js" },
+  { name: "cycles", label: "no cyclical file or package dependencies", module: "./cycles.js" },
+];
+
+// Non-bus validators — run as subprocesses.
+const SUBPROCESS_VALIDATIONS = [
+  {
+    name: "built",
+    label: "all packages have build artifacts",
+    script: "built.js",
+    inspects: ["dist-cjs", "dist-es", "dist-types"],
+  },
+  {
+    name: "esm-compat",
+    label: "dist-cjs exports visible via ESM import()",
+    script: "esm-compat.js",
+    inspects: ["dist-cjs"],
+  },
+  {
+    name: "export-names",
+    label: "export function names match their keys",
+    script: "export-names.js",
+    inspects: ["dist-cjs"],
+  },
+  { name: "eslint", label: "eslint passes on source", script: "eslint.js", inspects: ["src"] },
+  {
+    name: "filenames",
+    label: "no suspicious multi-dot filenames in dist",
+    script: "filenames.js",
+    inspects: ["dist-cjs", "dist-es"],
+  },
 ];
 
 function parseArgs() {
   const args = process.argv.slice(2);
   const skip = new Set();
 
-  for (let i = 0; i < args.length; i++) {
+  for (let i = 0; i < args.length; ++i) {
     if (args[i] === "--skip") {
       skip.add(args[++i]);
     }
@@ -48,23 +83,60 @@ function parseArgs() {
   return { skip };
 }
 
-function main() {
-  const { skip } = parseArgs();
-
-  let count = 0;
-  for (const pkgRoot of PACKAGE_ROOTS) {
-    const dir = path.join(root, pkgRoot);
-    if (fs.existsSync(dir)) {
-      count += fs.readdirSync(dir).filter((f) => fs.existsSync(path.join(dir, f, "package.json"))).length;
-    }
-  }
-
-  console.log(`Running validations on ${count} package(s)...\n`);
-
+async function runBusValidations(skip, packages) {
   const failures = [];
   const warnings = [];
 
-  for (const { name, label, script } of VALIDATIONS) {
+  // Only load validators not being skipped.
+  const activeValidations = BUS_VALIDATIONS.filter((v) => !skip.has(v.name));
+  if (!activeValidations.length) {
+    return { failures, warnings, summary: "" };
+  }
+
+  const bus = createBus({ packages });
+  const validatorMap = new Map();
+
+  for (const validation of activeValidations) {
+    const mod = require(validation.module);
+    // deps-used needs the packages list to compare declared deps against usage.
+    const validator = validation.name === "deps-used" ? mod.createValidator(packages) : mod.createValidator();
+    bus.register(validator);
+    validatorMap.set(validation.name, { validation, validator });
+  }
+
+  // Single AST pass over all files — each validator fires its callbacks.
+  await bus.run();
+
+  for (const { validation, validator } of validatorMap.values()) {
+    const errors = validator.getErrors ? validator.getErrors() : [];
+    const validatorWarnings = validator.getWarnings ? validator.getWarnings() : [];
+    const inspected = validator.inspects || validator.targets;
+
+    if (errors.length) {
+      console.log(`❌ ${validation.label}`);
+      console.log(`    [${inspected.join(", ")}]`);
+      failures.push({ name: validation.name, output: `${errors.length} error(s):\n  ${errors.join("\n  ")}` });
+    } else if (validatorWarnings.length) {
+      console.log(`⚠️  ${validation.label}`);
+      console.log(`    [${inspected.join(", ")}]`);
+      warnings.push({
+        name: validation.name,
+        output: `${validatorWarnings.length} warning(s):\n  ${validatorWarnings.join("\n  ")}`,
+      });
+    } else {
+      console.log(`✅ ${validation.label}`);
+      console.log(`    [${inspected.join(", ")}]`);
+    }
+  }
+
+  return { failures, warnings, summary: bus.getSummary() };
+}
+
+function runSubprocessValidations(skip) {
+  const failures = [];
+  const warnings = [];
+
+  for (const { name, label, script, inspects } of SUBPROCESS_VALIDATIONS) {
     if (skip.has(name)) {
       console.log(`⏭  ${label}`);
       continue;
@@ -78,16 +150,46 @@ function main() {
       });
       if (output.includes("⚠️")) {
         console.log(`⚠️  ${label}`);
+        console.log(`    [${inspects.join(", ")}]`);
         warnings.push({ name, output });
       } else {
         const counts = output.match(/\(([^)]+)\)/)?.[1] || "";
         console.log(`✅ ${label}${counts ? ` (${counts})` : ""}`);
+        console.log(`    [${inspects.join(", ")}]`);
       }
     } catch (e) {
       console.log(`❌ ${label}`);
+      console.log(`    [${inspects.join(", ")}]`);
       failures.push({ name, output: e.stdout || e.stderr || e.message });
     }
   }
+
+  return { failures, warnings };
+}
+
+async function main() {
+  const { skip } = parseArgs();
+
+  const packages = getPackageDirs();
+  let count = 0;
+  for (const pkgRoot of PACKAGE_ROOTS) {
+    const dir = path.join(root, pkgRoot);
+    if (fs.existsSync(dir)) {
+      count += fs.readdirSync(dir).filter((f) => fs.existsSync(path.join(dir, f, "package.json"))).length;
+    }
+  }
+
+  const totalValidations = BUS_VALIDATIONS.length + SUBPROCESS_VALIDATIONS.length;
+  console.log(`Running validations on ${count} package(s)...\n`);
+
+  // Subprocess validators run first (no AST, fast feedback on missing build artifacts).
+  const subprocess = runSubprocessValidations(skip);
+
+  // Bus validators share a single AST walk over all dist files.
+  const busResult = await runBusValidations(skip, packages);
+
+  const failures = [...subprocess.failures, ...busResult.failures];
+  const warnings = [...subprocess.warnings, ...busResult.warnings];
 
   if (warnings.length) {
     console.log("");
@@ -98,7 +200,8 @@ function main() {
 
   console.log("");
   if (failures.length) {
-    console.error(`${failures.length}/${VALIDATIONS.length - skip.size} validation(s) failed:\n`);
+    const active = totalValidations - skip.size;
+    console.error(`${failures.length}/${active} validation(s) failed:\n`);
     for (const { name, output } of failures) {
       console.error(`--- ${name} ---\n${output}\n`);
     }
@@ -118,7 +221,7 @@ function main() {
     process.exit(1);
   }
 
-  console.log(`\nAll validations passed.`);
+  console.log(`\nAll validations passed. (${busResult.summary})`);
 }
 
 main();

--- a/scripts/validation/validate-all.test.js
+++ b/scripts/validation/validate-all.test.js
@@ -22,6 +22,7 @@ const distEs = path.join(tmpPkgDir, "dist-es");
 function setup() {
   fs.mkdirSync(distCjs, { recursive: true });
   fs.mkdirSync(distEs, { recursive: true });
+  fs.mkdirSync(path.join(tmpPkgDir, "src"), { recursive: true });
 
   // package.json declares "tslib" (implicit, always passes) and "@aws-sdk/util-arn-parser" (unused).
   fs.writeFileSync(
@@ -74,6 +75,12 @@ module.exports = { blorp: toHex };
   // orphan.js — unreachable (not imported from index)
   fs.writeFileSync(path.join(distCjs, "orphan.js"), `"use strict";\nmodule.exports = {};\n`);
   fs.writeFileSync(path.join(distEs, "orphan.js"), `"use strict";\nmodule.exports = {};\n`);
+
+  // no-export-star violation: src/barrel.ts uses export * from
+  fs.writeFileSync(path.join(tmpPkgDir, "src", "barrel.ts"), `export * from "./blorp";\nexport * from "./utils";\n`);
+
+  // filenames violation: multi-dot filename that is not an allowed suffix
+  fs.writeFileSync(path.join(distCjs, "blorp.spec.js"), `"use strict";\nmodule.exports = {};\n`);
 }
 
 function teardown() {
@@ -144,12 +151,24 @@ function runTests() {
 
   // 5. unreachable-files
   const unreachable = runValidator("unreachable-files.js", [pkg]);
-  check(unreachable.output.includes("orphan.js"), "unreachable-files detects orphan.js");
+  check(unreachable.exitCode !== 0, "unreachable-files detects orphan.js as an error");
+  check(unreachable.output.includes("orphan.js"), "unreachable-files names the unreachable file");
 
   // 6. deps-used (@aws-sdk/util-endpoints is declared but never imported)
   const deps = runValidator("deps-used.js", [pkg]);
   check(deps.exitCode !== 0, "deps-used detects unused @aws-sdk/util-endpoints");
   check(deps.output.includes("@aws-sdk/util-endpoints"), "deps-used names the unused dependency");
+
+  // 7. no-export-star (src/barrel.ts uses export *)
+  const exportStar = runValidator("no-export-star.js", [pkg]);
+  check(exportStar.exitCode !== 0, "no-export-star detects export * in source");
+  check(exportStar.output.includes("barrel.ts"), "no-export-star identifies the offending file");
+  check(exportStar.output.includes("export *"), "no-export-star mentions 'export *' in the error");
+
+  // 8. filenames (blorp.spec.js has suspicious multi-dot name)
+  const filenames = runValidator("filenames.js", [pkg]);
+  check(filenames.exitCode !== 0, "filenames detects suspicious multi-dot filename");
+  check(filenames.output.includes("blorp.spec.js"), "filenames identifies the offending file");
 
   console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
   return failed === 0;

--- a/scripts/validation/validation-shared.js
+++ b/scripts/validation/validation-shared.js
@@ -178,9 +178,18 @@ const GENERATED_ROOTS = new Set(["clients", "private"]);
  * Each entry has .dir (absolute path) and .generated (boolean).
  */
 function getPackageDirs() {
-  const args = process.argv.slice(2).filter((a) => !a.startsWith("--"));
-  if (args.length) {
-    return args.map((d) => ({ dir: path.resolve(d), generated: false }));
+  // Extract positional args (package dirs), skipping --flag and its value.
+  const argv = process.argv.slice(2);
+  const positional = [];
+  for (let i = 0; i < argv.length; ++i) {
+    if (argv[i].startsWith("--")) {
+      ++i; // skip the flag's value
+    } else {
+      positional.push(argv[i]);
+    }
+  }
+  if (positional.length) {
+    return positional.map((d) => ({ dir: path.resolve(d), generated: false }));
   }
   const root = path.join(__dirname, "..", "..");
   const results = [];


### PR DESCRIPTION
### Issue
JS-7014

### Description

- reorganizes the static analysis validators to share a "bus" 🚌 for AST traversal
- this is to eliminate the redundant AST traversals when running all the validators at the same time. They now share a bus that traverses the AST and each validator looks at different parts of the code.

Excluding eslint, the static analyzers now run in ~7s instead of taking ~60s.