### PR TITLE
fix(credential-provider-login): always read token from disk

### DIFF
--- a/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.spec.ts
+++ b/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.spec.ts
@@ -258,6 +258,48 @@ describe("LoginCredentialsFetcher", () => {
     expect(mockMkdir).toHaveBeenCalledWith("/custom/cache/dir", { recursive: true });
   });
 
+  it("should always read token from disk", async () => {
+    mockReadFile
+      .mockResolvedValueOnce(JSON.stringify(mockExpiredCreds))
+      .mockResolvedValueOnce(JSON.stringify(mockValidCreds));
+
+    const fetcher = new LoginCredentialsFetcher(mockProfile);
+
+    const firstToken = await (fetcher as any).loadToken();
+    expect(firstToken.accessToken.accessKeyId).toBe("OLDEXPIREDKEY");
+
+    const secondToken = await (fetcher as any).loadToken();
+    expect(secondToken.accessToken.accessKeyId).toBe("AKIAIOSFODNN7EXAMPLE");
+  });
+
+  it("should re-read token from disk before refresh and skip API call if externally refreshed", async () => {
+    const freshCreds = {
+      ...mockExpiredCreds,
+      accessToken: {
+        ...mockExpiredCreds.accessToken,
+        accessKeyId: "FRESH_KEY",
+        secretAccessKey: "FRESH_SECRET",
+        sessionToken: "FRESH_SESSION",
+        expiresAt: "3000-01-01T00:00:00.000Z",
+      },
+    };
+
+    // First read returns expired token (triggers refresh path),
+    // second read returns fresh token (simulating external refresh)
+    mockReadFile
+      .mockResolvedValueOnce(JSON.stringify(mockExpiredCreds))
+      .mockResolvedValueOnce(JSON.stringify(freshCreds));
+
+    const fetcher = new LoginCredentialsFetcher(mockProfile);
+    const result = await fetcher.loadCredentials();
+
+    expect(result.accessKeyId).toBe("FRESH_KEY");
+    expect(result.secretAccessKey).toBe("FRESH_SECRET");
+    expect(result.sessionToken).toBe("FRESH_SESSION");
+    // Should NOT have called the API since the re-read token was fresh
+    expect(mockClient.send).not.toHaveBeenCalled();
+  });
+
   describe("DER to Raw Signature Conversion", () => {
     it("should convert valid DER signature to raw format", () => {
       const fetcher = new LoginCredentialsFetcher(mockProfile);

--- a/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.ts
+++ b/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.ts
@@ -1,9 +1,5 @@
 import type { CreateOAuth2TokenCommandInput } from "@aws-sdk/nested-clients/signin";
-import type {
-  AwsCredentialIdentity,
-  AwsIdentityProperties,
-  Logger,
-} from "@aws-sdk/types";
+import type { AwsCredentialIdentity, AwsIdentityProperties, Logger } from "@aws-sdk/types";
 import { CredentialsProviderError } from "@smithy/core/config";
 import { HttpRequest } from "@smithy/core/protocols";
 import type {
@@ -13,12 +9,7 @@ import type {
   IniSection,
   MetadataBearer,
 } from "@smithy/types";
-import {
-  createHash,
-  createPrivateKey,
-  createPublicKey,
-  sign,
-} from "node:crypto";
+import { createHash, createPrivateKey, createPublicKey, sign } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -35,8 +26,8 @@ export class LoginCredentialsFetcher {
   public constructor(
     private readonly profileData: IniSection,
     private readonly init?: FromLoginCredentialsInit,
-    private readonly callerClientConfig?: AwsIdentityProperties["callerClientConfig"],
-  ) { }
+    private readonly callerClientConfig?: AwsIdentityProperties["callerClientConfig"]
+  ) {}
 
   /**
    * Loads credentials and refreshes if necessary
@@ -47,7 +38,7 @@ export class LoginCredentialsFetcher {
     if (!token) {
       throw new CredentialsProviderError(
         `Failed to load a token for session ${this.loginSession}, please re-authenticate using aws login`,
-        { tryNextLink: false, logger: this.logger },
+        { tryNextLink: false, logger: this.logger }
       );
     }
 
@@ -61,13 +52,7 @@ export class LoginCredentialsFetcher {
       return this.refresh(token);
     }
 
-    return {
-      accessKeyId: accessToken.accessKeyId,
-      secretAccessKey: accessToken.secretAccessKey,
-      sessionToken: accessToken.sessionToken,
-      accountId: accessToken.accountId,
-      expiration: new Date(accessToken.expiresAt),
-    };
+    return this.toCredentials(token.accessToken);
   }
 
   private get logger(): Logger | undefined {
@@ -78,23 +63,29 @@ export class LoginCredentialsFetcher {
     return this.profileData.login_session!;
   }
 
+  private toCredentials(token: LoginToken["accessToken"]): AwsCredentialIdentity {
+    return {
+      accessKeyId: token.accessKeyId,
+      secretAccessKey: token.secretAccessKey,
+      sessionToken: token.sessionToken,
+      accountId: token.accountId,
+      expiration: new Date(token.expiresAt),
+    };
+  }
+
   private async refresh(token: LoginToken): Promise<AwsCredentialIdentity> {
     // first reload the token from disk to ensure the token hasn't already been refreshed externally.
-    const freshToken = await this.loadToken();
+    // Pick whichever token has the later expiry.
+    const diskToken = await this.loadToken().catch(() => token);
+    const tokenExpiry = new Date(token.accessToken.expiresAt).getTime();
+    const diskExpiry = new Date(diskToken.accessToken.expiresAt).getTime();
+    const freshToken = diskExpiry >= tokenExpiry ? diskToken : token;
     const freshExpiry = new Date(freshToken.accessToken.expiresAt).getTime();
     if (freshExpiry - Date.now() > LoginCredentialsFetcher.REFRESH_THRESHOLD) {
-      return {
-        accessKeyId: freshToken.accessToken.accessKeyId,
-        secretAccessKey: freshToken.accessToken.secretAccessKey,
-        sessionToken: freshToken.accessToken.sessionToken,
-        accountId: freshToken.accessToken.accountId,
-        expiration: new Date(freshToken.accessToken.expiresAt),
-      };
+      return this.toCredentials(freshToken.accessToken);
     }
 
-    const { SigninClient, CreateOAuth2TokenCommand } = await import(
-      "@aws-sdk/nested-clients/signin"
-    );
+    const { SigninClient, CreateOAuth2TokenCommand } = await import("@aws-sdk/nested-clients/signin");
 
     // Extract config from caller client
     const { logger, userAgentAppId } = this.callerClientConfig ?? {};
@@ -105,10 +96,7 @@ export class LoginCredentialsFetcher {
       ? undefined
       : this.callerClientConfig?.requestHandler;
 
-    const region =
-      this.profileData.region ??
-      (await this.callerClientConfig?.region?.()) ??
-      process.env.AWS_REGION;
+    const region = this.profileData.region ?? (await this.callerClientConfig?.region?.()) ?? process.env.AWS_REGION;
 
     const client = new SigninClient({
       credentials: {
@@ -134,22 +122,16 @@ export class LoginCredentialsFetcher {
     };
 
     try {
-      const response = await client.send(
-        new CreateOAuth2TokenCommand(commandInput),
-      );
+      const response = await client.send(new CreateOAuth2TokenCommand(commandInput));
 
-      const { accessKeyId, secretAccessKey, sessionToken } =
-        response.tokenOutput?.accessToken ?? {};
+      const { accessKeyId, secretAccessKey, sessionToken } = response.tokenOutput?.accessToken ?? {};
       const { refreshToken, expiresIn } = response.tokenOutput ?? {};
 
       if (!accessKeyId || !secretAccessKey || !sessionToken || !refreshToken) {
-        throw new CredentialsProviderError(
-          "Token refresh response missing required fields",
-          {
-            logger: this.logger,
-            tryNextLink: false,
-          },
-        );
+        throw new CredentialsProviderError("Token refresh response missing required fields", {
+          logger: this.logger,
+          tryNextLink: false,
+        });
       }
 
       const expiresInMs = (expiresIn ?? 900) * 1000; // Default to 15 minutes in ms
@@ -169,15 +151,7 @@ export class LoginCredentialsFetcher {
 
       await this.saveToken(updatedToken);
 
-      const newAccessToken = updatedToken.accessToken;
-
-      return {
-        accessKeyId: newAccessToken.accessKeyId,
-        secretAccessKey: newAccessToken.secretAccessKey,
-        sessionToken: newAccessToken.sessionToken,
-        accountId: newAccessToken.accountId,
-        expiration,
-      };
+      return this.toCredentials(updatedToken.accessToken);
     } catch (error) {
       // Handle specific AccessDeniedException according to specification
       if (error.name === "AccessDeniedException") {
@@ -197,9 +171,7 @@ export class LoginCredentialsFetcher {
               "Unable to refresh credentials due to insufficient permissions. You may be missing permission for the 'CreateOAuth2Token' action.";
             break;
           default:
-            message = `Failed to refresh token: ${String(
-              error,
-            )}. Please re-authenticate using \`aws login\``;
+            message = `Failed to refresh token: ${String(error)}. Please re-authenticate using \`aws login\``;
         }
 
         throw new CredentialsProviderError(message, {
@@ -208,11 +180,16 @@ export class LoginCredentialsFetcher {
         });
       }
 
+      // If the token hasn't fully expired.
+      const tokenExpiry = new Date(freshToken.accessToken.expiresAt).getTime();
+      if (tokenExpiry > Date.now()) {
+        this.logger?.warn?.(`Failed to refresh token: ${String(error)}. Using existing token until expiry.`);
+        return this.toCredentials(freshToken.accessToken);
+      }
+
       throw new CredentialsProviderError(
-        `Failed to refresh token: ${String(
-          error,
-        )}. Please re-authenticate using aws login`,
-        { logger: this.logger },
+        `Failed to refresh token: ${String(error)}. Please re-authenticate using aws login`,
+        { logger: this.logger }
       );
     }
   }
@@ -223,37 +200,24 @@ export class LoginCredentialsFetcher {
       const tokenData = await fs.readFile(tokenFilePath, "utf8");
       const token = JSON.parse(tokenData);
 
-      const missingFields = [
-        "accessToken",
-        "clientId",
-        "refreshToken",
-        "dpopKey",
-      ].filter((k) => !token[k]);
+      const missingFields = ["accessToken", "clientId", "refreshToken", "dpopKey"].filter((k) => !token[k]);
       if (!token.accessToken?.accountId) {
         missingFields.push("accountId");
       }
 
       if (missingFields.length > 0) {
-        throw new CredentialsProviderError(
-          `Token validation failed, missing fields: ${missingFields.join(
-            ", ",
-          )}`,
-          {
-            logger: this.logger,
-            tryNextLink: false,
-          },
-        );
+        throw new CredentialsProviderError(`Token validation failed, missing fields: ${missingFields.join(", ")}`, {
+          logger: this.logger,
+          tryNextLink: false,
+        });
       }
 
       return token;
     } catch (error) {
-      throw new CredentialsProviderError(
-        `Failed to load token from ${tokenFilePath}: ${String(error)}`,
-        {
-          logger: this.logger,
-          tryNextLink: false,
-        },
-      );
+      throw new CredentialsProviderError(`Failed to load token from ${tokenFilePath}: ${String(error)}`, {
+        logger: this.logger,
+        tryNextLink: false,
+      });
     }
   }
 
@@ -271,13 +235,9 @@ export class LoginCredentialsFetcher {
   }
 
   private getTokenFilePath(): string {
-    const directory =
-      process.env.AWS_LOGIN_CACHE_DIRECTORY ??
-      join(homedir(), ".aws", "login", "cache");
+    const directory = process.env.AWS_LOGIN_CACHE_DIRECTORY ?? join(homedir(), ".aws", "login", "cache");
     const loginSessionBytes = Buffer.from(this.loginSession, "utf8");
-    const loginSessionSha256 = createHash("sha256")
-      .update(loginSessionBytes)
-      .digest("hex");
+    const loginSessionSha256 = createHash("sha256").update(loginSessionBytes).digest("hex");
     return join(directory, `${loginSessionSha256}.json`);
   }
 
@@ -329,23 +289,17 @@ export class LoginCredentialsFetcher {
    */
   private createDPoPInterceptor(middlewareStack: any) {
     middlewareStack.add(
-      <Output extends MetadataBearer>(
-        next: FinalizeHandler<any, Output>,
-      ): FinalizeHandler<any, Output> =>
-        async (
-          args: FinalizeHandlerArguments<any>,
-        ): Promise<FinalizeHandlerOutput<Output>> => {
+      <Output extends MetadataBearer>(next: FinalizeHandler<any, Output>): FinalizeHandler<any, Output> =>
+        async (args: FinalizeHandlerArguments<any>): Promise<FinalizeHandlerOutput<Output>> => {
           if (HttpRequest.isInstance(args.request)) {
             const request = args.request as HttpRequest;
             // Extract the actual endpoint URL after resolution
-            const actualEndpoint = `${request.protocol}//${request.hostname}${request.port ? `:${request.port}` : ""
-              }${request.path}`;
+            const actualEndpoint = `${request.protocol}//${request.hostname}${
+              request.port ? `:${request.port}` : ""
+            }${request.path}`;
 
             // Generate DPoP proof with correct endpoint
-            const dpop = await this.generateDpop(
-              request.method,
-              actualEndpoint,
-            );
+            const dpop = await this.generateDpop(request.method, actualEndpoint);
 
             // Add the DPoP header
             request.headers = {
@@ -360,14 +314,11 @@ export class LoginCredentialsFetcher {
         step: "finalizeRequest",
         name: "dpopInterceptor",
         override: true,
-      },
+      }
     );
   }
 
-  private async generateDpop(
-    method = "POST",
-    endpoint?: string,
-  ): Promise<string> {
+  private async generateDpop(method = "POST", endpoint?: string): Promise<string> {
     const token = await this.loadToken();
 
     try {
@@ -410,12 +361,8 @@ export class LoginCredentialsFetcher {
         iat: Math.floor(Date.now() / 1000),
       };
 
-      const headerB64 = Buffer.from(JSON.stringify(header)).toString(
-        "base64url",
-      );
-      const payloadB64 = Buffer.from(JSON.stringify(payload)).toString(
-        "base64url",
-      );
+      const headerB64 = Buffer.from(JSON.stringify(header)).toString("base64url");
+      const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url");
       const message = `${headerB64}.${payloadB64}`;
 
       // Sign using Node.js crypto (returns ASN.1 DER format)
@@ -428,9 +375,8 @@ export class LoginCredentialsFetcher {
       return `${message}.${signatureB64}`;
     } catch (error) {
       throw new CredentialsProviderError(
-        `Failed to generate Dpop proof: ${error instanceof Error ? error.message : String(error)
-        }`,
-        { logger: this.logger, tryNextLink: false },
+        `Failed to generate Dpop proof: ${error instanceof Error ? error.message : String(error)}`,
+        { logger: this.logger, tryNextLink: false }
       );
     }
   }

--- a/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.ts
+++ b/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.ts
@@ -1,6 +1,10 @@
 import type { CreateOAuth2TokenCommandInput } from "@aws-sdk/nested-clients/signin";
-import type { AwsCredentialIdentity, AwsIdentityProperties, Logger } from "@aws-sdk/types";
-import { CredentialsProviderError, readFile } from "@smithy/core/config";
+import type {
+  AwsCredentialIdentity,
+  AwsIdentityProperties,
+  Logger,
+} from "@aws-sdk/types";
+import { CredentialsProviderError } from "@smithy/core/config";
 import { HttpRequest } from "@smithy/core/protocols";
 import type {
   FinalizeHandler,
@@ -9,7 +13,12 @@ import type {
   IniSection,
   MetadataBearer,
 } from "@smithy/types";
-import { createHash, createPrivateKey, createPublicKey, sign } from "node:crypto";
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  sign,
+} from "node:crypto";
 import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -26,8 +35,8 @@ export class LoginCredentialsFetcher {
   public constructor(
     private readonly profileData: IniSection,
     private readonly init?: FromLoginCredentialsInit,
-    private readonly callerClientConfig?: AwsIdentityProperties["callerClientConfig"]
-  ) {}
+    private readonly callerClientConfig?: AwsIdentityProperties["callerClientConfig"],
+  ) { }
 
   /**
    * Loads credentials and refreshes if necessary
@@ -38,7 +47,7 @@ export class LoginCredentialsFetcher {
     if (!token) {
       throw new CredentialsProviderError(
         `Failed to load a token for session ${this.loginSession}, please re-authenticate using aws login`,
-        { tryNextLink: false, logger: this.logger }
+        { tryNextLink: false, logger: this.logger },
       );
     }
 
@@ -70,7 +79,22 @@ export class LoginCredentialsFetcher {
   }
 
   private async refresh(token: LoginToken): Promise<AwsCredentialIdentity> {
-    const { SigninClient, CreateOAuth2TokenCommand } = await import("@aws-sdk/nested-clients/signin");
+    // first reload the token from disk to ensure the token hasn't already been refreshed externally.
+    const freshToken = await this.loadToken();
+    const freshExpiry = new Date(freshToken.accessToken.expiresAt).getTime();
+    if (freshExpiry - Date.now() > LoginCredentialsFetcher.REFRESH_THRESHOLD) {
+      return {
+        accessKeyId: freshToken.accessToken.accessKeyId,
+        secretAccessKey: freshToken.accessToken.secretAccessKey,
+        sessionToken: freshToken.accessToken.sessionToken,
+        accountId: freshToken.accessToken.accountId,
+        expiration: new Date(freshToken.accessToken.expiresAt),
+      };
+    }
+
+    const { SigninClient, CreateOAuth2TokenCommand } = await import(
+      "@aws-sdk/nested-clients/signin"
+    );
 
     // Extract config from caller client
     const { logger, userAgentAppId } = this.callerClientConfig ?? {};
@@ -81,7 +105,10 @@ export class LoginCredentialsFetcher {
       ? undefined
       : this.callerClientConfig?.requestHandler;
 
-    const region = this.profileData.region ?? (await this.callerClientConfig?.region?.()) ?? process.env.AWS_REGION;
+    const region =
+      this.profileData.region ??
+      (await this.callerClientConfig?.region?.()) ??
+      process.env.AWS_REGION;
 
     const client = new SigninClient({
       credentials: {
@@ -100,32 +127,38 @@ export class LoginCredentialsFetcher {
 
     const commandInput: CreateOAuth2TokenCommandInput = {
       tokenInput: {
-        clientId: token.clientId,
-        refreshToken: token.refreshToken,
+        clientId: freshToken.clientId,
+        refreshToken: freshToken.refreshToken,
         grantType: "refresh_token",
       },
     };
 
     try {
-      const response = await client.send(new CreateOAuth2TokenCommand(commandInput));
+      const response = await client.send(
+        new CreateOAuth2TokenCommand(commandInput),
+      );
 
-      const { accessKeyId, secretAccessKey, sessionToken } = response.tokenOutput?.accessToken ?? {};
+      const { accessKeyId, secretAccessKey, sessionToken } =
+        response.tokenOutput?.accessToken ?? {};
       const { refreshToken, expiresIn } = response.tokenOutput ?? {};
 
       if (!accessKeyId || !secretAccessKey || !sessionToken || !refreshToken) {
-        throw new CredentialsProviderError("Token refresh response missing required fields", {
-          logger: this.logger,
-          tryNextLink: false,
-        });
+        throw new CredentialsProviderError(
+          "Token refresh response missing required fields",
+          {
+            logger: this.logger,
+            tryNextLink: false,
+          },
+        );
       }
 
       const expiresInMs = (expiresIn ?? 900) * 1000; // Default to 15 minutes in ms
       const expiration = new Date(Date.now() + expiresInMs);
 
       const updatedToken: LoginToken = {
-        ...token,
+        ...freshToken,
         accessToken: {
-          ...token.accessToken, // Preserve existing fields like accountId
+          ...freshToken.accessToken, // Preserve existing fields like accountId
           accessKeyId,
           secretAccessKey,
           sessionToken,
@@ -164,15 +197,22 @@ export class LoginCredentialsFetcher {
               "Unable to refresh credentials due to insufficient permissions. You may be missing permission for the 'CreateOAuth2Token' action.";
             break;
           default:
-            message = `Failed to refresh token: ${String(error)}. Please re-authenticate using \`aws login\``;
+            message = `Failed to refresh token: ${String(
+              error,
+            )}. Please re-authenticate using \`aws login\``;
         }
 
-        throw new CredentialsProviderError(message, { logger: this.logger, tryNextLink: false });
+        throw new CredentialsProviderError(message, {
+          logger: this.logger,
+          tryNextLink: false,
+        });
       }
 
       throw new CredentialsProviderError(
-        `Failed to refresh token: ${String(error)}. Please re-authenticate using aws login`,
-        { logger: this.logger }
+        `Failed to refresh token: ${String(
+          error,
+        )}. Please re-authenticate using aws login`,
+        { logger: this.logger },
       );
     }
   }
@@ -180,32 +220,40 @@ export class LoginCredentialsFetcher {
   private async loadToken(): Promise<LoginToken> {
     const tokenFilePath = this.getTokenFilePath();
     try {
-      let tokenData: string;
-      try {
-        tokenData = await readFile(tokenFilePath, { ignoreCache: this.init?.ignoreCache });
-      } catch {
-        tokenData = await fs.readFile(tokenFilePath, "utf8");
-      }
+      const tokenData = await fs.readFile(tokenFilePath, "utf8");
       const token = JSON.parse(tokenData);
 
-      const missingFields = ["accessToken", "clientId", "refreshToken", "dpopKey"].filter((k) => !token[k]);
+      const missingFields = [
+        "accessToken",
+        "clientId",
+        "refreshToken",
+        "dpopKey",
+      ].filter((k) => !token[k]);
       if (!token.accessToken?.accountId) {
         missingFields.push("accountId");
       }
 
       if (missingFields.length > 0) {
-        throw new CredentialsProviderError(`Token validation failed, missing fields: ${missingFields.join(", ")}`, {
-          logger: this.logger,
-          tryNextLink: false,
-        });
+        throw new CredentialsProviderError(
+          `Token validation failed, missing fields: ${missingFields.join(
+            ", ",
+          )}`,
+          {
+            logger: this.logger,
+            tryNextLink: false,
+          },
+        );
       }
 
       return token;
     } catch (error) {
-      throw new CredentialsProviderError(`Failed to load token from ${tokenFilePath}: ${String(error)}`, {
-        logger: this.logger,
-        tryNextLink: false,
-      });
+      throw new CredentialsProviderError(
+        `Failed to load token from ${tokenFilePath}: ${String(error)}`,
+        {
+          logger: this.logger,
+          tryNextLink: false,
+        },
+      );
     }
   }
 
@@ -223,9 +271,13 @@ export class LoginCredentialsFetcher {
   }
 
   private getTokenFilePath(): string {
-    const directory = process.env.AWS_LOGIN_CACHE_DIRECTORY ?? join(homedir(), ".aws", "login", "cache");
+    const directory =
+      process.env.AWS_LOGIN_CACHE_DIRECTORY ??
+      join(homedir(), ".aws", "login", "cache");
     const loginSessionBytes = Buffer.from(this.loginSession, "utf8");
-    const loginSessionSha256 = createHash("sha256").update(loginSessionBytes).digest("hex");
+    const loginSessionSha256 = createHash("sha256")
+      .update(loginSessionBytes)
+      .digest("hex");
     return join(directory, `${loginSessionSha256}.json`);
   }
 
@@ -277,17 +329,23 @@ export class LoginCredentialsFetcher {
    */
   private createDPoPInterceptor(middlewareStack: any) {
     middlewareStack.add(
-      <Output extends MetadataBearer>(next: FinalizeHandler<any, Output>): FinalizeHandler<any, Output> =>
-        async (args: FinalizeHandlerArguments<any>): Promise<FinalizeHandlerOutput<Output>> => {
+      <Output extends MetadataBearer>(
+        next: FinalizeHandler<any, Output>,
+      ): FinalizeHandler<any, Output> =>
+        async (
+          args: FinalizeHandlerArguments<any>,
+        ): Promise<FinalizeHandlerOutput<Output>> => {
           if (HttpRequest.isInstance(args.request)) {
             const request = args.request as HttpRequest;
             // Extract the actual endpoint URL after resolution
-            const actualEndpoint = `${request.protocol}//${request.hostname}${request.port ? `:${request.port}` : ""}${
-              request.path
-            }`;
+            const actualEndpoint = `${request.protocol}//${request.hostname}${request.port ? `:${request.port}` : ""
+              }${request.path}`;
 
             // Generate DPoP proof with correct endpoint
-            const dpop = await this.generateDpop(request.method, actualEndpoint);
+            const dpop = await this.generateDpop(
+              request.method,
+              actualEndpoint,
+            );
 
             // Add the DPoP header
             request.headers = {
@@ -302,11 +360,14 @@ export class LoginCredentialsFetcher {
         step: "finalizeRequest",
         name: "dpopInterceptor",
         override: true,
-      }
+      },
     );
   }
 
-  private async generateDpop(method = "POST", endpoint?: string): Promise<string> {
+  private async generateDpop(
+    method = "POST",
+    endpoint?: string,
+  ): Promise<string> {
     const token = await this.loadToken();
 
     try {
@@ -349,8 +410,12 @@ export class LoginCredentialsFetcher {
         iat: Math.floor(Date.now() / 1000),
       };
 
-      const headerB64 = Buffer.from(JSON.stringify(header)).toString("base64url");
-      const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url");
+      const headerB64 = Buffer.from(JSON.stringify(header)).toString(
+        "base64url",
+      );
+      const payloadB64 = Buffer.from(JSON.stringify(payload)).toString(
+        "base64url",
+      );
       const message = `${headerB64}.${payloadB64}`;
 
       // Sign using Node.js crypto (returns ASN.1 DER format)
@@ -363,8 +428,9 @@ export class LoginCredentialsFetcher {
       return `${message}.${signatureB64}`;
     } catch (error) {
       throw new CredentialsProviderError(
-        `Failed to generate Dpop proof: ${error instanceof Error ? error.message : String(error)}`,
-        { logger: this.logger, tryNextLink: false }
+        `Failed to generate Dpop proof: ${error instanceof Error ? error.message : String(error)
+        }`,
+        { logger: this.logger, tryNextLink: false },
       );
     }
   }

--- a/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.ts
+++ b/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.ts
@@ -74,7 +74,7 @@ export class LoginCredentialsFetcher {
   }
 
   private async refresh(token: LoginToken): Promise<AwsCredentialIdentity> {
-    // first reload the token from disk to ensure the token hasn't already been refreshed externally.
+    // first reload the token from disk in case the token has been refreshed externally.
     // Use disk token unless it's expired and the in-memory token is unexpired.
     const diskToken = await this.loadToken().catch(() => token);
     const now = Date.now();

--- a/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.ts
+++ b/packages-internal/credential-provider-login/src/LoginCredentialsFetcher.ts
@@ -75,11 +75,12 @@ export class LoginCredentialsFetcher {
 
   private async refresh(token: LoginToken): Promise<AwsCredentialIdentity> {
     // first reload the token from disk to ensure the token hasn't already been refreshed externally.
-    // Pick whichever token has the later expiry.
+    // Use disk token unless it's expired and the in-memory token is unexpired.
     const diskToken = await this.loadToken().catch(() => token);
-    const tokenExpiry = new Date(token.accessToken.expiresAt).getTime();
+    const now = Date.now();
     const diskExpiry = new Date(diskToken.accessToken.expiresAt).getTime();
-    const freshToken = diskExpiry >= tokenExpiry ? diskToken : token;
+    const tokenExpiry = new Date(token.accessToken.expiresAt).getTime();
+    const freshToken = diskExpiry <= now && tokenExpiry > now ? token : diskToken;
     const freshExpiry = new Date(freshToken.accessToken.expiresAt).getTime();
     if (freshExpiry - Date.now() > LoginCredentialsFetcher.REFRESH_THRESHOLD) {
       return this.toCredentials(freshToken.accessToken);

--- a/packages-internal/credential-provider-node/tests/credential-provider-node.integ.spec.ts
+++ b/packages-internal/credential-provider-node/tests/credential-provider-node.integ.spec.ts
@@ -16,6 +16,7 @@ import { NodeHttpHandler } from "@smithy/node-http-handler";
 import type { HttpRequest, MiddlewareStack, ParsedIniData } from "@smithy/types";
 import child_process from "node:child_process";
 import { createHash } from "node:crypto";
+import { promises as fsPromises } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
@@ -586,7 +587,8 @@ describe("credential-provider-node integration test", () => {
         dpopKey: "test-dpop-key",
       };
 
-      externalDataInterceptor.interceptFile(tokenPath, JSON.stringify(mockToken));
+      await fsPromises.mkdir(dir, { recursive: true });
+      await fsPromises.writeFile(tokenPath, JSON.stringify(mockToken), "utf8");
 
       setIniProfileData({
         default: {
@@ -596,6 +598,7 @@ describe("credential-provider-node integration test", () => {
       });
       await sts.getCallerIdentity({});
       const credentials = await sts.config.credentials();
+      await fsPromises.rm(tokenPath, { force: true });
       expect(credentials).toEqual({
         accessKeyId: "LOGIN_ACCESS_KEY_ID",
         secretAccessKey: "LOGIN_SECRET_ACCESS_KEY",

--- a/packages/credential-providers/tests/_test-lib.ts
+++ b/packages/credential-providers/tests/_test-lib.ts
@@ -7,8 +7,9 @@ import { HttpResponse } from "@smithy/core/protocols";
 import { externalDataInterceptor } from "@smithy/core/config";
 import type { HttpRequest, NodeHttpHandlerOptions } from "@smithy/types";
 import child_process from "node:child_process";
-import { createHash } from "node:crypto";
-import { homedir } from "node:os";
+import { createHash, randomUUID } from "node:crypto";
+import { promises as fsPromises } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, test as it } from "vitest";
@@ -155,6 +156,8 @@ export class CTest<P extends (init?: any) => RuntimeConfigAwsCredentialIdentityP
       externalDataInterceptor.interceptToken("token-filepath", "token-contents");
 
       // Setup login credentials cache
+      const loginCacheDir = join(tmpdir(), `aws-sdk-login-test-${randomUUID()}`);
+      process.env.AWS_LOGIN_CACHE_DIRECTORY = loginCacheDir;
       let loginCreds = {
         accessToken: {
           accessKeyId: "LOGIN_ACCESS_KEY_ID",
@@ -171,13 +174,11 @@ export class CTest<P extends (init?: any) => RuntimeConfigAwsCredentialIdentityP
       };
       const loginSessionBytes = Buffer.from("arn:aws:sts::012345678910:assumed-role/Test", "utf8");
       const loginCacheName = createHash("sha256").update(loginSessionBytes).digest("hex");
-      const loginCachePath = join(
-        process.env.AWS_LOGIN_CACHE_DIRECTORY ?? join(homedir(), ".aws", "login", "cache"),
-        `${loginCacheName}.json`
-      );
-      externalDataInterceptor.interceptFile(loginCachePath, JSON.stringify(loginCreds));
+      const loginCachePath = join(loginCacheDir, `${loginCacheName}.json`);
+      await fsPromises.mkdir(loginCacheDir, { recursive: true });
+      await fsPromises.writeFile(loginCachePath, JSON.stringify(loginCreds), "utf8");
       externalDataInterceptor.interceptToken("loginCachePath", loginCreds);
-      externalDataInterceptor.interceptToken("updateLoginCreds", (region: string) => {
+      externalDataInterceptor.interceptToken("updateLoginCreds", async (region: string) => {
         loginCreds = {
           ...loginCreds,
           accessToken: {
@@ -185,18 +186,21 @@ export class CTest<P extends (init?: any) => RuntimeConfigAwsCredentialIdentityP
             sessionToken: `LOGIN_SESSION_TOKEN_${region}`,
           },
         };
-        // Update the file content with new credentials
-        externalDataInterceptor.interceptFile(loginCachePath, JSON.stringify(loginCreds));
+        await fsPromises.writeFile(loginCachePath, JSON.stringify(loginCreds), "utf8");
       });
       externalDataInterceptor.interceptToken("login_session", "arn:aws:sts::012345678910:assumed-role/Test");
     });
 
     afterEach(async () => {
+      const loginCacheDir = process.env.AWS_LOGIN_CACHE_DIRECTORY;
       Object.assign(process.env, processSnapshot);
       setIniProfileData({
         default: {},
       });
       assumeRoleArns.length = 0;
+      if (loginCacheDir) {
+        await fsPromises.rm(loginCacheDir, { recursive: true, force: true });
+      }
     });
 
     afterAll(() => {
@@ -318,7 +322,7 @@ export class CTest<P extends (init?: any) => RuntimeConfigAwsCredentialIdentityP
       if (expectedRegion) {
         const updateLoginCreds = externalDataInterceptor.getTokenRecord().updateLoginCreds;
         if (updateLoginCreds) {
-          updateLoginCreds(expectedRegion);
+          await updateLoginCreds(expectedRegion);
         }
       }
     }

--- a/packages/credential-providers/tests/fromLoginCredentials.integ.spec.ts
+++ b/packages/credential-providers/tests/fromLoginCredentials.integ.spec.ts
@@ -1,9 +1,5 @@
 import { S3 } from "@aws-sdk/client-s3";
 import { fromLoginCredentials } from "@aws-sdk/credential-providers";
-import { externalDataInterceptor } from "@smithy/core/config";
-import { createHash } from "node:crypto";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { describe, expect, test as it } from "vitest";
 
 import { CTest } from "./_test-lib";
@@ -20,31 +16,7 @@ describe(fromLoginCredentials.name, () => {
     fallbackRegion: "unresolved",
   });
 
-  // Helper function to set up login cache file interception
-  const setupLoginCache = (loginSession: string) => {
-    const loginCreds = {
-      accessToken: {
-        accessKeyId: "LOGIN_ACCESS_KEY_ID",
-        secretAccessKey: "LOGIN_SECRET_ACCESS_KEY",
-        sessionToken: "LOGIN_SESSION_TOKEN",
-        accountId: "012345678910",
-        expiresAt: "3000-01-01T00:00:00.000Z",
-      },
-      clientId: "test-client-id",
-      refreshToken: "test-refresh-token",
-      dpopKey: "test-dpop-key",
-    };
-
-    const loginSessionBytes = Buffer.from(loginSession, "utf8");
-    const loginCacheName = createHash("sha256").update(loginSessionBytes).digest("hex");
-    const loginCachePath = join(
-      process.env.AWS_LOGIN_CACHE_DIRECTORY ?? join(homedir(), ".aws", "login", "cache"),
-      `${loginCacheName}.json`
-    );
-
-    externalDataInterceptor.interceptToken("login_session", loginSession);
-    externalDataInterceptor.interceptFile(loginCachePath, JSON.stringify(loginCreds));
-  };
+  const loginSession = "arn:aws:sts::012345678910:assumed-role/Test";
 
   ctest.testRegion();
 
@@ -56,16 +28,12 @@ describe(fromLoginCredentials.name, () => {
 
   describe("configure from profile", () => {
     it("should load credentials from profile with login_session", async () => {
-      const loginSession = "mock_login_session";
-
       ctest.setIni({
         default: {
           login_session: loginSession,
           region: "ap-south-2",
         },
       });
-
-      setupLoginCache(loginSession);
 
       const s3 = new S3({
         region: "us-east-1",
@@ -103,16 +71,12 @@ describe(fromLoginCredentials.name, () => {
 
   describe("configure from code", () => {
     it("should be configurable with profile parameter", async () => {
-      const loginSession = "mock_login_session";
-
       ctest.setIni({
         test: {
           login_session: loginSession,
           region: "us-west-2",
         },
       });
-
-      setupLoginCache(loginSession);
 
       const s3 = new S3({
         region: "us-west-2",


### PR DESCRIPTION
### Issue
Internal V2298487436

### Description
updated the credential fetcher to always re-read the token from disk and reload the token from disk to check whether it was already refreshed by another process before initiating a refresh.

### Testing
Added an integ test
```
yarn test: integration
 Test Files  1 passed (1)
      Tests  48 passed | 3 skipped (51)
   Start at  19:19:26
   Duration  2.86s (transform 1.08s, setup 0ms, import 1.50s, tests 883ms, environment 0ms)
```


### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
