### PR TITLE
chore(lib-dynamodb): add error msg and fallback when incompatible client is supplied

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
@@ -63,11 +63,11 @@ final class DocumentBareBonesClientGenerator implements Runnable {
         // Add required imports.
         // Note: using addImport would register these dependencies on the dynamodb client, which must be avoided.
         writer.write("""
-                     import type {
+                     import {
                        DynamoDBClient,
-                       DynamoDBClientResolvedConfig,
-                       ServiceInputTypes as __ServiceInputTypes,
-                       ServiceOutputTypes as __ServiceOutputTypes,
+                       type DynamoDBClientResolvedConfig,
+                       type ServiceInputTypes as __ServiceInputTypes,
+                       type ServiceOutputTypes as __ServiceOutputTypes,
                      } from "@aws-sdk/client-dynamodb";
                      import type { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
                      """);
@@ -205,6 +205,73 @@ final class DocumentBareBonesClientGenerator implements Runnable {
                     writer.write("  \" DynamoDBDocumentClient. This option must be set to false.\"");
                     writer.dedent();
                     writer.write(");");
+                });
+                writer.writeDocs(
+                    """
+                    The code below checks for incompatibility between the supplied
+                    DynamoDBClient and this DynamoDBDocumentClient.
+
+                    This can happen when the dependency graph is invalid, including
+                    for example, a Lambda layer exposing certain packages being merged
+                    with the Lambda Node.js runtime-bundled AWS SDK.
+
+                    This is not supported and we can only make a best-effort attempt
+                    to repair the error if there is a 2nd client-dynamodb within the
+                    dependency enclosure."""
+                );
+                writer.write(
+                    "const middlewares = client.middlewareStack.identify?.() ?? [];"
+                );
+                writer.write(
+                    "const hasSerializer = middlewares.some((m) => m.includes?.(\"serializerMiddleware\"));"
+                );
+                writer.openBlock("if (!hasSerializer) {", "}", () -> {
+                    writer.write("const configuredLogger = this.config.logger;");
+                    writer.openBlock("const logger =", ";", () -> {
+                        writer.write(
+                            "configuredLogger && !configuredLogger.constructor?.name.includes(\"NoOp\")"
+                        );
+                        writer.indent();
+                        writer.write("? configuredLogger");
+                        writer.write(": console");
+                        writer.dedent();
+                    });
+                    writer.write("const substituteClient = new $L(this.config as any);", symbol.getName());
+                    writer.write("const substituteClientHasSerializer = substituteClient.middlewareStack");
+                    writer.indent();
+                    writer.write(".identify?.()");
+                    writer.write(".some((m) => m.includes?.(\"serializerMiddleware\"));");
+                    writer.dedent();
+                    writer.openBlock("if (!substituteClientHasSerializer) {", "}", () -> {
+                        writer.write("throw new Error(");
+                        writer.indent();
+                        writer.write(
+                            "\"@aws-sdk/lib-dynamodb - ERROR: incompatible version of DynamoDBClient"
+                                + " given to DynamoDBDocumentClient. \" +"
+                        );
+                        writer.write("  \"Check @aws-sdk/lib-dynamodb package.json requirements.\"");
+                        writer.dedent();
+                        writer.write(");");
+                    });
+                    writer.openBlock("else {", "}", () -> {
+                        writer.write("this.middlewareStack = substituteClient.middlewareStack;");
+                        writer.write("this.config = substituteClient.config;");
+                        writer.write("this.config.translateConfig = translateConfig;");
+                        writer.write("logger.warn(");
+                        writer.indent();
+                        writer.write(
+                            "\"@aws-sdk/lib-dynamodb - WARN: incompatible version of DynamoDBClient"
+                                + " given to DynamoDBDocumentClient. \" +"
+                        );
+                        writer.write(
+                            "  \"We have forwarded your client's configuration to a newer version of DynamoDBClient in \" +"
+                        );
+                        writer.write(
+                            "  \"the dependency closure to instantiate DynamoDBDocumentClient.\""
+                        );
+                        writer.dedent();
+                        writer.write(");");
+                    });
                 });
                 writer.popState();
             }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
@@ -65,6 +65,7 @@ final class DocumentBareBonesClientGenerator implements Runnable {
         writer.write("""
                      import {
                        DynamoDBClient,
+                       type DynamoDBClientConfig,
                        type DynamoDBClientResolvedConfig,
                        type ServiceInputTypes as __ServiceInputTypes,
                        type ServiceOutputTypes as __ServiceOutputTypes,
@@ -236,7 +237,16 @@ final class DocumentBareBonesClientGenerator implements Runnable {
                         writer.write(": console");
                         writer.dedent();
                     });
-                    writer.write("const substituteClient = new $L(this.config as any);", symbol.getName());
+                    writer.write(
+                        """
+                        const substituteClient = new DynamoDBClient(Object.assign(
+                          {}, this.config, {
+                            defaultUserAgentProvider: undefined,
+                            retryStrategy: undefined,
+                            extensions: undefined
+                          } satisfies DynamoDBClientConfig
+                        ) as DynamoDBClientConfig);"""
+                    );
                     writer.write("const substituteClientHasSerializer = substituteClient.middlewareStack");
                     writer.indent();
                     writer.write(".identify?.()");

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.spec.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.spec.ts
@@ -1,0 +1,175 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { constructStack } from "@smithy/core/client";
+import { afterEach, beforeEach, describe, expect, test as it, vi } from "vitest";
+
+import { DynamoDBDocumentClient } from "./DynamoDBDocumentClient";
+
+/**
+ * Creates a mock DynamoDBClient that simulates a pre-schema-serde version
+ * (before v3.928.0) where the client does NOT register serializerMiddleware.
+ */
+function createOldClient(configOverrides: Record<string, any> = {}): DynamoDBClient {
+  const stack = constructStack();
+  // Old clients register these middlewares but NOT serializerMiddleware
+  // (commands registered it in the old model).
+  stack.add((() => {}) as any, { name: "loggerMiddleware", step: "initialize", override: true });
+  stack.add((() => {}) as any, { name: "retryMiddleware", step: "finalizeRequest", override: true });
+
+  const mockClient = {
+    config: {
+      region: async () => "us-east-1",
+      logger: configOverrides.logger ?? { warn() {}, error() {}, info() {}, debug() {} },
+      ...configOverrides,
+    },
+    middlewareStack: stack,
+    send: vi.fn(),
+    destroy: vi.fn(),
+  } as unknown as DynamoDBClient;
+
+  return mockClient;
+}
+
+/**
+ * Creates a real DynamoDBClient (modern version) that has serializerMiddleware.
+ */
+function createModernClient(configOverrides: Record<string, any> = {}): DynamoDBClient {
+  return new DynamoDBClient({
+    region: "us-east-1",
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    ...configOverrides,
+  });
+}
+
+describe("DynamoDBDocumentClient - serializerMiddleware compatibility check", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("should work normally with a modern DynamoDBClient that has serializerMiddleware", () => {
+    const client = createModernClient();
+    const docClient = DynamoDBDocumentClient.from(client);
+
+    expect(docClient).toBeDefined();
+    expect(docClient.config).toBeDefined();
+    // Should NOT emit a warning
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("should detect missing serializerMiddleware on an old client and self-heal", () => {
+    const client = createOldClient();
+    const docClient = DynamoDBDocumentClient.from(client);
+
+    expect(docClient).toBeDefined();
+    // The doc client should have serializerMiddleware after patching
+    const middlewares = docClient.middlewareStack.identify();
+    expect(middlewares.some((m: string) => m.includes("serializerMiddleware"))).toBe(true);
+  });
+
+  it("should emit a warning when patching an incompatible client", () => {
+    const client = createOldClient({ logger: undefined });
+    DynamoDBDocumentClient.from(client);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("incompatible version of DynamoDBClient"));
+  });
+
+  it("should use the configured logger for the warning when available", () => {
+    const warnFn = vi.fn();
+    const logger = { warn: warnFn, error: vi.fn(), info: vi.fn(), debug: vi.fn() };
+    const client = createOldClient({ logger });
+
+    DynamoDBDocumentClient.from(client);
+
+    expect(warnFn).toHaveBeenCalledWith(expect.stringContaining("incompatible version of DynamoDBClient"));
+    // Should NOT fall back to console
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to console when logger is NoOp", () => {
+    class NoOpLogger {
+      warn() {}
+      error() {}
+      info() {}
+      debug() {}
+    }
+    const logger = new NoOpLogger();
+    const client = createOldClient({ logger });
+
+    DynamoDBDocumentClient.from(client);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("incompatible version of DynamoDBClient"));
+  });
+
+  it("should not mutate the original client's middleware stack", () => {
+    const client = createOldClient();
+    const originalMiddlewares = client.middlewareStack.identify();
+
+    DynamoDBDocumentClient.from(client);
+
+    // The original client's stack should be unchanged
+    const afterMiddlewares = client.middlewareStack.identify();
+    expect(afterMiddlewares).toEqual(originalMiddlewares);
+  });
+
+  it("should preserve translateConfig when patching", () => {
+    const client = createOldClient();
+    const translateConfig = {
+      marshallOptions: { removeUndefinedValues: true },
+      unmarshallOptions: { wrapNumbers: true },
+    };
+
+    const docClient = DynamoDBDocumentClient.from(client, translateConfig);
+
+    expect(docClient.config.translateConfig).toEqual(translateConfig);
+  });
+
+  it("should preserve translateConfig in the normal (non-patching) path", () => {
+    const client = createModernClient();
+    const translateConfig = {
+      marshallOptions: { convertClassInstanceToMap: true },
+      unmarshallOptions: { wrapNumbers: false },
+    };
+
+    const docClient = DynamoDBDocumentClient.from(client, translateConfig);
+
+    expect(docClient.config.translateConfig).toEqual(translateConfig);
+  });
+
+  it("should throw if cacheMiddleware is true", () => {
+    const client = createModernClient({ cacheMiddleware: true });
+
+    expect(() => DynamoDBDocumentClient.from(client)).toThrow("cacheMiddleware=true is not compatible");
+  });
+
+  it("should use a different middleware stack than the original client after patching", () => {
+    const client = createOldClient();
+    const docClient = DynamoDBDocumentClient.from(client);
+
+    expect(docClient.middlewareStack).not.toBe(client.middlewareStack);
+  });
+
+  it("should handle a client whose identify() returns undefined gracefully", () => {
+    const stack = constructStack();
+    // Simulate a very old middleware stack that might not have identify
+    const mockClient = {
+      config: {
+        region: async () => "us-east-1",
+        logger: { warn() {}, error() {}, info() {}, debug() {} },
+      },
+      middlewareStack: {
+        ...stack,
+        identify: undefined,
+      },
+      send: vi.fn(),
+      destroy: vi.fn(),
+    } as unknown as DynamoDBClient;
+
+    const docClient = DynamoDBDocumentClient.from(mockClient);
+    expect(docClient).toBeDefined();
+  });
+});

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.spec.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.spec.ts
@@ -172,4 +172,77 @@ describe("DynamoDBDocumentClient - serializerMiddleware compatibility check", ()
     const docClient = DynamoDBDocumentClient.from(mockClient);
     expect(docClient).toBeDefined();
   });
+
+  describe("substitute client config field overrides", () => {
+    it("should not pass the original client's defaultUserAgentProvider to the substitute client", () => {
+      const customUserAgentProvider = vi.fn(async () => [["custom-ua", "1.0"]]);
+      const client = createOldClient({ defaultUserAgentProvider: customUserAgentProvider });
+
+      const docClient = DynamoDBDocumentClient.from(client);
+
+      // The substitute client should get a fresh defaultUserAgentProvider, not the original's
+      expect(docClient.config.defaultUserAgentProvider).not.toBe(customUserAgentProvider);
+    });
+
+    it("should not pass the original client's retryStrategy to the substitute client", () => {
+      const customRetryStrategy = {
+        mode: "standard",
+        retry: vi.fn(),
+      };
+      const client = createOldClient({ retryStrategy: customRetryStrategy });
+
+      const docClient = DynamoDBDocumentClient.from(client);
+
+      // The substitute client should resolve its own retry strategy, not reuse the original
+      expect(docClient.config.retryStrategy).not.toBe(customRetryStrategy);
+    });
+
+    it("should not pass the original client's extensions to the substitute client", () => {
+      const applyFn = vi.fn();
+      const customExtensions = [{ applyToStack: applyFn }];
+      const client = createOldClient({ extensions: customExtensions });
+
+      const docClient = DynamoDBDocumentClient.from(client);
+
+      // Extensions should not be double-applied; the substitute client gets none
+      // Verify the doc client was created successfully without re-applying extensions
+      expect(docClient).toBeDefined();
+      expect(docClient.middlewareStack.identify().some((m: string) => m.includes("serializerMiddleware"))).toBe(true);
+    });
+
+    it("should still preserve region from the original client's config in the substitute", () => {
+      const client = createOldClient({ region: async () => "eu-west-1" });
+
+      const docClient = DynamoDBDocumentClient.from(client);
+
+      // Region should be forwarded to the substitute client
+      expect(docClient.config.region).toBeDefined();
+    });
+
+    it("should still preserve credentials from the original client's config in the substitute", () => {
+      const customCredentials = async () => ({
+        accessKeyId: "AKID",
+        secretAccessKey: "SECRET",
+      });
+      const client = createOldClient({ credentials: customCredentials });
+
+      const docClient = DynamoDBDocumentClient.from(client);
+
+      // Credentials should be preserved in the substitute client
+      expect(docClient.config.credentials).toBeDefined();
+    });
+
+    it("should produce a fresh user-agent in the substitute client", async () => {
+      const staleUserAgent = async () => [["aws-sdk-js", "0.0.0-stale"]];
+      const client = createOldClient({ defaultUserAgentProvider: staleUserAgent });
+
+      const docClient = DynamoDBDocumentClient.from(client);
+
+      // The substitute client should have a new defaultUserAgentProvider that
+      // doesn't carry stale version info from the incompatible client
+      const userAgent = await docClient.config.defaultUserAgentProvider();
+      const userAgentStr = JSON.stringify(userAgent);
+      expect(userAgentStr).not.toContain("0.0.0-stale");
+    });
+  });
 });

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
@@ -21,11 +21,11 @@ import type { ScanCommandInput, ScanCommandOutput } from "./commands/ScanCommand
 import type { TransactGetCommandInput, TransactGetCommandOutput } from "./commands/TransactGetCommand";
 import type { TransactWriteCommandInput, TransactWriteCommandOutput } from "./commands/TransactWriteCommand";
 import type { UpdateCommandInput, UpdateCommandOutput } from "./commands/UpdateCommand";
-import type {
+import {
   DynamoDBClient,
-  DynamoDBClientResolvedConfig,
-  ServiceInputTypes as __ServiceInputTypes,
-  ServiceOutputTypes as __ServiceOutputTypes,
+  type DynamoDBClientResolvedConfig,
+  type ServiceInputTypes as __ServiceInputTypes,
+  type ServiceOutputTypes as __ServiceOutputTypes,
 } from "@aws-sdk/client-dynamodb";
 import type { marshallOptions, unmarshallOptions } from "@aws-sdk/util-dynamodb";
 
@@ -147,6 +147,48 @@ export class DynamoDBDocumentClient extends __Client<__HttpHandlerOptions, Servi
         "@aws-sdk/lib-dynamodb - cacheMiddleware=true is not compatible with the" +
           " DynamoDBDocumentClient. This option must be set to false."
       );
+    }
+    /**
+     * The code below checks for incompatibility between the supplied
+     * DynamoDBClient and this DynamoDBDocumentClient.
+     *
+     * This can happen when the dependency graph is invalid, including
+     * for example, a Lambda layer exposing certain packages being merged
+     * with the Lambda Node.js runtime-bundled AWS SDK.
+     *
+     * This is not supported and we can only make a best-effort attempt
+     * to repair the error if there is a 2nd client-dynamodb within the
+     * dependency enclosure.
+     */
+    const middlewares = client.middlewareStack.identify?.() ?? [];
+    const hasSerializer = middlewares.some((m) => m.includes?.("serializerMiddleware"));
+    if (!hasSerializer) {
+      const configuredLogger = this.config.logger;
+      const logger =
+        configuredLogger && !configuredLogger.constructor?.name.includes("NoOp")
+          ? configuredLogger
+          : console
+      ;
+      const substituteClient = new DynamoDBClient(this.config as any);
+      const substituteClientHasSerializer = substituteClient.middlewareStack
+        .identify?.()
+        .some((m) => m.includes?.("serializerMiddleware"));
+      if (!substituteClientHasSerializer) {
+        throw new Error(
+          "@aws-sdk/lib-dynamodb - ERROR: incompatible version of DynamoDBClient given to DynamoDBDocumentClient. " +
+            "Check @aws-sdk/lib-dynamodb package.json requirements."
+        );
+      }
+      else {
+        this.middlewareStack = substituteClient.middlewareStack;
+        this.config = substituteClient.config;
+        this.config.translateConfig = translateConfig;
+        logger.warn(
+          "@aws-sdk/lib-dynamodb - WARN: incompatible version of DynamoDBClient given to DynamoDBDocumentClient. " +
+            "We have forwarded your client's configuration to a newer version of DynamoDBClient in " +
+            "the dependency closure to instantiate DynamoDBDocumentClient."
+        );
+      }
     }
   }
 

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
@@ -155,7 +155,7 @@ export class DynamoDBDocumentClient extends __Client<__HttpHandlerOptions, Servi
      *
      * This can happen when the dependency graph is invalid, including
      * for example, a Lambda layer exposing certain packages being merged
-     * with the Lambda Node.js runtime-bundled AWS SDK.
+     * with the Node.js Lambda provided JS SDK.
      *
      * This is not supported and we can only make a best-effort attempt
      * to repair the error if there is a 2nd client-dynamodb within the

--- a/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
+++ b/lib/lib-dynamodb/src/DynamoDBDocumentClient.ts
@@ -23,6 +23,7 @@ import type { TransactWriteCommandInput, TransactWriteCommandOutput } from "./co
 import type { UpdateCommandInput, UpdateCommandOutput } from "./commands/UpdateCommand";
 import {
   DynamoDBClient,
+  type DynamoDBClientConfig,
   type DynamoDBClientResolvedConfig,
   type ServiceInputTypes as __ServiceInputTypes,
   type ServiceOutputTypes as __ServiceOutputTypes,
@@ -169,7 +170,13 @@ export class DynamoDBDocumentClient extends __Client<__HttpHandlerOptions, Servi
           ? configuredLogger
           : console
       ;
-      const substituteClient = new DynamoDBClient(this.config as any);
+      const substituteClient = new DynamoDBClient(Object.assign(
+        {}, this.config, {
+          defaultUserAgentProvider: undefined,
+          retryStrategy: undefined,
+          extensions: undefined
+        } satisfies DynamoDBClientConfig
+      ) as DynamoDBClientConfig);
       const substituteClientHasSerializer = substituteClient.middlewareStack
         .identify?.()
         .some((m) => m.includes?.("serializerMiddleware"));

--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -38,6 +38,57 @@ describe(DynamoDBDocument.name, () => {
       DynamoDBDocument.from(dynamodb);
     }).toThrow();
   });
+
+  it("should fallback to a substitute client when serializerMiddleware is missing", async () => {
+    // Simulate an old/incompatible DynamoDBClient whose middlewareStack
+    // does not contain serializerMiddleware (pre-v3.928.0 behavior where
+    // commands, not the client, registered the serializer).
+    const realClient = new DynamoDB({
+      region: "us-west-2",
+      credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    });
+
+    // Overwrite the middlewareStack's identify to simulate an old client
+    // that never registered serializerMiddleware.
+    const originalIdentify = realClient.middlewareStack.identify.bind(realClient.middlewareStack);
+    realClient.middlewareStack.identify = () => {
+      return originalIdentify().filter((m) => !m.includes("serializerMiddleware"));
+    };
+
+    // DynamoDBDocument.from should detect the missing serializer and substitute.
+    const doc = DynamoDBDocument.from(realClient);
+
+    // Prove the fallback produces a working client by performing a put and get
+    // using a middleware to intercept before the network call.
+    const captured: string[] = [];
+    doc.middlewareStack.add(
+      (next, context) => async (args) => {
+        captured.push(context.commandName ?? "unknown");
+        return {
+          output: {
+            $metadata: { httpStatusCode: 200 },
+            Item: context.commandName === "GetItemCommand" ? { id: "fallback-test", data: "hello" } : undefined,
+          },
+        } as any;
+      },
+      { step: "serialize", name: "MockDDBResponse", override: true }
+    );
+
+    await doc.put({
+      TableName: "test-table",
+      Item: { id: "fallback-test", data: "hello" },
+    });
+
+    const result = await doc.get({
+      TableName: "test-table",
+      Key: { id: "fallback-test" },
+    });
+
+    // Verify both operations went through the middleware stack without error.
+    expect(captured).toContain("PutItemCommand");
+    expect(captured).toContain("GetItemCommand");
+    expect(result.Item).toEqual({ id: "fallback-test", data: "hello" });
+  });
 });
 
 describe(


### PR DESCRIPTION
### Issue
D497419534

### Description
Adds runtime detection, warning, and fallback attempt for incompatible client-dynamodb passed into lib-dynamodb.

### Testing
new unit and e2e tests.

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
