### PR TITLE
test(middleware-sdk-route53): loosen date in path assertion

### DIFF
--- a/packages-internal/middleware-sdk-route53/src/middleware-sdk-route53.integ.spec.ts
+++ b/packages-internal/middleware-sdk-route53/src/middleware-sdk-route53.integ.spec.ts
@@ -49,7 +49,7 @@ describe("middleware-sdk-route53", () => {
       });
 
       requireRequestsFrom(client).toMatch({
-        path: "/2013-04-01/change/my-change",
+        path: /^\/20\d\d-\d\d-\d\d\/change\/my\-change$/,
       });
 
       await client.getChange({


### PR DESCRIPTION
### Issue
n/a

### Description
loosen path assertion in Route53 integ test.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
