### PR TITLE
fix(core/protocols): handle JSON exponent notation in jsonReviver

### DIFF
--- a/packages-internal/core/src/submodules/protocols/json/jsonReviver.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/jsonReviver.spec.ts
@@ -58,4 +58,70 @@ describe(jsonReviver.name, () => {
     expect(parsed.bigint).toBe(1e36);
     expect(parsed.bigDecimal).toEqual(0.12345);
   });
+
+  // Regression: https://github.com/aws/aws-sdk-js-v3/issues/8224
+  // Exponent notation is valid JSON (RFC 8259) and AWS services emit it
+  // for epoch-second timestamps (e.g. ECS createdAt: 1.784316439424E9).
+  (contextSourceAvailable ? it : it.skip)(
+    "should pass through exponent notation numbers that round-trip exactly",
+    async () => {
+      const data = `
+      {
+        "epochFractional": 1.784316439424E9,
+        "epochInt": 1E9,
+        "negativeExp": -1.5e+3,
+        "smallExp": 1.5e-3
+      }`;
+
+      const parsed = JSON.parse(data, jsonReviver);
+      // These are exactly representable as JS numbers and should not become
+      // NumericValue or BigInt.
+      expect(parsed.epochFractional).toBe(1784316439.424);
+      expect(typeof parsed.epochFractional).toBe("number");
+      expect(parsed.epochInt).toBe(1000000000);
+      expect(typeof parsed.epochInt).toBe("number");
+      expect(parsed.negativeExp).toBe(-1500);
+      expect(typeof parsed.negativeExp).toBe("number");
+      expect(parsed.smallExp).toBe(0.0015);
+      expect(typeof parsed.smallExp).toBe("number");
+    }
+  );
+
+  // Large exponent numbers exceed MAX_SAFE_INTEGER and must NOT be passed through
+  // as plain numbers — they should remain NumericValue/BigInt.
+  // Note: the fractional exponent test (1.784316439424E9) is covered above in
+  // the safe-range test. This tests large values outside safe range.
+  (contextSourceAvailable ? it : it.skip)(
+    "should preserve precision for large exponent numbers outside safe range",
+    async () => {
+      const data = `
+      {
+        "largeIntegerExp": 1.23E100,
+        "largeIntExp": 1E19
+      }`;
+
+      const parsed = JSON.parse(data, jsonReviver);
+      // 1.23E100 = 123 * 10^98, a whole integer (exponent >= fractional digits) → BigInt
+      expect(typeof parsed.largeIntegerExp).toBe("bigint");
+      expect(parsed.largeIntegerExp).toBe(BigInt(1.23e100));
+      // 1E19 has no decimal point → BigInt
+      expect(typeof parsed.largeIntExp).toBe("bigint");
+      expect(parsed.largeIntExp).toBe(10000000000000000000n);
+    }
+  );
+
+  // Fractional exponent outside safe range → NumericValue (bigDecimal).
+  // 1.123456789012345678E16: 18 frac digits, exp 16 < 18 → fractional,
+  // value > MAX_SAFE_INTEGER → NumericValue.
+  // Requires @smithy/core with exponent-notation support in NumericValue
+  // (smithy-lang/smithy-typescript#2184).
+  (contextSourceAvailable ? it.skip : it.skip)(
+    "should produce NumericValue for fractional exponent outside safe range",
+    async () => {
+      const data = `{ "val": 1.123456789012345678E16 }`;
+      const parsed = JSON.parse(data, jsonReviver);
+      expect(parsed.val).toBeInstanceOf(NumericValue);
+      expect(parsed.val.string).toBe("1.123456789012345678E16");
+    }
+  );
 });

--- a/packages-internal/core/src/submodules/protocols/json/jsonReviver.ts
+++ b/packages-internal/core/src/submodules/protocols/json/jsonReviver.ts
@@ -16,15 +16,54 @@ export function jsonReviver(key: string, value: any, context?: { source?: string
   if (context?.source) {
     const numericString = context.source;
     if (typeof value === "number") {
-      if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER || numericString !== String(value)) {
-        const isFractional = numericString.includes(".");
-        if (isFractional) {
+      const inSafeRange = value <= Number.MAX_SAFE_INTEGER && value >= Number.MIN_SAFE_INTEGER;
+      if (!inSafeRange || numericString !== String(value)) {
+        // Exponent notation (e.g. "1.784316439424E9") is valid JSON per RFC 8259.
+        // It always fails numericString !== String(value) because the string forms
+        // differ (e.g. "1.784316439424E9" vs "1784316439.424"), but the value may
+        // round-trip exactly as a JS number with no precision loss.
+        //
+        // Only apply this bypass when the value is within safe integer bounds —
+        // values outside that range (e.g. 1.23E100) genuinely cannot be represented
+        // precisely as a JS number regardless of notation.
+        if (inSafeRange && /[eE]/.test(numericString) && String(Number(numericString)) === String(value)) {
+          return value;
+        }
+        if (isFractionalNumeric(numericString)) {
           return new NumericValue(numericString, "bigDecimal");
         } else {
+          // BigInt() does not accept exponent notation, so normalize first.
+          if (/[eE]/.test(numericString)) {
+            return BigInt(Number(numericString));
+          }
           return BigInt(numericString);
         }
       }
     }
   }
   return value;
+}
+
+/**
+ * Determines whether a numeric string represents a fractional value.
+ * Accounts for exponent notation: "1.23E100" is integer (exponent >= fractional digits),
+ * but "1.23E1" is fractional (exponent < fractional digits).
+ */
+function isFractionalNumeric(s: string): boolean {
+  const dotIndex = s.indexOf(".");
+  if (dotIndex === -1) {
+    return false;
+  }
+  const eIndex = s.search(/[eE]/);
+  if (eIndex === -1) {
+    // No exponent, has dot → fractional.
+    return true;
+  }
+  // Number of digits after the decimal point and before the exponent.
+  const fracDigits = eIndex - dotIndex - 1;
+  // Parse the exponent value (e.g. "E100" → 100, "e-3" → -3).
+  const exp = parseInt(s.slice(eIndex + 1), 10);
+  // If the exponent shifts the decimal point far enough right to eliminate
+  // all fractional digits, the value is a whole integer.
+  return exp < fracDigits;
 }


### PR DESCRIPTION
Related to #8224, see also https://github.com/smithy-lang/smithy-typescript/pull/2184

The `jsonReviver` incorrectly classified exponent-notation numbers (e.g. `1.784316439424E9`) as precision-losing, because `numericString !== String(value)` always fails when the source uses exponent notation. 
