### PR TITLE
fix(core/protocols): v2 JSON codec updates and JsonBytesStringAdapter

### DIFF
--- a/clients/client-dynamodb/vitest.config.integ.mts
+++ b/clients/client-dynamodb/vitest.config.integ.mts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     include: ["**/*.integ.spec.ts"],
     environment: "node",
+    setupFiles: ["../../vitest.snapshots.setup.mts"],
   },
 });

--- a/clients/client-dynamodb/vitest.config.mts
+++ b/clients/client-dynamodb/vitest.config.mts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    exclude: ["**/*.{integ}.spec.ts"],
+    exclude: ["**/*.{integ,e2e}.spec.ts"],
     include: ["**/*.spec.ts"],
     globals: true,
   },

--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -24,6 +24,7 @@ import type {
 } from "@aws-sdk/lib-dynamodb";
 import { DynamoDBDocument, NumberValue } from "@aws-sdk/lib-dynamodb";
 import { HttpRequest } from "@smithy/core/protocols";
+import { toUtf8 } from "@smithy/core/serde";
 import { afterAll, beforeAll, describe, expect, test as it } from "vitest";
 
 // expected running time: table creation (~20s) + operations 10s
@@ -107,8 +108,9 @@ describe(
         const { request } = args;
         if (HttpRequest.isInstance(request)) {
           if (["GetCommand", "GetItemCommand", "QueryCommand", "ScanCommand"].includes(context.commandName ?? "")) {
-            expect(request.body).toContain(`"ConsistentRead":true`);
+            expect(toUtf8(request.body)).toContain(`"ConsistentRead":true`);
           }
+          request.body += "";
         }
         return next(args);
       },

--- a/packages-internal/core/scripts/benchmark-json-serializer.ts
+++ b/packages-internal/core/scripts/benchmark-json-serializer.ts
@@ -37,6 +37,11 @@ import {
 import { AttributeValue$ } from "@aws-sdk/client-dynamodb";
 import { DynamoDBJsonCodec, DynamoDBJsonCodec2 } from "@aws-sdk/dynamodb-codec";
 
+// ─── Configuration ───────────────────────────────────────────────────────────
+
+/** Controls the number of iterations for all scenarios. Higher = more stable results, slower run. */
+const SCALE = 10;
+
 // ─── Schemas ─────────────────────────────────────────────────────────────────
 
 const widget = [
@@ -85,7 +90,50 @@ const noBlobWidget: any = [
   [0, 4, 1, 64 | 1, 128 | 0, () => noBlobWidget],
 ];
 
-const wideMapSchema = [3, "", "WideMap", 0, ["tags"], [[2, "", "Map", 0, 0, 0]]] as any;
+const wideMapSchema = [3, "", "WideMap", 0, ["tags"], [[2, "", "Map", 0, 0, 0]]] satisfies StaticStructureSchema;
+
+const listStringSchema = [
+  3,
+  "",
+  "StringListInput",
+  0,
+  ["items"],
+  [[1, "", "StringList", 0, 0 satisfies StringSchema]],
+] satisfies StaticStructureSchema;
+const listFloatSchema = [
+  3,
+  "",
+  "FloatListInput",
+  0,
+  ["items"],
+  [[1, "", "FloatList", 0, 1 satisfies NumericSchema]],
+] satisfies StaticStructureSchema;
+const mapStringStringSchema = [
+  3,
+  "",
+  "StringMap",
+  0,
+  ["entries"],
+  [[2, "", "Map", 0, 0, 0]],
+] satisfies StaticStructureSchema;
+
+const listDdbItemSchema: StaticStructureSchema = [
+  3,
+  "",
+  "BatchGetItemOutput",
+  0,
+  ["Items"],
+  [[[1, "", "ItemList", 0, [2, "", "AttributeMap", 0, 0, () => AttributeValue$]], 0]],
+];
+
+const mapDdbItemSchema: StaticStructureSchema = [
+  3,
+  "",
+  "TableItemsOutput",
+  0,
+  ["Tables"],
+  [[2, "", "TableMap", 0, 0, [2, "", "AttributeMap", 0, 0, () => AttributeValue$]]],
+];
 
 // ─── Data generators ─────────────────────────────────────────────────────────
 
@@ -134,6 +182,26 @@ function createEscapyMap(numKeys: number) {
     tags[`key-"${i}"\n`] = `val\t${i}\u0000${'abc"\\'.repeat(5)}`;
   }
   return { tags };
+}
+
+function createListString(count: number) {
+  const l: string[] = [];
+  for (let i = 0; i < count; i++) l[i] = "string".repeat(((Math.random() * 35) | 0) + 1);
+  return l;
+}
+
+function createListFloat(count: number) {
+  const l: number[] = [];
+  for (let i = 0; i < count; i++) l[i] = Math.random() * 3.4e38;
+  return l;
+}
+
+function createMapStringString(count: number) {
+  const m: Record<string, string> = {};
+  for (let i = 0; i < count; i++) {
+    m["key".repeat(((Math.random() * 10) | 0) + 1) + i] = "val".repeat(((Math.random() * 50) | 0) + 1) + i;
+  }
+  return { entries: m };
 }
 
 function createDdbItem(targetBytes = 65536) {
@@ -197,7 +265,23 @@ function createDdbItem(targetBytes = 65536) {
   return item;
 }
 
-const ddbItemSchema: any = [
+function createListDdbItems(count: number, targetBytesPerItem = 4096) {
+  const items = [];
+  for (let i = 0; i < count; i++) {
+    items.push(createDdbItem(targetBytesPerItem));
+  }
+  return { Items: items };
+}
+
+function createMapDdbItems(count: number, targetBytesPerItem = 4096) {
+  const tables: Record<string, any> = {};
+  for (let i = 0; i < count; i++) {
+    tables[`table-${String(i).padStart(4, "0")}`] = createDdbItem(targetBytesPerItem);
+  }
+  return { Tables: tables };
+}
+
+const ddbItemSchema: StaticStructureSchema = [
   3,
   "",
   "GetItemOutput",
@@ -223,7 +307,7 @@ function getScenarios(): Scenario[] {
       name: `nested-struct (depth=${depth})`,
       schema: nestingWidget,
       data: createNestingWidget(depth),
-      iterations: depth > 256 ? 50 : 200,
+      iterations: depth > 256 ? SCALE : SCALE * 4,
     });
   }
 
@@ -232,7 +316,7 @@ function getScenarios(): Scenario[] {
       name: `no-blob nested (depth=${depth})`,
       schema: noBlobWidget,
       data: createNoBlobWidget(depth),
-      iterations: depth > 256 ? 50 : 200,
+      iterations: depth > 256 ? SCALE : SCALE * 4,
     });
   }
 
@@ -241,7 +325,7 @@ function getScenarios(): Scenario[] {
       name: `wide-map (keys=${keys})`,
       schema: wideMapSchema,
       data: createWideMap(keys),
-      iterations: keys > 5000 ? 20 : 100,
+      iterations: keys > 5000 ? SCALE : SCALE * 2,
     });
   }
 
@@ -250,7 +334,7 @@ function getScenarios(): Scenario[] {
       name: `escape-heavy map (keys=${keys})`,
       schema: wideMapSchema,
       data: createEscapyMap(keys),
-      iterations: keys > 1000 ? 20 : 100,
+      iterations: keys > 1000 ? SCALE : SCALE * 2,
     });
   }
 
@@ -263,15 +347,43 @@ function getScenarios(): Scenario[] {
       bigdecimal: new NumericValue("0.10000000000000000000000054321", "bigDecimal"),
       blob: new Uint8Array([0, 0, 0, 1]),
     },
-    iterations: 5000,
+    iterations: SCALE * 80,
   });
+
+  // String-heavy / numeric-heavy cases (JSON2 regression candidates)
+  for (const count of [1000, 5000, 30000]) {
+    scenarios.push({
+      name: `list<string> (n=${count})`,
+      schema: listStringSchema,
+      data: { items: createListString(count) },
+      iterations: count > 5000 ? SCALE : SCALE * 2,
+    });
+  }
+
+  for (const count of [1000, 10000, 30000]) {
+    scenarios.push({
+      name: `list<float> (n=${count})`,
+      schema: listFloatSchema,
+      data: { items: createListFloat(count) },
+      iterations: count > 10000 ? SCALE : SCALE * 2,
+    });
+  }
+
+  for (const count of [500, 2000, 5000]) {
+    scenarios.push({
+      name: `map<str,str> (n=${count})`,
+      schema: mapStringStringSchema,
+      data: createMapStringString(count),
+      iterations: count > 2000 ? SCALE : SCALE * 2,
+    });
+  }
 
   for (const kb of [16, 64, 256, 512]) {
     scenarios.push({
       name: `blob ${kb}KB`,
       schema: widget,
       data: { blob: new Uint8Array(kb * 1024) },
-      iterations: kb > 256 ? 50 : 200,
+      iterations: kb > 256 ? SCALE : SCALE * 4,
     });
   }
 
@@ -282,9 +394,24 @@ function getScenarios(): Scenario[] {
       name: `ddb item ~${kb}KB`,
       schema: ddbItemSchema,
       data,
-      iterations: kb > 16 ? 50 : 200,
+      iterations: kb > 16 ? SCALE : SCALE * 4,
     });
   }
+
+  // List/map of DDB items (batch-style workloads)
+  scenarios.push({
+    name: `list<ddb item 4KB> (n=200)`,
+    schema: listDdbItemSchema,
+    data: createListDdbItems(200, 4096),
+    iterations: SCALE,
+  });
+
+  scenarios.push({
+    name: `map<ddb item 4KB> (n=200)`,
+    schema: mapDdbItemSchema,
+    data: createMapDdbItems(200, 4096),
+    iterations: SCALE,
+  });
 
   return scenarios;
 }
@@ -313,16 +440,22 @@ function runVariant(variant: "multipass" | "byte"): BenchResult[] {
     // Warmup
     for (let i = 0; i < Math.min(iterations, 50); i++) {
       serializer.write(schema, data);
-      serializer.flush();
+      const r = serializer.flush();
+      if (typeof r === "string") Buffer.from(r, "utf8");
     }
 
-    // Measure
+    // Measure: include Buffer.from() for string output to capture full wire-ready cost.
     const start = performance.now();
     let size = 0;
     for (let i = 0; i < iterations; i++) {
       serializer.write(schema, data);
       const r = serializer.flush();
-      size = r instanceof Uint8Array ? r.byteLength : r.length;
+      if (typeof r === "string") {
+        const buf = Buffer.from(r, "utf8");
+        size = buf.byteLength;
+      } else {
+        size = r.byteLength;
+      }
     }
     const elapsed = performance.now() - start;
     const kbPerMs = (size * iterations) / 1024 / elapsed;
@@ -395,7 +528,7 @@ function getDdbScenarios(): Scenario[] {
       name: `ddb item ~${kb}KB`,
       schema: ddbItemSchema,
       data,
-      iterations: kb > 16 ? 50 : 200,
+      iterations: kb > 16 ? SCALE : SCALE * 4,
     });
   }
   return scenarios;
@@ -438,7 +571,8 @@ function runDdbSerVariant(variant: "ddb-multipass" | "ddb-byte" | "ddb-codec-ser
   for (const { name, schema, data, iterations } of scenarios) {
     for (let i = 0; i < Math.min(iterations, 50); i++) {
       serializer.write(schema, data);
-      serializer.flush();
+      const r = serializer.flush();
+      if (typeof r === "string") Buffer.from(r, "utf8");
     }
 
     const start = performance.now();
@@ -446,7 +580,12 @@ function runDdbSerVariant(variant: "ddb-multipass" | "ddb-byte" | "ddb-codec-ser
     for (let i = 0; i < iterations; i++) {
       serializer.write(schema, data);
       const r = serializer.flush();
-      size = r instanceof Uint8Array ? r.byteLength : r.length;
+      if (typeof r === "string") {
+        const buf = Buffer.from(r, "utf8");
+        size = buf.byteLength;
+      } else {
+        size = r.byteLength;
+      }
     }
     const elapsed = performance.now() - start;
     const kbPerMs = (size * iterations) / 1024 / elapsed;
@@ -514,7 +653,7 @@ function getDeserScenarios(): Scenario[] {
       name: `nested-struct (depth=${depth})`,
       schema: nestingWidget,
       data: createNestingWidget(depth),
-      iterations: depth > 256 ? 50 : 200,
+      iterations: depth > 256 ? SCALE : SCALE * 4,
     });
   }
 
@@ -523,7 +662,7 @@ function getDeserScenarios(): Scenario[] {
       name: `no-blob nested (depth=${depth})`,
       schema: noBlobWidget,
       data: createNoBlobWidget(depth),
-      iterations: depth > 256 ? 50 : 200,
+      iterations: depth > 256 ? SCALE : SCALE * 4,
     });
   }
 
@@ -532,7 +671,7 @@ function getDeserScenarios(): Scenario[] {
       name: `wide-map (keys=${keys})`,
       schema: wideMapSchema,
       data: createWideMap(keys),
-      iterations: keys > 5000 ? 20 : 100,
+      iterations: keys > 5000 ? SCALE : SCALE * 2,
     });
   }
 
@@ -545,8 +684,36 @@ function getDeserScenarios(): Scenario[] {
       bigdecimal: new NumericValue("0.10000000000000000000000054321", "bigDecimal"),
       blob: new Uint8Array([0, 0, 0, 1]),
     },
-    iterations: 5000,
+    iterations: SCALE * 80,
   });
+
+  // String-heavy / numeric-heavy cases (JSON2 regression candidates)
+  for (const count of [1000, 5000, 30000]) {
+    scenarios.push({
+      name: `list<string> (n=${count})`,
+      schema: listStringSchema,
+      data: { items: createListString(count) },
+      iterations: count > 5000 ? SCALE : SCALE * 2,
+    });
+  }
+
+  for (const count of [1000, 10000, 30000]) {
+    scenarios.push({
+      name: `list<float> (n=${count})`,
+      schema: listFloatSchema,
+      data: { items: createListFloat(count) },
+      iterations: count > 10000 ? SCALE : SCALE * 2,
+    });
+  }
+
+  for (const count of [500, 2000, 5000]) {
+    scenarios.push({
+      name: `map<str,str> (n=${count})`,
+      schema: mapStringStringSchema,
+      data: createMapStringString(count),
+      iterations: count > 2000 ? SCALE : SCALE * 2,
+    });
+  }
 
   // DDB-like items (typed AttributeValue schema, realistic shape)
   for (const kb of [4, 16, 64]) {
@@ -555,9 +722,24 @@ function getDeserScenarios(): Scenario[] {
       name: `ddb item ~${kb}KB`,
       schema: ddbItemSchema,
       data,
-      iterations: kb > 16 ? 50 : 200,
+      iterations: kb > 16 ? SCALE : SCALE * 4,
     });
   }
+
+  // List/map of DDB items (batch-style workloads)
+  scenarios.push({
+    name: `list<ddb item 4KB> (n=200)`,
+    schema: listDdbItemSchema,
+    data: createListDdbItems(200, 4096),
+    iterations: SCALE,
+  });
+
+  scenarios.push({
+    name: `map<ddb item 4KB> (n=200)`,
+    schema: mapDdbItemSchema,
+    data: createMapDdbItems(200, 4096),
+    iterations: SCALE,
+  });
 
   return scenarios;
 }

--- a/packages-internal/core/src/submodules/protocols/json/AwsJson1_0Protocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsJson1_0Protocol.spec.ts
@@ -100,7 +100,7 @@ describe(AwsJson1_0Protocol.name, () => {
       };
       serializer.write(schema, data);
       const serialized = serializer.flush();
-      expect(JSON.parse(serialized)).toEqual({
+      expect(JSON.parse(toUtf8(serialized))).toEqual({
         string: "string",
         number: 1234,
         boolean: false,

--- a/packages-internal/core/src/submodules/protocols/json/AwsRestJsonProtocol.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/AwsRestJsonProtocol.spec.ts
@@ -66,7 +66,7 @@ describe(AwsRestJsonProtocol.name, () => {
       };
       serializer.write(schema, data);
       const serialized = serializer.flush();
-      expect(JSON.parse(serialized)).toEqual({
+      expect(JSON.parse(toUtf8(serialized))).toEqual({
         string: "string",
         number: 1234,
         boolean: false,

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonBytesStringAdapter.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonBytesStringAdapter.spec.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test as it, vi, beforeEach, afterEach } from "vitest";
+
+import { JsonBytesStringAdapter } from "./JsonBytesStringAdapter";
+
+describe(JsonBytesStringAdapter.name, () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Advance time far enough past any prior throttle window.
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(120_000);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  const json = '{"ConsistentRead":true,"TableName":"my-table"}';
+  const bytes = new TextEncoder().encode(json);
+
+  function create(): JsonBytesStringAdapter {
+    return new JsonBytesStringAdapter(bytes);
+  }
+
+  // ─── Transport path (no string conversion) ──────────────────────────────
+
+  describe("used as Uint8Array (no warning)", () => {
+    it("is an instance of Uint8Array", () => {
+      const adapter = create();
+      expect(adapter).toBeInstanceOf(Uint8Array);
+    });
+
+    it("has correct byte length", () => {
+      const adapter = create();
+      expect(adapter.byteLength).toEqual(bytes.byteLength);
+    });
+
+    it("contains the original bytes", () => {
+      const adapter = create();
+      expect(Array.from(adapter)).toEqual(Array.from(bytes));
+    });
+
+    it("does not fire a warning when accessed as bytes", () => {
+      const adapter = create();
+      void adapter[0];
+      void adapter.byteLength;
+      void adapter.buffer;
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── String compatibility path (fires warning) ──────────────────────────
+
+  describe("used as string (fires warning, works correctly)", () => {
+    it("toString() decodes to the original JSON", () => {
+      const adapter = create();
+      expect(adapter.toString()).toEqual(json);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("valueOf() returns the decoded string", () => {
+      const adapter = create();
+      expect(adapter.valueOf()).toEqual(json);
+    });
+
+    it("+ operator coerces to string", () => {
+      const adapter = create();
+      expect("" + adapter).toEqual(json);
+    });
+
+    it("template literal coerces to string", () => {
+      const adapter = create();
+      expect(`${adapter}`).toEqual(json);
+    });
+
+    it("includes() finds a substring", () => {
+      const adapter = create();
+      expect(adapter.includes('"ConsistentRead":true')).toBe(true);
+      expect(adapter.includes("NotPresent")).toBe(false);
+    });
+
+    it("includes() with number still searches bytes", () => {
+      const adapter = create();
+      // 0x7b = 123 = '{'
+      expect(adapter.includes(0x7b)).toBe(true);
+      expect(adapter.includes(0xff)).toBe(false);
+      // Byte search should not trigger the warning
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("indexOf() finds substring position", () => {
+      const adapter = create();
+      expect(adapter.indexOf("ConsistentRead")).toBe(2);
+      expect(adapter.indexOf("NotPresent")).toBe(-1);
+    });
+
+    it("indexOf() with number searches bytes", () => {
+      const adapter = create();
+      expect(adapter.indexOf(0x7b)).toBe(0);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("lastIndexOf() finds last substring position", () => {
+      const adapter = create();
+      expect(adapter.lastIndexOf("}")).toBe(json.length - 1);
+    });
+
+    it("lastIndexOf() with number searches bytes", () => {
+      const adapter = create();
+      expect(adapter.lastIndexOf(0x7d)).toBe(bytes.length - 1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("startsWith() checks prefix", () => {
+      const adapter = create();
+      expect(adapter.startsWith("{")).toBe(true);
+      expect(adapter.startsWith("X")).toBe(false);
+    });
+
+    it("endsWith() checks suffix", () => {
+      const adapter = create();
+      expect(adapter.endsWith("}")).toBe(true);
+      expect(adapter.endsWith("X")).toBe(false);
+    });
+
+    it("match() works with regex", () => {
+      const adapter = create();
+      const result = adapter.match(/"TableName":"([^"]+)"/);
+      expect(result?.[1]).toEqual("my-table");
+    });
+
+    it("replace() substitutes text", () => {
+      const adapter = create();
+      expect(adapter.replace("my-table", "other-table")).toContain("other-table");
+    });
+
+    it("split() tokenizes the string", () => {
+      const adapter = create();
+      const parts = adapter.split(",");
+      expect(parts.length).toBe(2);
+    });
+
+    it("JSON.parse() works via toString coercion", () => {
+      const adapter = create();
+      const parsed = JSON.parse(adapter as any);
+      expect(parsed.ConsistentRead).toBe(true);
+      expect(parsed.TableName).toEqual("my-table");
+    });
+
+    it("caches the decoded string (does not re-decode on subsequent calls)", () => {
+      const adapter = create();
+      const first = adapter.toString();
+      const second = adapter.toString();
+      const third = adapter.includes("x");
+      // Same string reference returned each time — proves caching.
+      expect(first).toBe(second);
+      expect(first).toEqual(json);
+    });
+  });
+
+  // ─── Warning throttle ──────────────────────────────────────────────────
+
+  describe("warning throttle", () => {
+    it("warns only once within a 60s window across multiple instances", () => {
+      // First call triggers the warning.
+      const a = create();
+      a.toString();
+      const callsAfterFirst = warnSpy.mock.calls.length;
+
+      // Second instance within the same 10s window — no additional warning.
+      const b = create();
+      b.toString();
+      expect(warnSpy).toHaveBeenCalledTimes(callsAfterFirst);
+    });
+
+    it("warns again after 60s have elapsed", () => {
+      const a = create();
+      a.toString();
+      const callsAfterFirst = warnSpy.mock.calls.length;
+
+      // Advance past the throttle window.
+      vi.advanceTimersByTime(61_000);
+
+      const b = create();
+      b.toString();
+      expect(warnSpy).toHaveBeenCalledTimes(callsAfterFirst + 1);
+    });
+  });
+
+  // ─── allocUnsafe ────────────────────────────────────────────────────────
+
+  describe("allocUnsafe", () => {
+    it("returns a JsonBytesStringAdapter instance", () => {
+      const adapter = JsonBytesStringAdapter.allocUnsafe(64);
+      expect(adapter).toBeInstanceOf(JsonBytesStringAdapter);
+      expect(adapter).toBeInstanceOf(Uint8Array);
+      expect(adapter.byteLength).toBe(64);
+    });
+  });
+});

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonBytesStringAdapter.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonBytesStringAdapter.ts
@@ -1,0 +1,158 @@
+import { toUtf8 } from "@smithy/core/serde";
+
+/**
+ * A Uint8Array subclass holding serialized JSON bytes that provides
+ * string method compatibility for customer middleware.
+ *
+ * Middleware historically observed `request.body` as a string for JSON
+ * protocol services. This class preserves that contract: string methods
+ * and coercion (template literals, `+` operator) lazily decode the bytes
+ * to a cached string. The HTTP transport layer still sees a Uint8Array
+ * and sends raw bytes without conversion.
+ *
+ * @internal
+ * @deprecated this adapter will be removed in a future version.
+ */
+export class JsonBytesStringAdapter extends Uint8Array {
+  private string: string | null = null;
+
+  public static allocUnsafe(bytes: number) {
+    if (typeof Buffer === "function") {
+      const buffer = Buffer.allocUnsafe(bytes);
+      return new JsonBytesStringAdapter(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+    }
+    return new JsonBytesStringAdapter(bytes);
+  }
+
+  /**
+   * Enables string coercion via template literals and `+` operator.
+   */
+  public override toString(): string {
+    return this.s();
+  }
+
+  /**
+   * Enables string coercion in comparison and arithmetic contexts.
+   * @returns a string. The signature is set to avoid incompatibility with extending Uint8Array.
+   */
+  public override valueOf(): any {
+    return this.s();
+  }
+
+  // -- String.prototype methods for middleware compatibility --
+
+  public override includes(searchString: string | number, position?: number): boolean {
+    if (typeof searchString === "string") {
+      return this.s().includes(searchString, position);
+    }
+    return Uint8Array.prototype.includes.call(this, searchString, position);
+  }
+
+  public override indexOf(searchString: string | number, position?: number): number {
+    if (typeof searchString === "string") {
+      return this.s().indexOf(searchString, position);
+    }
+    return Uint8Array.prototype.indexOf.call(this, searchString, position);
+  }
+
+  public override lastIndexOf(searchString: string | number, position?: number): number {
+    if (typeof searchString === "string") {
+      return this.s().lastIndexOf(searchString, position);
+    }
+    const fn = Uint8Array.prototype.lastIndexOf;
+    if (position !== undefined) {
+      return fn.call(this, searchString, position);
+    }
+    return fn.call(this, searchString);
+  }
+
+  public startsWith(searchString: string, position?: number): boolean {
+    return this.s().startsWith(searchString, position);
+  }
+
+  public endsWith(searchString: string, endPosition?: number): boolean {
+    return this.s().endsWith(searchString, endPosition);
+  }
+
+  public match(regexp: string | RegExp): RegExpMatchArray | null {
+    return this.s().match(regexp);
+  }
+
+  public replace(searchValue: string | RegExp, replaceValue: string): string {
+    return this.s().replace(searchValue, replaceValue);
+  }
+
+  public search(regexp: string | RegExp): number {
+    return this.s().search(regexp);
+  }
+
+  public split(separator: string | RegExp, limit?: number): string[] {
+    return this.s().split(separator, limit);
+  }
+
+  public substring(start: number, end?: number): string {
+    return this.s().substring(start, end);
+  }
+
+  public trim(): string {
+    return this.s().trim();
+  }
+
+  public trimStart(): string {
+    return this.s().trimStart();
+  }
+
+  public trimEnd(): string {
+    return this.s().trimEnd();
+  }
+
+  public charAt(pos: number): string {
+    return this.s().charAt(pos);
+  }
+
+  public charCodeAt(index: number): number {
+    return this.s().charCodeAt(index);
+  }
+
+  public padStart(maxLength: number, fillString?: string): string {
+    return this.s().padStart(maxLength, fillString);
+  }
+
+  public padEnd(maxLength: number, fillString?: string): string {
+    return this.s().padEnd(maxLength, fillString);
+  }
+
+  public repeat(count: number): string {
+    return this.s().repeat(count);
+  }
+
+  public toUpperCase(): string {
+    return this.s().toUpperCase();
+  }
+
+  public toLowerCase(): string {
+    return this.s().toLowerCase();
+  }
+
+  /**
+   * Decodes the bytes to a UTF-8 string on first access, then caches.
+   * Subsequent calls return the cached string with zero cost.
+   */
+  private s(): string {
+    if (this.string == null) {
+      const n = Date.now();
+      if (n > warned + 60_000) {
+        console.warn(
+          "@aws-sdk/core/protocols - WARN - JsonCodec2: you have called a string method on a Uint8Array request body. " +
+            "It has been automatically converted to string. In a future version this will throw an error."
+        );
+        warned = n;
+      }
+
+      this.string = toUtf8(this);
+    }
+    return this.string;
+  }
+}
+
+var warned = 0;

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonCodec2.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonCodec2.spec.ts
@@ -40,4 +40,31 @@ describe(JsonCodec2.name, () => {
     codec.createDeserializer();
     expect(JsonShapeDeserializer2.prototype.setSerdeContext).toHaveBeenCalledWith(serdeContext);
   });
+
+  it("serializer works before setSerdeContext is called (uses fallback defaults)", () => {
+    const codec = new JsonCodec2({
+      jsonName: true,
+      timestampFormat: { default: 7, useTrait: true },
+    });
+    // Do NOT call setSerdeContext — simulates protocol constructor order
+    const serializer = codec.createSerializer() as JsonShapeSerializer2;
+
+    const schema = [3, "ns", "S", 0, ["blob"], [21]] as any;
+    serializer.write(schema, { blob: new Uint8Array([1, 2, 3]) });
+    const result = JSON.parse(new TextDecoder().decode(serializer.flush() as Uint8Array));
+    expect(result.blob).toEqual("AQID");
+  });
+
+  it("deserializer works before setSerdeContext is called for string input", async () => {
+    const codec = new JsonCodec2({
+      jsonName: true,
+      timestampFormat: { default: 7, useTrait: true },
+    });
+    // Do NOT call setSerdeContext
+    const deserializer = codec.createDeserializer() as JsonShapeDeserializer2;
+
+    const schema = [3, "ns", "S", 0, ["blob"], [21]] as any;
+    const result = await deserializer.read(schema, '{"blob":"AQID"}');
+    expect(result.blob).toEqual(new Uint8Array([1, 2, 3]));
+  });
 });

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonCodec2.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonCodec2.ts
@@ -6,6 +6,7 @@ import { JsonShapeSerializer2 } from "./JsonShapeSerializer2";
 import type { JsonSettings } from "../JsonSettings";
 
 /**
+ * Codec grouping the v2 serializer and deserializer.
  * @public
  */
 export class JsonCodec2 extends SerdeContextConfig implements $Codec<Uint8Array, string> {

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeDeserializer2.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeDeserializer2.spec.ts
@@ -1,5 +1,5 @@
 import { nv, NumericValue } from "@smithy/core/serde";
-import type { TimestampEpochSecondsSchema } from "@smithy/types";
+import type { StaticStructureSchema, TimestampEpochSecondsSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
 import { createNestingWidget, nestingWidget, unionStruct, unionStructControl, widget } from "../../test-schema.spec";
@@ -456,4 +456,97 @@ describe(JsonShapeDeserializer2.name, () => {
       }
     });
   }, 60_000);
+
+  // ─── __type struct deserialization with jsonName ─────────────────────────────
+
+  describe("__type struct deserialization with jsonName", () => {
+    const structWithJsonNames: StaticStructureSchema = [
+      3,
+      "ns",
+      "MyStruct",
+      0,
+      ["firstName", "lastName", "age"],
+      [
+        [0, "ns", "FirstName", { jsonName: "first_name" }, 0],
+        [0, "ns", "LastName", { jsonName: "last_name" }, 0],
+        [1, "ns", "Age", 0, 0],
+      ],
+    ];
+
+    it("deserializes struct with jsonName mappings when __type is absent", async () => {
+      const json = JSON.stringify({
+        first_name: "Alice",
+        last_name: "Smith",
+        age: 30,
+      });
+      const result = await deserializer.read(structWithJsonNames, json);
+      expect(result).toEqual({
+        firstName: "Alice",
+        lastName: "Smith",
+        age: 30,
+      });
+    });
+
+    it("deserializes struct with jsonName mappings when __type is present", async () => {
+      const json = JSON.stringify({
+        __type: "ns#MyStruct",
+        first_name: "Bob",
+        last_name: "Jones",
+        age: 25,
+        extra_field: "bonus",
+      });
+      const result = await deserializer.read(structWithJsonNames, json);
+      expect(result).toEqual({
+        __type: "ns#MyStruct",
+        firstName: "Bob",
+        lastName: "Jones",
+        age: 25,
+        extra_field: "bonus",
+      });
+    });
+
+    it("does not copy known members as extras when __type is present", async () => {
+      const json = JSON.stringify({
+        __type: "ns#MyStruct",
+        first_name: "Carol",
+        last_name: "White",
+        age: 40,
+      });
+      const result = await deserializer.read(structWithJsonNames, json);
+      const keys = Object.keys(result);
+      // jsonName wire keys should be mapped back to member names
+      expect(keys).not.toContain("first_name");
+      expect(keys).not.toContain("last_name");
+      expect(keys).toContain("firstName");
+      expect(keys).toContain("lastName");
+    });
+
+    it("deserializes with __type but no extra fields", async () => {
+      const json = JSON.stringify({
+        __type: "ns#MyStruct",
+        first_name: "Dave",
+        last_name: "Brown",
+        age: 50,
+      });
+      const result = await deserializer.read(structWithJsonNames, json);
+      expect(result.__type).toEqual("ns#MyStruct");
+      expect(result.firstName).toEqual("Dave");
+      expect(result.lastName).toEqual("Brown");
+      expect(result.age).toEqual(50);
+    });
+  });
+
+  // ─── serdeContext-less operation ────────────────────────────────────────────
+
+  describe("operation without serdeContext", () => {
+    it("deserializes from string input without serdeContext set", async () => {
+      const freshDeserializer = new JsonShapeDeserializer2({
+        jsonName: true,
+        timestampFormat: { default: 7 satisfies TimestampEpochSecondsSchema, useTrait: true },
+      });
+      // Do NOT call setSerdeContext
+      const result = await freshDeserializer.read(widget, '{"blob":"AQID"}');
+      expect(result.blob).toEqual(new Uint8Array([1, 2, 3]));
+    });
+  });
 });

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeDeserializer2.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeDeserializer2.ts
@@ -1,13 +1,13 @@
 import { determineTimestampFormat } from "@smithy/core/protocols";
 import { NormalizedSchema } from "@smithy/core/schema";
 import {
+  fromBase64,
   LazyJsonString,
   NumericValue,
   parseEpochTimestamp,
   parseRfc3339DateTimeWithOffset,
   parseRfc7231DateTime,
 } from "@smithy/core/serde";
-import { fromBase64 } from "@smithy/core/serde";
 import type {
   DocumentType,
   Schema,
@@ -53,14 +53,20 @@ export class JsonShapeDeserializer2 extends SerdeContextConfig implements ShapeD
     const reviver = needsReviver(schema) ? jsonReviver : undefined;
     let parsed: unknown;
     if (typeof data === "string") {
+      if (data.length === 0) {
+        return {};
+      }
       parsed = JSON.parse(data, reviver);
     } else if (data instanceof Uint8Array && detectBufferParsing()) {
+      if (data.byteLength === 0) {
+        return {};
+      }
       // detectBufferParsing() guarantees Buffer exists globally.
       const buf = Buffer.isBuffer(data) ? data : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
       parsed = JSON.parse(buf as any, reviver);
     } else {
       // Fallback: collect stream to string, then parse.
-      parsed = await parseJsonBody(data, this.serdeContext!);
+      parsed = await parseJsonBody(data, this.serdeContext!, schema);
     }
     return this._read(schema, parsed);
   }
@@ -80,19 +86,23 @@ export class JsonShapeDeserializer2 extends SerdeContextConfig implements ShapeD
       }
       if (Array.isArray(value) && ns.isListSchema()) {
         const listMember = ns.getValueSchema();
-        for (let i = 0; i < value.length; ++i) {
-          value[i] = this._read(listMember, value[i]);
+        if (this.needsTransform(listMember)) {
+          for (let i = 0; i < value.length; ++i) {
+            value[i] = this._read(listMember, value[i]);
+          }
         }
         return value;
       }
       if (ns.isMapSchema()) {
         const mapMember = ns.getValueSchema();
         const map = value as Record<string, unknown>;
-        for (const k in map) {
-          if (k === "__proto__") {
-            writeKey(map);
+        if (this.needsTransform(mapMember)) {
+          for (const k in map) {
+            if (k === "__proto__") {
+              writeKey(map);
+            }
+            map[k] = this._read(mapMember, map[k]);
           }
-          map[k] = this._read(mapMember, map[k]);
         }
         return map;
       }
@@ -175,23 +185,20 @@ export class JsonShapeDeserializer2 extends SerdeContextConfig implements ShapeD
             }
           }
         }
-        return value;
-      } else {
-        // Scalar document: locally owned, no clone needed.
-        return value;
       }
     }
 
-    // covers boolean, bigint (long/BigInt), bigDecimal
+    // covers document, boolean, bigint (long/BigInt), bigDecimal
     return value;
   }
 
   private _readStruct(ns: NormalizedSchema, record: Record<string, unknown>): any {
     const union = ns.isUnionSchema();
     const out = {} as any;
-    let nameMap: Record<string, string> | undefined = void 0;
+    let nameMap: Record<string, string> | undefined;
+    const hasType = typeof record.__type === "string";
     const { jsonName } = this.settings;
-    if (jsonName) {
+    if (jsonName && hasType) {
       nameMap = {};
     }
 
@@ -203,7 +210,9 @@ export class JsonShapeDeserializer2 extends SerdeContextConfig implements ShapeD
       let fromKey = memberName;
       if (jsonName) {
         fromKey = memberSchema.getMergedTraits().jsonName ?? fromKey;
-        nameMap![fromKey] = memberName;
+        if (hasType) {
+          nameMap![fromKey] = memberName;
+        }
       }
       if (union) {
         unionSerde!.mark(fromKey);
@@ -214,7 +223,7 @@ export class JsonShapeDeserializer2 extends SerdeContextConfig implements ShapeD
     }
     if (union) {
       unionSerde!.writeUnknown();
-    } else if (typeof record.__type === "string") {
+    } else if (hasType) {
       for (const k in record) {
         const v = record[k];
         const t = jsonName ? (nameMap![k] ?? k) : k;
@@ -224,5 +233,18 @@ export class JsonShapeDeserializer2 extends SerdeContextConfig implements ShapeD
       }
     }
     return out;
+  }
+
+  private needsTransform(ns: NormalizedSchema): boolean {
+    if (ns.isBlobSchema() || ns.isTimestampSchema() || ns.isBigIntegerSchema() || ns.isBigDecimalSchema()) {
+      return true;
+    }
+    if (ns.isDocumentSchema() || ns.isStructSchema() || ns.isListSchema() || ns.isMapSchema()) {
+      return true;
+    }
+    if (ns.isStringSchema() && ns.getMergedTraits().mediaType) {
+      return true;
+    }
+    return false;
   }
 }

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeSerializer2.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeSerializer2.spec.ts
@@ -565,6 +565,98 @@ describe(JsonShapeSerializer2.name, () => {
     });
   });
 
+  // ─── __type document member serialization ───────────────────────────────────
+
+  describe("__type struct serialization", () => {
+    const structWithJsonNames: StaticStructureSchema = [
+      3,
+      "ns",
+      "MyStruct",
+      0,
+      ["firstName", "lastName", "age"],
+      [
+        [0, "ns", "FirstName", { jsonName: "first_name" }, 0],
+        [0, "ns", "LastName", { jsonName: "last_name" }, 0],
+        [1, "ns", "Age", 0, 0],
+      ],
+    ];
+
+    it("serializes extra members not in the schema when __type is present", () => {
+      const data = {
+        __type: "ns#ExtendedStruct",
+        firstName: "Alice",
+        lastName: "Smith",
+        age: 30,
+        extraField: "extra_value",
+        anotherExtra: 42,
+      };
+      serializer.write(structWithJsonNames, data);
+      const result = JSON.parse(decode(serializer.flush()));
+
+      expect(result.first_name).toEqual("Alice");
+      expect(result.last_name).toEqual("Smith");
+      expect(result.age).toEqual(30);
+      expect(result.extraField).toEqual("extra_value");
+      expect(result.anotherExtra).toEqual(42);
+      expect(result.__type).toEqual("ns#ExtendedStruct");
+    });
+
+    it("does not duplicate schema members as extra members when __type is present", () => {
+      const data = {
+        __type: "ns#Thing",
+        firstName: "Bob",
+        lastName: "Jones",
+        age: 25,
+      };
+      serializer.write(structWithJsonNames, data);
+      const result = decode(serializer.flush());
+      const parsed = JSON.parse(result);
+
+      expect(parsed.first_name).toEqual("Bob");
+      // The raw key "firstName" should not appear — only the jsonName "first_name"
+      expect(Object.keys(parsed).filter((k) => k === "firstName")).toHaveLength(0);
+      // Each jsonName key should appear exactly once
+      expect((result.match(/first_name/g) || []).length).toEqual(1);
+    });
+
+    it("writtenKeys prevents raw member names from appearing as extras", () => {
+      const data = {
+        __type: "ns#Thing",
+        firstName: "Bob",
+        lastName: "Jones",
+        age: 25,
+      };
+      serializer.write(structWithJsonNames, data);
+      const result = decode(serializer.flush());
+
+      // "firstName" (source key) should NOT appear in output
+      expect(result).not.toContain('"firstName"');
+      // "first_name" (jsonName) SHOULD appear
+      expect(result).toContain('"first_name"');
+    });
+
+    it("serializes __type struct without jsonName settings", () => {
+      const noJsonSerializer = new JsonShapeSerializer2({
+        jsonName: false,
+        timestampFormat: { default: 7 satisfies TimestampEpochSecondsSchema, useTrait: true },
+      });
+      const simpleStruct: StaticStructureSchema = [3, "ns", "SimpleStruct", 0, ["name", "value"], [0, 0]];
+      const data = {
+        __type: "ns#NoRename",
+        name: "Dave",
+        value: "test",
+        unknownField: "mystery",
+      };
+      noJsonSerializer.write(simpleStruct, data);
+      const result = JSON.parse(decode(noJsonSerializer.flush()));
+
+      expect(result.__type).toEqual("ns#NoRename");
+      expect(result.name).toEqual("Dave");
+      expect(result.value).toEqual("test");
+      expect(result.unknownField).toEqual("mystery");
+    });
+  });
+
   // ─── flush() behavior ─────────────────────────────────────────────────────
 
   describe("flush", () => {

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeSerializer2.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeSerializer2.ts
@@ -13,6 +13,7 @@ import type {
 import { SerdeContextConfig } from "../../ConfigurableSerdeContext";
 import type { JsonSettings } from "../JsonSettings";
 import { writeKey } from "../../writeKey";
+import { JsonBytesStringAdapter } from "./JsonBytesStringAdapter";
 
 const encoder = new TextEncoder();
 
@@ -54,7 +55,8 @@ const INITIAL_BUFFER_SIZE = 2048;
  * Safe here because we track pos and always write before reading.
  */
 function alloc(size: number): Uint8Array {
-  return typeof Buffer !== "undefined" ? Buffer.allocUnsafe(size) : new Uint8Array(size);
+  // todo(kuhe): will be replaced by native Buffer/Uint8Array in the future.
+  return JsonBytesStringAdapter.allocUnsafe(size);
 }
 
 /**
@@ -79,10 +81,7 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
     this.i = 0;
     this.rawValue = value;
     this.rootSchema = NormalizedSchema.of(schema);
-    this.passthrough =
-      !this.rootSchema.isStructSchema() &&
-      !this.rootSchema.isDocumentSchema() &&
-      (this.rootSchema.isBlobSchema() || this.rootSchema.isStringSchema());
+    this.passthrough = this.rootSchema.isBlobSchema() || this.rootSchema.isStringSchema();
     if (!this.passthrough) {
       this.writeValue(this.rootSchema, value, undefined);
     }
@@ -95,34 +94,16 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
     this.i = 0;
     this.rootSchema = NormalizedSchema.of(schema);
     const ns = this.rootSchema;
-    // For discriminated documents, we need to inject __type as the first key
     if (ns.isStructSchema() && value != null && typeof value === "object") {
-      this.ensure(2);
-      this.json[this.i++] = OPEN_BRACE;
-      // Write __type first
-      this.writeAsciiQuoted("__type");
-      this.json[this.i++] = COLON;
-      this.writeAsciiQuoted(ns.getName(true) ?? "Unknown");
-      // Then write remaining struct members
-      let wroteAny = true; // we already wrote __type
-      const { jsonName } = this.settings;
-      for (const [memberName, memberSchema] of ns.structIterator()) {
-        const item = (value as any)[memberName];
-        if (item == null && !memberSchema.isIdempotencyToken()) {
-          continue;
-        }
-        if (wroteAny) {
-          this.ensure(1);
-          this.json[this.i++] = COMMA;
-        }
-        const targetKey = jsonName ? (memberSchema.getMergedTraits().jsonName ?? memberName) : memberName;
-        this.writeAsciiQuoted(targetKey);
-        this.json[this.i++] = COLON;
-        this.writeValue(memberSchema, item, ns);
-        wroteAny = true;
-      }
-      this.ensure(1);
-      this.json[this.i++] = CLOSE_BRACE;
+      // Serialize the struct normally, then inject __type as the first key
+      // by shifting the buffer contents after the opening brace.
+      this.writeValue(ns, value, undefined);
+      const prefix = `"__type":"${ns.getName(true) ?? "Unknown"}",`;
+      const z = prefix.length;
+      this.ensure(z);
+      this.json.copyWithin(1 + z, 1, this.i);
+      encoder.encodeInto(prefix, this.json.subarray(1));
+      this.i += z;
     } else {
       this.writeValue(ns, value, undefined);
     }
@@ -210,7 +191,7 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
   protected writeJsonString(s: string): void {
     // Worst case: every char needs \uXXXX (6 bytes) + 2 quotes
     // But we'll grow dynamically, so just ensure a reasonable amount
-    this.ensure(s.length * 2 + 2);
+    this.ensure(s.length * 3 + 2);
     this.json[this.i++] = QUOTE;
 
     const z = s.length;
@@ -239,7 +220,7 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
           this.ensure(4);
           const { written } = encoder.encodeInto(s.substring(j, j + 2), this.json.subarray(this.i));
           this.i += written!;
-          j++; // skip the low surrogate in the loop
+          ++j; // skip the low surrogate in the loop
         } else {
           this.ensure(6);
           this.writeUnicodeEscape(c);
@@ -281,7 +262,9 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
   protected static readonly B64: Uint8Array = /* @__PURE__ */ (() => {
     const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     const table = new Uint8Array(64);
-    for (let i = 0; i < 64; i++) table[i] = chars.charCodeAt(i);
+    for (let i = 0; i < 64; ++i) {
+      table[i] = chars.charCodeAt(i);
+    }
     return table;
   })();
 
@@ -398,7 +381,6 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
       }
 
       if (value instanceof NumericValue) {
-        // Write the raw numeric string without quotes
         this.writeAscii(value.string);
         return;
       }
@@ -419,7 +401,6 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
       return;
     }
 
-    // Primitives
     if (typeof value === "string") {
       if (ns.isBlobSchema()) {
         // string blob (already base64 or needs encoding)
@@ -445,13 +426,15 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
 
     if (typeof value === "boolean") {
       this.ensure(5);
+      let { i, json } = this;
       if (value) {
-        this.json.set(TRUE, this.i);
-        this.i += 4;
+        json.set(TRUE, i);
+        i += 4;
       } else {
-        this.json.set(FALSE, this.i);
-        this.i += 5;
+        json.set(FALSE, i);
+        i += 5;
       }
+      this.i = i;
       return;
     }
 
@@ -468,7 +451,6 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
   protected writeStruct(ns: NormalizedSchema, value: Record<string, unknown>): void {
     this.ensure(2);
     this.json[this.i++] = OPEN_BRACE;
-    let first = true;
     let wroteAny = false;
 
     // Track written keys (both source member names and target json names)
@@ -481,13 +463,14 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
 
     for (const [memberName, memberSchema] of ns.structIterator()) {
       const item = value[memberName];
-      if (item == null && !memberSchema.isIdempotencyToken()) continue;
+      if (item == null && !memberSchema.isIdempotencyToken()) {
+        continue;
+      }
 
-      if (!first) {
+      if (wroteAny) {
         this.ensure(1);
         this.json[this.i++] = COMMA;
       }
-      first = false;
       wroteAny = true;
 
       const targetKey = this.settings.jsonName ? (memberSchema.getMergedTraits().jsonName ?? memberName) : memberName;
@@ -512,16 +495,17 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
     } else if (hasType) {
       // Write extra document members not covered by the struct schema.
       for (const k in value) {
-        const targetKey = this.settings.jsonName ? (writtenKeys!.has(k) ? k : k) : k;
-        if (writtenKeys!.has(targetKey)) continue;
-        writtenKeys!.add(targetKey);
+        if (writtenKeys!.has(k)) {
+          continue;
+        }
+        writtenKeys!.add(k);
         const v = value[k];
-        if (!first) {
+        if (wroteAny) {
           this.ensure(1);
           this.json[this.i++] = COMMA;
         }
-        first = false;
-        this.writeAsciiQuoted(targetKey);
+        wroteAny = true;
+        this.writeAsciiQuoted(k);
         this.ensure(1);
         this.json[this.i++] = COLON;
         this.writeValue(15 satisfies DocumentSchema, v, undefined);
@@ -533,21 +517,34 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
   }
 
   protected writeList(ns: NormalizedSchema, value: unknown[], isDocument?: boolean): void {
-    this.ensure(2);
-    this.json[this.i++] = OPEN_BRACKET;
     const sparse = !!ns.getMergedTraits().sparse;
     const valueSchema = ns.getValueSchema();
+
+    if (!isDocument) {
+      if (valueSchema.isStringSchema() || valueSchema.isNumericSchema() || valueSchema.isBooleanSchema()) {
+        const json = sparse ? JSON.stringify(value) : JSON.stringify(value.filter((_) => _ != null));
+        this.ensure(json.length * 3);
+        this.i += encoder.encodeInto(json, this.json.subarray(this.i)).written;
+        return;
+      }
+    }
+
+    this.ensure(2);
+    this.json[this.i++] = OPEN_BRACKET;
+    let wroteFirstItem = false;
 
     for (let i = 0; i < value.length; ++i) {
       const item = value[i];
       if (isDocument ? item === undefined : item == null && !sparse) {
         continue;
       }
-      if (i !== 0) {
+      if (wroteFirstItem) {
         this.ensure(1);
         this.json[this.i++] = COMMA;
       }
+      // undefined is the correct "container" here.
       this.writeValue(valueSchema, item, undefined);
+      wroteFirstItem = true;
     }
 
     this.ensure(1);
@@ -565,7 +562,7 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
     if (!isDocument) {
       if (valueSchema.isStringSchema() || valueSchema.isNumericSchema() || valueSchema.isBooleanSchema()) {
         // For sparse maps, JSON.stringify omits undefined values instead of writing null.
-        // Convert undefined → null to match production serializer behavior.
+        // Convert undefined to null to match production serializer behavior.
         let input: Record<string, unknown> = value;
         if (sparse) {
           input = {};
@@ -578,8 +575,7 @@ export class JsonShapeSerializer2 extends SerdeContextConfig implements ShapeSer
         }
         const json = JSON.stringify(input);
         this.ensure(json.length * 3); // worst-case UTF-8 expansion
-        const { written } = encoder.encodeInto(json, this.json.subarray(this.i));
-        this.i += written!;
+        this.i += encoder.encodeInto(json, this.json.subarray(this.i)).written;
         return;
       }
     }

--- a/packages-internal/core/src/submodules/protocols/json/json.schema.equivalence.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/json.schema.equivalence.spec.ts
@@ -591,4 +591,108 @@ describe("JSON v2 codec equivalence: schema-based permutations", () => {
       assertSerializationEquivalence(schema, value);
     });
   });
+
+  describe("__type with jsonName (document member forward-compat)", () => {
+    const structWithJsonNames: StaticStructureSchema = [
+      3,
+      "ns",
+      "MyStruct",
+      0,
+      ["firstName", "lastName", "age"],
+      [
+        [0, "ns", "FirstName", { jsonName: "first_name" }, 0],
+        [0, "ns", "LastName", { jsonName: "last_name" }, 0],
+        [1, "ns", "Age", 0, 0],
+      ],
+    ];
+
+    it("serialization: __type with known members only", () => {
+      const value = {
+        __type: "ns#MyStruct",
+        firstName: "Alice",
+        lastName: "Smith",
+        age: 30,
+      };
+      assertSerializationEquivalence(structWithJsonNames, value);
+    });
+
+    it("serialization: __type with extra unknown members", () => {
+      const value = {
+        __type: "ns#Extended",
+        firstName: "Bob",
+        lastName: "Jones",
+        age: 25,
+        extraField: "bonus",
+        anotherExtra: 99,
+      };
+      assertSerializationEquivalence(structWithJsonNames, value);
+    });
+
+    it("deserialization: __type with known jsonName keys", async () => {
+      const json = JSON.stringify({
+        __type: "ns#MyStruct",
+        first_name: "Carol",
+        last_name: "White",
+        age: 40,
+      });
+      await assertDeserializationEquivalence(structWithJsonNames, json);
+    });
+
+    it("deserialization: __type with extra unknown keys", async () => {
+      const json = JSON.stringify({
+        __type: "ns#MyStruct",
+        first_name: "Dave",
+        last_name: "Brown",
+        age: 50,
+        unknown_key: "mystery",
+        another: 123,
+      });
+      await assertDeserializationEquivalence(structWithJsonNames, json);
+    });
+
+    it("deserialization: no __type (normal path)", async () => {
+      const json = JSON.stringify({
+        first_name: "Eve",
+        last_name: "Green",
+        age: 35,
+      });
+      await assertDeserializationEquivalence(structWithJsonNames, json);
+    });
+
+    it("serialization: __type without jsonName settings", () => {
+      const ser1NoJson = new JsonShapeSerializer({ ...settings, jsonName: false });
+      const ser2NoJson = new JsonShapeSerializer2({ ...settings, jsonName: false });
+
+      const simpleStruct: StaticStructureSchema = [3, "ns", "Simple", 0, ["name", "value"], [0, 1]];
+      const value = {
+        __type: "ns#Simple",
+        name: "Frank",
+        value: 42,
+        extra: "field",
+      };
+
+      ser1NoJson.write(simpleStruct, value);
+      const v1Json = ser1NoJson.flush();
+      ser2NoJson.write(simpleStruct, value);
+      const v2Json = decoder.decode(ser2NoJson.flush());
+      expect(v2Json).toEqual(v1Json);
+    });
+
+    it("deserialization: __type without jsonName settings", async () => {
+      const de1NoJson = new JsonShapeDeserializer({ ...settings, jsonName: false });
+      const de2NoJson = new JsonShapeDeserializer2({ ...settings, jsonName: false });
+
+      const simpleStruct: StaticStructureSchema = [3, "ns", "Simple", 0, ["name", "value"], [0, 1]];
+      const json = JSON.stringify({
+        __type: "ns#Simple",
+        name: "Grace",
+        value: 99,
+        extra: "bonus",
+      });
+
+      const v1Result = await de1NoJson.read(simpleStruct, json);
+      const v2Result = await de2NoJson.read(simpleStruct, json);
+      expect(v2Result).toEqual(v1Result);
+    });
+  });
 });

--- a/packages-internal/core/src/submodules/protocols/schema-testing/schema-documents.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/schema-testing/schema-documents.spec.ts
@@ -5,7 +5,6 @@ import type {
   BlobSchema,
   BooleanSchema,
   DocumentSchema,
-  DocumentType,
   NumericSchema,
   StaticListSchema,
   StaticMapSchema,
@@ -21,8 +20,13 @@ import { describe, expect, test as it } from "vitest";
 
 import type { JsonSettings } from "../json/JsonSettings";
 import { JsonCodec } from "../json/codec-v1/JsonCodec";
-import type { JsonShapeDeserializer } from "../json/codec-v1/JsonShapeDeserializer";
+import { JsonCodec2 } from "../json/codec-v2/JsonCodec2";
 import { testCases } from "./new-document-type-test-cases.spec";
+import { toUtf8 } from "@smithy/core/serde";
+import type { JsonShapeSerializer } from "../json/codec-v1/JsonShapeSerializer";
+import type { JsonShapeSerializer2 } from "../json/codec-v2/JsonShapeSerializer2";
+import type { JsonShapeDeserializer } from "../json/codec-v1/JsonShapeDeserializer";
+import type { JsonShapeDeserializer2 } from "../json/codec-v2/JsonShapeDeserializer2";
 
 /* eslint no-var: 0 */
 export var OmniWidget: StaticStructureSchema = [
@@ -89,7 +93,10 @@ export var OmniWidget: StaticStructureSchema = [
 
 TypeRegistry.for(OmniWidget[1]).register(`${OmniWidget[1]}#${OmniWidget[2]}`, OmniWidget);
 
-function getJsonCodec(test: { settings: JsonSettings }): JsonCodec {
+function getJsonCodec(
+  CodecCtor: { new (args: any): JsonCodec | JsonCodec2 },
+  test: { settings: JsonSettings }
+): JsonCodec | JsonCodec2 {
   const { settings } = test;
   const format =
     {
@@ -98,7 +105,7 @@ function getJsonCodec(test: { settings: JsonSettings }): JsonCodec {
       "epoch-seconds": 7 as const satisfies TimestampEpochSecondsSchema,
     }[(settings.timestampFormat?.default as unknown as string) ?? "epoch-seconds"] ??
     (7 as const satisfies TimestampEpochSecondsSchema);
-  return new JsonCodec({
+  return new CodecCtor({
     jsonName: settings.jsonName ?? false,
     timestampFormat: {
       default: format,
@@ -108,66 +115,55 @@ function getJsonCodec(test: { settings: JsonSettings }): JsonCodec {
   });
 }
 
-/**
- * Attempts to use the discriminator on the data instead of requiring a
- * schema as input.
- */
-function readDocument(deserializer: JsonShapeDeserializer, data: DocumentType): any {
-  if (data && typeof data === "object" && typeof (data as any).__type === "string") {
-    const object = data as any;
-    const [namespace, name] = object.__type.split("#");
-    delete object.__type;
-    const schema = TypeRegistry.for(namespace).getSchema(name);
-    const ns = NormalizedSchema.of(schema);
-    return deserializer.readObject(ns, object);
-  }
-  return deserializer.readObject(15 satisfies DocumentSchema, data);
+for (const Codec of [JsonCodec, JsonCodec2]) {
+  describe("schema conversion tests for serializations, data objects, and documents", () => {
+    for (const test of testCases.serdeTests) {
+      it(test.name, async () => {
+        const subjectSchema = NormalizedSchema.of(TypeRegistry.for("smithy.example").getSchema(test.subject));
+
+        const codec = getJsonCodec(Codec, test);
+        const serializer = codec.createSerializer() as JsonShapeSerializer | JsonShapeSerializer2;
+        const deserializer = codec.createDeserializer() as JsonShapeDeserializer | JsonShapeDeserializer2;
+
+        serializer.write(15 satisfies DocumentSchema, test.serialized);
+        const serialization = toUtf8(serializer.flush());
+        const documentFromSerialization = await deserializer.read(15 satisfies DocumentSchema, serialization);
+        const canonicalDataObject = await deserializer.read(subjectSchema, serialization);
+
+        serializer.writeDiscriminatedDocument(subjectSchema, canonicalDataObject);
+        const documentFromDataObject = await deserializer.read(15 satisfies DocumentSchema, toUtf8(serializer.flush()));
+
+        // 1. data object from serialization
+        expect(typeof documentFromSerialization).toBe("object");
+
+        // 2. data object document back to data object
+        const dataObjectFromDocument = await deserializer.readObject(subjectSchema, documentFromDataObject);
+        delete dataObjectFromDocument.__type;
+        expect(dataObjectFromDocument).toEqual(canonicalDataObject);
+
+        // 3. data object from serialization document
+        const dataObjectFromSerializedDocument = await deserializer.readObject(
+          subjectSchema,
+          documentFromSerialization
+        );
+        expect(dataObjectFromSerializedDocument).toEqual(canonicalDataObject);
+
+        // 4. serialization from data object
+        serializer.write(subjectSchema, canonicalDataObject);
+        const serializationFromDataObject = toUtf8(serializer.flush());
+        expect(serializationFromDataObject).toEqual(serialization);
+
+        // 5. serialization from serialization document
+        serializer.write(15 satisfies DocumentSchema, documentFromSerialization);
+        const serializationFromSerializedDocument = toUtf8(serializer.flush());
+        expect(serializationFromSerializedDocument).toEqual(serialization);
+
+        // 6. serialization from data object document
+        delete documentFromDataObject.__type;
+        serializer.write(15 satisfies DocumentSchema, documentFromDataObject);
+        const serializationFromDocumentFromDataObject = toUtf8(serializer.flush());
+        expect(serializationFromDocumentFromDataObject).toEqual(serialization);
+      });
+    }
+  });
 }
-
-describe("schema conversion tests for serializations, data objects, and documents", () => {
-  for (const test of testCases.serdeTests) {
-    it(test.name, async () => {
-      const subjectSchema = NormalizedSchema.of(TypeRegistry.for("smithy.example").getSchema(test.subject));
-
-      const codec = getJsonCodec(test);
-      const serializer = codec.createSerializer();
-      const deserializer = codec.createDeserializer();
-
-      serializer.write(15 satisfies DocumentSchema, test.serialized);
-      const serialization = serializer.flush();
-      const documentFromSerialization = await deserializer.read(15 satisfies DocumentSchema, serialization);
-      const canonicalDataObject = await deserializer.read(subjectSchema, serialization);
-
-      serializer.writeDiscriminatedDocument(subjectSchema, canonicalDataObject);
-      const documentFromDataObject = await deserializer.read(15 satisfies DocumentSchema, serializer.flush());
-
-      // 1. data object from serialization
-      expect(typeof documentFromSerialization).toBe("object");
-
-      // 2. data object document back to data object
-      const dataObjectFromDocument = await deserializer.readObject(subjectSchema, documentFromDataObject);
-      delete dataObjectFromDocument.__type;
-      expect(dataObjectFromDocument).toEqual(canonicalDataObject);
-
-      // 3. data object from serialization document
-      const dataObjectFromSerializedDocument = await deserializer.readObject(subjectSchema, documentFromSerialization);
-      expect(dataObjectFromSerializedDocument).toEqual(canonicalDataObject);
-
-      // 4. serialization from data object
-      serializer.write(subjectSchema, canonicalDataObject);
-      const serializationFromDataObject = serializer.flush();
-      expect(serializationFromDataObject).toEqual(serialization);
-
-      // 5. serialization from serialization document
-      serializer.write(15 satisfies DocumentSchema, documentFromSerialization);
-      const serializationFromSerializedDocument = serializer.flush();
-      expect(serializationFromSerializedDocument).toEqual(serialization);
-
-      // 6. serialization from data object document
-      delete documentFromDataObject.__type;
-      serializer.write(15 satisfies DocumentSchema, documentFromDataObject);
-      const serializationFromDocumentFromDataObject = serializer.flush();
-      expect(serializationFromDocumentFromDataObject).toEqual(serialization);
-    });
-  }
-});

--- a/packages-internal/dynamodb-codec/src/codec-v2/DynamoDBJsonCodec2.spec.ts
+++ b/packages-internal/dynamodb-codec/src/codec-v2/DynamoDBJsonCodec2.spec.ts
@@ -111,7 +111,7 @@ describe(DynamoDBJsonCodec2.name, () => {
   it("serializes identically to the default codec", async () => {
     serializer.write(AttributeValue, avInput);
     const serialization = serializer.flush();
-    expect(serialization).toEqual(JSON.stringify(canonicalSerialization));
+    expect(toUtf8(serialization)).toEqual(JSON.stringify(canonicalSerialization));
     expect(JSON.parse(toUtf8(serialization))).toEqual(canonicalSerialization);
 
     baseSerializer.write(AttributeValue, avInput);

--- a/packages-internal/dynamodb-codec/src/codec-v2/DynamoDBJsonCodec2.ts
+++ b/packages-internal/dynamodb-codec/src/codec-v2/DynamoDBJsonCodec2.ts
@@ -32,9 +32,6 @@ type AttributeValueOutput = {
  * @internal
  */
 class DynamoDBJsonShapeSerializer2 extends JsonShapeSerializer2 {
-  /**
-   * @override
-   */
   protected override writeValue(schema: Schema, value: unknown, container: NormalizedSchema | undefined): void {
     if (value != null && typeof value === "object") {
       const ns = NormalizedSchema.of(schema);
@@ -172,16 +169,6 @@ class DynamoDBJsonShapeSerializer2 extends JsonShapeSerializer2 {
 }
 
 /**
- * String adapter for the DynamoDB byte serializer.
- * @internal
- */
-class DynamoDBStringShapeSerializer2 extends DynamoDBJsonShapeSerializer2 implements $ShapeSerializer<string> {
-  public override flush(): any {
-    return (this.serdeContext?.utf8Encoder ?? toUtf8)(super.flush());
-  }
-}
-
-/**
  * @internal
  */
 class DynamoDBJsonShapeDeserializer2 extends JsonShapeDeserializer2 {
@@ -247,7 +234,7 @@ export class DynamoDBJsonCodec2 extends JsonCodec2 {
   }
 
   public override createSerializer(): $ShapeSerializer<Uint8Array> {
-    const serializer = new DynamoDBStringShapeSerializer2(this.settings);
+    const serializer = new DynamoDBJsonShapeSerializer2(this.settings);
     serializer.setSerdeContext(this.serdeContext!);
     return serializer;
   }


### PR DESCRIPTION
### Issue
preparation for https://github.com/aws/aws-sdk-js-v3/pull/8234

### Description
- add JsonBytesStringAdapter: Uint8Array subclass with string method compat for customer middleware
  - if customer middleware treats `request.body` as a string, this will now try to use a cached string and emit a `console.warn`ing. in the future this adapter layer will be removed.

- Benchmark and test improvements
- Does NOT include the actual cutover to v2 codecs in protocols or DynamoDB

### Testing
CI, new tests

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [x] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [ ] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.
