### PR TITLE
fix(core): deserialize numeric members to number when the reviver is active

### DIFF
--- a/packages-internal/core/src/submodules/protocols/json/codec-v1/JsonShapeDeserializer.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v1/JsonShapeDeserializer.spec.ts
@@ -150,6 +150,15 @@ describe(JsonShapeDeserializer.name, () => {
     });
   });
 
+  it("deserializes numeric members to number when the reviver is active", async () => {
+    expect(await deserializer.read(widget, `{ "scalar": 1.0 }`)).toEqual({ scalar: 1 });
+    expect(await deserializer.read(widget, `{ "scalar": 0.0 }`)).toEqual({ scalar: 0 });
+    expect(await deserializer.read(widget, `{ "scalar": 1e3 }`)).toEqual({ scalar: 1000 });
+
+    const data = (await deserializer.read(widget, `{ "scalar": 1.0 }`)) as { scalar: unknown };
+    expect(typeof data.scalar).toBe("number");
+  });
+
   it("deserializes infinite and NaN numerics", async () => {
     expect(await deserializer.read(widget, JSON.stringify({ scalar: "Infinity" }))).toEqual({ scalar: Infinity });
     expect(await deserializer.read(widget, JSON.stringify({ scalar: "-Infinity" }))).toEqual({ scalar: -Infinity });

--- a/packages-internal/core/src/submodules/protocols/json/codec-v1/JsonShapeDeserializer.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v1/JsonShapeDeserializer.ts
@@ -159,16 +159,28 @@ export class JsonShapeDeserializer extends SerdeContextConfig implements ShapeDe
       return new NumericValue(String(value), "bigDecimal");
     }
 
-    if (ns.isNumericSchema() && typeof value === "string") {
-      switch (value) {
-        case "Infinity":
-          return Infinity;
-        case "-Infinity":
-          return -Infinity;
-        case "NaN":
-          return NaN;
+    if (ns.isNumericSchema() && value != undefined) {
+      if (typeof value === "string") {
+        switch (value) {
+          case "Infinity":
+            return Infinity;
+          case "-Infinity":
+            return -Infinity;
+          case "NaN":
+            return NaN;
+        }
+        return value;
       }
-      return value;
+      if (typeof value === "bigint") {
+        return Number(value);
+      }
+      if (value instanceof NumericValue) {
+        return Number(value.string);
+      }
+      const untyped = value as any;
+      if (untyped.type === "bigDecimal" && "string" in untyped) {
+        return Number(untyped.string);
+      }
     }
 
     if (ns.isDocumentSchema()) {

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeDeserializer2.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeDeserializer2.spec.ts
@@ -1,4 +1,4 @@
-import { nv, NumericValue } from "@smithy/core/serde";
+import { NumericValue } from "@smithy/core/serde";
 import type { StaticStructureSchema, TimestampEpochSecondsSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
@@ -151,6 +151,15 @@ describe(JsonShapeDeserializer2.name, () => {
     });
   });
 
+  it("deserializes numeric members to number when the reviver is active", async () => {
+    expect(await deserializer.read(widget, `{ "scalar": 1.0 }`)).toEqual({ scalar: 1 });
+    expect(await deserializer.read(widget, `{ "scalar": 0.0 }`)).toEqual({ scalar: 0 });
+    expect(await deserializer.read(widget, `{ "scalar": 1e3 }`)).toEqual({ scalar: 1000 });
+
+    const data = (await deserializer.read(widget, `{ "scalar": 1.0 }`)) as { scalar: unknown };
+    expect(typeof data.scalar).toBe("number");
+  });
+
   it("deserializes infinite and NaN numerics", async () => {
     expect(await deserializer.read(widget, JSON.stringify({ scalar: "Infinity" }))).toEqual({ scalar: Infinity });
     expect(await deserializer.read(widget, JSON.stringify({ scalar: "-Infinity" }))).toEqual({ scalar: -Infinity });
@@ -300,10 +309,10 @@ describe(JsonShapeDeserializer2.name, () => {
       async () => {
         const json = `{"scalar": 1.123456789012345678E16}`;
         await expect(v1Deserializer.read(widget, json)).resolves.toEqual({
-          scalar: nv("1.123456789012345678E16"),
+          scalar: 11234567890123456,
         });
         await expect(deserializer.read(widget, json)).resolves.toEqual({
-          scalar: nv("1.123456789012345678E16"),
+          scalar: 11234567890123456,
         });
       }
     );

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeDeserializer2.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeDeserializer2.ts
@@ -151,16 +151,28 @@ export class JsonShapeDeserializer2 extends SerdeContextConfig implements ShapeD
       return new NumericValue(String(value), "bigDecimal");
     }
 
-    if (ns.isNumericSchema() && typeof value === "string") {
-      switch (value) {
-        case "Infinity":
-          return Infinity;
-        case "-Infinity":
-          return -Infinity;
-        case "NaN":
-          return NaN;
+    if (ns.isNumericSchema() && value != undefined) {
+      if (typeof value === "string") {
+        switch (value) {
+          case "Infinity":
+            return Infinity;
+          case "-Infinity":
+            return -Infinity;
+          case "NaN":
+            return NaN;
+        }
+        return value;
       }
-      return value;
+      if (typeof value === "bigint") {
+        return Number(value);
+      }
+      if (value instanceof NumericValue) {
+        return Number(value.string);
+      }
+      const untyped = value as any;
+      if (untyped.type === "bigDecimal" && "string" in untyped) {
+        return Number(untyped.string);
+      }
     }
 
     if (ns.isDocumentSchema()) {


### PR DESCRIPTION
### Issue
#8246

### Description

`needsReviver` returns `true` when a response schema contains a bigInteger, bigDecimal or **document** member, which enables the `JSON.parse` reviver for the whole body. `jsonReviver` then rewrites every numeric literal that does not round-trip (`1.0`, `0.0`, `1e3`, anything past `Number.MAX_SAFE_INTEGER`), including literals that belong to plain numeric members, and the shape deserializer passed those values through unchanged.

The result is that a member whose generated type is `number` can deserialize to a `NumericValue`. It fails silently: `typeof result.score` becomes `"object"` and `result.score + 1` evaluates to the string `"1.01"` instead of `2`. TypeScript cannot catch it, because the generated type says `score?: number`, so a `typeof x === "number"` guard looks redundant and is a candidate for removal.

This affects any client whose response shape contains a document member. It was found on `bedrock-agent-runtime` `Retrieve`, where `RetrievalResultMetadata` is `Map<String, Document>`: the knowledge base returns page numbers as `22.0` inside `metadata`, and the relevance `score` in the same response was corrupted as collateral for exact `1.0` / `0.0` values.

Numeric members now coerce a revived `NumericValue` or `BigInt` back to `number`, which matches the generated types and the behaviour before `@aws-sdk/core@3.977.0`. Documents keep the revived representation, which is unchanged and appears intended.

Applied to both codecs (`JsonShapeDeserializer` and `JsonShapeDeserializer2`) so v1/v2 equivalence is preserved.

### Testing

Added a test to each codec spec asserting that a numeric member deserializes to `number` while the reviver is active (`1.0` → `1`, `0.0` → `0`, `1e3` → `1000`). Both fail without the change:

```
× JsonShapeDeserializer > deserializes numeric members to number when the reviver is active
  → expected { scalar: NumericValue{ …(2) } } to deeply equal { scalar: 1 }
```

Full protocols suite after the change: **32 files, 516 passed, 2 skipped**.

One existing expectation is updated. In `JsonShapeDeserializer2.spec.ts`, `fractional exponent with many digits does not throw in reviver` asserted that `{"scalar": 1.123456789012345678E16}` stays a `NumericValue`. `scalar` is a numeric member, and `JSON.parse` produced `11234567890123456` for that input before the reviver existed, so the expectation is changed to that value. The purpose of the test — that the reviver does not throw — is unaffected, and the neighbouring `v1/v2` equivalence cases still pass.

I could not run the repo's full `yarn` install locally, so verification was scoped to `packages-internal/core/src/submodules/protocols` with dependencies installed from npm.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
