### PR TITLE
chore(core/protocols): JSON serde consistency testing and perf tuning

### DIFF
--- a/.github/workflows/fuzz-testing.yml
+++ b/.github/workflows/fuzz-testing.yml
@@ -52,12 +52,11 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        working-directory: packages-internal/xml-builder
         run: yarn install
 
       - name: Build parser
         working-directory: packages-internal/xml-builder
-        run: yarn build:cjs
+        run: yarn build
 
       - name: Restore fuzz corpus
         uses: actions/cache/restore@v4

--- a/packages-internal/core/scripts/benchmark-json-serializer.ts
+++ b/packages-internal/core/scripts/benchmark-json-serializer.ts
@@ -32,6 +32,8 @@ import { ByteJsonShapeSerializer } from "../src/submodules/protocols/json/experi
 import { BufferJsonShapeDeserializer } from "../src/submodules/protocols/json/experimental/BufferJsonShapeDeserializer";
 import { JsonShapeDeserializer } from "../src/submodules/protocols/json/JsonShapeDeserializer";
 import { JsonShapeSerializer } from "../src/submodules/protocols/json/JsonShapeSerializer";
+import { AttributeValue$ } from "../../../clients/client-dynamodb/src/schemas/schemas_0";
+import { DynamoDBJsonCodec } from "../../../packages-internal/dynamodb-codec/src/index";
 
 // ─── Schemas ─────────────────────────────────────────────────────────────────
 
@@ -193,7 +195,14 @@ function createDdbItem(targetBytes = 65536) {
   return item;
 }
 
-const ddbItemSchema = 15; // DocumentSchema — DDB items are untyped document shapes
+const ddbItemSchema: any = [
+  3,
+  "",
+  "GetItemOutput",
+  0,
+  ["Item"],
+  [[2, "", "AttributeMap", 0, 0, () => AttributeValue$]],
+];
 
 // ─── Scenario definitions ────────────────────────────────────────────────────
 
@@ -264,9 +273,9 @@ function getScenarios(): Scenario[] {
     });
   }
 
-  // DDB-like items (document schema, realistic shape)
+  // DDB-like items (typed AttributeValue schema, realistic shape)
   for (const kb of [4, 16, 64]) {
-    const data = createDdbItem(kb * 1024);
+    const data = { Item: createDdbItem(kb * 1024) };
     scenarios.push({
       name: `ddb item ~${kb}KB`,
       schema: ddbItemSchema,
@@ -375,6 +384,117 @@ async function runDeserVariant(variant: DeserVariant): Promise<BenchResult[]> {
   return results;
 }
 
+// ─── DynamoDB codec benchmark runner ─────────────────────────────────────────
+
+function getDdbScenarios(): Scenario[] {
+  const scenarios: Scenario[] = [];
+  for (const kb of [4, 16, 64]) {
+    const data = { Item: createDdbItem(kb * 1024) };
+    scenarios.push({
+      name: `ddb item ~${kb}KB`,
+      schema: ddbItemSchema,
+      data,
+      iterations: kb > 16 ? 50 : 200,
+    });
+  }
+  return scenarios;
+}
+
+type DdbVariant =
+  | "ddb-multipass"
+  | "ddb-byte"
+  | "ddb-codec-ser"
+  | "ddb-codec-deser"
+  | "ddb-deser-original"
+  | "ddb-deser-buffer";
+
+function runDdbSerVariant(variant: "ddb-multipass" | "ddb-byte" | "ddb-codec-ser"): BenchResult[] {
+  const settings = {
+    jsonName: true,
+    timestampFormat: { default: 7 satisfies TimestampEpochSecondsSchema, useTrait: true },
+  };
+
+  let serializer: any;
+  if (variant === "ddb-codec-ser") {
+    const codec = new DynamoDBJsonCodec();
+    codec.setSerdeContext({ base64Encoder: (input: Uint8Array) => Buffer.from(input).toString("base64") } as any);
+    serializer = codec.createSerializer();
+  } else if (variant === "ddb-byte") {
+    serializer = new ByteJsonShapeSerializer(settings);
+  } else {
+    serializer = new JsonShapeSerializer(settings);
+  }
+
+  const scenarios = getDdbScenarios();
+  const results: BenchResult[] = [];
+
+  for (const { name, schema, data, iterations } of scenarios) {
+    for (let i = 0; i < Math.min(iterations, 50); i++) {
+      serializer.write(schema, data);
+      serializer.flush();
+    }
+
+    const start = performance.now();
+    let size = 0;
+    for (let i = 0; i < iterations; i++) {
+      serializer.write(schema, data);
+      const r = serializer.flush();
+      size = r instanceof Uint8Array ? r.byteLength : r.length;
+    }
+    const elapsed = performance.now() - start;
+    const kbPerMs = (size * iterations) / 1024 / elapsed;
+    results.push({ name, ms: elapsed / iterations, kbPerMs, size });
+  }
+
+  return results;
+}
+
+async function runDdbDeserVariant(
+  variant: "ddb-deser-original" | "ddb-deser-buffer" | "ddb-codec-deser"
+): Promise<BenchResult[]> {
+  const settings = {
+    jsonName: true,
+    timestampFormat: { default: 7 satisfies TimestampEpochSecondsSchema, useTrait: true },
+  };
+
+  const refSerializer = new JsonShapeSerializer(settings);
+  refSerializer.setSerdeContext({ base64Encoder: (input: Uint8Array) => Buffer.from(input).toString("base64") } as any);
+
+  let deserializer: any;
+  if (variant === "ddb-codec-deser") {
+    const codec = new DynamoDBJsonCodec();
+    codec.setSerdeContext({ base64Decoder: (input: string) => Buffer.from(input, "base64") } as any);
+    deserializer = codec.createDeserializer();
+  } else if (variant === "ddb-deser-buffer") {
+    deserializer = new BufferJsonShapeDeserializer(settings);
+  } else {
+    deserializer = new JsonShapeDeserializer(settings);
+  }
+
+  const scenarios = getDdbScenarios();
+  const results: BenchResult[] = [];
+
+  for (const { name, schema, data, iterations } of scenarios) {
+    refSerializer.write(schema, data);
+    const jsonString = refSerializer.flush() as string;
+    const size = jsonString.length;
+
+    for (let i = 0; i < Math.min(iterations, 50); ++i) {
+      await deserializer.read(schema, jsonString);
+    }
+
+    const start = performance.now();
+    for (let i = 0; i < iterations; ++i) {
+      await deserializer.read(schema, jsonString);
+    }
+    const elapsed = performance.now() - start;
+    const kbPerMs = (size * iterations) / 1024 / elapsed;
+    results.push({ name, ms: elapsed / iterations, kbPerMs, size });
+  }
+
+  return results;
+}
+
 function getDeserScenarios(): Scenario[] {
   const scenarios: Scenario[] = [];
 
@@ -417,9 +537,9 @@ function getDeserScenarios(): Scenario[] {
     iterations: 5000,
   });
 
-  // DDB-like items (document schema, realistic shape)
+  // DDB-like items (typed AttributeValue schema, realistic shape)
   for (const kb of [4, 16, 64]) {
-    const data = createDdbItem(kb * 1024);
+    const data = { Item: createDdbItem(kb * 1024) };
     scenarios.push({
       name: `ddb item ~${kb}KB`,
       schema: ddbItemSchema,
@@ -437,8 +557,15 @@ const variantArg = process.argv.find((a) => a.startsWith("--variant="));
 
 if (variantArg) {
   // Child process mode: run one variant, output JSON
-  const variant = variantArg.split("=")[1] as "multipass" | "byte" | DeserVariant;
-  if (variant.startsWith("deser-")) {
+  const variant = variantArg.split("=")[1] as string;
+  if (variant.startsWith("ddb-deser") || variant === "ddb-codec-deser") {
+    runDdbDeserVariant(variant as any).then((results) => {
+      process.stdout.write(JSON.stringify(results));
+    });
+  } else if (variant.startsWith("ddb-")) {
+    const results = runDdbSerVariant(variant as any);
+    process.stdout.write(JSON.stringify(results));
+  } else if (variant.startsWith("deser-")) {
     runDeserVariant(variant as DeserVariant).then((results) => {
       process.stdout.write(JSON.stringify(results));
     });
@@ -554,4 +681,108 @@ if (variantArg) {
   console.log();
   console.log("Δ str   = buffer (string input) speed improvement over original (positive = faster)");
   console.log("Δ bytes = buffer (Uint8Array input) speed improvement over original (positive = faster)");
+
+  // ─── DynamoDB codec benchmark ───────────────────────────────────────────────
+
+  console.log();
+  console.log();
+  console.log("DynamoDB Serializer Benchmark (isolated processes)");
+  console.log("═".repeat(110));
+  console.log();
+
+  process.stdout.write("Running DDB multipass serializer...     ");
+  const ddbMultipassResults = runChild("ddb-multipass");
+  console.log("done.");
+
+  process.stdout.write("Running DDB byte serializer...          ");
+  const ddbByteResults = runChild("ddb-byte");
+  console.log("done.");
+
+  process.stdout.write("Running DDB codec serializer...         ");
+  const ddbCodecSerResults = runChild("ddb-codec-ser");
+  console.log("done.");
+  console.log();
+
+  const ddbSerHeader = `${col("Scenario", 20)} │ ${colR("Size", 8)} │ ${colR("Multipass", 12)} │ ${colR("Byte", 12)} │ ${colR("DDB Codec", 12)} │ ${colR("Byte vs MP", 10)} │ ${colR("Codec vs MP", 11)}`;
+  console.log(ddbSerHeader);
+  console.log(
+    "─".repeat(20) +
+      "─┼─" +
+      "─".repeat(8) +
+      "─┼─" +
+      "─".repeat(12) +
+      "─┼─" +
+      "─".repeat(12) +
+      "─┼─" +
+      "─".repeat(12) +
+      "─┼─" +
+      "─".repeat(10) +
+      "─┼─" +
+      "─".repeat(11)
+  );
+
+  for (let i = 0; i < ddbMultipassResults.length; i++) {
+    const mp = ddbMultipassResults[i];
+    const bp = ddbByteResults[i];
+    const codec = ddbCodecSerResults[i];
+    const size = mp.size < 1024 ? `${mp.size} B` : `${(mp.size / 1024).toFixed(1)} KB`;
+    const byteVsMp = ((mp.ms - bp.ms) / mp.ms) * 100;
+    const codecVsMp = ((mp.ms - codec.ms) / mp.ms) * 100;
+    console.log(
+      `${col(mp.name, 20)} │ ${colR(size, 8)} │ ${colR(`${mp.kbPerMs.toFixed(1)} kb/ms`, 12)} │ ${colR(`${bp.kbPerMs.toFixed(1)} kb/ms`, 12)} │ ${colR(`${codec.kbPerMs.toFixed(1)} kb/ms`, 12)} │ ${colR(`${byteVsMp > 0 ? "+" : ""}${byteVsMp.toFixed(1)}%`, 10)} │ ${colR(`${codecVsMp > 0 ? "+" : ""}${codecVsMp.toFixed(1)}%`, 11)}`
+    );
+  }
+
+  console.log();
+  console.log();
+  console.log("DynamoDB Deserializer Benchmark (isolated processes)");
+  console.log("═".repeat(110));
+  console.log();
+
+  process.stdout.write("Running DDB original deserializer...    ");
+  const ddbDeserOrigResults = runChild("ddb-deser-original");
+  console.log("done.");
+
+  process.stdout.write("Running DDB buffer deserializer...      ");
+  const ddbDeserBufResults = runChild("ddb-deser-buffer");
+  console.log("done.");
+
+  process.stdout.write("Running DDB codec deserializer...       ");
+  const ddbCodecDeserResults = runChild("ddb-codec-deser");
+  console.log("done.");
+  console.log();
+
+  const ddbDeserHeader = `${col("Scenario", 20)} │ ${colR("Size", 8)} │ ${colR("Original", 12)} │ ${colR("Buffer", 12)} │ ${colR("DDB Codec", 12)} │ ${colR("Buf vs Orig", 11)} │ ${colR("Codec vs Orig", 13)}`;
+  console.log(ddbDeserHeader);
+  console.log(
+    "─".repeat(20) +
+      "─┼─" +
+      "─".repeat(8) +
+      "─┼─" +
+      "─".repeat(12) +
+      "─┼─" +
+      "─".repeat(12) +
+      "─┼─" +
+      "─".repeat(12) +
+      "─┼─" +
+      "─".repeat(11) +
+      "─┼─" +
+      "─".repeat(13)
+  );
+
+  for (let i = 0; i < ddbDeserOrigResults.length; i++) {
+    const orig = ddbDeserOrigResults[i];
+    const buf = ddbDeserBufResults[i];
+    const codec = ddbCodecDeserResults[i];
+    const size = orig.size < 1024 ? `${orig.size} B` : `${(orig.size / 1024).toFixed(1)} KB`;
+    const bufVsOrig = ((orig.ms - buf.ms) / orig.ms) * 100;
+    const codecVsOrig = ((orig.ms - codec.ms) / orig.ms) * 100;
+    console.log(
+      `${col(orig.name, 20)} │ ${colR(size, 8)} │ ${colR(`${orig.kbPerMs.toFixed(1)} kb/ms`, 12)} │ ${colR(`${buf.kbPerMs.toFixed(1)} kb/ms`, 12)} │ ${colR(`${codec.kbPerMs.toFixed(1)} kb/ms`, 12)} │ ${colR(`${bufVsOrig > 0 ? "+" : ""}${bufVsOrig.toFixed(1)}%`, 11)} │ ${colR(`${codecVsOrig > 0 ? "+" : ""}${codecVsOrig.toFixed(1)}%`, 13)}`
+    );
+  }
+
+  console.log();
+  console.log("Buf vs Orig   = BufferJsonShapeDeserializer speed improvement over original (positive = faster)");
+  console.log("Codec vs Orig = DynamoDBJsonCodec deserializer speed improvement over original (positive = faster)");
 }

--- a/packages-internal/core/src/submodules/protocols/json/JsonShapeDeserializer.ts
+++ b/packages-internal/core/src/submodules/protocols/json/JsonShapeDeserializer.ts
@@ -21,6 +21,7 @@ import { SerdeContextConfig } from "../ConfigurableSerdeContext";
 import { UnionSerde } from "../UnionSerde";
 import type { JsonSettings } from "./JsonCodec";
 import { jsonReviver } from "./jsonReviver";
+import { needsReviver } from "./needsReviver";
 import { parseJsonBody } from "./parseJsonBody";
 import { writeKey } from "../writeKey";
 
@@ -33,9 +34,10 @@ export class JsonShapeDeserializer extends SerdeContextConfig implements ShapeDe
   }
 
   public async read(schema: Schema, data: string | Uint8Array | unknown): Promise<any> {
+    const reviver = needsReviver(schema) ? jsonReviver : undefined;
     return this._read(
       schema,
-      typeof data === "string" ? JSON.parse(data, jsonReviver) : await parseJsonBody(data, this.serdeContext!)
+      typeof data === "string" ? JSON.parse(data, reviver) : await parseJsonBody(data, this.serdeContext!, schema)
     );
   }
 

--- a/packages-internal/core/src/submodules/protocols/json/JsonShapeDeserializer.ts
+++ b/packages-internal/core/src/submodules/protocols/json/JsonShapeDeserializer.ts
@@ -22,6 +22,7 @@ import { UnionSerde } from "../UnionSerde";
 import type { JsonSettings } from "./JsonCodec";
 import { jsonReviver } from "./jsonReviver";
 import { parseJsonBody } from "./parseJsonBody";
+import { writeKey } from "../writeKey";
 
 /**
  * @public
@@ -103,6 +104,9 @@ export class JsonShapeDeserializer extends SerdeContextConfig implements ShapeDe
         const mapMember = ns.getValueSchema();
         const out = {} as any;
         for (const _k in value) {
+          if (_k === "__proto__") {
+            writeKey(out);
+          }
           out[_k] = this._read(mapMember, (value as Record<string, unknown>)[_k]);
         }
         return out;
@@ -168,6 +172,9 @@ export class JsonShapeDeserializer extends SerdeContextConfig implements ShapeDe
       if (isObject) {
         const out = Array.isArray(value) ? [] : ({} as any);
         for (const k in value) {
+          if (k === "__proto__") {
+            writeKey(out);
+          }
           const v = (value as Record<string, unknown>)[k];
           if (v instanceof NumericValue) {
             out[k] = v;

--- a/packages-internal/core/src/submodules/protocols/json/JsonShapeSerializer.ts
+++ b/packages-internal/core/src/submodules/protocols/json/JsonShapeSerializer.ts
@@ -13,6 +13,7 @@ import type {
 import { SerdeContextConfig } from "../ConfigurableSerdeContext";
 import type { JsonSettings } from "./JsonCodec";
 import { JsonReplacer } from "./jsonReplacer";
+import { writeKey } from "../writeKey";
 
 /**
  * @public
@@ -96,6 +97,9 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
           const { $unknown } = record;
           if (Array.isArray($unknown)) {
             const [k, v] = $unknown;
+            if (k === "__proto__") {
+              writeKey(out);
+            }
             out[k] = this._write(15 satisfies DocumentSchema, v);
           }
         } else if (typeof record.__type === "string") {
@@ -132,6 +136,9 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
         for (const _k in value as Record<string, unknown>) {
           const _v = (value as Record<string, unknown>)[_k];
           if (sparse || _v != null) {
+            if (_k === "__proto__") {
+              writeKey(out);
+            }
             out[_k] = this._write(mapMember, _v);
           }
         }
@@ -208,6 +215,9 @@ export class JsonShapeSerializer extends SerdeContextConfig implements ShapeSeri
         const out = Array.isArray(value) ? [] : ({} as any);
         for (const k in value as Record<string, unknown>) {
           const v = (value as Record<string, unknown>)[k];
+          if (k === "__proto__") {
+            writeKey(out);
+          }
           if (v instanceof NumericValue) {
             this.useReplacer = true;
             out[k] = v;

--- a/packages-internal/core/src/submodules/protocols/json/detectBufferParsing.ts
+++ b/packages-internal/core/src/submodules/protocols/json/detectBufferParsing.ts
@@ -1,0 +1,22 @@
+/**
+ * One-time detection: can JSON.parse accept a Buffer directly?
+ * Node.js 22+ supports this, browsers and older runtimes do not.
+ * @internal
+ */
+let canParseBuffer: boolean | undefined;
+
+export function detectBufferParsing(): boolean {
+  if (canParseBuffer === undefined) {
+    try {
+      if (typeof Buffer !== "function") {
+        canParseBuffer = false;
+      } else {
+        const result = JSON.parse(Buffer.from([0x7b, 0x7d]) as any);
+        canParseBuffer = result !== null && typeof result === "object";
+      }
+    } catch {
+      canParseBuffer = false;
+    }
+  }
+  return canParseBuffer;
+}

--- a/packages-internal/core/src/submodules/protocols/json/experimental/BufferJsonShapeDeserializer.ts
+++ b/packages-internal/core/src/submodules/protocols/json/experimental/BufferJsonShapeDeserializer.ts
@@ -19,28 +19,12 @@ import type {
 
 import { SerdeContextConfig } from "../../ConfigurableSerdeContext";
 import { UnionSerde } from "../../UnionSerde";
+import { detectBufferParsing } from "../detectBufferParsing";
 import type { JsonSettings } from "../JsonCodec";
 import { jsonReviver } from "../jsonReviver";
+import { needsReviver } from "../needsReviver";
 import { parseJsonBody } from "../parseJsonBody";
-
-/**
- * One-time detection: can JSON.parse accept a Uint8Array/Buffer directly?
- * Node.js 22+ supports this, browsers and older runtimes do not.
- */
-let canParseBuffer: boolean | undefined;
-
-function detectBufferParsing(): boolean {
-  if (canParseBuffer === undefined) {
-    try {
-      // 0x7b 0x7d = "{}"
-      const result = JSON.parse(new Uint8Array([0x7b, 0x7d]) as any);
-      canParseBuffer = result !== null && typeof result === "object";
-    } catch {
-      canParseBuffer = false;
-    }
-  }
-  return canParseBuffer;
-}
+import { writeKey } from "../../writeKey";
 
 /**
  * Performance-optimized JSON deserializer.
@@ -66,12 +50,14 @@ export class BufferJsonShapeDeserializer extends SerdeContextConfig implements S
   }
 
   public async read(schema: Schema, data: string | Uint8Array | unknown): Promise<any> {
+    const reviver = needsReviver(schema) ? jsonReviver : undefined;
     let parsed: unknown;
     if (typeof data === "string") {
-      parsed = JSON.parse(data, jsonReviver);
+      parsed = JSON.parse(data, reviver);
     } else if (data instanceof Uint8Array && detectBufferParsing()) {
-      // Fast path: skip UTF-8 decode, parse bytes directly.
-      parsed = JSON.parse(data as any, jsonReviver);
+      // detectBufferParsing() guarantees Buffer exists globally.
+      const buf = Buffer.isBuffer(data) ? data : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+      parsed = JSON.parse(buf as any, reviver);
     } else {
       // Fallback: collect stream to string, then parse.
       parsed = await parseJsonBody(data, this.serdeContext!);
@@ -103,6 +89,9 @@ export class BufferJsonShapeDeserializer extends SerdeContextConfig implements S
         const mapMember = ns.getValueSchema();
         const map = value as Record<string, unknown>;
         for (const k in map) {
+          if (k === "__proto__") {
+            writeKey(map);
+          }
           map[k] = this._read(mapMember, map[k]);
         }
         return map;
@@ -177,6 +166,9 @@ export class BufferJsonShapeDeserializer extends SerdeContextConfig implements S
         } else {
           const doc = value as Record<string, unknown>;
           for (const k in doc) {
+            if (k === "__proto__") {
+              writeKey(doc);
+            }
             const v = doc[k];
             if (!(v instanceof NumericValue)) {
               doc[k] = this._read(ns, v);

--- a/packages-internal/core/src/submodules/protocols/json/experimental/ByteJsonShapeSerializer.ts
+++ b/packages-internal/core/src/submodules/protocols/json/experimental/ByteJsonShapeSerializer.ts
@@ -12,6 +12,7 @@ import type {
 
 import { SerdeContextConfig } from "../../ConfigurableSerdeContext";
 import type { JsonSettings } from "../JsonCodec";
+import { writeKey } from "../../writeKey";
 
 const encoder = new TextEncoder();
 
@@ -210,11 +211,10 @@ export class ByteJsonShapeSerializer extends SerdeContextConfig implements Shape
         // ASCII range — check if it needs escaping
         const esc = ESCAPE_TABLE[c];
         if (esc !== null) {
-          // Write back before potential ensure
           this.ensure(esc.length + 1);
           this.json[this.i++] = BACKSLASH;
-          for (let j = 0; j < esc.length; j++) {
-            this.json[this.i++] = esc.charCodeAt(j);
+          for (let k = 0; k < esc.length; k++) {
+            this.json[this.i++] = esc.charCodeAt(k);
           }
         } else {
           this.json[this.i++] = c;
@@ -539,10 +539,37 @@ export class ByteJsonShapeSerializer extends SerdeContextConfig implements Shape
   }
 
   private writeMap(ns: NormalizedSchema, value: Record<string, unknown>, isDocument?: boolean): void {
-    this.ensure(2);
-    this.json[this.i++] = OPEN_BRACE;
     const sparse = !!ns.getMergedTraits().sparse;
     const valueSchema = ns.getValueSchema();
+
+    // Fast path: when value type is a JSON-native primitive (string, number, boolean),
+    // delegate the entire map to JSON.stringify + encodeInto.
+    // This leverages V8's native C++ string escaping which is significantly faster than
+    // character-by-character escaping in JS for string-heavy maps.
+    if (!isDocument) {
+      if (valueSchema.isStringSchema() || valueSchema.isNumericSchema() || valueSchema.isBooleanSchema()) {
+        // For sparse maps, JSON.stringify omits undefined values instead of writing null.
+        // Convert undefined → null to match production serializer behavior.
+        let input: Record<string, unknown> = value;
+        if (sparse) {
+          input = {};
+          for (const k in value) {
+            if (k === "__proto__") {
+              writeKey(input);
+            }
+            input[k] = value[k] ?? null;
+          }
+        }
+        const json = JSON.stringify(input);
+        this.ensure(json.length * 3); // worst-case UTF-8 expansion
+        const { written } = encoder.encodeInto(json, this.json.subarray(this.i));
+        this.i += written!;
+        return;
+      }
+    }
+
+    this.ensure(2);
+    this.json[this.i++] = OPEN_BRACE;
     let first = true;
 
     for (const k in value) {

--- a/packages-internal/core/src/submodules/protocols/json/json-serde.fuzz.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/json-serde.fuzz.spec.ts
@@ -1,0 +1,701 @@
+import fc from "fast-check";
+import { NumericValue } from "@smithy/core/serde";
+import type {
+  BlobSchema,
+  BigDecimalSchema,
+  BigIntegerSchema,
+  BooleanSchema,
+  DocumentSchema,
+  NumericSchema,
+  StaticListSchema,
+  StaticStructureSchema,
+  StaticUnionSchema,
+  StringSchema,
+  TimestampDefaultSchema,
+  TimestampEpochSecondsSchema,
+  TimestampDateTimeSchema,
+  TimestampHttpDateSchema,
+} from "@smithy/types";
+import { describe, expect, it } from "vitest";
+
+import { ByteJsonShapeSerializer } from "./experimental/ByteJsonShapeSerializer";
+import { BufferJsonShapeDeserializer } from "./experimental/BufferJsonShapeDeserializer";
+import { JsonShapeDeserializer } from "./JsonShapeDeserializer";
+import { JsonShapeSerializer } from "./JsonShapeSerializer";
+
+// ─── Settings ────────────────────────────────────────────────────────────────
+
+const settings = {
+  jsonName: true,
+  timestampFormat: { default: 7 satisfies TimestampEpochSecondsSchema, useTrait: true },
+} as const;
+
+// ─── Production (reference) implementations ──────────────────────────────────
+
+const refSerializer = new JsonShapeSerializer(settings);
+const refDeserializer = new JsonShapeDeserializer(settings);
+
+// ─── Experimental (candidate) implementations ────────────────────────────────
+
+const byteSerializer = new ByteJsonShapeSerializer(settings);
+const bufferDeserializer = new BufferJsonShapeDeserializer(settings);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const decoder = new TextDecoder();
+
+function serializeRef(schema: any, data: unknown): string {
+  refSerializer.write(schema, data);
+  return refSerializer.flush();
+}
+
+function serializeByte(schema: any, data: unknown): string {
+  byteSerializer.write(schema, data);
+  return decoder.decode(byteSerializer.flush());
+}
+
+async function deserializeRef(schema: any, json: string): Promise<unknown> {
+  return refDeserializer.read(schema, json);
+}
+
+async function deserializeBuffer(schema: any, json: string): Promise<unknown> {
+  return bufferDeserializer.read(schema, json);
+}
+
+async function deserializeBufferBytes(schema: any, json: string): Promise<unknown> {
+  const bytes = new TextEncoder().encode(json);
+  return bufferDeserializer.read(schema, bytes);
+}
+
+// ─── Schemas ─────────────────────────────────────────────────────────────────
+
+const stringMapSchema = [3, "", "S", 0, ["tags"], [[2, "", "Map", 0, 0, 0]]] satisfies StaticStructureSchema;
+const numericMapSchema = [3, "", "S", 0, ["values"], [[2, "", "Map", 0, 0, 1]]] satisfies StaticStructureSchema;
+const booleanMapSchema = [3, "", "S", 0, ["flags"], [[2, "", "Map", 0, 0, 2]]] satisfies StaticStructureSchema;
+
+const sparseStringMapSchema = [
+  3,
+  "",
+  "S",
+  0,
+  ["tags"],
+  [[[2, "", "Map", 0, 0, 0], { sparse: 1 }]],
+] satisfies StaticStructureSchema;
+
+const listOfStringsSchema = [
+  3,
+  "",
+  "S",
+  0,
+  ["items"],
+  [[[1, "", "List", 0, 0] satisfies StaticListSchema, 0]],
+] satisfies StaticStructureSchema;
+
+const listOfNumbersSchema = [
+  3,
+  "",
+  "S",
+  0,
+  ["items"],
+  [[[1, "", "List", 0, 1] satisfies StaticListSchema, 0]],
+] satisfies StaticStructureSchema;
+
+const blobSchema = [3, "", "S", 0, ["data"], [21 satisfies BlobSchema]] satisfies StaticStructureSchema;
+
+const timestampSchema = [
+  3,
+  "",
+  "S",
+  0,
+  ["epochTs", "isoTs", "httpTs"],
+  [7 satisfies TimestampEpochSecondsSchema, 5 satisfies TimestampDateTimeSchema, 6 satisfies TimestampHttpDateSchema],
+] satisfies StaticStructureSchema;
+
+const bigNumberSchema = [
+  3,
+  "",
+  "S",
+  0,
+  ["bigint", "bigdecimal"],
+  [17 satisfies BigIntegerSchema, 19 satisfies BigDecimalSchema],
+] satisfies StaticStructureSchema;
+
+const nestingStruct: StaticStructureSchema = [
+  3,
+  "ns",
+  "Nested",
+  0,
+  ["str", "num", "bool", "list", "map", "nested"],
+  [
+    0 satisfies StringSchema,
+    1 satisfies NumericSchema,
+    2 satisfies BooleanSchema,
+    64 | 1,
+    128 | 0,
+    () => nestingStruct,
+  ],
+];
+
+const unionSchema = [
+  4,
+  "ns",
+  "MyUnion",
+  0,
+  ["strVal", "numVal", "boolVal"],
+  [0 satisfies StringSchema, 1 satisfies NumericSchema, 2 satisfies BooleanSchema],
+] satisfies StaticUnionSchema;
+
+const structWithUnion = [3, "ns", "S", 0, ["union"], [unionSchema]] satisfies StaticStructureSchema;
+
+const documentSchema = 15 satisfies DocumentSchema;
+const documentStructSchema = [3, "", "S", 0, ["doc"], [15 satisfies DocumentSchema]] satisfies StaticStructureSchema;
+
+const allTypesSchema: StaticStructureSchema = [
+  3,
+  "ns",
+  "AllTypes",
+  0,
+  ["str", "num", "bool", "blob", "ts", "bigint", "list", "map", "nested"],
+  [
+    0 satisfies StringSchema,
+    1 satisfies NumericSchema,
+    2 satisfies BooleanSchema,
+    21 satisfies BlobSchema,
+    7 satisfies TimestampEpochSecondsSchema,
+    17 satisfies BigIntegerSchema,
+    [1, "", "List", 0, 0] satisfies StaticListSchema,
+    [2, "", "Map", 0, 0, 0],
+    () => allTypesSchema,
+  ],
+] satisfies StaticStructureSchema;
+
+// ─── Arbitraries ─────────────────────────────────────────────────────────────
+
+/** Arbitrary string with varied characters including ones that need JSON escaping. */
+const jsonString = fc.oneof(
+  fc.string({ minLength: 0, maxLength: 100 }),
+  // Strings with control characters and special JSON chars
+  fc.string({
+    unit: fc.oneof(
+      fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".split("")),
+      fc.constantFrom('"', "\\", "\n", "\t", "\r", "\b", "\f", "\0"),
+      // Unicode chars
+      fc.constantFrom("\u00e9", "\u2603", "\ud83d\ude00", "\u0001", "\u001f")
+    ),
+    minLength: 0,
+    maxLength: 50,
+  }),
+  // ASCII-safe strings (common case)
+  fc.string({
+    unit: fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz0123456789-_.".split("")),
+    minLength: 0,
+    maxLength: 50,
+  })
+);
+
+/** Arbitrary safe map key. */
+const mapKey = fc
+  .oneof(
+    fc.string({ minLength: 1, maxLength: 30 }),
+    fc.string({
+      unit: fc.oneof(
+        fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz0123456789".split("")),
+        fc.constantFrom('"', "\\", "\n", "\t", "\r", "\0")
+      ),
+      minLength: 1,
+      maxLength: 20,
+    })
+    // __proto__ is excluded because fc.dictionary assigns keys via normal property
+    // assignment, which triggers the __proto__ setter instead of creating an own
+    // property. This makes the test data itself inconsistent. The __proto__ handling
+    // is covered by dedicated unit tests instead.
+  )
+  .filter((k) => k !== "__proto__");
+
+/** Arbitrary number that's JSON-safe (no Infinity, no NaN for basic tests). */
+const jsonNumber = fc.oneof(
+  fc.integer(),
+  fc.double({ noNaN: true, noDefaultInfinity: true, min: -1e15, max: 1e15 }),
+  fc.constantFrom(0, -0, 1, -1, 0.1, -0.1, 1e10, -1e10)
+);
+
+/** Arbitrary map with string values. */
+const stringMap = fc.dictionary(mapKey, jsonString, { minKeys: 0, maxKeys: 50 });
+
+/** Arbitrary map with numeric values. */
+const numericMap = fc.dictionary(mapKey, jsonNumber, { minKeys: 0, maxKeys: 50 });
+
+/** Arbitrary map with boolean values. */
+const booleanMap = fc.dictionary(mapKey, fc.boolean(), { minKeys: 0, maxKeys: 50 });
+
+/** Arbitrary sparse map (string values, some nulls). */
+const sparseStringMap = fc.dictionary(mapKey, fc.option(jsonString, { nil: null }), { minKeys: 0, maxKeys: 50 });
+
+/** Arbitrary Uint8Array for blob testing. */
+const blob = fc.uint8Array({ minLength: 0, maxLength: 512 });
+
+/** Arbitrary Date for timestamp testing (only valid dates). */
+const timestamp = fc
+  .date({ min: new Date("1970-01-01"), max: new Date("2100-01-01") })
+  .filter((d) => !isNaN(d.getTime()));
+
+/** Arbitrary bigint. */
+const bigint = fc.bigInt({ min: -10000000000000000000000000000n, max: 10000000000000000000000000000n });
+
+/**
+ * Arbitrary bigint that stays within JSON.parse precision bounds.
+ * Used for deserialization tests where the reference uses JSON.parse
+ * which loses precision beyond Number.MAX_SAFE_INTEGER.
+ */
+const safeBigint = fc.bigInt({ min: -9007199254740991n, max: 9007199254740991n });
+
+/** Arbitrary nested struct (recursive). */
+const nestedStruct: fc.Arbitrary<any> = fc.letrec((tie) => ({
+  struct: fc.record(
+    {
+      str: fc.option(jsonString, { nil: undefined }),
+      num: fc.option(jsonNumber, { nil: undefined }),
+      bool: fc.option(fc.boolean(), { nil: undefined }),
+      list: fc.option(fc.array(jsonNumber, { minLength: 0, maxLength: 10 }), { nil: undefined }),
+      map: fc.option(fc.dictionary(mapKey, jsonString, { minKeys: 0, maxKeys: 5 }), { nil: undefined }),
+      nested: fc.option(tie("struct") as fc.Arbitrary<any>, { nil: undefined, depthSize: "small" }),
+    },
+    { requiredKeys: [] }
+  ),
+})).struct;
+
+/** Arbitrary data for the allTypes schema. */
+const allTypesData: fc.Arbitrary<any> = fc.letrec((tie) => ({
+  data: fc.record(
+    {
+      str: fc.option(jsonString, { nil: undefined }),
+      num: fc.option(jsonNumber, { nil: undefined }),
+      bool: fc.option(fc.boolean(), { nil: undefined }),
+      blob: fc.option(blob, { nil: undefined }),
+      ts: fc.option(timestamp, { nil: undefined }),
+      bigint: fc.option(bigint, { nil: undefined }),
+      list: fc.option(fc.array(jsonString, { minLength: 0, maxLength: 10 }), { nil: undefined }),
+      map: fc.option(fc.dictionary(mapKey, jsonString, { minKeys: 0, maxKeys: 5 }), { nil: undefined }),
+      nested: fc.option(tie("data") as fc.Arbitrary<any>, { nil: undefined, depthSize: "small" }),
+    },
+    { requiredKeys: [] }
+  ),
+})).data;
+
+/**
+ * Same as allTypesData but with bigints constrained to safe integer range.
+ * Used in deserialization and round-trip tests where the reference deserializer
+ * uses JSON.parse which loses precision on large integers.
+ */
+const safeAllTypesData: fc.Arbitrary<any> = fc.letrec((tie) => ({
+  data: fc.record(
+    {
+      str: fc.option(jsonString, { nil: undefined }),
+      num: fc.option(jsonNumber, { nil: undefined }),
+      bool: fc.option(fc.boolean(), { nil: undefined }),
+      blob: fc.option(blob, { nil: undefined }),
+      ts: fc.option(timestamp, { nil: undefined }),
+      bigint: fc.option(safeBigint, { nil: undefined }),
+      list: fc.option(fc.array(jsonString, { minLength: 0, maxLength: 10 }), { nil: undefined }),
+      map: fc.option(fc.dictionary(mapKey, jsonString, { minKeys: 0, maxKeys: 5 }), { nil: undefined }),
+      nested: fc.option(tie("data") as fc.Arbitrary<any>, { nil: undefined, depthSize: "small" }),
+    },
+    { requiredKeys: [] }
+  ),
+})).data;
+
+/** Arbitrary document value (recursive JSON-like). */
+const documentValue: fc.Arbitrary<any> = fc.letrec((tie) => ({
+  value: fc.oneof(
+    { depthSize: "small" },
+    jsonString,
+    jsonNumber,
+    fc.boolean(),
+    fc.constant(null),
+    fc.array(tie("value") as fc.Arbitrary<any>, { minLength: 0, maxLength: 5 }),
+    fc.dictionary(mapKey, tie("value") as fc.Arbitrary<any>, { minKeys: 0, maxKeys: 5 })
+  ),
+})).value;
+
+// ─── Fuzz Tests ──────────────────────────────────────────────────────────────
+
+describe("JSON serde fuzz testing", () => {
+  describe("Serializer: ByteJsonShapeSerializer matches JsonShapeSerializer", () => {
+    it("string maps", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(stringMap, (tags) => {
+          const ref = serializeRef(stringMapSchema, { tags });
+          const exp = serializeByte(stringMapSchema, { tags });
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("numeric maps", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(numericMap, (values) => {
+          const ref = serializeRef(numericMapSchema, { values });
+          const exp = serializeByte(numericMapSchema, { values });
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("boolean maps", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(booleanMap, (flags) => {
+          const ref = serializeRef(booleanMapSchema, { flags });
+          const exp = serializeByte(booleanMapSchema, { flags });
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("sparse maps with null values", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(sparseStringMap, (tags) => {
+          const ref = serializeRef(sparseStringMapSchema, { tags });
+          const exp = serializeByte(sparseStringMapSchema, { tags });
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("lists of strings", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(fc.array(jsonString, { minLength: 0, maxLength: 50 }), (items) => {
+          const ref = serializeRef(listOfStringsSchema, { items });
+          const exp = serializeByte(listOfStringsSchema, { items });
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("lists of numbers", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(fc.array(jsonNumber, { minLength: 0, maxLength: 50 }), (items) => {
+          const ref = serializeRef(listOfNumbersSchema, { items });
+          const exp = serializeByte(listOfNumbersSchema, { items });
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("blobs", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(blob, (data) => {
+          const ref = serializeRef(blobSchema, { data });
+          const exp = serializeByte(blobSchema, { data });
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 5_000 }
+      );
+    });
+
+    it("timestamps", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(timestamp, (ts) => {
+          const data = { epochTs: ts, isoTs: ts, httpTs: ts };
+          const ref = serializeRef(timestampSchema, data);
+          const exp = serializeByte(timestampSchema, data);
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("bigints", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(bigint, (bi) => {
+          const data = {
+            bigint: bi,
+            bigdecimal: new NumericValue(`${bi}.${Math.abs(Number(bi % 1000n))}`, "bigDecimal"),
+          };
+          const ref = serializeRef(bigNumberSchema, data);
+          const exp = serializeByte(bigNumberSchema, data);
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 5_000 }
+      );
+    });
+
+    it("nested structs", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(nestedStruct, (data) => {
+          const ref = serializeRef(nestingStruct, data);
+          const exp = serializeByte(nestingStruct, data);
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("all types combined", { timeout: 60_000 }, () => {
+      fc.assert(
+        fc.property(allTypesData, (data) => {
+          const ref = serializeRef(allTypesSchema, data);
+          const exp = serializeByte(allTypesSchema, data);
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("document schema (untyped)", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(documentValue, (doc) => {
+          const ref = serializeRef(documentStructSchema, { doc });
+          const exp = serializeByte(documentStructSchema, { doc });
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("unions", { timeout: 30_000 }, () => {
+      const unionData = fc.oneof(
+        jsonString.map((s) => ({ union: { strVal: s } })),
+        jsonNumber.map((n) => ({ union: { numVal: n } })),
+        fc.boolean().map((b) => ({ union: { boolVal: b } }))
+      );
+      fc.assert(
+        fc.property(unionData, (data) => {
+          const ref = serializeRef(structWithUnion, data);
+          const exp = serializeByte(structWithUnion, data);
+          expect(exp).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+  });
+
+  describe("Deserializer: BufferJsonShapeDeserializer matches JsonShapeDeserializer", () => {
+    it("string maps", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(stringMap, async (tags) => {
+          const json = JSON.stringify({ tags });
+          const ref = await deserializeRef(stringMapSchema, json);
+          const exp = await deserializeBuffer(stringMapSchema, json);
+          const expBytes = await deserializeBufferBytes(stringMapSchema, json);
+          expect(exp).toEqual(ref);
+          expect(expBytes).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("numeric maps", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(numericMap, async (values) => {
+          const json = JSON.stringify({ values });
+          const ref = await deserializeRef(numericMapSchema, json);
+          const exp = await deserializeBuffer(numericMapSchema, json);
+          const expBytes = await deserializeBufferBytes(numericMapSchema, json);
+          expect(exp).toEqual(ref);
+          expect(expBytes).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("blobs (base64 round-trip)", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(blob, async (data) => {
+          // Serialize with reference, then deserialize with both
+          const json = serializeRef(blobSchema, { data });
+          const ref = await deserializeRef(blobSchema, json);
+          const exp = await deserializeBuffer(blobSchema, json);
+          const expBytes = await deserializeBufferBytes(blobSchema, json);
+          expect(exp).toEqual(ref);
+          expect(expBytes).toEqual(ref);
+        }),
+        { numRuns: 5_000 }
+      );
+    });
+
+    it("timestamps", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(timestamp, async (ts) => {
+          const data = { epochTs: ts, isoTs: ts, httpTs: ts };
+          const json = serializeRef(timestampSchema, data);
+          const ref = await deserializeRef(timestampSchema, json);
+          const exp = await deserializeBuffer(timestampSchema, json);
+          const expBytes = await deserializeBufferBytes(timestampSchema, json);
+          expect(exp).toEqual(ref);
+          expect(expBytes).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("nested structs", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(nestedStruct, async (data) => {
+          const json = serializeRef(nestingStruct, data);
+          const ref = await deserializeRef(nestingStruct, json);
+          const exp = await deserializeBuffer(nestingStruct, json);
+          const expBytes = await deserializeBufferBytes(nestingStruct, json);
+          expect(exp).toEqual(ref);
+          expect(expBytes).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("all types combined", { timeout: 60_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(safeAllTypesData, async (data) => {
+          const json = serializeRef(allTypesSchema, data);
+          const ref = await deserializeRef(allTypesSchema, json);
+          const exp = await deserializeBuffer(allTypesSchema, json);
+          const expBytes = await deserializeBufferBytes(allTypesSchema, json);
+          expect(exp).toEqual(ref);
+          expect(expBytes).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("document schema (untyped)", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(documentValue, async (doc) => {
+          const json = JSON.stringify({ doc });
+          const ref = await deserializeRef(documentStructSchema, json);
+          const exp = await deserializeBuffer(documentStructSchema, json);
+          const expBytes = await deserializeBufferBytes(documentStructSchema, json);
+          expect(exp).toEqual(ref);
+          expect(expBytes).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("unions", { timeout: 30_000 }, async () => {
+      const unionData = fc.oneof(
+        jsonString.map((s) => ({ union: { strVal: s } })),
+        jsonNumber.map((n) => ({ union: { numVal: n } })),
+        fc.boolean().map((b) => ({ union: { boolVal: b } }))
+      );
+      await fc.assert(
+        fc.asyncProperty(unionData, async (data) => {
+          const json = serializeRef(structWithUnion, data);
+          const ref = await deserializeRef(structWithUnion, json);
+          const exp = await deserializeBuffer(structWithUnion, json);
+          const expBytes = await deserializeBufferBytes(structWithUnion, json);
+          expect(exp).toEqual(ref);
+          expect(expBytes).toEqual(ref);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+  });
+
+  describe("Round-trip: serialize with byte → deserialize with buffer", () => {
+    it("string maps survive round-trip", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(stringMap, async (tags) => {
+          const input = { tags };
+          byteSerializer.write(stringMapSchema, input);
+          const bytes = byteSerializer.flush();
+          const output = await bufferDeserializer.read(stringMapSchema, bytes);
+          expect(output).toEqual(input);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("nested structs survive round-trip", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(nestedStruct, async (data) => {
+          byteSerializer.write(nestingStruct, data);
+          const bytes = byteSerializer.flush();
+          const json = decoder.decode(bytes);
+          // Round-trip through reference to normalize (dates→epoch, blobs→base64→Uint8Array)
+          const refJson = serializeRef(nestingStruct, data);
+          const expected = await deserializeRef(nestingStruct, refJson);
+          const actual = await bufferDeserializer.read(nestingStruct, bytes);
+          expect(actual).toEqual(expected);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("all types survive round-trip", { timeout: 60_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(safeAllTypesData, async (data) => {
+          byteSerializer.write(allTypesSchema, data);
+          const bytes = byteSerializer.flush();
+          // Normalize through reference path
+          const refJson = serializeRef(allTypesSchema, data);
+          const expected = await deserializeRef(allTypesSchema, refJson);
+          const actual = await bufferDeserializer.read(allTypesSchema, bytes);
+          expect(actual).toEqual(expected);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("documents survive round-trip", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(documentValue, async (doc) => {
+          const input = { doc };
+          byteSerializer.write(documentStructSchema, input);
+          const bytes = byteSerializer.flush();
+          const refJson = serializeRef(documentStructSchema, input);
+          const expected = await deserializeRef(documentStructSchema, refJson);
+          const actual = await bufferDeserializer.read(documentStructSchema, bytes);
+          expect(actual).toEqual(expected);
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+  });
+
+  describe("Serializer: should never crash on arbitrary inputs", () => {
+    it("byte serializer handles arbitrary objects without crashing", { timeout: 30_000 }, () => {
+      fc.assert(
+        fc.property(documentValue, (value) => {
+          // Should not throw
+          byteSerializer.write(documentSchema, value);
+          const result = byteSerializer.flush();
+          expect(result).toBeInstanceOf(Uint8Array);
+          // Should produce valid JSON
+          expect(() => JSON.parse(decoder.decode(result))).not.toThrow();
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+  });
+
+  describe("Deserializer: should never crash on valid JSON", () => {
+    it("buffer deserializer handles arbitrary valid JSON without crashing", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(documentValue, async (value) => {
+          const json = JSON.stringify({ doc: value });
+          // Should not throw
+          const result = await bufferDeserializer.read(documentStructSchema, json);
+          expect(result).toBeDefined();
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+
+    it("buffer deserializer handles Uint8Array input without crashing", { timeout: 30_000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(documentValue, async (value) => {
+          const json = JSON.stringify({ doc: value });
+          const bytes = new TextEncoder().encode(json);
+          const result = await bufferDeserializer.read(documentStructSchema, bytes);
+          expect(result).toBeDefined();
+        }),
+        { numRuns: 10_000 }
+      );
+    });
+  });
+});

--- a/packages-internal/core/src/submodules/protocols/json/needsReviver.ts
+++ b/packages-internal/core/src/submodules/protocols/json/needsReviver.ts
@@ -1,0 +1,60 @@
+import { NormalizedSchema } from "@smithy/core/schema";
+import type { Schema } from "@smithy/types";
+
+const REVIVER_SYMBOL = Symbol.for("@aws-sdk/reviver");
+
+/**
+ * Determines whether a schema tree contains BigInteger or BigDecimal members,
+ * which require a JSON.parse reviver to preserve numeric precision.
+ *
+ * The result is cached on the root static schema array (struct schemas) via a Symbol key,
+ * so subsequent calls for the same schema are O(1).
+ *
+ * @internal
+ */
+export function needsReviver(schema: Schema): boolean {
+  const ns = NormalizedSchema.of(schema);
+  const raw = ns.getSchema();
+
+  // Cache on the static schema array if it's a struct.
+  if (Array.isArray(raw) && ns.isStructSchema()) {
+    if (REVIVER_SYMBOL in raw) {
+      return (raw as any)[REVIVER_SYMBOL];
+    }
+    const result = _check(ns, new Set());
+    (raw as any)[REVIVER_SYMBOL] = result;
+    return result;
+  }
+
+  // For non-struct or non-array schemas, just compute without caching.
+  return _check(ns, new Set());
+}
+
+function _check(ns: NormalizedSchema, seen: Set<unknown>): boolean {
+  const raw = ns.getSchema();
+  if (seen.has(raw)) {
+    return false;
+  }
+  seen.add(raw);
+
+  if (ns.isBigIntegerSchema() || ns.isBigDecimalSchema()) {
+    return true;
+  }
+
+  if (ns.isStructSchema()) {
+    for (const [, memberSchema] of ns.structIterator()) {
+      if (_check(memberSchema, seen)) {
+        return true;
+      }
+    }
+  } else if (ns.isListSchema() || ns.isMapSchema()) {
+    if (_check(ns.getValueSchema(), seen)) {
+      return true;
+    }
+  } else if (ns.isDocumentSchema()) {
+    // Documents can contain anything — must assume reviver is needed.
+    return true;
+  }
+
+  return false;
+}

--- a/packages-internal/core/src/submodules/protocols/json/parseJsonBody.ts
+++ b/packages-internal/core/src/submodules/protocols/json/parseJsonBody.ts
@@ -1,26 +1,55 @@
-import type { HttpResponse, SerdeFunctions } from "@smithy/types";
+import type { HttpResponse, Schema, SerdeFunctions } from "@smithy/types";
 
 import { collectBodyString } from "../common";
+import { detectBufferParsing } from "./detectBufferParsing";
+import { jsonReviver } from "./jsonReviver";
+import { needsReviver } from "./needsReviver";
 
 /**
  * @internal
  */
-export const parseJsonBody = (streamBody: any, context: SerdeFunctions): any =>
-  collectBodyString(streamBody, context).then((encoded) => {
-    if (encoded.length) {
-      try {
-        return JSON.parse(encoded);
-      } catch (e: any) {
-        if (e?.name === "SyntaxError") {
-          Object.defineProperty(e, "$responseBodyText", {
-            value: encoded,
-          });
-        }
-        throw e;
-      }
+export const parseJsonBody = async (streamBody: any, context: SerdeFunctions, schema?: Schema): Promise<any> => {
+  // Fast path: if streamBody is an async iterable and JSON.parse(Buffer) is supported,
+  // collect chunks directly and parse the concatenated Buffer without UTF-8 decode.
+  let parsingInput: any;
+
+  if (detectBufferParsing() && typeof streamBody?.[Symbol.asyncIterator] === "function") {
+    const chunks: any[] = [];
+    for await (const chunk of streamBody) {
+      chunks.push(chunk);
     }
-    return {};
-  });
+    if (chunks.length > 0) {
+      const buffer = Buffer.concat(chunks);
+      if (buffer.byteLength === 0) {
+        return {};
+      }
+      parsingInput = buffer;
+    }
+  }
+
+  if (!parsingInput) {
+    // Fallback: collect to string, then parse.
+    const encoded = await collectBodyString(streamBody, context);
+    if (encoded.length) {
+      parsingInput = encoded;
+    } else {
+      return {};
+    }
+  }
+
+  const reviver = schema && !needsReviver(schema) ? undefined : jsonReviver;
+
+  try {
+    return JSON.parse(parsingInput, reviver);
+  } catch (e: any) {
+    if (e?.name === "SyntaxError") {
+      Object.defineProperty(e, "$responseBodyText", {
+        value: typeof parsingInput === "string" ? parsingInput : parsingInput.toString("utf8"),
+      });
+    }
+    throw e;
+  }
+};
 
 /**
  * @internal

--- a/packages-internal/core/src/submodules/protocols/json/parseJsonBody.ts
+++ b/packages-internal/core/src/submodules/protocols/json/parseJsonBody.ts
@@ -1,43 +1,50 @@
 import type { HttpResponse, Schema, SerdeFunctions } from "@smithy/types";
-
+import { collectBody } from "@smithy/core/protocols";
 import { collectBodyString } from "../common";
 import { detectBufferParsing } from "./detectBufferParsing";
 import { jsonReviver } from "./jsonReviver";
 import { needsReviver } from "./needsReviver";
 
 /**
+ * @deprecated new calls to parseJsonBody must pass schema.
  * @internal
  */
-export const parseJsonBody = async (streamBody: any, context: SerdeFunctions, schema?: Schema): Promise<any> => {
+export async function parseJsonBody(streamBody: any, context: SerdeFunctions): Promise<any>;
+/**
+ * @internal
+ */
+export async function parseJsonBody(streamBody: any, context: SerdeFunctions, schema: Schema): Promise<any>;
+/**
+ * @internal
+ */
+export async function parseJsonBody(streamBody: any, context: SerdeFunctions, schema?: Schema): Promise<any> {
   // Fast path: if streamBody is an async iterable and JSON.parse(Buffer) is supported,
   // collect chunks directly and parse the concatenated Buffer without UTF-8 decode.
   let parsingInput: any;
 
   if (detectBufferParsing() && typeof streamBody?.[Symbol.asyncIterator] === "function") {
-    const chunks: any[] = [];
-    for await (const chunk of streamBody) {
-      chunks.push(chunk);
-    }
-    if (chunks.length > 0) {
-      const buffer = Buffer.concat(chunks);
-      if (buffer.byteLength === 0) {
-        return {};
+    const buffer = await collectBody(streamBody, context);
+    if (typeof Buffer === "function") {
+      if (Buffer.isBuffer(buffer)) {
+        parsingInput = buffer;
+      } else {
+        parsingInput = Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength);
       }
-      parsingInput = buffer;
     }
   }
-
   if (!parsingInput) {
-    // Fallback: collect to string, then parse.
-    const encoded = await collectBodyString(streamBody, context);
-    if (encoded.length) {
-      parsingInput = encoded;
-    } else {
-      return {};
-    }
+    // Fallback: collect to string
+    parsingInput = await collectBodyString(streamBody, context);
+  }
+  if (parsingInput.length === 0) {
+    return {};
   }
 
-  const reviver = schema && !needsReviver(schema) ? undefined : jsonReviver;
+  /**
+   * We require a schema to use the reviver, because in the pre-schema implementation
+   * of this function, no reviver was used to parse JSON.
+   */
+  const reviver = schema && needsReviver(schema) ? jsonReviver : undefined;
 
   try {
     return JSON.parse(parsingInput, reviver);
@@ -49,7 +56,7 @@ export const parseJsonBody = async (streamBody: any, context: SerdeFunctions, sc
     }
     throw e;
   }
-};
+}
 
 /**
  * @internal

--- a/packages-internal/core/src/submodules/protocols/writeKey.ts
+++ b/packages-internal/core/src/submodules/protocols/writeKey.ts
@@ -1,0 +1,6 @@
+/**
+ * Makes __proto__ writable on a given object.
+ */
+export function writeKey(obj: object | Record<string, unknown> | any) {
+  Object.defineProperty(obj, "__proto__", { value: undefined, writable: true, enumerable: true, configurable: true });
+}

--- a/packages-internal/core/src/submodules/protocols/xml/XmlShapeDeserializer.ts
+++ b/packages-internal/core/src/submodules/protocols/xml/XmlShapeDeserializer.ts
@@ -7,6 +7,7 @@ import type { Schema, SerdeFunctions, ShapeDeserializer } from "@smithy/types";
 
 import { SerdeContextConfig } from "../ConfigurableSerdeContext";
 import { UnionSerde } from "../UnionSerde";
+import { writeKey } from "../writeKey";
 import type { XmlSettings } from "./XmlCodec";
 
 /**
@@ -112,6 +113,9 @@ export class XmlShapeDeserializer extends SerdeContextConfig implements ShapeDes
         for (const entry of entries) {
           const key = entry[keyProperty];
           const value = entry[valueProperty];
+          if (key === "__proto__") {
+            writeKey(buffer);
+          }
           buffer[key] = this.readSchema(memberNs, value);
         }
         return buffer;

--- a/packages-internal/xml-builder/src/xml-parser.ts
+++ b/packages-internal/xml-builder/src/xml-parser.ts
@@ -1,6 +1,15 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
 
 /**
+ * Prepares __proto__ as a writable own property on the target object.
+ * After this call, normal assignment to obj["__proto__"] writes the own
+ * property instead of triggering the prototype setter.
+ */
+function writeKey(obj: any): void {
+  Object.defineProperty(obj, "__proto__", { value: undefined, writable: true, enumerable: true, configurable: true });
+}
+
+/**
  * AWS SDK XML to object converter.
  * @internal
  */
@@ -120,7 +129,7 @@ class AwsXmlParser {
     }
 
     let hasAttrs = false;
-    const attrs: Record<string, string> = Object.create(null);
+    const attrs: Record<string, string> = {};
 
     // attributes.
     while (p.i < p.z) {
@@ -138,6 +147,9 @@ class AwsXmlParser {
       }
       ++p.i; // =
       p.trim();
+      if (name === "__proto__") {
+        writeKey(attrs);
+      }
       attrs[name] = p.readAttrValue();
       hasAttrs = true;
     }
@@ -155,7 +167,6 @@ class AwsXmlParser {
       }
 
       ++p.i; // >
-      Object.setPrototypeOf(attrs, Object.prototype);
       return { tag, value: hasAttrs ? attrs : "" };
     }
 
@@ -224,7 +235,7 @@ class AwsXmlParser {
       return { tag, value: text };
     }
 
-    const obj: any = Object.create(null);
+    const obj: any = {};
 
     for (const text of textParts) {
       if (text.trim() === "" && text.includes("\n")) {
@@ -235,6 +246,9 @@ class AwsXmlParser {
     }
 
     for (const child of childTags) {
+      if (child.tag === "__proto__") {
+        writeKey(obj);
+      }
       if (child.tag in obj) {
         if (Array.isArray(obj[child.tag])) {
           obj[child.tag].push(child.value);
@@ -251,10 +265,12 @@ class AwsXmlParser {
 
     // Add attributes after children (fxp puts attrs after children)
     for (const [k, v] of Object.entries(attrs)) {
+      if (k === "__proto__") {
+        writeKey(obj);
+      }
       obj[k] = v;
     }
 
-    Object.setPrototypeOf(obj, Object.prototype);
     return { tag, value: obj };
   }
 

--- a/packages-internal/xml-builder/tests/xml-parser.fuzz.js
+++ b/packages-internal/xml-builder/tests/xml-parser.fuzz.js
@@ -9,9 +9,9 @@ const { FuzzedDataProvider } = require("@jazzer.js/core");
 /** @type {import('../src/xml-parser')['parseXML']} */
 let parseXML;
 try {
-  parseXML = require("../dist-cjs/xml-parser").parseXML;
+  parseXML = require("../dist-cjs/index").parseXML;
 } catch {
-  parseXML = require("./xml-parser").parseXML;
+  parseXML = require("../src/xml-parser").parseXML;
 }
 
 /**

--- a/tests/bundlers/bundler-output-analysis.cjs
+++ b/tests/bundlers/bundler-output-analysis.cjs
@@ -221,6 +221,10 @@ function collectGuardedRanges(ast) {
     },
   });
 
+  // Functions whose bodies contain typeof Buffer checks (e.g. detectBufferParsing).
+  // Calling these functions in a condition is equivalent to a typeof Buffer guard.
+  const guardFunctionNames = collectGuardFunctionNames(ast);
+
   function isTypeofBufferVar(node) {
     if (node.type === IDENTIFIER && typeofBufferVars.has(node.name)) {
       return true;
@@ -231,25 +235,113 @@ function collectGuardedRanges(ast) {
     return false;
   }
 
+  function isGuardFunctionCall(node) {
+    if (node.type === "CallExpression" && isGuardCallee(node.callee)) {
+      return true;
+    }
+    // !guardFn()
+    if (node.type === UNARY_EXPRESSION && node.operator === NOT && isGuardFunctionCall(node.argument)) {
+      return true;
+    }
+    // guardFn() && expr  or  expr && guardFn()
+    if (node.type === BINARY_EXPRESSION || node.type === LOGICAL_EXPRESSION) {
+      return isGuardFunctionCall(node.left) || isGuardFunctionCall(node.right);
+    }
+    return false;
+  }
+
+  // Checks if a callee node refers to a guard function.
+  // Handles: direct call `guardFn()`, member `mod.guardFn()`,
+  // and webpack's `(0, mod.guardFn)()` (SequenceExpression callee).
+  function isGuardCallee(callee) {
+    if (callee.type === IDENTIFIER && guardFunctionNames.has(callee.name)) {
+      return true;
+    }
+    if (
+      callee.type === MEMBER_EXPRESSION &&
+      callee.property.type === IDENTIFIER &&
+      guardFunctionNames.has(callee.property.name)
+    ) {
+      return true;
+    }
+    if (callee.type === "SequenceExpression" && callee.expressions.length > 0) {
+      const last = callee.expressions[callee.expressions.length - 1];
+      return isGuardCallee(last);
+    }
+    return false;
+  }
+
+  function isGuardTest(node) {
+    return containsTypeofBuffer(node) || isTypeofBufferVar(node) || isGuardFunctionCall(node);
+  }
+
   const ranges = [];
   walk.simple(ast, {
     ConditionalExpression(node) {
-      if (containsTypeofBuffer(node.test) || isTypeofBufferVar(node.test)) {
+      if (isGuardTest(node.test)) {
         ranges.push(node);
       }
     },
     IfStatement(node) {
-      if (containsTypeofBuffer(node.test) || isTypeofBufferVar(node.test)) {
+      if (isGuardTest(node.test)) {
         ranges.push(node);
       }
     },
     LogicalExpression(node) {
-      if (node.operator === LOGICAL_AND && (containsTypeofBuffer(node.left) || isTypeofBufferVar(node.left))) {
+      if (node.operator === LOGICAL_AND && isGuardTest(node.left)) {
         ranges.push(node);
       }
     },
   });
   return ranges;
+}
+
+/**
+ * Finds names of functions whose bodies contain typeof Buffer checks.
+ * These act as indirect guards: calling them in a condition means
+ * the guarded branch only executes when Buffer is available.
+ */
+function collectGuardFunctionNames(ast) {
+  const names = new Set();
+
+  walk.simple(ast, {
+    FunctionDeclaration(node) {
+      if (node.id && node.id.type === IDENTIFIER && functionBodyContainsTypeofBuffer(node)) {
+        names.add(node.id.name);
+      }
+    },
+    VariableDeclarator(node) {
+      if (
+        node.id.type === IDENTIFIER &&
+        node.init &&
+        (node.init.type === FUNCTION_EXPRESSION || node.init.type === ARROW_FUNCTION_EXPRESSION) &&
+        functionBodyContainsTypeofBuffer(node.init)
+      ) {
+        names.add(node.id.name);
+      }
+    },
+  });
+
+  return names;
+}
+
+/**
+ * Checks if a function node's body contains a typeof Buffer expression.
+ */
+function functionBodyContainsTypeofBuffer(fnNode) {
+  let found = false;
+  const body = fnNode.body;
+  if (!body) return false;
+
+  walk.simple(body, {
+    UnaryExpression(node) {
+      if (!found && node.operator === TYPEOF && node.argument.type === IDENTIFIER && node.argument.name === BUFFER) {
+        found = true;
+      }
+    },
+  });
+
+  return found;
 }
 
 /**


### PR DESCRIPTION
### Issue
n/a

### Description
- uses a `defineKey` call to prep writes to the `__proto__` key across AWS protocols.
- detects a fast path in JSON map ser: use JSON.stringify on the entire map if the map is a simple type like `Map<string, number>`. This covers enough of the gap such that both experimental serde implementations are now faster than the original multi-pass JSON serde.

### Net effects
  
For typical AWS SDK usage, switching to the byte serializer and buffer deserializer will give 30–65% faster serde on common payloads, with no regressions in other cases. The only scenario that doesn't improve is the small widget struct with bigint members (reviver still required). Public AWS SDK models don't use bigint or bigdecimal so as to even need a reviver.

### Testing
added a bit of fuzz testing to the JSON serde

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.


```
JSON Shape Serializer Benchmark (isolated processes)
══════════════════════════════════════════════════════════════════════════════════════════

Running multipass serializer... done.
Running byte serializer...      done.

Scenario                       │     Size │    Multipass │         Byte │        Δ
───────────────────────────────┼──────────┼──────────────┼──────────────┼─────────
nested-struct (depth=4)        │    695 B │   17.5 kb/ms │   15.5 kb/ms │   -13.2%
nested-struct (depth=16)       │   2.3 KB │   38.7 kb/ms │   40.0 kb/ms │    +3.4%
nested-struct (depth=64)       │   8.9 KB │   64.0 kb/ms │   65.6 kb/ms │    +2.4%
nested-struct (depth=256)      │  35.4 KB │   73.3 kb/ms │   89.4 kb/ms │   +18.0%
nested-struct (depth=1024)     │ 141.1 KB │   46.6 kb/ms │   88.2 kb/ms │   +47.1%
no-blob nested (depth=16)      │   2.0 KB │   43.3 kb/ms │   45.3 kb/ms │    +4.5%
no-blob nested (depth=64)      │   7.5 KB │   85.2 kb/ms │   81.1 kb/ms │    -5.1%
no-blob nested (depth=256)     │  29.9 KB │   80.2 kb/ms │   82.0 kb/ms │    +2.2%
no-blob nested (depth=1024)    │ 119.1 KB │   47.9 kb/ms │   80.5 kb/ms │   +40.5%
wide-map (keys=100)            │   4.2 KB │  167.6 kb/ms │  333.7 kb/ms │   +49.8%
wide-map (keys=500)            │  21.4 KB │  248.9 kb/ms │  458.9 kb/ms │   +45.8%
wide-map (keys=1000)           │  42.9 KB │  240.0 kb/ms │  465.6 kb/ms │   +48.5%
wide-map (keys=5000)           │ 218.7 KB │  127.9 kb/ms │  258.1 kb/ms │   +50.5%
wide-map (keys=10000)          │ 438.4 KB │  114.3 kb/ms │  244.6 kb/ms │   +53.3%
escape-heavy map (keys=100)    │   6.4 KB │  313.3 kb/ms │  514.5 kb/ms │   +39.1%
escape-heavy map (keys=1000)   │  66.2 KB │  333.2 kb/ms │  516.1 kb/ms │   +35.4%
escape-heavy map (keys=5000)   │ 339.6 KB │  178.2 kb/ms │  336.7 kb/ms │   +47.1%
small struct (widget)          │    117 B │   25.3 kb/ms │   46.1 kb/ms │   +45.1%
blob 16KB                      │  21.3 KB │  371.7 kb/ms │  663.5 kb/ms │   +44.0%
blob 64KB                      │  85.3 KB │  387.9 kb/ms │  707.2 kb/ms │   +45.1%
blob 256KB                     │ 341.3 KB │  265.2 kb/ms │  714.6 kb/ms │   +62.9%
blob 512KB                     │ 682.7 KB │  268.9 kb/ms │  717.3 kb/ms │   +62.5%
ddb item ~4KB                  │   4.1 KB │   43.6 kb/ms │   47.5 kb/ms │    +8.3%
ddb item ~16KB                 │  15.6 KB │   48.0 kb/ms │   61.5 kb/ms │   +22.0%
ddb item ~64KB                 │  61.1 KB │   47.2 kb/ms │   60.7 kb/ms │   +22.3%

Δ = byte serializer speed improvement over multipass (positive = faster)


JSON Shape Deserializer Benchmark (isolated processes)
════════════════════════════════════════════════════════════════════════════════════════════════════

Running original deserializer (string)...       done.
Running buffer deserializer (string)...         done.
Running buffer deserializer (Uint8Array)...     done.

Scenario                       │     Size │     Original │       Buffer │    Buf+Bytes │    Δ str │  Δ bytes
───────────────────────────────┼──────────┼──────────────┼──────────────┼──────────────┼──────────┼─────────
nested-struct (depth=4)        │    695 B │    7.9 kb/ms │   14.2 kb/ms │   13.9 kb/ms │   +44.5% │   +43.3%
nested-struct (depth=16)       │   2.3 KB │   13.8 kb/ms │   20.8 kb/ms │   24.5 kb/ms │   +33.6% │   +43.7%
nested-struct (depth=64)       │   8.9 KB │   14.5 kb/ms │   41.8 kb/ms │   42.5 kb/ms │   +65.3% │   +65.8%
nested-struct (depth=256)      │  35.4 KB │   15.8 kb/ms │   54.8 kb/ms │   55.5 kb/ms │   +71.2% │   +71.5%
nested-struct (depth=1024)     │ 141.1 KB │   14.8 kb/ms │   52.9 kb/ms │   49.8 kb/ms │   +72.0% │   +70.2%
no-blob nested (depth=16)      │   2.0 KB │   14.0 kb/ms │   42.9 kb/ms │   43.3 kb/ms │   +67.3% │   +67.5%
no-blob nested (depth=64)      │   7.5 KB │   15.0 kb/ms │   58.9 kb/ms │   57.7 kb/ms │   +74.5% │   +73.9%
no-blob nested (depth=256)     │  29.9 KB │   15.0 kb/ms │   60.7 kb/ms │   59.2 kb/ms │   +75.3% │   +74.7%
no-blob nested (depth=1024)    │ 119.1 KB │   14.3 kb/ms │   55.2 kb/ms │   60.2 kb/ms │   +74.0% │   +76.2%
wide-map (keys=100)            │   4.2 KB │   59.2 kb/ms │  137.8 kb/ms │  140.9 kb/ms │   +57.1% │   +58.0%
wide-map (keys=500)            │  21.4 KB │   75.4 kb/ms │  214.3 kb/ms │  207.7 kb/ms │   +64.8% │   +63.7%
wide-map (keys=1000)           │  42.9 KB │   75.2 kb/ms │  205.2 kb/ms │  205.1 kb/ms │   +63.3% │   +63.3%
wide-map (keys=5000)           │ 218.7 KB │   53.0 kb/ms │  145.8 kb/ms │  135.5 kb/ms │   +63.7% │   +60.9%
wide-map (keys=10000)          │ 438.4 KB │   50.7 kb/ms │  138.2 kb/ms │  127.7 kb/ms │   +63.4% │   +60.3%
small struct (widget)          │    117 B │   19.6 kb/ms │   20.8 kb/ms │   19.0 kb/ms │    +5.8% │    -3.3%
ddb item ~4KB                  │   4.1 KB │   21.6 kb/ms │   33.0 kb/ms │   33.8 kb/ms │   +34.7% │   +36.1%
ddb item ~16KB                 │  15.6 KB │   21.9 kb/ms │   35.5 kb/ms │   34.9 kb/ms │   +38.3% │   +37.3%
ddb item ~64KB                 │  61.1 KB │   20.6 kb/ms │   34.2 kb/ms │   33.8 kb/ms │   +39.7% │   +39.0%

Δ str   = buffer (string input) speed improvement over original (positive = faster)
Δ bytes = buffer (Uint8Array input) speed improvement over original (positive = faster)


DynamoDB Serializer Benchmark (isolated processes)
══════════════════════════════════════════════════════════════════════════════════════════════════════════════

Running DDB multipass serializer...     done.
Running DDB byte serializer...          done.
Running DDB codec serializer...         done.

Scenario             │     Size │    Multipass │         Byte │    DDB Codec │ Byte vs MP │ Codec vs MP
─────────────────────┼──────────┼──────────────┼──────────────┼──────────────┼────────────┼────────────
ddb item ~4KB        │   4.1 KB │   42.8 kb/ms │   50.1 kb/ms │   86.9 kb/ms │     +14.5% │      +56.2%
ddb item ~16KB       │  15.6 KB │   45.1 kb/ms │   64.4 kb/ms │  116.9 kb/ms │     +29.9% │      +62.5%
ddb item ~64KB       │  61.1 KB │   46.9 kb/ms │   64.9 kb/ms │  109.2 kb/ms │     +27.7% │      +57.3%


DynamoDB Deserializer Benchmark (isolated processes)
══════════════════════════════════════════════════════════════════════════════════════════════════════════════

Running DDB original deserializer...    done.
Running DDB buffer deserializer...      done.
Running DDB codec deserializer...       done.

Scenario             │     Size │     Original │       Buffer │    DDB Codec │ Buf vs Orig │ Codec vs Orig
─────────────────────┼──────────┼──────────────┼──────────────┼──────────────┼─────────────┼──────────────
ddb item ~4KB        │   4.1 KB │   21.6 kb/ms │   34.5 kb/ms │   39.9 kb/ms │      +37.4% │        +45.9%
ddb item ~16KB       │  15.6 KB │   22.2 kb/ms │   36.6 kb/ms │   38.7 kb/ms │      +39.4% │        +42.8%
ddb item ~64KB       │  61.1 KB │   21.3 kb/ms │   30.7 kb/ms │   38.8 kb/ms │      +30.7% │        +45.1%
```