### PR TITLE
fix(core): parse JSON numbers in exponent notation

### DIFF
--- a/packages-internal/core/src/submodules/protocols/json/jsonReviver.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/jsonReviver.spec.ts
@@ -58,4 +58,41 @@ describe(jsonReviver.name, () => {
     expect(parsed.bigint).toBe(1e36);
     expect(parsed.bigDecimal).toEqual(0.12345);
   });
+
+  (contextSourceAvailable ? it : it.skip)("parses numbers in exponent notation", async () => {
+    // AWS services serialize epoch-second timestamps this way, e.g. ECS DescribeServices.
+    const data = `
+    {
+      "epochSeconds": 1.784316439424E9,
+      "integral": 1E9,
+      "lowercase": 1e9,
+      "negative": -2.5E3,
+      "fraction": 1.23E1
+    }`;
+
+    const parsed = JSON.parse(data, jsonReviver);
+    expect(parsed.epochSeconds).toBe(1784316439.424);
+    expect(parsed.integral).toBe(1000000000);
+    expect(parsed.lowercase).toBe(1000000000);
+    expect(parsed.negative).toBe(-2500);
+    expect(parsed.fraction).toBe(12.3);
+  });
+
+  (contextSourceAvailable ? it : it.skip)("preserves precision of exponent notation values", async () => {
+    const data = `
+    {
+      "smallMagnitude": 1.5E-10,
+      "largeMagnitude": 1.2345678901234567890E30
+    }`;
+
+    const parsed = JSON.parse(data, jsonReviver);
+    expect(parsed.smallMagnitude).toEqual(new NumericValue("0.00000000015", "bigDecimal"));
+    expect(parsed.largeMagnitude).toBe(1234567890123456789000000000000n);
+  });
+
+  (contextSourceAvailable ? it : it.skip)("falls back to the parsed double for extreme exponents", async () => {
+    const parsed = JSON.parse(`{ "high": 1e5000, "low": 1e-5000 }`, jsonReviver);
+    expect(parsed.high).toBe(Infinity);
+    expect(parsed.low).toBe(0);
+  });
 });

--- a/packages-internal/core/src/submodules/protocols/json/jsonReviver.ts
+++ b/packages-internal/core/src/submodules/protocols/json/jsonReviver.ts
@@ -1,6 +1,56 @@
 import { NumericValue } from "@smithy/core/serde";
 
 /**
+ * Matches a JSON number in exponent notation, capturing the sign, integral
+ * digits, fractional digits, and exponent.
+ */
+const EXPONENT_NOTATION = /^(-?)(\d+)(?:\.(\d*))?[eE]([+-]?\d+)$/;
+
+/**
+ * Upper bound on the digit count of an expanded number, so that an extreme
+ * exponent cannot cause an enormous string allocation.
+ */
+const MAX_EXPANDED_DIGITS = 1024;
+
+/**
+ * Rewrites a JSON number in exponent notation to plain decimal notation, for
+ * example 1.5e3 to 1500.
+ *
+ * @param source - the original numeric string.
+ *
+ * @internal
+ *
+ * @returns the plain decimal form, or undefined when source is not exponent
+ * notation or when expanding it would exceed MAX_EXPANDED_DIGITS.
+ */
+function expandExponentNotation(source: string): string | undefined {
+  const match = EXPONENT_NOTATION.exec(source);
+  if (!match) {
+    return undefined;
+  }
+  const [, sign, integerDigits, fractionDigits = "", exponentDigits] = match;
+  const exponent = Number(exponentDigits);
+  const digits = integerDigits + fractionDigits;
+  if (digits.length + Math.abs(exponent) > MAX_EXPANDED_DIGITS) {
+    return undefined;
+  }
+  // Where the decimal point lands within `digits` once the exponent is applied.
+  const pointIndex = integerDigits.length + exponent;
+  let expanded: string;
+  if (pointIndex <= 0) {
+    expanded = "0." + "0".repeat(-pointIndex) + digits;
+  } else if (pointIndex >= digits.length) {
+    expanded = digits + "0".repeat(pointIndex - digits.length);
+  } else {
+    expanded = digits.slice(0, pointIndex) + "." + digits.slice(pointIndex);
+  }
+  if (expanded.includes(".")) {
+    expanded = expanded.replace(/0+$/, "").replace(/\.$/, "");
+  }
+  return sign + expanded.replace(/^0+(?=\d)/, "");
+}
+
+/**
  * @param key - JSON object key.
  * @param value - parsed value.
  * @param context - original JSON string for reference. Not available until Node.js 21 and unavailable in Safari as
@@ -14,8 +64,17 @@ import { NumericValue } from "@smithy/core/serde";
  */
 export function jsonReviver(key: string, value: any, context?: { source?: string }) {
   if (context?.source) {
-    const numericString = context.source;
+    let numericString = context.source;
     if (typeof value === "number") {
+      if (EXPONENT_NOTATION.test(numericString)) {
+        const expanded = expandExponentNotation(numericString);
+        if (expanded === undefined) {
+          // The exponent is too extreme to expand, so the parsed double is the
+          // best available representation.
+          return value;
+        }
+        numericString = expanded;
+      }
       if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER || numericString !== String(value)) {
         const isFractional = numericString.includes(".");
         if (isFractional) {


### PR DESCRIPTION
### Issue

Fixes #8224

### Description

`jsonReviver` throws on any JSON number written in exponent notation, e.g. `1.784316439424E9`:

```
Error: @smithy/core/serde - NumericValue must only contain [0-9], at most one decimal point ".", and an optional negation prefix "-".
```

Exponent notation is valid JSON, and AWS services emit it — ECS serializes epoch-second timestamps that way, so every `ecs:DescribeServices` response currently fails to deserialize.

The reviver decides a token is precision-losing by comparing the raw source text against `String(value)`:

```ts
if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER || numericString !== String(value)) {
  const isFractional = numericString.includes(".");
  if (isFractional) {
    return new NumericValue(numericString, "bigDecimal");
  } else {
    return BigInt(numericString);
  }
}
```

An exponent-notation token always fails that string comparison (`"1.784316439424E9" !== "1784316439.424"`), so it is treated as precision-losing even when the `double` round-trips exactly. Both branches then reject it:

- fractional → `NumericValue`, whose format is `/^-?\d*(\.\d+)?$/` and forbids `E`
- non-fractional → `BigInt("1E9")` throws `SyntaxError: Cannot convert 1E9 to a BigInt`

This change normalizes exponent notation to plain decimal *before* the classification, so the existing logic sees a form it understands. Values that round-trip (the common case, including ECS timestamps) now fall through to a plain `number`; values that genuinely exceed `double` precision are still preserved as `BigInt` / `NumericValue`.

Expansion is bounded by `MAX_EXPANDED_DIGITS` (1024) so an extreme exponent cannot cause a large string allocation; past that bound the reviver returns the parsed double rather than throwing.

### Behavior notes for reviewers

Two consequences worth a look, both currently exceptions rather than values:

- `1e1000` / `1e-1000` were `SyntaxError` / `NumericValue` throws; they are now preserved exactly (`BigInt` and `NumericValue` respectively) instead of collapsing to `Infinity` / `0`. This follows the reviver's stated purpose, but it is a behavior choice — happy to return the double instead if you'd prefer the narrower change.
- Beyond `MAX_EXPANDED_DIGITS` the parsed double is returned (`Infinity` / `0`), matching no-reviver behavior. The threshold is arbitrary; say the word if you want a different bound.

I did not widen `NumericValue`'s format regex in `smithy-typescript`, since fixing the classification here keeps the change in one repo. If you'd rather accept the full JSON number grammar there, that would also solve it and I'm glad to follow up.

### Testing

Added cases to `jsonReviver.spec.ts`, gated on `contextSourceAvailable` like the existing tests:

- exponent notation parses to plain numbers — including the ECS-style `1.784316439424E9`, integral `1E9`, lowercase `1e9`, negative `-2.5E3`, and fractional `1.23E1`
- precision is still preserved for exponent values that need it — `1.5E-10` → `NumericValue("0.00000000015")`, `1.2345678901234567890E30` → `BigInt`
- extreme exponents fall back to the parsed double instead of throwing

The existing tests in that file (small ints/decimals, 37-digit `BigInt`, 41-digit `bigDecimal`) are unchanged and still pass — those inputs contain no exponent, so they take the original path untouched.

Verified end to end by patching the compiled fix into `@aws-sdk/core@3.977.0` in a local install: `describeServices` goes from the error above to returning `createdAt` as a `Date`, both against a stubbed response and against the live ECS API.

`tsc --strict --noEmit` is clean on the changed file.

### Additional context

Regression range: `@aws-sdk/core@3.976.0` is fine, `3.977.0` fails. Suspect #8214, which enabled the reviver more broadly via `needsReviver` / `parseJsonBody`.

`botocore` parses these identical bodies without complaint, so the divergence is specific to this reviver.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
