### PR TITLE
chore(scripts): add api-extractor.json validation for packages with public annotations

### DIFF
--- a/scripts/validation/api-extractor-config.js
+++ b/scripts/validation/api-extractor-config.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+// Usage: node api-extractor-config.js [packageDir ...]
+//
+//
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { getPackageDirs, summarizePackages } = require("./validation-shared");
+
+const EXTENDS_BY_ROOT = {
+  clients: "../../api-extractor.json",
+  lib: "../../api-extractor.lib.json",
+  packages: "../../api-extractor.packages.json",
+  "packages-internal": "../../api-extractor.packages.json",
+};
+
+// Packages with @public symbols that lack api-extractor.json.
+const KNOWN_GAPS = new Set([
+  "@aws-sdk/credential-provider-http",
+  "@aws-sdk/credential-provider-ini",
+  "@aws-sdk/credential-provider-login",
+  "@aws-sdk/credential-provider-node",
+  "@aws-sdk/credential-provider-sso",
+  "@aws-sdk/credential-provider-web-identity",
+  "@aws-sdk/ec2-metadata-service",
+  "@aws-sdk/middleware-api-key",
+  "@aws-sdk/middleware-eventstream",
+  "@aws-sdk/middleware-sdk-glacier",
+  "@aws-sdk/middleware-sdk-sqs",
+  "@aws-sdk/middleware-sdk-sts",
+  "@aws-sdk/middleware-token",
+  "@aws-sdk/middleware-websocket",
+  "@aws-sdk/nested-clients",
+  "@aws-sdk/signature-v4-multi-region",
+]);
+
+const PUBLIC_TAG = /^\s*(\/\*\*|\*)?\s*@public\b/m;
+
+function hasPublicSymbol(dir) {
+  if (!fs.existsSync(dir)) {
+    return false;
+  }
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__") {
+        continue;
+      }
+      if (hasPublicSymbol(p)) {
+        return true;
+      }
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".spec.ts") && !entry.name.endsWith(".test.ts")) {
+      if (PUBLIC_TAG.test(fs.readFileSync(p, "utf-8"))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const positional = [];
+  for (let i = 0; i < argv.length; ++i) {
+    if (argv[i].startsWith("--")) {
+      ++i;
+    } else {
+      positional.push(argv[i]);
+    }
+  }
+  const isFullScan = positional.length === 0;
+
+  const packages = getPackageDirs();
+  const validated = [];
+  const errors = [];
+  const knownGaps = [];
+
+  for (const { dir } of packages) {
+    const folder = path.basename(path.dirname(dir));
+    const expectedExtends = EXTENDS_BY_ROOT[folder];
+    if (!expectedExtends) {
+      continue;
+    }
+
+    const pkgJsonPath = path.join(dir, "package.json");
+    if (!fs.existsSync(pkgJsonPath)) {
+      continue;
+    }
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+    if (pkgJson.private) {
+      continue;
+    }
+
+    if (!hasPublicSymbol(path.join(dir, "src"))) {
+      continue;
+    }
+    validated.push({ dir });
+
+    const configPath = path.join(dir, "api-extractor.json");
+    if (!fs.existsSync(configPath)) {
+      if (KNOWN_GAPS.has(pkgJson.name)) {
+        knownGaps.push(pkgJson.name);
+      } else {
+        errors.push(`${pkgJson.name} has @public symbols but no api-extractor.json`);
+      }
+      continue;
+    }
+
+    let config;
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    } catch (e) {
+      errors.push(
+        `${pkgJson.name} api-extractor.json must be comment-free JSON (this script uses JSON.parse): ${e.message}`
+      );
+      continue;
+    }
+    if (config.extends !== expectedExtends) {
+      errors.push(
+        `${pkgJson.name} api-extractor.json extends "${config.extends}" but packages under ${folder}/ must extend "${expectedExtends}"`
+      );
+    }
+    if (!config.mainEntryPointFilePath) {
+      errors.push(`${pkgJson.name} api-extractor.json is missing mainEntryPointFilePath`);
+    }
+
+    if (!pkgJson.scripts?.["extract:docs"]) {
+      errors.push(`${pkgJson.name} has @public symbols but no extract:docs script in package.json`);
+    }
+  }
+
+  // Only enforce on full scans, positional runs see a subset of packages.
+  if (isFullScan) {
+    const unmatched = [...KNOWN_GAPS].filter((name) => !knownGaps.includes(name));
+    if (unmatched.length) {
+      errors.push(
+        `KNOWN_GAPS entries no longer match a real gap (fixed or renamed — remove them): ${unmatched.join(", ")}`
+      );
+    }
+  }
+
+  if (errors.length) {
+    console.error(`${errors.length} api-extractor coverage error(s):\n  ${errors.join("\n  ")}`);
+    process.exit(1);
+  }
+  if (knownGaps.length) {
+    console.log(
+      `${knownGaps.length} known gap(s) pending team decision (see KNOWN_GAPS):\n  ${knownGaps.join("\n  ")}`
+    );
+  }
+  console.log(`All packages with @public symbols are configured for API docs. (${summarizePackages(validated)})`);
+}
+
+main();

--- a/scripts/validation/validate-all.js
+++ b/scripts/validation/validate-all.js
@@ -63,6 +63,12 @@ const SUBPROCESS_VALIDATIONS = [
   },
   { name: "eslint", label: "oxlint passes on source", script: "oxlint.js", inspects: ["src"] },
   {
+    name: "api-extractor-config",
+    label: "packages with @public symbols are configured for API docs",
+    script: "api-extractor-config.js",
+    inspects: ["src"],
+  },
+  {
     name: "filenames",
     label: "no suspicious multi-dot filenames in dist",
     script: "filenames.js",

--- a/scripts/validation/validate-all.test.js
+++ b/scripts/validation/validate-all.test.js
@@ -81,6 +81,12 @@ module.exports = { blorp: toHex };
 
   // filenames violation: multi-dot filename that is not an allowed suffix
   fs.writeFileSync(path.join(distCjs, "blorp.spec.js"), `"use strict";\nmodule.exports = {};\n`);
+
+  // api-extractor-config violation: @public symbol without api-extractor.json
+  fs.writeFileSync(
+    path.join(tmpPkgDir, "src", "public-api.ts"),
+    `/**\n * @public\n */\nexport const blorp = () => {};\n`
+  );
 }
 
 function teardown() {
@@ -169,6 +175,11 @@ function runTests() {
   const filenames = runValidator("filenames.js", [pkg]);
   check(filenames.exitCode !== 0, "filenames detects suspicious multi-dot filename");
   check(filenames.output.includes("blorp.spec.js"), "filenames identifies the offending file");
+
+  // 9. api-extractor-config (src/public-api.ts has @public but package has no api-extractor.json)
+  const apiExtractorConfig = runValidator("api-extractor-config.js", [pkg]);
+  check(apiExtractorConfig.exitCode !== 0, "api-extractor-config detects @public without api-extractor.json");
+  check(apiExtractorConfig.output.includes("no api-extractor.json"), "api-extractor-config names the missing config");
 
   console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
   return failed === 0;


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/6174

### Description
adds a validation that checks packages with `@public` typedoc annotations have correctly configured  `api-extractor.json`, so their types are published to the API docs.

scans all packages under `clients/`, `lib/`, `packages/`, and `packages-internal/` for `@public` annotations and for each package, validates:
- `api-extractor.json` exists
- `extends` points to the correct base config for its root
- `mainEntryPointFilePath` is set
- `package.json` has an `extract:docs` script


### Testing
added test case that creates a temp package with a `@public` but no `api-extractor.json` 

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [ ] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [ ] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
