### PR TITLE
test: extend TypeScript compatibility check to 3.4-4.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,9 @@ test-types: reset-test-credentials
 	npx tsc -p tsconfig.test.index-types.json
 
 # verify clients compile across supported TypeScript versions (see tests/ts-compat/README.md).
+# Downlevel the .d.ts first so TypeScript < 4.5 resolves the clients' dist-types/ts3.4 declarations.
 test-typescript-versions:
+	yarn build:types:downlevel
 	(cd ./tests/ts-compat && npm install --no-audit --no-fund && node ./run.mjs)
 
 test-indices:

--- a/tests/ts-compat/README.md
+++ b/tests/ts-compat/README.md
@@ -41,8 +41,7 @@ isolation with its own dependency installs.
 For versions below TypeScript 4.5, the clients resolve their types to the
 downleveled `dist-types/ts3.4` declarations via each client's `typesVersions`
 (`"<4.5"`) entry. Those declarations are produced by a separate build step
-(`yarn build:types:downlevel` in the client), so they must exist too. `run.mjs`
-errors with guidance if a version below 4.5 is under test and they are missing.
+(`yarn build:types:downlevel` in the client), so they must exist too.
 
 ## Protocol coverage
 

--- a/tests/ts-compat/README.md
+++ b/tests/ts-compat/README.md
@@ -40,8 +40,10 @@ isolation with its own dependency installs.
 
 For versions below TypeScript 4.5, the clients resolve their types to the
 downleveled `dist-types/ts3.4` declarations via each client's `typesVersions`
-(`"<4.5"`) entry. Those declarations are produced by a separate build step
-(`yarn build:types:downlevel` in the client), so they must exist too.
+(`"<4.5"`) entry. These are produced by a separate build step
+(`build:types:downlevel`). The `test-typescript-versions` Make target runs the
+root `yarn build:types:downlevel` before the suite so they are present. If you
+run `run.mjs` directly, run `yarn build:types:downlevel` at the repo root first.
 
 ## Protocol coverage
 

--- a/tests/ts-compat/README.md
+++ b/tests/ts-compat/README.md
@@ -38,6 +38,12 @@ Either way assumes the referenced clients are already built (their `dist-types`
 are present). `run.mjs` errors with guidance if they are not. It runs in
 isolation with its own dependency installs.
 
+For versions below TypeScript 4.5, the clients resolve their types to the
+downleveled `dist-types/ts3.4` declarations via each client's `typesVersions`
+(`"<4.5"`) entry. Those declarations are produced by a separate build step
+(`yarn build:types:downlevel` in the client), so they must exist too. `run.mjs`
+errors with guidance if a version below 4.5 is under test and they are missing.
+
 ## Protocol coverage
 
 | Protocol   | Client                            |

--- a/tests/ts-compat/run.mjs
+++ b/tests/ts-compat/run.mjs
@@ -43,35 +43,96 @@ function loadVersions() {
   return specs.map(({ version, tscArgs = [] }) => ({ version, tscArgs }));
 }
 
+const CLIENTS = [
+  "@aws-sdk/client-dynamodb",
+  "@aws-sdk/client-cloudwatch-logs",
+  "@aws-sdk/client-sts",
+  "@aws-sdk/client-ec2",
+  "@aws-sdk/client-lambda",
+  "@aws-sdk/client-s3",
+];
+
+// Clients expose downleveled declarations for older compilers via a package.json
+// `typesVersions` entry ("<4.5" -> dist-types/ts3.4/*). Any version we test below
+// 4.5 therefore resolves to dist-types/ts3.4, which must be generated separately
+// from the primary dist-types (client script: build:types:downlevel).
+const DOWNLEVEL_BOUNDARY = 4.5;
+
+/**
+ * Parse a bare minor spec (e.g. "3.4", "4.10") into a comparable number.
+ * @param {string} version
+ * @returns {number}
+ */
+function minorValue(version) {
+  const [major, minor = "0"] = version.split(".");
+  return Number(major) + Number(minor) / 1000;
+}
+
 /**
  * Ensure the workspace clients are installed and built (dist-types present).
  * The clients are consumed via file: links, so their .d.ts must exist on disk.
+ * When any version below 4.5 is under test, the downleveled dist-types/ts3.4
+ * declarations must also be present.
+ * @param {{ version: string }[]} versions
  */
-function ensureClientsReady() {
+function ensureClientsReady(versions) {
   if (!existsSync(path.join(root, "node_modules"))) {
     console.log("Installing fixture dependencies (clients) ...");
-    execFileSync("npm", ["install", "--no-audit", "--no-fund"], { cwd: root, stdio: "inherit" });
+    execFileSync("npm", ["install", "--no-audit", "--no-fund"], {
+      cwd: root,
+      stdio: "inherit",
+    });
   }
 
-  const clients = [
-    "@aws-sdk/client-dynamodb",
-    "@aws-sdk/client-cloudwatch-logs",
-    "@aws-sdk/client-sts",
-    "@aws-sdk/client-ec2",
-    "@aws-sdk/client-lambda",
-    "@aws-sdk/client-s3",
-  ];
-  const missing = clients.filter(
-    (name) => !existsSync(path.join(root, "node_modules", ...name.split("/"), "dist-types", "index.d.ts"))
+  const missing = CLIENTS.filter(
+    (name) =>
+      !existsSync(
+        path.join(
+          root,
+          "node_modules",
+          ...name.split("/"),
+          "dist-types",
+          "index.d.ts",
+        ),
+      ),
   );
   if (missing.length > 0) {
     console.error(
       `\nThe following clients are not built (dist-types missing): ${missing.join(", ")}.\n` +
         `Build them first, e.g.:\n` +
         `  node ./scripts/turbo build -F=@aws-sdk/client-dynamodb -F=@aws-sdk/client-cloudwatch-logs \\\n` +
-        `    -F=@aws-sdk/client-sts -F=@aws-sdk/client-ec2 -F=@aws-sdk/client-lambda -F=@aws-sdk/client-s3\n`
+        `    -F=@aws-sdk/client-sts -F=@aws-sdk/client-ec2 -F=@aws-sdk/client-lambda -F=@aws-sdk/client-s3\n`,
     );
     process.exit(1);
+  }
+
+  const needsDownlevel = versions.some(
+    (v) => minorValue(v.version) < DOWNLEVEL_BOUNDARY,
+  );
+  if (needsDownlevel) {
+    const missingDownlevel = CLIENTS.filter(
+      (name) =>
+        !existsSync(
+          path.join(
+            root,
+            "node_modules",
+            ...name.split("/"),
+            "dist-types",
+            "ts3.4",
+            "index.d.ts",
+          ),
+        ),
+    );
+    if (missingDownlevel.length > 0) {
+      console.error(
+        `\nTesting TypeScript < ${DOWNLEVEL_BOUNDARY} requires the downleveled ts3.4 declarations, ` +
+          `which are missing for: ${missingDownlevel.join(", ")}.\n` +
+          `Generate them from each client directory, e.g.:\n` +
+          `  yarn build:types:downlevel\n` +
+          `or build the clients including the downlevel step before running this suite.\n`,
+      );
+      process.exit(1);
+    }
   }
 }
 
@@ -122,12 +183,14 @@ async function runPool(versions) {
   return results;
 }
 
-ensureClientsReady();
 const versions = loadVersions();
+ensureClientsReady(versions);
 const results = await runPool(versions);
 
 results.sort(
-  (a, b) => versions.findIndex((v) => v.version === a.version) - versions.findIndex((v) => v.version === b.version)
+  (a, b) =>
+    versions.findIndex((v) => v.version === a.version) -
+    versions.findIndex((v) => v.version === b.version),
 );
 
 const failures = results.filter((r) => !r.ok);

--- a/tests/ts-compat/run.mjs
+++ b/tests/ts-compat/run.mjs
@@ -52,30 +52,11 @@ const CLIENTS = [
   "@aws-sdk/client-s3",
 ];
 
-// Clients expose downleveled declarations for older compilers via a package.json
-// `typesVersions` entry ("<4.5" -> dist-types/ts3.4/*). Any version we test below
-// 4.5 therefore resolves to dist-types/ts3.4, which must be generated separately
-// from the primary dist-types (client script: build:types:downlevel).
-const DOWNLEVEL_BOUNDARY = 4.5;
-
-/**
- * Parse a bare minor spec (e.g. "3.4", "4.10") into a comparable number.
- * @param {string} version
- * @returns {number}
- */
-function minorValue(version) {
-  const [major, minor = "0"] = version.split(".");
-  return Number(major) + Number(minor) / 1000;
-}
-
 /**
  * Ensure the workspace clients are installed and built (dist-types present).
  * The clients are consumed via file: links, so their .d.ts must exist on disk.
- * When any version below 4.5 is under test, the downleveled dist-types/ts3.4
- * declarations must also be present.
- * @param {{ version: string }[]} versions
  */
-function ensureClientsReady(versions) {
+function ensureClientsReady() {
   if (!existsSync(path.join(root, "node_modules"))) {
     console.log("Installing fixture dependencies (clients) ...");
     execFileSync("npm", ["install", "--no-audit", "--no-fund"], {
@@ -104,35 +85,6 @@ function ensureClientsReady(versions) {
         `    -F=@aws-sdk/client-sts -F=@aws-sdk/client-ec2 -F=@aws-sdk/client-lambda -F=@aws-sdk/client-s3\n`,
     );
     process.exit(1);
-  }
-
-  const needsDownlevel = versions.some(
-    (v) => minorValue(v.version) < DOWNLEVEL_BOUNDARY,
-  );
-  if (needsDownlevel) {
-    const missingDownlevel = CLIENTS.filter(
-      (name) =>
-        !existsSync(
-          path.join(
-            root,
-            "node_modules",
-            ...name.split("/"),
-            "dist-types",
-            "ts3.4",
-            "index.d.ts",
-          ),
-        ),
-    );
-    if (missingDownlevel.length > 0) {
-      console.error(
-        `\nTesting TypeScript < ${DOWNLEVEL_BOUNDARY} requires the downleveled ts3.4 declarations, ` +
-          `which are missing for: ${missingDownlevel.join(", ")}.\n` +
-          `Generate them from each client directory, e.g.:\n` +
-          `  yarn build:types:downlevel\n` +
-          `or build the clients including the downlevel step before running this suite.\n`,
-      );
-      process.exit(1);
-    }
   }
 }
 
@@ -183,8 +135,8 @@ async function runPool(versions) {
   return results;
 }
 
+ensureClientsReady();
 const versions = loadVersions();
-ensureClientsReady(versions);
 const results = await runPool(versions);
 
 results.sort(

--- a/tests/ts-compat/run.mjs
+++ b/tests/ts-compat/run.mjs
@@ -43,15 +43,6 @@ function loadVersions() {
   return specs.map(({ version, tscArgs = [] }) => ({ version, tscArgs }));
 }
 
-const CLIENTS = [
-  "@aws-sdk/client-dynamodb",
-  "@aws-sdk/client-cloudwatch-logs",
-  "@aws-sdk/client-sts",
-  "@aws-sdk/client-ec2",
-  "@aws-sdk/client-lambda",
-  "@aws-sdk/client-s3",
-];
-
 /**
  * Ensure the workspace clients are installed and built (dist-types present).
  * The clients are consumed via file: links, so their .d.ts must exist on disk.
@@ -65,7 +56,15 @@ function ensureClientsReady() {
     });
   }
 
-  const missing = CLIENTS.filter(
+  const clients = [
+    "@aws-sdk/client-dynamodb",
+    "@aws-sdk/client-cloudwatch-logs",
+    "@aws-sdk/client-sts",
+    "@aws-sdk/client-ec2",
+    "@aws-sdk/client-lambda",
+    "@aws-sdk/client-s3",
+  ];
+  const missing = clients.filter(
     (name) =>
       !existsSync(
         path.join(

--- a/tests/ts-compat/tsconfig.json
+++ b/tests/ts-compat/tsconfig.json
@@ -7,7 +7,12 @@
     "target": "es2018",
     "module": "commonjs",
     "moduleResolution": "node",
-    "lib": ["es2020", "dom"],
+    // es2019 is the newest lib value accepted by every version under test:
+    // TypeScript 3.4 rejects "es2020" at config-parse time (TS6046) and that
+    // error can't be overridden via command-line tscArgs, so the base value
+    // must be valid down to 3.4. es2019 covers everything the fixture and the
+    // clients' (downleveled) .d.ts need.
+    "lib": ["es2019", "dom"],
     // types:[] keeps @types/node out of the program. The fixture uses no Node
     // APIs, and no single @types/node version parses across all the TypeScript
     // versions under test.

--- a/tests/ts-compat/typescript-versions.json
+++ b/tests/ts-compat/typescript-versions.json
@@ -1,4 +1,15 @@
 [
+  { "version": "3.4" },
+  { "version": "3.5" },
+  { "version": "3.6" },
+  { "version": "3.7" },
+  { "version": "3.8" },
+  { "version": "3.9" },
+  { "version": "4.0" },
+  { "version": "4.1" },
+  { "version": "4.2" },
+  { "version": "4.3" },
+  { "version": "4.4" },
   { "version": "4.5" },
   { "version": "4.6" },
   { "version": "4.7" },
@@ -15,5 +26,8 @@
   { "version": "5.8" },
   { "version": "5.9" },
   { "version": "6.0", "tscArgs": ["--ignoreDeprecations", "6.0"] },
-  { "version": "7.0", "tscArgs": ["--moduleResolution", "bundler", "--module", "preserve"] }
+  {
+    "version": "7.0",
+    "tscArgs": ["--moduleResolution", "bundler", "--module", "preserve"]
+  }
 ]


### PR DESCRIPTION
### Issue

Internal JS-7050

### Description

Add TypeScript 3.4 through 4.4 to the compatibility matrix so the suite
now guards the full supported range (3.4 -> 7.0).

Versions below 4.5 resolve client types to the downleveled
dist-types/ts3.4 declarations via each client's typesVersions "<4.5"
entry, so run.mjs now fails early with guidance when those declarations
are missing for a sub-4.5 version under test.

Change the base tsconfig lib from es2020 to es2019: TypeScript 3.4
rejects es2020 at config-parse time (TS6046) and that error cannot be
overridden by per-version tscArgs. es2019 is accepted by every version
under test and covers everything the fixture and downleveled .d.ts need.

### Testing

```console
$ aws-sdk-js-v3> time make test-typescript-versions
(cd ./tests/ts-compat && npm install --no-audit --no-fund && node ./run.mjs)

up to date in 381ms

============================================================
TypeScript compatibility summary
============================================================
  PASS  typescript@3.4
  PASS  typescript@3.5
  PASS  typescript@3.6
  PASS  typescript@3.7
  PASS  typescript@3.8
  PASS  typescript@3.9
  PASS  typescript@4.0
  PASS  typescript@4.1
  PASS  typescript@4.2
  PASS  typescript@4.3
  PASS  typescript@4.4
  PASS  typescript@4.5
  PASS  typescript@4.6
  PASS  typescript@4.7
  PASS  typescript@4.8
  PASS  typescript@4.9
  PASS  typescript@5.0
  PASS  typescript@5.1
  PASS  typescript@5.2
  PASS  typescript@5.3
  PASS  typescript@5.4
  PASS  typescript@5.5
  PASS  typescript@5.6
  PASS  typescript@5.7
  PASS  typescript@5.8
  PASS  typescript@5.9
  PASS  typescript@6.0
  PASS  typescript@7.0
make test-typescript-versions  132.71s user 14.92s system 1408% cpu 10.482 total
```

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
