### PR TITLE
chore(codegen): smithy-aws-typescript-codegen 0.52.0

### DIFF
--- a/clients/client-accessanalyzer/src/index.ts
+++ b/clients/client-accessanalyzer/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AccessAnalyzerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-account/src/index.ts
+++ b/clients/client-account/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AccountExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-acm-pca/src/index.ts
+++ b/clients/client-acm-pca/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ACMPCAExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-acm/src/index.ts
+++ b/clients/client-acm/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ACMExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-agent-registry-control/src/index.ts
+++ b/clients/client-agent-registry-control/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AgentRegistryControlExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-agent-registry/src/index.ts
+++ b/clients/client-agent-registry/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AgentRegistryExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-aiops/src/index.ts
+++ b/clients/client-aiops/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AIOpsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-amp/src/index.ts
+++ b/clients/client-amp/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AmpExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-amplify/src/index.ts
+++ b/clients/client-amplify/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AmplifyExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-amplifyuibuilder/src/index.ts
+++ b/clients/client-amplifyuibuilder/src/index.ts
@@ -20,8 +20,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AmplifyUIBuilderExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-api-gateway/src/index.ts
+++ b/clients/client-api-gateway/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { APIGatewayExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-apigatewayv2/src/index.ts
+++ b/clients/client-apigatewayv2/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ApiGatewayV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-app-mesh/src/index.ts
+++ b/clients/client-app-mesh/src/index.ts
@@ -26,8 +26,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AppMeshExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-appconfig/src/index.ts
+++ b/clients/client-appconfig/src/index.ts
@@ -85,9 +85,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AppConfigExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-appfabric/src/index.ts
+++ b/clients/client-appfabric/src/index.ts
@@ -20,8 +20,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AppFabricExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-appflow/src/index.ts
+++ b/clients/client-appflow/src/index.ts
@@ -46,8 +46,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AppflowExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-appintegrations/src/index.ts
+++ b/clients/client-appintegrations/src/index.ts
@@ -45,8 +45,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AppIntegrationsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-application-auto-scaling/src/index.ts
+++ b/clients/client-application-auto-scaling/src/index.ts
@@ -91,8 +91,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ApplicationAutoScalingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-application-discovery-service/src/index.ts
+++ b/clients/client-application-discovery-service/src/index.ts
@@ -117,8 +117,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ApplicationDiscoveryServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-application-insights/src/index.ts
+++ b/clients/client-application-insights/src/index.ts
@@ -23,8 +23,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ApplicationInsightsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-application-signals/src/index.ts
+++ b/clients/client-application-signals/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ApplicationSignalsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-applicationcostprofiler/src/index.ts
+++ b/clients/client-applicationcostprofiler/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ApplicationCostProfilerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-apprunner/src/index.ts
+++ b/clients/client-apprunner/src/index.ts
@@ -28,8 +28,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AppRunnerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-appstream/src/index.ts
+++ b/clients/client-appstream/src/index.ts
@@ -29,9 +29,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AppStreamExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-appsync/src/index.ts
+++ b/clients/client-appsync/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AppSyncExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-arc-region-switch/src/index.ts
+++ b/clients/client-arc-region-switch/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ARCRegionSwitchExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-arc-zonal-shift/src/index.ts
+++ b/clients/client-arc-zonal-shift/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ARCZonalShiftExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-artifact/src/index.ts
+++ b/clients/client-artifact/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ArtifactExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-athena/src/index.ts
+++ b/clients/client-athena/src/index.ts
@@ -22,8 +22,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AthenaExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-auditmanager/src/index.ts
+++ b/clients/client-auditmanager/src/index.ts
@@ -47,8 +47,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AuditManagerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-auto-scaling/src/index.ts
+++ b/clients/client-auto-scaling/src/index.ts
@@ -17,9 +17,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { AutoScalingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-b2bi/src/index.ts
+++ b/clients/client-b2bi/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { B2biExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-backup-gateway/src/index.ts
+++ b/clients/client-backup-gateway/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BackupGatewayExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-backup/src/index.ts
+++ b/clients/client-backup/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BackupExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-backupsearch/src/index.ts
+++ b/clients/client-backupsearch/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BackupSearchExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-batch/src/index.ts
+++ b/clients/client-batch/src/index.ts
@@ -22,8 +22,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BatchExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bcm-dashboards/src/index.ts
+++ b/clients/client-bcm-dashboards/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BCMDashboardsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bcm-data-exports/src/index.ts
+++ b/clients/client-bcm-data-exports/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BCMDataExportsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bcm-pricing-calculator/src/index.ts
+++ b/clients/client-bcm-pricing-calculator/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BCMPricingCalculatorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bcm-recommended-actions/src/index.ts
+++ b/clients/client-bcm-recommended-actions/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BCMRecommendedActionsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bedrock-agent-runtime/src/index.ts
+++ b/clients/client-bedrock-agent-runtime/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BedrockAgentRuntimeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bedrock-agent/src/index.ts
+++ b/clients/client-bedrock-agent/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BedrockAgentExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bedrock-agentcore-control/src/index.ts
+++ b/clients/client-bedrock-agentcore-control/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BedrockAgentCoreControlExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bedrock-agentcore/src/index.ts
+++ b/clients/client-bedrock-agentcore/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BedrockAgentCoreExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bedrock-data-automation/src/index.ts
+++ b/clients/client-bedrock-data-automation/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BedrockDataAutomationExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bedrock-runtime/src/index.ts
+++ b/clients/client-bedrock-runtime/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BedrockRuntimeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-bedrock/src/index.ts
+++ b/clients/client-bedrock/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BedrockExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-billing/src/index.ts
+++ b/clients/client-billing/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BillingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-billingconductor/src/index.ts
+++ b/clients/client-billingconductor/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BillingconductorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-braket/src/index.ts
+++ b/clients/client-braket/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BraketExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-budgets/src/index.ts
+++ b/clients/client-budgets/src/index.ts
@@ -54,8 +54,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { BudgetsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-chatbot/src/index.ts
+++ b/clients/client-chatbot/src/index.ts
@@ -35,8 +35,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ChatbotExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-chime-sdk-identity/src/index.ts
+++ b/clients/client-chime-sdk-identity/src/index.ts
@@ -15,8 +15,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ChimeSDKIdentityExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-chime-sdk-media-pipelines/src/index.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ChimeSDKMediaPipelinesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-chime-sdk-meetings/src/index.ts
+++ b/clients/client-chime-sdk-meetings/src/index.ts
@@ -14,8 +14,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ChimeSDKMeetingsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-chime-sdk-messaging/src/index.ts
+++ b/clients/client-chime-sdk-messaging/src/index.ts
@@ -15,8 +15,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ChimeSDKMessagingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-chime-sdk-voice/src/index.ts
+++ b/clients/client-chime-sdk-voice/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ChimeSDKVoiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-chime/src/index.ts
+++ b/clients/client-chime/src/index.ts
@@ -54,8 +54,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ChimeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cleanrooms/src/index.ts
+++ b/clients/client-cleanrooms/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CleanRoomsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cleanroomsml/src/index.ts
+++ b/clients/client-cleanroomsml/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CleanRoomsMLExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cloud9/src/index.ts
+++ b/clients/client-cloud9/src/index.ts
@@ -84,8 +84,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Cloud9ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cloudcontrol/src/index.ts
+++ b/clients/client-cloudcontrol/src/index.ts
@@ -13,9 +13,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CloudControlExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-clouddirectory/src/index.ts
+++ b/clients/client-clouddirectory/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CloudDirectoryExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cloudformation/src/index.ts
+++ b/clients/client-cloudformation/src/index.ts
@@ -23,9 +23,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CloudFormationExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cloudfront-keyvaluestore/src/index.ts
+++ b/clients/client-cloudfront-keyvaluestore/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CloudFrontKeyValueStoreExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/errors";
 export * from "./models/models_0";

--- a/clients/client-cloudfront/src/index.ts
+++ b/clients/client-cloudfront/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CloudFrontExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cloudhsm-v2/src/index.ts
+++ b/clients/client-cloudhsm-v2/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CloudHSMV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cloudtrail/src/index.ts
+++ b/clients/client-cloudtrail/src/index.ts
@@ -27,8 +27,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CloudTrailExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cloudwatch-logs/src/index.ts
+++ b/clients/client-cloudwatch-logs/src/index.ts
@@ -53,8 +53,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CloudWatchLogsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cloudwatch/src/index.ts
+++ b/clients/client-cloudwatch/src/index.ts
@@ -62,9 +62,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CloudWatchExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codeartifact/src/index.ts
+++ b/clients/client-codeartifact/src/index.ts
@@ -355,8 +355,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodeartifactExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codebuild/src/index.ts
+++ b/clients/client-codebuild/src/index.ts
@@ -22,8 +22,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodeBuildExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codecatalyst/src/index.ts
+++ b/clients/client-codecatalyst/src/index.ts
@@ -186,8 +186,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodeCatalystExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codecommit/src/index.ts
+++ b/clients/client-codecommit/src/index.ts
@@ -397,8 +397,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodeCommitExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codeconnections/src/index.ts
+++ b/clients/client-codeconnections/src/index.ts
@@ -90,8 +90,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodeConnectionsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codedeploy/src/index.ts
+++ b/clients/client-codedeploy/src/index.ts
@@ -104,9 +104,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodeDeployExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codeguru-reviewer/src/index.ts
+++ b/clients/client-codeguru-reviewer/src/index.ts
@@ -26,9 +26,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodeGuruReviewerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codeguru-security/src/index.ts
+++ b/clients/client-codeguru-security/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodeGuruSecurityExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codeguruprofiler/src/index.ts
+++ b/clients/client-codeguruprofiler/src/index.ts
@@ -34,8 +34,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodeGuruProfilerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codepipeline/src/index.ts
+++ b/clients/client-codepipeline/src/index.ts
@@ -208,8 +208,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodePipelineExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codestar-connections/src/index.ts
+++ b/clients/client-codestar-connections/src/index.ts
@@ -91,8 +91,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodeStarConnectionsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-codestar-notifications/src/index.ts
+++ b/clients/client-codestar-notifications/src/index.ts
@@ -89,8 +89,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CodestarNotificationsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cognito-identity-provider/src/index.ts
+++ b/clients/client-cognito-identity-provider/src/index.ts
@@ -42,8 +42,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CognitoIdentityProviderExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cognito-identity/src/index.ts
+++ b/clients/client-cognito-identity/src/index.ts
@@ -26,8 +26,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CognitoIdentityExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-comprehend/src/index.ts
+++ b/clients/client-comprehend/src/index.ts
@@ -15,8 +15,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ComprehendExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-compute-optimizer-automation/src/index.ts
+++ b/clients/client-compute-optimizer-automation/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ComputeOptimizerAutomationExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-compute-optimizer/src/index.ts
+++ b/clients/client-compute-optimizer/src/index.ts
@@ -23,8 +23,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ComputeOptimizerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-config-service/src/index.ts
+++ b/clients/client-config-service/src/index.ts
@@ -32,8 +32,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ConfigServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-connect-contact-lens/src/index.ts
+++ b/clients/client-connect-contact-lens/src/index.ts
@@ -31,8 +31,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ConnectContactLensExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-connect/src/index.ts
+++ b/clients/client-connect/src/index.ts
@@ -37,8 +37,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ConnectExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-connectcampaigns/src/index.ts
+++ b/clients/client-connectcampaigns/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ConnectCampaignsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-connectcampaignsv2/src/index.ts
+++ b/clients/client-connectcampaignsv2/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ConnectCampaignsV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-connectcases/src/index.ts
+++ b/clients/client-connectcases/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ConnectCasesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-connecthealth/src/index.ts
+++ b/clients/client-connecthealth/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ConnectHealthExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-connectparticipant/src/index.ts
+++ b/clients/client-connectparticipant/src/index.ts
@@ -32,8 +32,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ConnectParticipantExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-controlcatalog/src/index.ts
+++ b/clients/client-controlcatalog/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ControlCatalogExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-controltower/src/index.ts
+++ b/clients/client-controltower/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ControlTowerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cost-and-usage-report-service/src/index.ts
+++ b/clients/client-cost-and-usage-report-service/src/index.ts
@@ -28,8 +28,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CostAndUsageReportServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cost-explorer/src/index.ts
+++ b/clients/client-cost-explorer/src/index.ts
@@ -27,8 +27,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CostExplorerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-cost-optimization-hub/src/index.ts
+++ b/clients/client-cost-optimization-hub/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CostOptimizationHubExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-customer-profiles/src/index.ts
+++ b/clients/client-customer-profiles/src/index.ts
@@ -30,8 +30,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { CustomerProfilesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-data-pipeline/src/index.ts
+++ b/clients/client-data-pipeline/src/index.ts
@@ -28,8 +28,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DataPipelineExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-database-migration-service/src/index.ts
+++ b/clients/client-database-migration-service/src/index.ts
@@ -21,9 +21,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DatabaseMigrationServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-databrew/src/index.ts
+++ b/clients/client-databrew/src/index.ts
@@ -15,8 +15,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DataBrewExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-dataexchange/src/index.ts
+++ b/clients/client-dataexchange/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DataExchangeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-datasync/src/index.ts
+++ b/clients/client-datasync/src/index.ts
@@ -23,8 +23,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DataSyncExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-datazone/src/index.ts
+++ b/clients/client-datazone/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DataZoneExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-deadline/src/index.ts
+++ b/clients/client-deadline/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DeadlineExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-detective/src/index.ts
+++ b/clients/client-detective/src/index.ts
@@ -87,8 +87,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DetectiveExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-device-farm/src/index.ts
+++ b/clients/client-device-farm/src/index.ts
@@ -26,8 +26,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DeviceFarmExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-devops-agent/src/index.ts
+++ b/clients/client-devops-agent/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DevOpsAgentExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-devops-guru/src/index.ts
+++ b/clients/client-devops-guru/src/index.ts
@@ -23,8 +23,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DevOpsGuruExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-directory-service-data/src/index.ts
+++ b/clients/client-directory-service-data/src/index.ts
@@ -62,8 +62,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DirectoryServiceDataExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-directory-service/src/index.ts
+++ b/clients/client-directory-service/src/index.ts
@@ -25,9 +25,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DirectoryServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-docdb-elastic/src/index.ts
+++ b/clients/client-docdb-elastic/src/index.ts
@@ -26,8 +26,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DocDBElasticExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-docdb/src/index.ts
+++ b/clients/client-docdb/src/index.ts
@@ -14,9 +14,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DocDBExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-drs/src/index.ts
+++ b/clients/client-drs/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DrsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-dsql/src/index.ts
+++ b/clients/client-dsql/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DSQLExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-dynamodb/src/index.ts
+++ b/clients/client-dynamodb/src/index.ts
@@ -28,9 +28,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { DynamoDBExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ebs/src/index.ts
+++ b/clients/client-ebs/src/index.ts
@@ -28,8 +28,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { EBSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ec2/src/index.ts
+++ b/clients/client-ec2/src/index.ts
@@ -64,9 +64,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { EC2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/models_0";

--- a/clients/client-ecr-public/src/index.ts
+++ b/clients/client-ecr-public/src/index.ts
@@ -18,8 +18,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ECRPUBLICExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ecr/src/index.ts
+++ b/clients/client-ecr/src/index.ts
@@ -20,9 +20,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ECRExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ecs/src/index.ts
+++ b/clients/client-ecs/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ECSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-efs/src/index.ts
+++ b/clients/client-efs/src/index.ts
@@ -19,8 +19,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { EFSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-eks/src/index.ts
+++ b/clients/client-eks/src/index.ts
@@ -21,9 +21,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { EKSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-elastic-beanstalk/src/index.ts
+++ b/clients/client-elastic-beanstalk/src/index.ts
@@ -24,9 +24,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ElasticBeanstalkExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-elastic-load-balancing-v2/src/index.ts
+++ b/clients/client-elastic-load-balancing-v2/src/index.ts
@@ -40,9 +40,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ElasticLoadBalancingV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-elastic-load-balancing/src/index.ts
+++ b/clients/client-elastic-load-balancing/src/index.ts
@@ -32,9 +32,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ElasticLoadBalancingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/errors";
 export * from "./models/models_0";

--- a/clients/client-elasticache/src/index.ts
+++ b/clients/client-elasticache/src/index.ts
@@ -21,9 +21,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ElastiCacheExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-elasticsearch-service/src/index.ts
+++ b/clients/client-elasticsearch-service/src/index.ts
@@ -18,8 +18,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ElasticsearchServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-elementalinference/src/index.ts
+++ b/clients/client-elementalinference/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ElementalInferenceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-emr-containers/src/index.ts
+++ b/clients/client-emr-containers/src/index.ts
@@ -35,8 +35,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { EMRContainersExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-emr-serverless/src/index.ts
+++ b/clients/client-emr-serverless/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { EMRServerlessExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-emr/src/index.ts
+++ b/clients/client-emr/src/index.ts
@@ -14,9 +14,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { EMRExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-entityresolution/src/index.ts
+++ b/clients/client-entityresolution/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { EntityResolutionExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-evs/src/index.ts
+++ b/clients/client-evs/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { EvsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-finspace-data/src/index.ts
+++ b/clients/client-finspace-data/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { FinspaceDataExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-finspace/src/index.ts
+++ b/clients/client-finspace/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { FinspaceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-fis/src/index.ts
+++ b/clients/client-fis/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { FisExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-fms/src/index.ts
+++ b/clients/client-fms/src/index.ts
@@ -18,8 +18,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { FMSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-forecast/src/index.ts
+++ b/clients/client-forecast/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ForecastExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-frauddetector/src/index.ts
+++ b/clients/client-frauddetector/src/index.ts
@@ -21,8 +21,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { FraudDetectorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-freetier/src/index.ts
+++ b/clients/client-freetier/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { FreeTierExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-fsx/src/index.ts
+++ b/clients/client-fsx/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { FSxExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-gamelift/src/index.ts
+++ b/clients/client-gamelift/src/index.ts
@@ -69,8 +69,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { GameLiftExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-gameliftstreams/src/index.ts
+++ b/clients/client-gameliftstreams/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { GameLiftStreamsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-glacier/src/index.ts
+++ b/clients/client-glacier/src/index.ts
@@ -49,9 +49,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { GlacierExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-global-accelerator/src/index.ts
+++ b/clients/client-global-accelerator/src/index.ts
@@ -59,8 +59,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { GlobalAcceleratorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-glue/src/index.ts
+++ b/clients/client-glue/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { GlueExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-grafana/src/index.ts
+++ b/clients/client-grafana/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { GrafanaExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-greengrassv2/src/index.ts
+++ b/clients/client-greengrassv2/src/index.ts
@@ -22,8 +22,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { GreengrassV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-groundstation/src/index.ts
+++ b/clients/client-groundstation/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { GroundStationExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-guardduty/src/index.ts
+++ b/clients/client-guardduty/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { GuardDutyExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-health/src/index.ts
+++ b/clients/client-health/src/index.ts
@@ -54,8 +54,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { HealthExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-healthlake/src/index.ts
+++ b/clients/client-healthlake/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { HealthLakeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iam/src/index.ts
+++ b/clients/client-iam/src/index.ts
@@ -67,9 +67,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IAMExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-identitystore/src/index.ts
+++ b/clients/client-identitystore/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IdentitystoreExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-imagebuilder/src/index.ts
+++ b/clients/client-imagebuilder/src/index.ts
@@ -15,8 +15,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ImagebuilderExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-inspector/src/index.ts
+++ b/clients/client-inspector/src/index.ts
@@ -15,8 +15,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { InspectorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-inspector2/src/index.ts
+++ b/clients/client-inspector2/src/index.ts
@@ -13,9 +13,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Inspector2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-interconnect/src/index.ts
+++ b/clients/client-interconnect/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { InterconnectExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-internetmonitor/src/index.ts
+++ b/clients/client-internetmonitor/src/index.ts
@@ -27,8 +27,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { InternetMonitorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-invoicing/src/index.ts
+++ b/clients/client-invoicing/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { InvoicingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iot-data-plane/src/index.ts
+++ b/clients/client-iot-data-plane/src/index.ts
@@ -22,8 +22,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IoTDataPlaneExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iot-managed-integrations/src/index.ts
+++ b/clients/client-iot-managed-integrations/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IoTManagedIntegrationsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iot-wireless/src/index.ts
+++ b/clients/client-iot-wireless/src/index.ts
@@ -30,8 +30,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IoTWirelessExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iot/src/index.ts
+++ b/clients/client-iot/src/index.ts
@@ -27,8 +27,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IoTExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iotdeviceadvisor/src/index.ts
+++ b/clients/client-iotdeviceadvisor/src/index.ts
@@ -20,8 +20,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IotDeviceAdvisorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iotfleetwise/src/index.ts
+++ b/clients/client-iotfleetwise/src/index.ts
@@ -21,8 +21,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IoTFleetWiseExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iotsecuretunneling/src/index.ts
+++ b/clients/client-iotsecuretunneling/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IoTSecureTunnelingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iotsitewise/src/index.ts
+++ b/clients/client-iotsitewise/src/index.ts
@@ -13,9 +13,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IoTSiteWiseExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iotthingsgraph/src/index.ts
+++ b/clients/client-iotthingsgraph/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IoTThingsGraphExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-iottwinmaker/src/index.ts
+++ b/clients/client-iottwinmaker/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IoTTwinMakerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ivs-realtime/src/index.ts
+++ b/clients/client-ivs-realtime/src/index.ts
@@ -89,8 +89,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IVSRealTimeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ivs/src/index.ts
+++ b/clients/client-ivs/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IvsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ivschat/src/index.ts
+++ b/clients/client-ivschat/src/index.ts
@@ -117,8 +117,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { IvschatExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-kafka/src/index.ts
+++ b/clients/client-kafka/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KafkaExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-kafkaconnect/src/index.ts
+++ b/clients/client-kafkaconnect/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KafkaConnectExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-kendra-ranking/src/index.ts
+++ b/clients/client-kendra-ranking/src/index.ts
@@ -14,8 +14,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KendraRankingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-kendra/src/index.ts
+++ b/clients/client-kendra/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KendraExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-keyspaces/src/index.ts
+++ b/clients/client-keyspaces/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KeyspacesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-keyspacesstreams/src/index.ts
+++ b/clients/client-keyspacesstreams/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KeyspacesStreamsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-kinesis-analytics-v2/src/index.ts
+++ b/clients/client-kinesis-analytics-v2/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KinesisAnalyticsV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-kinesis-video-archived-media/src/index.ts
+++ b/clients/client-kinesis-video-archived-media/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KinesisVideoArchivedMediaExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-kinesis-video/src/index.ts
+++ b/clients/client-kinesis-video/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KinesisVideoExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-kinesis/src/index.ts
+++ b/clients/client-kinesis/src/index.ts
@@ -14,9 +14,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KinesisExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-kms/src/index.ts
+++ b/clients/client-kms/src/index.ts
@@ -109,8 +109,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { KMSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-lakeformation/src/index.ts
+++ b/clients/client-lakeformation/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LakeFormationExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-lambda-core/src/index.ts
+++ b/clients/client-lambda-core/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LambdaCoreExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-lambda-microvms/src/index.ts
+++ b/clients/client-lambda-microvms/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LambdaMicrovmsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-lambda/src/index.ts
+++ b/clients/client-lambda/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LambdaExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-launch-wizard/src/index.ts
+++ b/clients/client-launch-wizard/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LaunchWizardExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-lex-model-building-service/src/index.ts
+++ b/clients/client-lex-model-building-service/src/index.ts
@@ -15,8 +15,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LexModelBuildingServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-lex-models-v2/src/index.ts
+++ b/clients/client-lex-models-v2/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LexModelsV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-license-manager-linux-subscriptions/src/index.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LicenseManagerLinuxSubscriptionsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-license-manager-user-subscriptions/src/index.ts
+++ b/clients/client-license-manager-user-subscriptions/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LicenseManagerUserSubscriptionsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-location/src/index.ts
+++ b/clients/client-location/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LocationExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-lookoutequipment/src/index.ts
+++ b/clients/client-lookoutequipment/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { LookoutEquipmentExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-m2/src/index.ts
+++ b/clients/client-m2/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { M2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-machine-learning/src/index.ts
+++ b/clients/client-machine-learning/src/index.ts
@@ -13,9 +13,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MachineLearningExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-macie2/src/index.ts
+++ b/clients/client-macie2/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Macie2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mailmanager/src/index.ts
+++ b/clients/client-mailmanager/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MailManagerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-managedblockchain-query/src/index.ts
+++ b/clients/client-managedblockchain-query/src/index.ts
@@ -18,8 +18,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ManagedBlockchainQueryExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-managedblockchain/src/index.ts
+++ b/clients/client-managedblockchain/src/index.ts
@@ -15,8 +15,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ManagedBlockchainExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-marketplace-agreement/src/index.ts
+++ b/clients/client-marketplace-agreement/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MarketplaceAgreementExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-marketplace-catalog/src/index.ts
+++ b/clients/client-marketplace-catalog/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MarketplaceCatalogExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-marketplace-discovery/src/index.ts
+++ b/clients/client-marketplace-discovery/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MarketplaceDiscoveryExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-marketplace-entitlement-service/src/index.ts
+++ b/clients/client-marketplace-entitlement-service/src/index.ts
@@ -28,8 +28,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MarketplaceEntitlementServiceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mediaconnect/src/index.ts
+++ b/clients/client-mediaconnect/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MediaConnectExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mediaconvert/src/index.ts
+++ b/clients/client-mediaconvert/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MediaConvertExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-medialive/src/index.ts
+++ b/clients/client-medialive/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MediaLiveExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mediapackage-vod/src/index.ts
+++ b/clients/client-mediapackage-vod/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MediaPackageVodExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mediapackage/src/index.ts
+++ b/clients/client-mediapackage/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MediaPackageExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mediapackagev2/src/index.ts
+++ b/clients/client-mediapackagev2/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MediaPackageV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mediastore-data/src/index.ts
+++ b/clients/client-mediastore-data/src/index.ts
@@ -14,8 +14,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MediaStoreDataExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mediastore/src/index.ts
+++ b/clients/client-mediastore/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MediaStoreExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mediatailor/src/index.ts
+++ b/clients/client-mediatailor/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MediaTailorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-medical-imaging/src/index.ts
+++ b/clients/client-medical-imaging/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MedicalImagingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-memorydb/src/index.ts
+++ b/clients/client-memorydb/src/index.ts
@@ -14,8 +14,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MemoryDBExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mgn/src/index.ts
+++ b/clients/client-mgn/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MgnExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-migration-hub-refactor-spaces/src/index.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/index.ts
@@ -19,8 +19,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MigrationHubRefactorSpacesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-migration-hub/src/index.ts
+++ b/clients/client-migration-hub/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MigrationHubExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-migrationhub-config/src/index.ts
+++ b/clients/client-migrationhub-config/src/index.ts
@@ -35,8 +35,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MigrationHubConfigExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-migrationhuborchestrator/src/index.ts
+++ b/clients/client-migrationhuborchestrator/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MigrationHubOrchestratorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-migrationhubstrategy/src/index.ts
+++ b/clients/client-migrationhubstrategy/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MigrationHubStrategyExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mpa/src/index.ts
+++ b/clients/client-mpa/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MPAExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mq/src/index.ts
+++ b/clients/client-mq/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MqExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mturk/src/index.ts
+++ b/clients/client-mturk/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MTurkExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mwaa-serverless/src/index.ts
+++ b/clients/client-mwaa-serverless/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MWAAServerlessExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-mwaa/src/index.ts
+++ b/clients/client-mwaa/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { MWAAExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-neptune-graph/src/index.ts
+++ b/clients/client-neptune-graph/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { NeptuneGraphExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-neptune/src/index.ts
+++ b/clients/client-neptune/src/index.ts
@@ -28,9 +28,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { NeptuneExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-network-firewall/src/index.ts
+++ b/clients/client-network-firewall/src/index.ts
@@ -98,8 +98,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { NetworkFirewallExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-networkflowmonitor/src/index.ts
+++ b/clients/client-networkflowmonitor/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { NetworkFlowMonitorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-networkmanager/src/index.ts
+++ b/clients/client-networkmanager/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { NetworkManagerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-networkmonitor/src/index.ts
+++ b/clients/client-networkmonitor/src/index.ts
@@ -23,8 +23,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { NetworkMonitorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-notifications/src/index.ts
+++ b/clients/client-notifications/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { NotificationsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-notificationscontacts/src/index.ts
+++ b/clients/client-notificationscontacts/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { NotificationsContactsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-nova-act/src/index.ts
+++ b/clients/client-nova-act/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { NovaActExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-oam/src/index.ts
+++ b/clients/client-oam/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { OAMExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-observabilityadmin/src/index.ts
+++ b/clients/client-observabilityadmin/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ObservabilityAdminExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-odb/src/index.ts
+++ b/clients/client-odb/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { OdbExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-omics/src/index.ts
+++ b/clients/client-omics/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { OmicsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-opensearch/src/index.ts
+++ b/clients/client-opensearch/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { OpenSearchExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-opensearchserverless/src/index.ts
+++ b/clients/client-opensearchserverless/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { OpenSearchServerlessExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-organizations/src/index.ts
+++ b/clients/client-organizations/src/index.ts
@@ -133,8 +133,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { OrganizationsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-osis/src/index.ts
+++ b/clients/client-osis/src/index.ts
@@ -14,8 +14,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { OSISExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-outposts/src/index.ts
+++ b/clients/client-outposts/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { OutpostsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-partnercentral-account/src/index.ts
+++ b/clients/client-partnercentral-account/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PartnerCentralAccountExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-partnercentral-benefits/src/index.ts
+++ b/clients/client-partnercentral-benefits/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PartnerCentralBenefitsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-partnercentral-channel/src/index.ts
+++ b/clients/client-partnercentral-channel/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PartnerCentralChannelExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-partnercentral-revenue-measurement/src/index.ts
+++ b/clients/client-partnercentral-revenue-measurement/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PartnerCentralRevenueMeasurementExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-partnercentral-selling/src/index.ts
+++ b/clients/client-partnercentral-selling/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PartnerCentralSellingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-payment-cryptography/src/index.ts
+++ b/clients/client-payment-cryptography/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PaymentCryptographyExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-pca-connector-ad/src/index.ts
+++ b/clients/client-pca-connector-ad/src/index.ts
@@ -14,8 +14,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PcaConnectorAdExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-pca-connector-scep/src/index.ts
+++ b/clients/client-pca-connector-scep/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PcaConnectorScepExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-pcs/src/index.ts
+++ b/clients/client-pcs/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PCSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-personalize/src/index.ts
+++ b/clients/client-personalize/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PersonalizeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-pi/src/index.ts
+++ b/clients/client-pi/src/index.ts
@@ -36,8 +36,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PIExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-pinpoint-email/src/index.ts
+++ b/clients/client-pinpoint-email/src/index.ts
@@ -40,8 +40,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PinpointEmailExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-pinpoint-sms-voice-v2/src/index.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PinpointSMSVoiceV2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-pipes/src/index.ts
+++ b/clients/client-pipes/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PipesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-polly/src/index.ts
+++ b/clients/client-polly/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PollyExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-pricing-plan-manager/src/index.ts
+++ b/clients/client-pricing-plan-manager/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PricingPlanManagerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-pricing/src/index.ts
+++ b/clients/client-pricing/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { PricingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-proton/src/index.ts
+++ b/clients/client-proton/src/index.ts
@@ -140,9 +140,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ProtonExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-qapps/src/index.ts
+++ b/clients/client-qapps/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { QAppsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-qbusiness/src/index.ts
+++ b/clients/client-qbusiness/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { QBusinessExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-qconnect/src/index.ts
+++ b/clients/client-qconnect/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { QConnectExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-quicksight/src/index.ts
+++ b/clients/client-quicksight/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { QuickSightExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ram/src/index.ts
+++ b/clients/client-ram/src/index.ts
@@ -31,8 +31,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RAMExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-rbin/src/index.ts
+++ b/clients/client-rbin/src/index.ts
@@ -23,8 +23,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RbinExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-rds/src/index.ts
+++ b/clients/client-rds/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RDSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-redshift-data/src/index.ts
+++ b/clients/client-redshift-data/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RedshiftDataExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-redshift-serverless/src/index.ts
+++ b/clients/client-redshift-serverless/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RedshiftServerlessExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-redshift/src/index.ts
+++ b/clients/client-redshift/src/index.ts
@@ -32,9 +32,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RedshiftExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-rekognition/src/index.ts
+++ b/clients/client-rekognition/src/index.ts
@@ -385,9 +385,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RekognitionExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-repostspace/src/index.ts
+++ b/clients/client-repostspace/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RepostspaceExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-resiliencehub/src/index.ts
+++ b/clients/client-resiliencehub/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ResiliencehubExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-resiliencehubv2/src/index.ts
+++ b/clients/client-resiliencehubv2/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Resiliencehubv2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-resource-explorer-2/src/index.ts
+++ b/clients/client-resource-explorer-2/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ResourceExplorer2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-resource-groups-tagging-api/src/index.ts
+++ b/clients/client-resource-groups-tagging-api/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ResourceGroupsTaggingAPIExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-resource-groups/src/index.ts
+++ b/clients/client-resource-groups/src/index.ts
@@ -45,8 +45,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ResourceGroupsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-rolesanywhere/src/index.ts
+++ b/clients/client-rolesanywhere/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RolesAnywhereExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-route-53-domains/src/index.ts
+++ b/clients/client-route-53-domains/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Route53DomainsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-route-53/src/index.ts
+++ b/clients/client-route-53/src/index.ts
@@ -28,9 +28,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Route53ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-route53-recovery-cluster/src/index.ts
+++ b/clients/client-route53-recovery-cluster/src/index.ts
@@ -51,8 +51,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Route53RecoveryClusterExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-route53-recovery-control-config/src/index.ts
+++ b/clients/client-route53-recovery-control-config/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Route53RecoveryControlConfigExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-route53-recovery-readiness/src/index.ts
+++ b/clients/client-route53-recovery-readiness/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Route53RecoveryReadinessExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-route53globalresolver/src/index.ts
+++ b/clients/client-route53globalresolver/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Route53GlobalResolverExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-route53profiles/src/index.ts
+++ b/clients/client-route53profiles/src/index.ts
@@ -14,8 +14,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Route53ProfilesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-route53resolver/src/index.ts
+++ b/clients/client-route53resolver/src/index.ts
@@ -38,8 +38,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { Route53ResolverExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-rtbfabric/src/index.ts
+++ b/clients/client-rtbfabric/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RTBFabricExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-rum/src/index.ts
+++ b/clients/client-rum/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { RUMExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-s3-control/src/index.ts
+++ b/clients/client-s3-control/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { S3ControlExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-s3/src/index.ts
+++ b/clients/client-s3/src/index.ts
@@ -28,9 +28,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { S3ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-s3files/src/index.ts
+++ b/clients/client-s3files/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { S3FilesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-s3outposts/src/index.ts
+++ b/clients/client-s3outposts/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { S3OutpostsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-s3tables/src/index.ts
+++ b/clients/client-s3tables/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { S3TablesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-s3vectors/src/index.ts
+++ b/clients/client-s3vectors/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { S3VectorsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sagemaker-a2i-runtime/src/index.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/index.ts
@@ -37,8 +37,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SageMakerA2IRuntimeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sagemaker-featurestore-runtime/src/index.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/index.ts
@@ -38,8 +38,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SageMakerFeatureStoreRuntimeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sagemaker-geospatial/src/index.ts
+++ b/clients/client-sagemaker-geospatial/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SageMakerGeospatialExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sagemaker/src/index.ts
+++ b/clients/client-sagemaker/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SageMakerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-scheduler/src/index.ts
+++ b/clients/client-scheduler/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SchedulerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-schemas/src/index.ts
+++ b/clients/client-schemas/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SchemasExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-secrets-manager/src/index.ts
+++ b/clients/client-secrets-manager/src/index.ts
@@ -37,8 +37,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SecretsManagerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-security-ir/src/index.ts
+++ b/clients/client-security-ir/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SecurityIRExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-securityagent/src/index.ts
+++ b/clients/client-securityagent/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SecurityAgentExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-securityhub/src/index.ts
+++ b/clients/client-securityhub/src/index.ts
@@ -83,8 +83,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SecurityHubExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-securitylake/src/index.ts
+++ b/clients/client-securitylake/src/index.ts
@@ -37,8 +37,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SecurityLakeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-serverlessapplicationrepository/src/index.ts
+++ b/clients/client-serverlessapplicationrepository/src/index.ts
@@ -31,8 +31,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ServerlessApplicationRepositoryExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-service-catalog-appregistry/src/index.ts
+++ b/clients/client-service-catalog-appregistry/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ServiceCatalogAppRegistryExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-service-catalog/src/index.ts
+++ b/clients/client-service-catalog/src/index.ts
@@ -18,8 +18,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ServiceCatalogExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-service-quotas/src/index.ts
+++ b/clients/client-service-quotas/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ServiceQuotasExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-servicediscovery/src/index.ts
+++ b/clients/client-servicediscovery/src/index.ts
@@ -18,8 +18,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ServiceDiscoveryExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ses/src/index.ts
+++ b/clients/client-ses/src/index.ts
@@ -45,9 +45,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SESExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sesv2/src/index.ts
+++ b/clients/client-sesv2/src/index.ts
@@ -18,8 +18,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SESv2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sfn/src/index.ts
+++ b/clients/client-sfn/src/index.ts
@@ -21,8 +21,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SFNExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-shield/src/index.ts
+++ b/clients/client-shield/src/index.ts
@@ -15,8 +15,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { ShieldExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-signer/src/index.ts
+++ b/clients/client-signer/src/index.ts
@@ -29,9 +29,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SignerExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-signin/src/index.ts
+++ b/clients/client-signin/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SigninExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-simpledbv2/src/index.ts
+++ b/clients/client-simpledbv2/src/index.ts
@@ -21,9 +21,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SimpleDBv2ExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-snow-device-management/src/index.ts
+++ b/clients/client-snow-device-management/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SnowDeviceManagementExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-snowball/src/index.ts
+++ b/clients/client-snowball/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SnowballExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sns/src/index.ts
+++ b/clients/client-sns/src/index.ts
@@ -24,8 +24,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SNSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-socialmessaging/src/index.ts
+++ b/clients/client-socialmessaging/src/index.ts
@@ -37,8 +37,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SocialMessagingExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sqs/src/index.ts
+++ b/clients/client-sqs/src/index.ts
@@ -82,8 +82,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SQSExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ssm-contacts/src/index.ts
+++ b/clients/client-ssm-contacts/src/index.ts
@@ -19,8 +19,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SSMContactsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ssm-incidents/src/index.ts
+++ b/clients/client-ssm-incidents/src/index.ts
@@ -19,9 +19,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SSMIncidentsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ssm-quicksetup/src/index.ts
+++ b/clients/client-ssm-quicksetup/src/index.ts
@@ -14,8 +14,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SSMQuickSetupExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ssm-sap/src/index.ts
+++ b/clients/client-ssm-sap/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SsmSapExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-ssm/src/index.ts
+++ b/clients/client-ssm/src/index.ts
@@ -49,9 +49,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SSMExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sso-admin/src/index.ts
+++ b/clients/client-sso-admin/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SSOAdminExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sso/src/index.ts
+++ b/clients/client-sso/src/index.ts
@@ -27,8 +27,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SSOExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/errors";
 export * from "./models/models_0";

--- a/clients/client-storage-gateway/src/index.ts
+++ b/clients/client-storage-gateway/src/index.ts
@@ -75,8 +75,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { StorageGatewayExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-supplychain/src/index.ts
+++ b/clients/client-supplychain/src/index.ts
@@ -18,8 +18,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SupplyChainExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-support-app/src/index.ts
+++ b/clients/client-support-app/src/index.ts
@@ -65,8 +65,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SupportAppExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-support/src/index.ts
+++ b/clients/client-support/src/index.ts
@@ -55,8 +55,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SupportExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/errors";
 export * from "./models/models_0";

--- a/clients/client-supportauthz/src/index.ts
+++ b/clients/client-supportauthz/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SupportAuthZExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-sustainability/src/index.ts
+++ b/clients/client-sustainability/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SustainabilityExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-swf/src/index.ts
+++ b/clients/client-swf/src/index.ts
@@ -24,8 +24,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SWFExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-synthetics/src/index.ts
+++ b/clients/client-synthetics/src/index.ts
@@ -26,8 +26,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { SyntheticsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-taxsettings/src/index.ts
+++ b/clients/client-taxsettings/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { TaxSettingsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-textract/src/index.ts
+++ b/clients/client-textract/src/index.ts
@@ -14,8 +14,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { TextractExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-timestream-influxdb/src/index.ts
+++ b/clients/client-timestream-influxdb/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { TimestreamInfluxDBExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-timestream-query/src/index.ts
+++ b/clients/client-timestream-query/src/index.ts
@@ -14,8 +14,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { TimestreamQueryExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-timestream-write/src/index.ts
+++ b/clients/client-timestream-write/src/index.ts
@@ -24,8 +24,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { TimestreamWriteExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-tnb/src/index.ts
+++ b/clients/client-tnb/src/index.ts
@@ -16,8 +16,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { TnbExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-transcribe/src/index.ts
+++ b/clients/client-transcribe/src/index.ts
@@ -33,9 +33,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { TranscribeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-transfer/src/index.ts
+++ b/clients/client-transfer/src/index.ts
@@ -12,9 +12,9 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { TransferExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
 export * from "./waiters";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-translate/src/index.ts
+++ b/clients/client-translate/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { TranslateExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-trustedadvisor/src/index.ts
+++ b/clients/client-trustedadvisor/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { TrustedAdvisorExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-uxc/src/index.ts
+++ b/clients/client-uxc/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { UxcExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-verifiedpermissions/src/index.ts
+++ b/clients/client-verifiedpermissions/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { VerifiedPermissionsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-voice-id/src/index.ts
+++ b/clients/client-voice-id/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { VoiceIDExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-vpc-lattice/src/index.ts
+++ b/clients/client-vpc-lattice/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { VPCLatticeExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-wellarchitected/src/index.ts
+++ b/clients/client-wellarchitected/src/index.ts
@@ -17,8 +17,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { WellArchitectedExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-wickr/src/index.ts
+++ b/clients/client-wickr/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { WickrExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-wisdom/src/index.ts
+++ b/clients/client-wisdom/src/index.ts
@@ -15,8 +15,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { WisdomExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-workdocs/src/index.ts
+++ b/clients/client-workdocs/src/index.ts
@@ -70,8 +70,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { WorkDocsExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-workmail/src/index.ts
+++ b/clients/client-workmail/src/index.ts
@@ -47,8 +47,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { WorkMailExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-workspaces-instances/src/index.ts
+++ b/clients/client-workspaces-instances/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { WorkspacesInstancesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-workspaces-thin-client/src/index.ts
+++ b/clients/client-workspaces-thin-client/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { WorkSpacesThinClientExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-workspaces-web/src/index.ts
+++ b/clients/client-workspaces-web/src/index.ts
@@ -12,8 +12,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { WorkSpacesWebExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-workspaces/src/index.ts
+++ b/clients/client-workspaces/src/index.ts
@@ -28,8 +28,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { WorkSpacesExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/clients/client-xray/src/index.ts
+++ b/clients/client-xray/src/index.ts
@@ -13,8 +13,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { XRayExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Commit logs](https://github.com/aws/aws-sdk-js-v3/commits/main/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen)
 
+## 0.52.0 (2026-08-07)
+
+### Chores
+
+- Upgraded to smithy-typescript 0.52.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0520-2026-08-07))
+
 ## 0.51.0 (2026-07-13)
 
 ### Chores

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -37,7 +37,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.51.0"
+    version = "0.52.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.51.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.52.0")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentBareBonesClientGenerator.java
@@ -214,7 +214,7 @@ final class DocumentBareBonesClientGenerator implements Runnable {
 
                     This can happen when the dependency graph is invalid, including
                     for example, a Lambda layer exposing certain packages being merged
-                    with the Lambda Node.js runtime-bundled AWS SDK.
+                    with the Node.js Lambda provided JS SDK.
 
                     This is not supported and we can only make a best-effort attempt
                     to repair the error if there is a 2nd client-dynamodb within the

--- a/private/aws-protocoltests-restjson-schema-apigateway/src/index.ts
+++ b/private/aws-protocoltests-restjson-schema-apigateway/src/index.ts
@@ -7,8 +7,8 @@ export type { RuntimeExtension } from "./runtimeExtensions";
 export type { APIGatewayExtensionConfiguration } from "./extensionConfiguration";
 export * from "./commands";
 export { Command as $Command } from "@smithy/core/client";
-export * from "./schemas/schemas_0";
 export * from "./pagination";
+export * from "./schemas/schemas_0";
 
 export * from "./models/enums";
 export * from "./models/errors";

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/bcff71dba309446910f7a23b050350d3be77200d...TBD
-  SMITHY_TS_COMMIT: "TBD",
+  // https://github.com/smithy-lang/smithy-typescript/compare/bcff71dba309446910f7a23b050350d3be77200d...eda8e9796c241eef879074440b8fb275e459aa85
+  SMITHY_TS_COMMIT: "eda8e9796c241eef879074440b8fb275e459aa85",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/5458500fc2776717fe64f27b709b660f7a3ff7b3...bcff71dba309446910f7a23b050350d3be77200d
-  SMITHY_TS_COMMIT: "bcff71dba309446910f7a23b050350d3be77200d",
+  // https://github.com/smithy-lang/smithy-typescript/compare/bcff71dba309446910f7a23b050350d3be77200d...TBD
+  SMITHY_TS_COMMIT: "TBD",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
Bumps the Maven version of `smithy-aws-typescript-codegen` to 0.52.0.

tied to https://github.com/smithy-lang/smithy-typescript/pull/2215
