### PR TITLE
chore: remove redundant type assertions

### DIFF
--- a/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.ts
+++ b/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.ts
@@ -126,12 +126,12 @@ export class LoginCredentialsFetcher {
         ...token,
         accessToken: {
           ...token.accessToken, // Preserve existing fields like accountId
-          accessKeyId: accessKeyId!,
-          secretAccessKey: secretAccessKey!,
-          sessionToken: sessionToken!,
+          accessKeyId,
+          secretAccessKey,
+          sessionToken,
           expiresAt: expiration.toISOString(),
         },
-        refreshToken: refreshToken!,
+        refreshToken,
       };
 
       await this.saveToken(updatedToken);

--- a/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.ts
+++ b/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.ts
@@ -57,7 +57,7 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
       throw new Error("Eventstream payload must be a Readable stream.");
     }
 
-    const payloadStream = payload as Readable;
+    const payloadStream = payload;
     request.body = new PassThrough({
       objectMode: true,
     });

--- a/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.ts
+++ b/packages-internal/eventstream-handler-node/src/EventStreamPayloadHandler.ts
@@ -57,7 +57,6 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
       throw new Error("Eventstream payload must be a Readable stream.");
     }
 
-    const payloadStream = payload;
     request.body = new PassThrough({
       objectMode: true,
     });
@@ -81,7 +80,7 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
     let resolvePipeline: () => void;
     const pipelineError = new Promise<FinalizeHandlerOutput<any>>((resolve, reject) => {
       resolvePipeline = () => resolve(undefined as any);
-      pipeline(payloadStream, signingStream, request.body, (err: NodeJS.ErrnoException | null) => {
+      pipeline(payload, signingStream, request.body, (err: NodeJS.ErrnoException | null) => {
         if (err) {
           reject(new Error(`Pipeline error in @aws-sdk/eventstream-handler-node: ${err.message}`, { cause: err }));
         }


### PR DESCRIPTION
### Issue

N/A

### Description

Drop assertions that are unnecessary because the values are already
narrowed by a preceding type guard in the same scope.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
