### PR TITLE
fix(core/protocols): fix number precision check

### DIFF
--- a/packages-internal/core/src/submodules/protocols/json/codec-v1/JsonShapeDeserializer.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v1/JsonShapeDeserializer.spec.ts
@@ -1,4 +1,4 @@
-import { NumericValue } from "@smithy/core/serde";
+import { NumericValue, nv } from "@smithy/core/serde";
 import type { TimestampEpochSecondsSchema } from "@smithy/types";
 import { describe, expect, test as it } from "vitest";
 
@@ -100,12 +100,42 @@ describe(JsonShapeDeserializer.name, () => {
     });
   });
 
+  (contextSourceAvailable ? it : it.skip)(
+    "deserializes numeric members to number when the reviver is active",
+    async () => {
+      expect(await deserializer.read(widget, `{ "scalar": 1.0 }`)).toEqual({ scalar: 1 });
+      expect(await deserializer.read(widget, `{ "scalar": 0.0 }`)).toEqual({ scalar: 0 });
+      expect(
+        await deserializer.read(
+          widget,
+          `{
+            "scalar": 1.000000000000000000000001e3,
+            "documentMap": {
+              "a": 1.000000000000000000000001e3,
+              "b": 1.000000000000000000000001e3,
+              "c": 1.000000000000000000000000e3,
+              "d": 1.000000000000000000000000e3
+            }
+          }`
+        )
+      ).toEqual({
+        scalar: nv("1.000000000000000000000001e3"),
+        documentMap: {
+          a: nv("1.000000000000000000000001e3"),
+          b: nv("1.000000000000000000000001e3"),
+          c: 1000,
+          d: 1000,
+        },
+      });
+    }
+  );
+
   it("deserializes big integers from string or number", async () => {
     expect(
       await deserializer.read(
         widget,
         `{
-      "bigint": "1000000000000000000000000000000000000" 
+      "bigint": "1000000000000000000000000000000000000"
     }`
       )
     ).toEqual({
@@ -131,7 +161,7 @@ describe(JsonShapeDeserializer.name, () => {
       await deserializer.read(
         widget,
         `{
-      "bigdecimal": "0.0000000000000000000000000000000000001" 
+      "bigdecimal": "0.0000000000000000000000000000000000001"
     }`
       )
     ).toEqual({
@@ -142,7 +172,7 @@ describe(JsonShapeDeserializer.name, () => {
       await deserializer.read(
         widget,
         `{
-      "bigdecimal": 0.0001 
+      "bigdecimal": 0.0001
     }`
       )
     ).toEqual({

--- a/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeDeserializer2.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/codec-v2/JsonShapeDeserializer2.spec.ts
@@ -296,6 +296,36 @@ describe(JsonShapeDeserializer2.name, () => {
     });
 
     (contextSourceAvailable ? it : it.skip)(
+      "deserializes numeric members to number when the reviver is active",
+      async () => {
+        expect(await deserializer.read(widget, `{ "scalar": 1.0 }`)).toEqual({ scalar: 1 });
+        expect(await deserializer.read(widget, `{ "scalar": 0.0 }`)).toEqual({ scalar: 0 });
+        expect(
+          await deserializer.read(
+            widget,
+            `{
+            "scalar": 1.000000000000000000000001e3,
+            "documentMap": {
+              "a": 1.000000000000000000000001e3,
+              "b": 1.000000000000000000000001e3,
+              "c": 1.000000000000000000000000e3,
+              "d": 1.000000000000000000000000e3
+            }
+          }`
+          )
+        ).toEqual({
+          scalar: nv("1.000000000000000000000001e3"),
+          documentMap: {
+            a: nv("1.000000000000000000000001e3"),
+            b: nv("1.000000000000000000000001e3"),
+            c: 1000,
+            d: 1000,
+          },
+        });
+      }
+    );
+
+    (contextSourceAvailable ? it : it.skip)(
       "fractional exponent with many digits does not throw in reviver",
       async () => {
         const json = `{"scalar": 1.123456789012345678E16}`;

--- a/packages-internal/core/src/submodules/protocols/json/jsonReviver.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/json/jsonReviver.spec.ts
@@ -1,127 +1,122 @@
 import { NumericValue } from "@smithy/core/serde";
-import { describe, expect, test as it } from "vitest";
+import { beforeAll, describe, expect, test as it } from "vitest";
 
 import { jsonReviver } from "./jsonReviver";
 
 describe(jsonReviver.name, () => {
   let contextSourceAvailable = false;
+
   JSON.parse(`{ "key": 1 }`, function (key, value, context?: { source?: string }) {
     if (context?.source) {
       contextSourceAvailable = true;
     }
   });
 
-  it("control suite without reviver", async () => {
-    const data = `
-    {
-      "smallInt": 1,
-      "smallDecimal": 1.1,
-      "bigint": 1000000000000000000000000000000054321,
-      "bigDecimal": 0.12345000000000000000000000000000000054321
-    }`;
+  const data = `
+  {
+    "zero": [0E00, 0, 0.00, -0, -0.00, -0E00],
+    "smallInt": [-1, 1],
+    "smallDecimal": [-0.1, -0.000000000000000000000010, 5E-324, 5.0E-324, 5.01E-324, -0.0001, 0.000000000000000000000000000100, 0.01, 0.1],
+    "underflow": [5E-325, 1E-400, 1.5E-1000],
+    "safeBoundary": [-9007199254740992, -9007199254740991, 9007199254740991, 9007199254740991.0, 9007199254740992, 9007199254740993],
+    "nearOne": [1.0000000000000002, 1.00000000000000020, 1.0000000000000003, 1.0000000000000004],
+    "bigint": [-1000000000000000000000000000000054321, 1000000000000000000000000000000054321],
+    "bigDecimal": [-0.123450000000000000000000000000000000543210, 0.123450000000000000000000000000000000543210],
+    "epochFractional": [-1.784316439424E9, -1.7843164394240000E9, 1.784316439424E9, 1.7843164394240000E9],
+    "epochInt": [-1.2E90, -1E9, 1E9, 1.2E90],
+    "negativeExp": -1.5e+3,
+    "smallExp": 1.5e-3,
+    "largeIntegerExp": [-1.230E1000, -1.23E100, 1.23E100, 1.230E1000],
+    "largeIntExp": [-1E19, 1E19],
+    "fractionalExpOutsideSafe": 1.123456789012345678E16,
+    "trailingZeroes": [1, 2.0, 3.00, 4.000]
+  }`;
 
-    const parsed = JSON.parse(data);
-    expect(parsed.smallInt).toBe(1);
-    expect(parsed.smallDecimal).toBe(1.1);
-    expect(parsed.bigint).toBe(1e36);
-    expect(parsed.bigDecimal).toEqual(0.12345);
+  let parsedWithoutReviver: Record<string, unknown>;
+  let parsed: Record<string, unknown>;
+
+  beforeAll(() => {
+    parsedWithoutReviver = JSON.parse(data);
+    parsed = JSON.parse(data, jsonReviver);
   });
 
-  (contextSourceAvailable ? it : it.skip)("handles large numbers if context source is available", async () => {
-    const data = `
-    {
-      "smallInt": 1,
-      "smallDecimal": 1.1,
-      "bigint": 1000000000000000000000000000000054321,
-      "bigDecimal": 0.12345000000000000000000000000000000054321
-    }`;
-
-    const parsed = JSON.parse(data, jsonReviver);
-    expect(parsed.smallInt).toBe(1);
-    expect(parsed.smallDecimal).toBe(1.1);
-    expect(parsed.bigint).toBe(1000000000000000000000000000000054321n);
-    expect(parsed.bigDecimal).toEqual(new NumericValue("0.12345000000000000000000000000000000054321", "bigDecimal"));
+  it("control - without reviver", () => {
+    expect(parsedWithoutReviver).toEqual({
+      zero: [0, 0, 0, -0, -0, -0],
+      smallInt: [-1, 1],
+      smallDecimal: [
+        -0.1, -0.00000000000000000000001, 5e-324, 5e-324, 5e-324, -0.0001, 0.0000000000000000000000000001, 0.01, 0.1,
+      ],
+      underflow: [0, 0, 0],
+      safeBoundary: [
+        -9007199254740992, -9007199254740991, 9007199254740991, 9007199254740991, 9007199254740992, 9007199254740992,
+      ],
+      nearOne: [1.0000000000000002, 1.0000000000000002, 1.0000000000000002, 1.0000000000000004],
+      bigint: [-1e36, 1e36],
+      bigDecimal: [-0.12345, 0.12345],
+      epochFractional: [-1784316439.424, -1784316439.424, 1784316439.424, 1784316439.424],
+      epochInt: [-1.2e90, -1000000000, 1000000000, 1.2e90],
+      negativeExp: -1500,
+      smallExp: 0.0015,
+      largeIntegerExp: [-Infinity, -1.23e100, 1.23e100, Infinity],
+      largeIntExp: [-10000000000000000000, 10000000000000000000],
+      fractionalExpOutsideSafe: 11234567890123456,
+      trailingZeroes: [1, 2, 3, 4],
+    });
   });
 
-  (contextSourceAvailable ? it.skip : it)("doesn't handle large numbers if context source is unavailable", async () => {
-    const data = `
-    {
-      "smallInt": 1,
-      "smallDecimal": 1.1,
-      "bigint": 1000000000000000000000000000000054321,
-      "bigDecimal": 0.12345000000000000000000000000000000054321
-    }`;
-
-    const parsed = JSON.parse(data, jsonReviver);
-    expect(parsed.smallInt).toBe(1);
-    expect(parsed.smallDecimal).toBe(1.1);
-    expect(parsed.bigint).toBe(1e36);
-    expect(parsed.bigDecimal).toEqual(0.12345);
+  (contextSourceAvailable ? it : it.skip)("with reviver", () => {
+    expect(parsed).toEqual({
+      zero: [0, 0, 0, -0, -0, -0],
+      smallInt: [-1, 1],
+      smallDecimal: [
+        -0.1,
+        -1e-23,
+        5e-324,
+        5e-324,
+        new NumericValue("5.01E-324", "bigDecimal"),
+        -0.0001,
+        1e-28,
+        0.01,
+        0.1,
+      ],
+      underflow: [
+        new NumericValue("5E-325", "bigDecimal"),
+        new NumericValue("1E-400", "bigDecimal"),
+        new NumericValue("1.5E-1000", "bigDecimal"),
+      ],
+      safeBoundary: [
+        -9007199254740992n,
+        -9007199254740991,
+        9007199254740991,
+        9007199254740991,
+        9007199254740992n,
+        9007199254740993n,
+      ],
+      nearOne: [
+        1.0000000000000002,
+        1.0000000000000002,
+        new NumericValue("1.0000000000000003", "bigDecimal"),
+        1.0000000000000004,
+      ],
+      bigint: [-1000000000000000000000000000000054321n, 1000000000000000000000000000000054321n],
+      bigDecimal: [
+        new NumericValue("-0.123450000000000000000000000000000000543210", "bigDecimal"),
+        new NumericValue("0.123450000000000000000000000000000000543210", "bigDecimal"),
+      ],
+      epochFractional: [-1784316439.424, -1784316439.424, 1784316439.424, 1784316439.424],
+      epochInt: [-BigInt("12" + "0".repeat(89)), -1000000000, 1000000000, BigInt("12" + "0".repeat(89))],
+      negativeExp: -1500,
+      smallExp: 0.0015,
+      largeIntegerExp: [
+        -BigInt("123" + "0".repeat(998)),
+        -BigInt("123" + "0".repeat(98)),
+        BigInt("123" + "0".repeat(98)),
+        BigInt("123" + "0".repeat(998)),
+      ],
+      largeIntExp: [-10000000000000000000n, 10000000000000000000n],
+      fractionalExpOutsideSafe: new NumericValue("1.123456789012345678E16", "bigDecimal"),
+      trailingZeroes: [1, 2, 3, 4],
+    });
   });
-
-  // Regression: https://github.com/aws/aws-sdk-js-v3/issues/8224
-  // Exponent notation is valid JSON (RFC 8259) and AWS services emit it
-  // for epoch-second timestamps (e.g. ECS createdAt: 1.784316439424E9).
-  (contextSourceAvailable ? it : it.skip)(
-    "should pass through exponent notation numbers that round-trip exactly",
-    async () => {
-      const data = `
-      {
-        "epochFractional": 1.784316439424E9,
-        "epochInt": 1E9,
-        "negativeExp": -1.5e+3,
-        "smallExp": 1.5e-3
-      }`;
-
-      const parsed = JSON.parse(data, jsonReviver);
-      // These are exactly representable as JS numbers and should not become
-      // NumericValue or BigInt.
-      expect(parsed.epochFractional).toBe(1784316439.424);
-      expect(typeof parsed.epochFractional).toBe("number");
-      expect(parsed.epochInt).toBe(1000000000);
-      expect(typeof parsed.epochInt).toBe("number");
-      expect(parsed.negativeExp).toBe(-1500);
-      expect(typeof parsed.negativeExp).toBe("number");
-      expect(parsed.smallExp).toBe(0.0015);
-      expect(typeof parsed.smallExp).toBe("number");
-    }
-  );
-
-  // Large exponent numbers exceed MAX_SAFE_INTEGER and must NOT be passed through
-  // as plain numbers — they should remain NumericValue/BigInt.
-  // Note: the fractional exponent test (1.784316439424E9) is covered above in
-  // the safe-range test. This tests large values outside safe range.
-  (contextSourceAvailable ? it : it.skip)(
-    "should preserve precision for large exponent numbers outside safe range",
-    async () => {
-      const data = `
-      {
-        "largeIntegerExp": 1.23E100,
-        "largeIntExp": 1E19
-      }`;
-
-      const parsed = JSON.parse(data, jsonReviver);
-      // 1.23E100 = 123 * 10^98, a whole integer (exponent >= fractional digits) → BigInt
-      expect(typeof parsed.largeIntegerExp).toBe("bigint");
-      expect(parsed.largeIntegerExp).toBe(BigInt(1.23e100));
-      // 1E19 has no decimal point → BigInt
-      expect(typeof parsed.largeIntExp).toBe("bigint");
-      expect(parsed.largeIntExp).toBe(10000000000000000000n);
-    }
-  );
-
-  // Fractional exponent outside safe range → NumericValue (bigDecimal).
-  // 1.123456789012345678E16: 18 frac digits, exp 16 < 18 → fractional,
-  // value > MAX_SAFE_INTEGER → NumericValue.
-  // Requires @smithy/core with exponent-notation support in NumericValue
-  // (smithy-lang/smithy-typescript#2184).
-  (contextSourceAvailable ? it.skip : it.skip)(
-    "should produce NumericValue for fractional exponent outside safe range",
-    async () => {
-      const data = `{ "val": 1.123456789012345678E16 }`;
-      const parsed = JSON.parse(data, jsonReviver);
-      expect(parsed.val).toBeInstanceOf(NumericValue);
-      expect(parsed.val.string).toBe("1.123456789012345678E16");
-    }
-  );
 });

--- a/packages-internal/core/src/submodules/protocols/json/jsonReviver.ts
+++ b/packages-internal/core/src/submodules/protocols/json/jsonReviver.ts
@@ -17,27 +17,28 @@ export function jsonReviver(key: string, value: any, context?: { source?: string
     const numericString = context.source;
     if (typeof value === "number") {
       const inSafeRange = value <= Number.MAX_SAFE_INTEGER && value >= Number.MIN_SAFE_INTEGER;
-      if (!inSafeRange || numericString !== String(value)) {
-        // Exponent notation (e.g. "1.784316439424E9") is valid JSON per RFC 8259.
-        // It always fails numericString !== String(value) because the string forms
-        // differ (e.g. "1.784316439424E9" vs "1784316439.424"), but the value may
-        // round-trip exactly as a JS number with no precision loss.
-        //
-        // Only apply this bypass when the value is within safe integer bounds —
-        // values outside that range (e.g. 1.23E100) genuinely cannot be represented
-        // precisely as a JS number regardless of notation.
-        if (inSafeRange && /[eE]/.test(numericString) && String(Number(numericString)) === String(value)) {
+
+      if (inSafeRange) {
+        // Within safe integer bounds. Check if the value is precisely representable.
+        if (isRepresentable(numericString, value)) {
           return value;
         }
-        if (isFractionalNumeric(numericString)) {
+
+        // In range but not precisely representable (e.g. excess decimal digits).
+        return new NumericValue(numericString, "bigDecimal");
+      } else {
+        // Outside safe integer bounds, so JS number is considered as unable to represent this precisely
+        // even if it is one of the large doubles that can be represented exactly.
+        if (isFractionalBigNumeric(numericString)) {
           return new NumericValue(numericString, "bigDecimal");
-        } else {
-          // BigInt() does not accept exponent notation, so normalize first.
-          if (/[eE]/.test(numericString)) {
-            return BigInt(Number(numericString));
-          }
-          return BigInt(numericString);
         }
+        // Integer outside safe range → BigInt.
+        // BigInt() does not accept exponent notation, so expand manually
+        // to avoid precision loss from intermediate Number conversion.
+        if (/[eE]/.test(numericString)) {
+          return expandExponentToBigInt(numericString);
+        }
+        return BigInt(numericString);
       }
     }
   }
@@ -49,7 +50,7 @@ export function jsonReviver(key: string, value: any, context?: { source?: string
  * Accounts for exponent notation: "1.23E100" is integer (exponent >= fractional digits),
  * but "1.23E1" is fractional (exponent < fractional digits).
  */
-function isFractionalNumeric(s: string): boolean {
+function isFractionalBigNumeric(s: string): boolean {
   const dotIndex = s.indexOf(".");
   if (dotIndex === -1) {
     return false;
@@ -66,4 +67,124 @@ function isFractionalNumeric(s: string): boolean {
   // If the exponent shifts the decimal point far enough right to eliminate
   // all fractional digits, the value is a whole integer.
   return exp < fracDigits;
+}
+
+/**
+ * Determines whether a numeric source string is precisely representable by the
+ * given JS number value. Returns true when the difference between the source
+ * string and String(value) is purely cosmetic (trailing fractional zeros,
+ * exponent notation differences) rather than indicating precision loss.
+ */
+function isRepresentable(numericString: string, value: number): boolean {
+  // Fast path: source already matches canonical form (most common case).
+  if (numericString === String(value)) {
+    return true;
+  }
+  // -0 is representable but String(-0) === "0", so handle it explicitly.
+  if (Object.is(value, -0)) {
+    return true;
+  }
+  if (/[eE]/.test(numericString)) {
+    // Expand source exponent notation to plain decimal and compare against
+    // the canonical form. This catches all precision-loss cases including:
+    // - mantissa digit rounding ("1.0000000000000003e0" → "1.0000000000000002")
+    // - subnormal truncation ("5.01E-324" → "5e-324")
+    // - underflow to zero ("5E-325" → "0")
+    // - excess precision with exponent ("1.000000000000000000000001e3" → "1000")
+    return expandToDecimal(numericString) === expandToDecimal(String(value));
+  }
+  // For non-exponent numeric strings, strip trailing zeros from the fractional
+  // part. If the result matches String(value), it's just cosmetic trailing zeros.
+  const normalized = numericString.replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
+  const canonical = String(value);
+  if (normalized === canonical) {
+    return true;
+  }
+  // The source may be in decimal notation while JS uses exponent notation for
+  // the same value (e.g. "-0.00000000000000000000001" → "-1e-23").
+  // Expand the canonical form and compare.
+  if (/[eE]/.test(canonical)) {
+    return normalized === expandToDecimal(canonical);
+  }
+  return false;
+}
+
+/**
+ * Expands a numeric string (potentially in exponent notation) to a normalized
+ * plain decimal form with trailing fractional zeros stripped.
+ * E.g. "1.784316439424E9" → "1784316439.424", "5.0E-324" → "0.000...0005",
+ * "-1.5e+3" → "-1500", "2.0" → "2".
+ */
+function expandToDecimal(s: string): string {
+  const negative = s.startsWith("-");
+  const abs = negative ? s.slice(1) : s;
+  const eIndex = abs.search(/[eE]/);
+
+  let result: string;
+  if (eIndex === -1) {
+    // No exponent, just normalize trailing fractional zeros.
+    result = abs;
+  } else {
+    const exp = parseInt(abs.slice(eIndex + 1), 10);
+    const mantissa = abs.slice(0, eIndex);
+    const dotIndex = mantissa.indexOf(".");
+    let digits: string;
+    let intLen: number;
+    if (dotIndex === -1) {
+      digits = mantissa;
+      intLen = mantissa.length;
+    } else {
+      digits = mantissa.slice(0, dotIndex) + mantissa.slice(dotIndex + 1);
+      intLen = dotIndex;
+    }
+    // Strip trailing zeros from mantissa digits (cosmetic).
+    digits = digits.replace(/0+$/, "") || "0";
+    const newDotPos = intLen + exp;
+    if (digits === "0") {
+      result = "0";
+    } else if (newDotPos <= 0) {
+      result = "0." + "0".repeat(-newDotPos) + digits;
+    } else if (newDotPos >= digits.length) {
+      result = digits + "0".repeat(newDotPos - digits.length);
+    } else {
+      result = digits.slice(0, newDotPos) + "." + digits.slice(newDotPos);
+    }
+  }
+
+  // Strip trailing fractional zeros.
+  if (result.includes(".")) {
+    result = result.replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
+  }
+  return (negative ? "-" : "") + result;
+}
+
+/**
+ * Expands a numeric string in exponent notation to a BigInt by
+ * manually shifting the significant digits. Handles cases where
+ * Number() would overflow to Infinity (e.g. "1.230E1000").
+ */
+function expandExponentToBigInt(s: string): bigint {
+  const eIndex = s.search(/[eE]/);
+  const exp = parseInt(s.slice(eIndex + 1), 10);
+  const negative = s.startsWith("-");
+  const mantissa = s.slice(negative ? 1 : 0, eIndex);
+  const dotIndex = mantissa.indexOf(".");
+
+  let digits: string;
+  let shift: number;
+  if (dotIndex === -1) {
+    digits = mantissa;
+    shift = exp;
+  } else {
+    // Remove the dot and adjust exponent by the number of fractional digits.
+    digits = mantissa.slice(0, dotIndex) + mantissa.slice(dotIndex + 1);
+    const fracDigits = mantissa.length - dotIndex - 1;
+    shift = exp - fracDigits;
+  }
+
+  // Strip trailing zeros from digits (they're already accounted for in shift).
+  digits = digits.replace(/0+$/, "") || "0";
+
+  const result = BigInt(digits) * 10n ** BigInt(shift + (mantissa.replace(".", "").length - digits.length));
+  return negative ? -result : result;
 }

--- a/packages-internal/core/src/submodules/protocols/test-schema.spec.ts
+++ b/packages-internal/core/src/submodules/protocols/test-schema.spec.ts
@@ -3,6 +3,7 @@ import type {
   BigDecimalSchema,
   BigIntegerSchema,
   BlobSchema,
+  DocumentSchema,
   NumericSchema,
   StaticListSchema,
   StaticOperationSchema,
@@ -23,7 +24,20 @@ export const widget = [
   "",
   "Struct",
   0,
-  ["list", "sparseList", "map", "sparseMap", "blob", "media", "timestamp", "bigint", "bigdecimal", "scalar"],
+  [
+    "list",
+    "sparseList",
+    "map",
+    "sparseMap",
+    "blob",
+    "media",
+    "timestamp",
+    "bigint",
+    "bigdecimal",
+    "scalar",
+    "document",
+    "documentMap",
+  ],
   [
     [[1, "", "List", 0, 0] satisfies StaticListSchema, 0],
     [[1, "", "List", 0, 0] satisfies StaticListSchema, { sparse: 1 }],
@@ -35,6 +49,8 @@ export const widget = [
     17 satisfies BigIntegerSchema,
     19 satisfies BigDecimalSchema,
     1 satisfies NumericSchema,
+    15 satisfies DocumentSchema,
+    128 | 15,
   ],
 ] satisfies StaticStructureSchema;
 


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8246

### Description
Fix for number precision evaluation during deserialization, deciding whether to return number, NumericValue, or BigInt.

### Testing
jsonReviver unit tests

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
