### PR TITLE
fix(lib-transfer-manager): optimize worker HTTP connections and file I/O

### DIFF
--- a/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
+++ b/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
@@ -7,10 +7,48 @@
  */
 import { HttpRequest } from "@smithy/core/protocols";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
-import { open } from "node:fs/promises";
+import dns from "node:dns";
+import { openSync, readSync, closeSync } from "node:fs";
 import { Agent as httpsAgent } from "node:https";
 import { parentPort } from "node:worker_threads";
 import { crc32 } from "node:zlib";
+
+/**
+ * Resolves all A records for a hostname, picks one at random per connection
+ * to spread load across S3's fleet. Falls back to dns.lookup for IPv6 or
+ * on resolution failure.
+ * @internal
+ */
+const DNS_TTL_MS = 1000;
+const dnsCache = new Map<string, { ips: string[]; ts: number }>();
+
+function spreadLookup(hostname: string, options: any, callback: any): void {
+  if (options && options.family === 6) {
+    return dns.lookup(hostname, options, callback);
+  }
+
+  const deliver = (ips: string[]) => {
+    const ip = ips[Math.floor(Math.random() * ips.length)];
+    if (options && options.all) {
+      callback(null, [{ address: ip, family: 4 }]);
+    } else {
+      callback(null, ip, 4);
+    }
+  };
+
+  const cached = dnsCache.get(hostname);
+  if (cached && cached.ips.length && Date.now() - cached.ts < DNS_TTL_MS) {
+    return deliver(cached.ips);
+  }
+
+  dns.resolve4(hostname, (err, ips) => {
+    if (err || !ips || !ips.length) {
+      return dns.lookup(hostname, options, callback);
+    }
+    dnsCache.set(hostname, { ips, ts: Date.now() });
+    deliver(ips);
+  });
+}
 
 /**
  * Types duplicated from worker-http-handler to avoid cross-submodule imports.
@@ -91,15 +129,27 @@ if (parentPort) {
   let handler: NodeHttpHandler | undefined;
   const port = parentPort;
 
-  const readFileSlice = async (filePath: string, offset: number, length: number): Promise<Buffer> => {
-    const fh = await open(filePath, "r");
-    try {
-      const buffer = Buffer.allocUnsafe(length);
-      await fh.read(buffer, 0, length, offset);
-      return buffer;
-    } finally {
-      await fh.close();
+  // Hold file descriptors open for the lifetime of the worker.
+  const fdCache = new Map<string, number>();
+  function getFd(filePath: string): number {
+    let fd = fdCache.get(filePath);
+    if (fd === undefined) {
+      fd = openSync(filePath, "r");
+      fdCache.set(filePath, fd);
     }
+    return fd;
+  }
+
+  const readFileSlice = (filePath: string, offset: number, length: number): Buffer => {
+    const fd = getFd(filePath);
+    const buffer = Buffer.allocUnsafe(length);
+    let read = 0;
+    while (read < length) {
+      const n = readSync(fd, buffer, read, length - read, offset + read);
+      if (n === 0) break;
+      read += n;
+    }
+    return buffer;
   };
 
   const buildAwsChunkedBody = (data: Buffer, checksumHeader?: string, checksumValue?: string): Buffer => {
@@ -129,7 +179,7 @@ if (parentPort) {
           body = fileData;
         }
       } else if (msg.type === "httpRequestFromFile") {
-        const fileData = await readFileSlice(msg.filePath, msg.offset, msg.length);
+        const fileData = readFileSlice(msg.filePath, msg.offset, msg.length);
 
         if (msg.checksumAlgorithm && msg.checksumHeader) {
           const crcValue = crc32(fileData);
@@ -195,6 +245,13 @@ if (parentPort) {
 
   port.on("message", (msg: HttpWorkerInboundMessage) => {
     if (msg.type === "done") {
+      for (const fd of fdCache.values()) {
+        try {
+          closeSync(fd);
+        } catch {
+          /* ignore */
+        }
+      }
       handler?.destroy();
       process.exit(0);
       return;
@@ -203,7 +260,7 @@ if (parentPort) {
     if (msg.type === "config") {
       const { maxSockets } = msg as HttpWorkerConfigMessage;
       handler = new NodeHttpHandler({
-        httpsAgent: new httpsAgent({ maxSockets }),
+        httpsAgent: new httpsAgent({ maxSockets, keepAlive: true, lookup: spreadLookup }),
       });
       return;
     }

--- a/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
+++ b/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
@@ -9,9 +9,13 @@ import { HttpRequest } from "@smithy/core/protocols";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import dns from "node:dns";
 import { openSync, readSync, closeSync } from "node:fs";
+import type { LookupOptions } from "node:dns";
 import { Agent as httpsAgent } from "node:https";
 import { parentPort } from "node:worker_threads";
 import { crc32 } from "node:zlib";
+
+const DNS_TTL_MS = 1000;
+const dnsCache = new Map<string, { ips: string[]; ts: number }>();
 
 /**
  * Resolves all A records for a hostname, picks one at random per connection
@@ -19,10 +23,11 @@ import { crc32 } from "node:zlib";
  * on resolution failure.
  * @internal
  */
-const DNS_TTL_MS = 1000;
-const dnsCache = new Map<string, { ips: string[]; ts: number }>();
-
-function spreadLookup(hostname: string, options: any, callback: any): void {
+function spreadLookup(
+  hostname: string,
+  options: LookupOptions,
+  callback: (err: NodeJS.ErrnoException | null, address: string | dns.LookupAddress[], family?: number) => void
+): void {
   if (options && options.family === 6) {
     return dns.lookup(hostname, options, callback);
   }
@@ -42,7 +47,7 @@ function spreadLookup(hostname: string, options: any, callback: any): void {
   }
 
   dns.resolve4(hostname, (err, ips) => {
-    if (err || !ips || !ips.length) {
+    if (err || !ips?.length) {
       return dns.lookup(hostname, options, callback);
     }
     dnsCache.set(hostname, { ips, ts: Date.now() });
@@ -249,7 +254,10 @@ if (parentPort) {
         try {
           closeSync(fd);
         } catch {
-          /* ignore */
+          /**
+           * Safe to ignore: process.exit(0) below will close all file descriptors.
+           * If we throw here, handler.destroy() would be skipped.
+           */
         }
       }
       handler?.destroy();


### PR DESCRIPTION
### Description
Optimizes worker thread HTTP and I/O performance in the transfer manager by adding dns spread lookup, configuring `keepAlive: true` to reuse TCP connections and reuse the fd for all part reads.

### Testing
CI

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
