### PR TITLE
feat(lib-transfer-manager): add file based download api and worker thread based download.

### DIFF
--- a/lib/lib-transfer-manager/package.json
+++ b/lib/lib-transfer-manager/package.json
@@ -83,7 +83,7 @@
     "test:browser:watch": "yarn g:vitest watch -c vitest.config.browser.mts"
   },
   "dependencies": {
-    "@aws-sdk/checksums": "workspace:^3.1000.27",
+    "@aws-sdk/checksums": "workspace:^3.1000.28",
     "@smithy/core": "^3.31.1",
     "@smithy/node-http-handler": "^4.9.13",
     "@smithy/types": "^4.16.1",

--- a/lib/lib-transfer-manager/package.json
+++ b/lib/lib-transfer-manager/package.json
@@ -83,6 +83,7 @@
     "test:browser:watch": "yarn g:vitest watch -c vitest.config.browser.mts"
   },
   "dependencies": {
+    "@aws-sdk/checksums": "workspace:3.1000.26",
     "@smithy/core": "^3.31.1",
     "@smithy/node-http-handler": "^4.9.13",
     "@smithy/types": "^4.16.1",

--- a/lib/lib-transfer-manager/package.json
+++ b/lib/lib-transfer-manager/package.json
@@ -83,7 +83,7 @@
     "test:browser:watch": "yarn g:vitest watch -c vitest.config.browser.mts"
   },
   "dependencies": {
-    "@aws-sdk/checksums": "workspace:3.1000.26",
+    "@aws-sdk/checksums": "workspace:^3.1000.27",
     "@smithy/core": "^3.31.1",
     "@smithy/node-http-handler": "^4.9.13",
     "@smithy/types": "^4.16.1",

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.e2e.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.e2e.spec.ts
@@ -992,8 +992,8 @@ describe(S3TransferManager.name, () => {
                   },
                 ],
               },
-            },
-          ),
+            }
+          )
         ).rejects.toThrow(/abort/i);
 
         // Verify no temp files and no destination file remain

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.e2e.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.e2e.spec.ts
@@ -2,7 +2,7 @@ import { getE2eTestResources } from "@aws-sdk/aws-util-test/src";
 import type { GetObjectCommandOutput } from "@aws-sdk/client-s3";
 import { S3 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeAll, describe, expect, test as it } from "vitest";
@@ -883,5 +883,126 @@ describe(S3TransferManager.name, () => {
         await cleanupS3Objects(s3Prefix);
       }
     });
+  });
+
+  describe("downloadToFile", () => {
+    it("should download a multipart object to file with correct content and no leftover temp files", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-downloadToFile-"));
+
+      try {
+        const destination = join(tmpDir, "downloaded-multipart.bin");
+        const expectedData = data(SIZE_11MB);
+
+        const response = await tmPart.downloadToFile({
+          Bucket,
+          Key: FIXTURES.multipart_11mb,
+          destination,
+        });
+
+        // Verify response metadata
+        expect(response.bytesWritten).toBe(SIZE_11MB);
+
+        // Verify file content matches the original
+        const fileContent = await readFile(destination);
+        expect(fileContent.length).toBe(SIZE_11MB);
+        expect(Buffer.from(fileContent).equals(Buffer.from(expectedData))).toBe(true);
+
+        // Verify no temp files remain
+        const files = await readdir(tmpDir);
+        expect(files.filter((f) => f.includes(".s3tmp."))).toHaveLength(0);
+        expect(files).toEqual(["downloaded-multipart.bin"]);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+      }
+    }, 60_000);
+
+    it("should download a multipart object to file using RANGE mode", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-downloadToFile-"));
+
+      try {
+        const destination = join(tmpDir, "downloaded-range.bin");
+        const expectedData = data(SIZE_11MB);
+
+        const response = await tmRange.downloadToFile({
+          Bucket,
+          Key: FIXTURES.multipart_11mb,
+          destination,
+        });
+
+        expect(response.bytesWritten).toBe(SIZE_11MB);
+
+        const fileContent = await readFile(destination);
+        expect(fileContent.length).toBe(SIZE_11MB);
+        expect(Buffer.from(fileContent).equals(Buffer.from(expectedData))).toBe(true);
+
+        // Verify no temp files remain
+        const files = await readdir(tmpDir);
+        expect(files.filter((f) => f.includes(".s3tmp."))).toHaveLength(0);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+      }
+    }, 60_000);
+
+    it("should download a single-part object to file", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-downloadToFile-"));
+
+      try {
+        const destination = join(tmpDir, "downloaded-single.bin");
+        const expectedData = data(SIZE_6MB);
+
+        const response = await tmPart.downloadToFile({
+          Bucket,
+          Key: FIXTURES.single_6mb,
+          destination,
+        });
+
+        expect(response.bytesWritten).toBe(SIZE_6MB);
+
+        const fileContent = await readFile(destination);
+        expect(fileContent.length).toBe(SIZE_6MB);
+        expect(Buffer.from(fileContent).equals(Buffer.from(expectedData))).toBe(true);
+
+        const files = await readdir(tmpDir);
+        expect(files.filter((f) => f.includes(".s3tmp."))).toHaveLength(0);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+      }
+    }, 60_000);
+
+    it("should clean up temp file on abort and leave no destination file", async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), "tm-e2e-downloadToFile-"));
+
+      try {
+        const destination = join(tmpDir, "aborted.bin");
+        const controller = new AbortController();
+
+        await expect(
+          tmPart.downloadToFile(
+            {
+              Bucket,
+              Key: FIXTURES.multipart_11mb,
+              destination,
+            },
+            {
+              abortSignal: controller.signal,
+              eventListeners: {
+                transferInitiated: [
+                  () => {
+                    controller.abort();
+                  },
+                ],
+              },
+            },
+          ),
+        ).rejects.toThrow(/abort/i);
+
+        // Verify no temp files and no destination file remain
+        const files = await readdir(tmpDir);
+        expect(files.filter((f) => f.includes(".s3tmp."))).toHaveLength(0);
+        expect(files).toHaveLength(0);
+      } finally {
+        await rm(tmpDir, { recursive: true });
+      }
+    }, 60_000);
   });
 });

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
@@ -189,14 +189,18 @@ describe("S3TransferManager Unit Tests", () => {
         const controller = new AbortController();
         const callback = vi.fn();
         controller.abort();
-        tm.addEventListener("transferInitiated", callback, { signal: controller.signal });
+        tm.addEventListener("transferInitiated", callback, {
+          signal: controller.signal,
+        });
         expect((tm as any).eventListeners.transferInitiated).toEqual([]);
       });
 
       it("Should remove listener after included AbortSignal was aborted", () => {
         const controller = new AbortController();
         const callback = vi.fn();
-        tm.addEventListener("transferInitiated", callback, { signal: controller.signal });
+        tm.addEventListener("transferInitiated", callback, {
+          signal: controller.signal,
+        });
 
         const event = Object.assign(new Event("transferInitiated"), {
           request: {},
@@ -215,7 +219,9 @@ describe("S3TransferManager Unit Tests", () => {
         const controller = new AbortController();
         const callback = vi.fn();
 
-        tm.addEventListener("transferInitiated", callback, { signal: controller.signal });
+        tm.addEventListener("transferInitiated", callback, {
+          signal: controller.signal,
+        });
 
         expect((tm as any).eventListeners.transferInitiated).toEqual([callback]);
         expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(true);
@@ -485,9 +491,18 @@ describe("S3TransferManager Unit Tests", () => {
       const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
 
       expect(results).toHaveLength(3);
-      expect(results[0][0]).toEqual({ eventType: "transferInitiated", callback: callback1 });
-      expect(results[1][0]).toEqual({ eventType: "bytesTransferred", callback: callback2 });
-      expect(results[2][0]).toEqual({ eventType: "bytesTransferred", callback: callback3 });
+      expect(results[0][0]).toEqual({
+        eventType: "transferInitiated",
+        callback: callback1,
+      });
+      expect(results[1][0]).toEqual({
+        eventType: "bytesTransferred",
+        callback: callback2,
+      });
+      expect(results[2][0]).toEqual({
+        eventType: "bytesTransferred",
+        callback: callback3,
+      });
     });
 
     it("Should handle empty event listeners object", () => {
@@ -520,9 +535,18 @@ describe("S3TransferManager Unit Tests", () => {
       const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
 
       expect(results).toHaveLength(3);
-      expect(results[0][0]).toEqual({ eventType: "transferInitiated", callback: callback1 });
-      expect(results[1][0]).toEqual({ eventType: "transferFailed", callback: callback2 });
-      expect(results[2][0]).toEqual({ eventType: "transferFailed", callback: objectCallback });
+      expect(results[0][0]).toEqual({
+        eventType: "transferInitiated",
+        callback: callback1,
+      });
+      expect(results[1][0]).toEqual({
+        eventType: "transferFailed",
+        callback: callback2,
+      });
+      expect(results[2][0]).toEqual({
+        eventType: "transferFailed",
+        callback: objectCallback,
+      });
     });
 
     it("Should handle event listeners with duplicate callbacks in the same event type", () => {
@@ -539,7 +563,10 @@ describe("S3TransferManager Unit Tests", () => {
 
       expect(results).toHaveLength(4);
       for (let i = 0; i < results.length; i++) {
-        expect(results[i][0]).toEqual({ eventType: results[i][0].eventType, callback });
+        expect(results[i][0]).toEqual({
+          eventType: results[i][0].eventType,
+          callback,
+        });
       }
     });
 
@@ -908,9 +935,21 @@ describe("S3TransferManager Unit Tests", () => {
       const clientLevelCallback = vi.fn();
       tm.addEventListener("transferComplete", clientLevelCallback);
 
-      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content1" });
-      await tm.upload({ Bucket: "test-bucket", Key: "file2.txt", Body: "content2" });
-      await tm.upload({ Bucket: "test-bucket", Key: "file3.txt", Body: "content3" });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "file1.txt",
+        Body: "content1",
+      });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "file2.txt",
+        Body: "content2",
+      });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "file3.txt",
+        Body: "content3",
+      });
 
       expect(clientLevelCallback).toHaveBeenCalledTimes(3);
     });
@@ -918,14 +957,22 @@ describe("S3TransferManager Unit Tests", () => {
     it("Should fire request-level listener only for that specific request", async () => {
       const requestLevelCallback = vi.fn();
 
-      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content1" });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "file1.txt",
+        Body: "content1",
+      });
 
       await tm.upload(
         { Bucket: "test-bucket", Key: "file2.txt", Body: "content2" },
         { eventListeners: { transferComplete: [requestLevelCallback] } }
       );
 
-      await tm.upload({ Bucket: "test-bucket", Key: "file3.txt", Body: "content3" });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "file3.txt",
+        Body: "content3",
+      });
 
       expect(requestLevelCallback).toHaveBeenCalledTimes(1);
     });
@@ -951,7 +998,11 @@ describe("S3TransferManager Unit Tests", () => {
       const initiatedCallback = vi.fn();
       tm.addEventListener("transferInitiated", initiatedCallback);
 
-      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "file1.txt",
+        Body: "content",
+      });
 
       expect(initiatedCallback).toHaveBeenCalledTimes(1);
     });
@@ -960,7 +1011,11 @@ describe("S3TransferManager Unit Tests", () => {
       const completeCallback = vi.fn();
       tm.addEventListener("transferComplete", completeCallback);
 
-      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "file1.txt",
+        Body: "content",
+      });
 
       expect(completeCallback).toHaveBeenCalledTimes(1);
     });
@@ -982,7 +1037,11 @@ describe("S3TransferManager Unit Tests", () => {
       const bytesCallback = vi.fn();
       tm.addEventListener("bytesTransferred", bytesCallback);
 
-      await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "file1.txt",
+        Body: "content",
+      });
 
       expect(bytesCallback.mock.calls.length).toBeGreaterThanOrEqual(1);
     });
@@ -1044,7 +1103,11 @@ describe("S3TransferManager Unit Tests", () => {
       // 20MB buffer - above threshold, triggers multipart
       const body = Buffer.alloc(20 * 1024 * 1024, "x");
 
-      await tm.upload({ Bucket: "test-bucket", Key: "buffer-upload.bin", Body: body });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "buffer-upload.bin",
+        Body: body,
+      });
 
       // Should have called CreateMPU, UploadPart (x3), CompleteMPU
       const commandNames = sendCalls.map((c: any) => c.constructor?.name);
@@ -1065,7 +1128,11 @@ describe("S3TransferManager Unit Tests", () => {
 
       const body = "x".repeat(20 * 1024 * 1024);
 
-      await tm.upload({ Bucket: "test-bucket", Key: "string-upload.txt", Body: body });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "string-upload.txt",
+        Body: body,
+      });
 
       const commandNames = sendCalls.map((c: any) => c.constructor?.name);
       expect(commandNames).toContain("CreateMultipartUploadCommand");
@@ -1113,7 +1180,10 @@ describe("S3TransferManager Unit Tests", () => {
         send: vi.fn().mockImplementation((command: any) => {
           const commandName = command.constructor?.name ?? "";
           if (commandName === "CreateMultipartUploadCommand") {
-            return Promise.resolve({ UploadId: "abort-test-id", $metadata: {} });
+            return Promise.resolve({
+              UploadId: "abort-test-id",
+              $metadata: {},
+            });
           }
           if (commandName === "UploadPartCommand") {
             uploadPartCallCount++;
@@ -1121,7 +1191,11 @@ describe("S3TransferManager Unit Tests", () => {
             if (uploadPartCallCount === 1) {
               controller.abort();
             }
-            return Promise.resolve({ ETag: `"etag-${uploadPartCallCount}"`, ChecksumCRC32: "abc==", $metadata: {} });
+            return Promise.resolve({
+              ETag: `"etag-${uploadPartCallCount}"`,
+              ChecksumCRC32: "abc==",
+              $metadata: {},
+            });
           }
           if (commandName === "AbortMultipartUploadCommand") {
             return Promise.resolve({ $metadata: {} });
@@ -1207,7 +1281,11 @@ describe("S3TransferManager Unit Tests", () => {
       const contentLength = 24 * 1024 * 1024; // 3 parts of 8MB
       const body = Buffer.alloc(contentLength, "c");
 
-      await tm.upload({ Bucket: "test-bucket", Key: "progress-test.bin", Body: body });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "progress-test.bin",
+        Body: body,
+      });
 
       // Should have 3 bytesTransferred events (one per part)
       expect(bytesEvents.length).toBe(3);
@@ -1220,7 +1298,10 @@ describe("S3TransferManager Unit Tests", () => {
         send: vi.fn().mockImplementation((command: any) => {
           const commandName = command.constructor?.name ?? "";
           if (commandName === "CreateMultipartUploadCommand") {
-            return Promise.resolve({ UploadId: "event-fail-id", $metadata: {} });
+            return Promise.resolve({
+              UploadId: "event-fail-id",
+              $metadata: {},
+            });
           }
           if (commandName === "UploadPartCommand") {
             return Promise.reject(new Error("Part failed"));
@@ -1264,7 +1345,11 @@ describe("S3TransferManager Unit Tests", () => {
       expect(tm.workerHttpHandler).toBeUndefined();
 
       const body = Buffer.alloc(20 * 1024 * 1024, "e");
-      await tm.upload({ Bucket: "test-bucket", Key: "no-thread.bin", Body: body });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "no-thread.bin",
+        Body: body,
+      });
 
       // Still completes multipart upload successfully via non-threaded path
       const commandNames = sendCalls.map((c: any) => c.constructor?.name);
@@ -1294,7 +1379,11 @@ describe("S3TransferManager Unit Tests", () => {
       });
 
       const body = Buffer.alloc(24 * 1024 * 1024, "f"); // 3 parts
-      await tm.upload({ Bucket: "test-bucket", Key: "sort-test.bin", Body: body });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "sort-test.bin",
+        Body: body,
+      });
 
       const completeCalls = sendCalls.filter((c: any) => c.constructor?.name === "CompleteMultipartUploadCommand");
       expect(completeCalls.length).toBe(1);
@@ -1316,7 +1405,11 @@ describe("S3TransferManager Unit Tests", () => {
       });
 
       const body = Buffer.alloc(20 * 1024 * 1024, "g");
-      await tm.upload({ Bucket: "test-bucket", Key: "checksum-test.bin", Body: body });
+      await tm.upload({
+        Bucket: "test-bucket",
+        Key: "checksum-test.bin",
+        Body: body,
+      });
 
       const createCalls = sendCalls.filter((c: any) => c.constructor?.name === "CreateMultipartUploadCommand");
       expect(createCalls[0].input.ChecksumAlgorithm).toBe("CRC32");

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
@@ -1,25 +1,10 @@
 import { S3, S3Client } from "@aws-sdk/client-s3";
 import { existsSync } from "node:fs";
-import {
-  mkdir,
-  mkdtemp,
-  readdir,
-  readFile,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
-import {
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test as it,
-  vi,
-} from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, test as it, vi } from "vitest";
 
 import { S3TransferManager } from "./S3TransferManager";
 import type { TransferCompleteEvent, TransferEvent } from "./types";
@@ -88,9 +73,7 @@ describe("S3TransferManager Unit Tests", () => {
         new S3TransferManager({
           targetPartSizeBytes: 2 * 1024 * 1024,
         });
-      }).toThrow(
-        `targetPartSizeBytes must be at least ${5 * 1024 * 1024} bytes`,
-      );
+      }).toThrow(`targetPartSizeBytes must be at least ${5 * 1024 * 1024} bytes`);
     });
   });
 
@@ -149,10 +132,7 @@ describe("S3TransferManager Unit Tests", () => {
         tm.addEventListener("transferInitiated", callback1);
         tm.addEventListener("transferInitiated", callback1);
 
-        expect((tm as any).eventListeners.transferInitiated).toEqual([
-          callback1,
-          callback1,
-        ]);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([callback1, callback1]);
       });
 
       it("Should handle different callbacks for the same event type", () => {
@@ -162,10 +142,7 @@ describe("S3TransferManager Unit Tests", () => {
         tm.addEventListener("bytesTransferred", callback1);
         tm.addEventListener("bytesTransferred", callback2);
 
-        expect((tm as any).eventListeners.bytesTransferred).toEqual([
-          callback1,
-          callback2,
-        ]);
+        expect((tm as any).eventListeners.bytesTransferred).toEqual([callback1, callback2]);
       });
 
       it("Should handle object-style callbacks", () => {
@@ -174,9 +151,7 @@ describe("S3TransferManager Unit Tests", () => {
         };
         tm.addEventListener("transferInitiated", objectCallback as any);
 
-        expect((tm as any).eventListeners.transferInitiated).toEqual([
-          objectCallback,
-        ]);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([objectCallback]);
       });
 
       it("Should handle a mix of object-style callbacks and function for the same event", () => {
@@ -187,10 +162,7 @@ describe("S3TransferManager Unit Tests", () => {
         tm.addEventListener("transferInitiated", objectCallback as any);
         tm.addEventListener("transferInitiated", callback);
 
-        expect((tm as any).eventListeners.transferInitiated).toEqual([
-          objectCallback,
-          callback,
-        ]);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([objectCallback, callback]);
       });
 
       it("Should throw an error for an invalid event type", () => {
@@ -238,9 +210,7 @@ describe("S3TransferManager Unit Tests", () => {
         tm.dispatchEvent(event);
 
         expect(callback).toHaveBeenCalledTimes(1);
-        expect((tm as any).eventListeners.transferInitiated).toEqual([
-          callback,
-        ]);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([callback]);
 
         controller.abort();
         expect((tm as any).eventListeners.transferInitiated).toEqual([]);
@@ -254,33 +224,21 @@ describe("S3TransferManager Unit Tests", () => {
           signal: controller.signal,
         });
 
-        expect((tm as any).eventListeners.transferInitiated).toEqual([
-          callback,
-        ]);
-        expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(
-          true,
-        );
+        expect((tm as any).eventListeners.transferInitiated).toEqual([callback]);
+        expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(true);
 
-        const cleanupFn = (tm as any).abortCleanupFunctions.get(
-          controller.signal,
-        );
+        const cleanupFn = (tm as any).abortCleanupFunctions.get(controller.signal);
         cleanupFn();
         (tm as any).abortCleanupFunctions.delete(controller.signal);
 
-        expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(
-          false,
-        );
+        expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(false);
         controller.abort();
-        expect((tm as any).eventListeners.transferInitiated).toEqual([
-          callback,
-        ]);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([callback]);
       });
 
       it("Should handle boolean options parameter", () => {
         tm.addEventListener("transferInitiated", initiated, true);
-        expect((tm as any).eventListeners.transferInitiated).toContain(
-          initiated,
-        );
+        expect((tm as any).eventListeners.transferInitiated).toContain(initiated);
       });
 
       it("Should handle null callback", () => {
@@ -292,9 +250,7 @@ describe("S3TransferManager Unit Tests", () => {
       it("Should handle object-style callback with handleEvent", () => {
         const objectCallback = { handleEvent: vi.fn() };
         tm.addEventListener("transferInitiated", objectCallback as any);
-        expect((tm as any).eventListeners.transferInitiated).toContain(
-          objectCallback,
-        );
+        expect((tm as any).eventListeners.transferInitiated).toContain(objectCallback);
       });
     });
 
@@ -533,9 +489,7 @@ describe("S3TransferManager Unit Tests", () => {
         transferFailed: [],
       };
 
-      const results = Array.from(
-        (tm as any).iterateListeners(eventListeners),
-      ) as any[];
+      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
 
       expect(results).toHaveLength(3);
       expect(results[0][0]).toEqual({
@@ -560,9 +514,7 @@ describe("S3TransferManager Unit Tests", () => {
         transferFailed: [],
       };
 
-      const results = Array.from(
-        (tm as any).iterateListeners(eventListeners),
-      ) as any[];
+      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
 
       expect(results).toHaveLength(0);
     });
@@ -581,9 +533,7 @@ describe("S3TransferManager Unit Tests", () => {
         transferFailed: [callback2, objectCallback],
       };
 
-      const results = Array.from(
-        (tm as any).iterateListeners(eventListeners),
-      ) as any[];
+      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
 
       expect(results).toHaveLength(3);
       expect(results[0][0]).toEqual({
@@ -610,9 +560,7 @@ describe("S3TransferManager Unit Tests", () => {
         transferFailed: [],
       };
 
-      const results = Array.from(
-        (tm as any).iterateListeners(eventListeners),
-      ) as any[];
+      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
 
       expect(results).toHaveLength(4);
       for (let i = 0; i < results.length; i++) {
@@ -626,9 +574,7 @@ describe("S3TransferManager Unit Tests", () => {
     it("Should return empty iterator when no callbacks are present", () => {
       const eventListeners = {};
 
-      const results = Array.from(
-        (tm as any).iterateListeners(eventListeners),
-      ) as any[];
+      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
 
       expect(results).toHaveLength(0);
     });
@@ -679,11 +625,7 @@ describe("S3TransferManager Unit Tests", () => {
       }).toThrow("Expected part 2 to end at 10485759 but got 10485760");
 
       expect(() => {
-        tm.validatePartDownload(
-          "bytes 10485760-13631480/13631488",
-          3,
-          partSize,
-        );
+        tm.validatePartDownload("bytes 10485760-13631480/13631488", 3, partSize);
       }).toThrow("Expected part 3 to end at 13631487 but got 13631480");
     });
 
@@ -691,11 +633,7 @@ describe("S3TransferManager Unit Tests", () => {
       const partSize = 5242880;
 
       expect(() => {
-        tm.validatePartDownload(
-          "bytes 10485760-13631487/13631488",
-          3,
-          partSize,
-        );
+        tm.validatePartDownload("bytes 10485760-13631487/13631488", 3, partSize);
       }).not.toThrow();
     });
 
@@ -730,10 +668,7 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("Should pass when response range ends at total size", () => {
       expect(() => {
-        tm.validateRangeDownload(
-          "bytes=10485760-13631500",
-          "bytes 10485760-13631487/13631488",
-        );
+        tm.validateRangeDownload("bytes=10485760-13631500", "bytes 10485760-13631487/13631488");
       }).not.toThrow();
     });
 
@@ -823,9 +758,7 @@ describe("S3TransferManager Unit Tests", () => {
 
       expect(() => {
         tm.validateUploadPart(dataPart, partSize);
-      }).toThrow(
-        `The byte size for part number 2, size ${7 * 1024 * 1024} does not match expected size ${partSize}`,
-      );
+      }).toThrow(`The byte size for part number 2, size ${7 * 1024 * 1024} does not match expected size ${partSize}`);
     });
 
     it("should throw error when part has zero content length", () => {
@@ -838,9 +771,7 @@ describe("S3TransferManager Unit Tests", () => {
 
       expect(() => {
         tm.validateUploadPart(dataPart, partSize);
-      }).toThrow(
-        `The byte size for part number 2, size 0 does not match expected size ${partSize}`,
-      );
+      }).toThrow(`The byte size for part number 2, size 0 does not match expected size ${partSize}`);
     });
   });
 
@@ -852,8 +783,7 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("should use targetPartSizeBytes for small files", () => {
       const contentLength = 50 * 1024 * 1024; // 50MB
-      const { partSize, expectedPartsCount } =
-        tm.calculatePartSize(contentLength);
+      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
 
       expect(partSize).toBe(8 * 1024 * 1024); // Default 8MB
       expect(expectedPartsCount).toBe(7); // ceil(50/8) = 7
@@ -861,8 +791,7 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("should calculate larger part size for files approaching 10,000 parts limit", () => {
       const contentLength = 100 * 1024 * 1024 * 1024; // 100GB
-      const { partSize, expectedPartsCount } =
-        tm.calculatePartSize(contentLength);
+      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
 
       expect(partSize).toBeGreaterThan(8 * 1024 * 1024);
       expect(partSize).toBe(Math.ceil(contentLength / 10_000));
@@ -873,8 +802,7 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("should handle very large files correctly", () => {
       const contentLength = 5 * 1024 * 1024 * 1024 * 1024; // 5TB
-      const { partSize, expectedPartsCount } =
-        tm.calculatePartSize(contentLength);
+      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
 
       expect(partSize).toBe(Math.ceil(contentLength / 10_000));
       expect(expectedPartsCount).toBe(Math.ceil(contentLength / partSize));
@@ -885,8 +813,7 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("should return correct values for minimum size file", () => {
       const contentLength = 8 * 1024 * 1024; // 8MB (one part)
-      const { partSize, expectedPartsCount } =
-        tm.calculatePartSize(contentLength);
+      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
 
       expect(partSize).toBe(8 * 1024 * 1024);
       expect(expectedPartsCount).toBe(1);
@@ -899,8 +826,7 @@ describe("S3TransferManager Unit Tests", () => {
         targetPartSizeBytes: customPartSize,
       }) as any;
 
-      const { partSize, expectedPartsCount } =
-        tm.calculatePartSize(contentLength);
+      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
 
       expect(partSize).toBe(customPartSize);
       expect(expectedPartsCount).toBe(3); // 15MB / 5MB = 3 parts
@@ -941,10 +867,7 @@ describe("S3TransferManager Unit Tests", () => {
         });
       });
 
-      const { promises, onStreamConsumed } = tm.createConcurrentTaskPool(
-        tasks,
-        2,
-      );
+      const { promises, onStreamConsumed } = tm.createConcurrentTaskPool(tasks, 2);
       expect(launched).toBe(2);
 
       // Resolve first task and signal stream consumed
@@ -978,10 +901,7 @@ describe("S3TransferManager Unit Tests", () => {
         },
       ];
 
-      const { promises, onStreamConsumed } = tm.createConcurrentTaskPool(
-        tasks,
-        2,
-      );
+      const { promises, onStreamConsumed } = tm.createConcurrentTaskPool(tasks, 2);
       expect(launched).toBe(2);
 
       // Wait for the rejection to propagate
@@ -1046,7 +966,7 @@ describe("S3TransferManager Unit Tests", () => {
 
       await tm.upload(
         { Bucket: "test-bucket", Key: "file2.txt", Body: "content2" },
-        { eventListeners: { transferComplete: [requestLevelCallback] } },
+        { eventListeners: { transferComplete: [requestLevelCallback] } }
       );
 
       await tm.upload({
@@ -1067,7 +987,7 @@ describe("S3TransferManager Unit Tests", () => {
       await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "a" });
       await tm.upload(
         { Bucket: "test-bucket", Key: "file2.txt", Body: "b" },
-        { eventListeners: { transferComplete: [requestCallback] } },
+        { eventListeners: { transferComplete: [requestCallback] } }
       );
       await tm.upload({ Bucket: "test-bucket", Key: "file3.txt", Body: "c" });
 
@@ -1107,9 +1027,9 @@ describe("S3TransferManager Unit Tests", () => {
 
       mockSend.mockRejectedValueOnce(new Error("Upload failed"));
 
-      await expect(
-        tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" }),
-      ).rejects.toThrow("Upload failed");
+      await expect(tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" })).rejects.toThrow(
+        "Upload failed"
+      );
 
       expect(failedCallback).toHaveBeenCalledTimes(1);
     });
@@ -1195,9 +1115,7 @@ describe("S3TransferManager Unit Tests", () => {
       expect(commandNames).toContain("CreateMultipartUploadCommand");
       expect(commandNames).toContain("UploadPartCommand");
       expect(commandNames).toContain("CompleteMultipartUploadCommand");
-      expect(
-        commandNames.filter((n: string) => n === "UploadPartCommand").length,
-      ).toBe(3);
+      expect(commandNames.filter((n: string) => n === "UploadPartCommand").length).toBe(3);
     });
 
     it("should route string body to threadedUploadInParts when workerThreadCount > 1", async () => {
@@ -1298,15 +1216,12 @@ describe("S3TransferManager Unit Tests", () => {
       const body = Buffer.alloc(24 * 1024 * 1024, "a");
 
       await expect(
-        tm.upload(
-          { Bucket: "test-bucket", Key: "abort-test.bin", Body: body },
-          { abortSignal: controller.signal },
-        ),
+        tm.upload({ Bucket: "test-bucket", Key: "abort-test.bin", Body: body }, { abortSignal: controller.signal })
       ).rejects.toThrow("Transfer aborted.");
 
       // Verify AbortMultipartUpload was called
       const abortCalls = mockClient.send.mock.calls.filter(
-        (c: any) => c[0].constructor?.name === "AbortMultipartUploadCommand",
+        (c: any) => c[0].constructor?.name === "AbortMultipartUploadCommand"
       );
       expect(abortCalls.length).toBe(1);
       expect(abortCalls[0][0].input.UploadId).toBe("abort-test-id");
@@ -1339,12 +1254,12 @@ describe("S3TransferManager Unit Tests", () => {
 
       const body = Buffer.alloc(20 * 1024 * 1024, "b");
 
-      await expect(
-        tm.upload({ Bucket: "test-bucket", Key: "fail-test.bin", Body: body }),
-      ).rejects.toThrow("Network error on part upload");
+      await expect(tm.upload({ Bucket: "test-bucket", Key: "fail-test.bin", Body: body })).rejects.toThrow(
+        "Network error on part upload"
+      );
 
       const abortCalls = mockClient.send.mock.calls.filter(
-        (c: any) => c[0].constructor?.name === "AbortMultipartUploadCommand",
+        (c: any) => c[0].constructor?.name === "AbortMultipartUploadCommand"
       );
       expect(abortCalls.length).toBe(1);
       expect(abortCalls[0][0].input.UploadId).toBe("fail-test-id");
@@ -1412,9 +1327,9 @@ describe("S3TransferManager Unit Tests", () => {
 
       const body = Buffer.alloc(20 * 1024 * 1024, "d");
 
-      await expect(
-        tm.upload({ Bucket: "test-bucket", Key: "event-fail.bin", Body: body }),
-      ).rejects.toThrow("Part failed");
+      await expect(tm.upload({ Bucket: "test-bucket", Key: "event-fail.bin", Body: body })).rejects.toThrow(
+        "Part failed"
+      );
 
       expect(failedCallback).toHaveBeenCalledTimes(1);
     });
@@ -1471,9 +1386,7 @@ describe("S3TransferManager Unit Tests", () => {
         Body: body,
       });
 
-      const completeCalls = sendCalls.filter(
-        (c: any) => c.constructor?.name === "CompleteMultipartUploadCommand",
-      );
+      const completeCalls = sendCalls.filter((c: any) => c.constructor?.name === "CompleteMultipartUploadCommand");
       expect(completeCalls.length).toBe(1);
 
       const parts = completeCalls[0].input.MultipartUpload.Parts;
@@ -1499,9 +1412,7 @@ describe("S3TransferManager Unit Tests", () => {
         Body: body,
       });
 
-      const createCalls = sendCalls.filter(
-        (c: any) => c.constructor?.name === "CreateMultipartUploadCommand",
-      );
+      const createCalls = sendCalls.filter((c: any) => c.constructor?.name === "CreateMultipartUploadCommand");
       expect(createCalls[0].input.ChecksumAlgorithm).toBe("CRC32");
     });
   });
@@ -1655,7 +1566,7 @@ describe("S3TransferManager Unit Tests", () => {
             bucket: "test-bucket",
             source: tmpDir,
             failurePolicy: "terminate" as CannedFailurePolicy,
-          }),
+          })
         ).rejects.toThrow("S3 error");
 
         expect(mockClient.send.mock.calls.length).toBeLessThanOrEqual(1);
@@ -1799,7 +1710,7 @@ describe("S3TransferManager Unit Tests", () => {
             source: tmpDir,
             failurePolicy: customPolicy,
             maxConcurrency: 1,
-          }),
+          })
         ).rejects.toThrow("Access Denied");
 
         // file1 and file2 succeeded, file3 failed with AccessDenied → terminate
@@ -1851,7 +1762,7 @@ describe("S3TransferManager Unit Tests", () => {
             uploadObjectRequestModifier: () => {
               throw new Error("uploadObjectRequestModifier failed");
             },
-          }),
+          })
         ).rejects.toThrow("uploadObjectRequestModifier failed");
 
         expect(mockClient.send).not.toHaveBeenCalled();
@@ -1868,7 +1779,7 @@ describe("S3TransferManager Unit Tests", () => {
         tm.uploadDirectory({
           bucket: "test-bucket",
           source: "/nonexistent/path/abc123",
-        }),
+        })
       ).rejects.toThrow("Cannot access directory at");
     });
 
@@ -1889,8 +1800,8 @@ describe("S3TransferManager Unit Tests", () => {
               bucket: "test-bucket",
               source: tmpDir,
             },
-            { abortSignal: ac.signal },
-          ),
+            { abortSignal: ac.signal }
+          )
         ).rejects.toThrow("Transfer aborted");
       } finally {
         await rm(tmpDir, { recursive: true });
@@ -1947,7 +1858,7 @@ describe("S3TransferManager Unit Tests", () => {
           Bucket: "test-bucket",
           Key: "test-key",
           destination: "",
-        }),
+        })
       ).rejects.toThrow("destination must be a non-empty string");
     });
 
@@ -1966,7 +1877,7 @@ describe("S3TransferManager Unit Tests", () => {
           Key: "test-key",
           destination,
           failIfExists: true,
-        }),
+        })
       ).rejects.toThrow(/File already exists at destination/);
     });
 
@@ -2031,9 +1942,7 @@ describe("S3TransferManager Unit Tests", () => {
         // Part 2: observe temp file exists and cleanup handler is registered, then fail
         mockSend.mockImplementationOnce(async () => {
           const files = await readdir(tmpDir);
-          tempFileExistedDuringDownload = files.some((f) =>
-            f.includes(".s3tmp."),
-          );
+          tempFileExistedDuringDownload = files.some((f) => f.includes(".s3tmp."));
           exitListenersDuringDownload = process.listenerCount("exit");
           throw new Error("S3 service error");
         });
@@ -2043,14 +1952,12 @@ describe("S3TransferManager Unit Tests", () => {
             Bucket: "test-bucket",
             Key: "fail-key",
             destination,
-          }),
+          })
         ).rejects.toThrow("S3 service error");
 
         // Verify temp file DID exist before failure
         expect(tempFileExistedDuringDownload).toBe(true);
-        expect(exitListenersDuringDownload).toBeGreaterThan(
-          exitListenersBefore,
-        );
+        expect(exitListenersDuringDownload).toBeGreaterThan(exitListenersBefore);
 
         // Verify temp file was cleaned up after failure
         const files = await readdir(tmpDir);

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
@@ -1,9 +1,25 @@
 import { S3, S3Client } from "@aws-sdk/client-s3";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
-import { beforeAll, beforeEach, describe, expect, test as it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test as it,
+  vi,
+} from "vitest";
 
 import { S3TransferManager } from "./S3TransferManager";
 import type { TransferCompleteEvent, TransferEvent } from "./types";
@@ -72,7 +88,9 @@ describe("S3TransferManager Unit Tests", () => {
         new S3TransferManager({
           targetPartSizeBytes: 2 * 1024 * 1024,
         });
-      }).toThrow(`targetPartSizeBytes must be at least ${5 * 1024 * 1024} bytes`);
+      }).toThrow(
+        `targetPartSizeBytes must be at least ${5 * 1024 * 1024} bytes`,
+      );
     });
   });
 
@@ -131,7 +149,10 @@ describe("S3TransferManager Unit Tests", () => {
         tm.addEventListener("transferInitiated", callback1);
         tm.addEventListener("transferInitiated", callback1);
 
-        expect((tm as any).eventListeners.transferInitiated).toEqual([callback1, callback1]);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([
+          callback1,
+          callback1,
+        ]);
       });
 
       it("Should handle different callbacks for the same event type", () => {
@@ -141,7 +162,10 @@ describe("S3TransferManager Unit Tests", () => {
         tm.addEventListener("bytesTransferred", callback1);
         tm.addEventListener("bytesTransferred", callback2);
 
-        expect((tm as any).eventListeners.bytesTransferred).toEqual([callback1, callback2]);
+        expect((tm as any).eventListeners.bytesTransferred).toEqual([
+          callback1,
+          callback2,
+        ]);
       });
 
       it("Should handle object-style callbacks", () => {
@@ -150,7 +174,9 @@ describe("S3TransferManager Unit Tests", () => {
         };
         tm.addEventListener("transferInitiated", objectCallback as any);
 
-        expect((tm as any).eventListeners.transferInitiated).toEqual([objectCallback]);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([
+          objectCallback,
+        ]);
       });
 
       it("Should handle a mix of object-style callbacks and function for the same event", () => {
@@ -161,7 +187,10 @@ describe("S3TransferManager Unit Tests", () => {
         tm.addEventListener("transferInitiated", objectCallback as any);
         tm.addEventListener("transferInitiated", callback);
 
-        expect((tm as any).eventListeners.transferInitiated).toEqual([objectCallback, callback]);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([
+          objectCallback,
+          callback,
+        ]);
       });
 
       it("Should throw an error for an invalid event type", () => {
@@ -209,7 +238,9 @@ describe("S3TransferManager Unit Tests", () => {
         tm.dispatchEvent(event);
 
         expect(callback).toHaveBeenCalledTimes(1);
-        expect((tm as any).eventListeners.transferInitiated).toEqual([callback]);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([
+          callback,
+        ]);
 
         controller.abort();
         expect((tm as any).eventListeners.transferInitiated).toEqual([]);
@@ -223,21 +254,33 @@ describe("S3TransferManager Unit Tests", () => {
           signal: controller.signal,
         });
 
-        expect((tm as any).eventListeners.transferInitiated).toEqual([callback]);
-        expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(true);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([
+          callback,
+        ]);
+        expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(
+          true,
+        );
 
-        const cleanupFn = (tm as any).abortCleanupFunctions.get(controller.signal);
+        const cleanupFn = (tm as any).abortCleanupFunctions.get(
+          controller.signal,
+        );
         cleanupFn();
         (tm as any).abortCleanupFunctions.delete(controller.signal);
 
-        expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(false);
+        expect((tm as any).abortCleanupFunctions.has(controller.signal)).toBe(
+          false,
+        );
         controller.abort();
-        expect((tm as any).eventListeners.transferInitiated).toEqual([callback]);
+        expect((tm as any).eventListeners.transferInitiated).toEqual([
+          callback,
+        ]);
       });
 
       it("Should handle boolean options parameter", () => {
         tm.addEventListener("transferInitiated", initiated, true);
-        expect((tm as any).eventListeners.transferInitiated).toContain(initiated);
+        expect((tm as any).eventListeners.transferInitiated).toContain(
+          initiated,
+        );
       });
 
       it("Should handle null callback", () => {
@@ -249,7 +292,9 @@ describe("S3TransferManager Unit Tests", () => {
       it("Should handle object-style callback with handleEvent", () => {
         const objectCallback = { handleEvent: vi.fn() };
         tm.addEventListener("transferInitiated", objectCallback as any);
-        expect((tm as any).eventListeners.transferInitiated).toContain(objectCallback);
+        expect((tm as any).eventListeners.transferInitiated).toContain(
+          objectCallback,
+        );
       });
     });
 
@@ -488,7 +533,9 @@ describe("S3TransferManager Unit Tests", () => {
         transferFailed: [],
       };
 
-      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
+      const results = Array.from(
+        (tm as any).iterateListeners(eventListeners),
+      ) as any[];
 
       expect(results).toHaveLength(3);
       expect(results[0][0]).toEqual({
@@ -513,7 +560,9 @@ describe("S3TransferManager Unit Tests", () => {
         transferFailed: [],
       };
 
-      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
+      const results = Array.from(
+        (tm as any).iterateListeners(eventListeners),
+      ) as any[];
 
       expect(results).toHaveLength(0);
     });
@@ -532,7 +581,9 @@ describe("S3TransferManager Unit Tests", () => {
         transferFailed: [callback2, objectCallback],
       };
 
-      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
+      const results = Array.from(
+        (tm as any).iterateListeners(eventListeners),
+      ) as any[];
 
       expect(results).toHaveLength(3);
       expect(results[0][0]).toEqual({
@@ -559,7 +610,9 @@ describe("S3TransferManager Unit Tests", () => {
         transferFailed: [],
       };
 
-      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
+      const results = Array.from(
+        (tm as any).iterateListeners(eventListeners),
+      ) as any[];
 
       expect(results).toHaveLength(4);
       for (let i = 0; i < results.length; i++) {
@@ -573,7 +626,9 @@ describe("S3TransferManager Unit Tests", () => {
     it("Should return empty iterator when no callbacks are present", () => {
       const eventListeners = {};
 
-      const results = Array.from((tm as any).iterateListeners(eventListeners)) as any[];
+      const results = Array.from(
+        (tm as any).iterateListeners(eventListeners),
+      ) as any[];
 
       expect(results).toHaveLength(0);
     });
@@ -624,7 +679,11 @@ describe("S3TransferManager Unit Tests", () => {
       }).toThrow("Expected part 2 to end at 10485759 but got 10485760");
 
       expect(() => {
-        tm.validatePartDownload("bytes 10485760-13631480/13631488", 3, partSize);
+        tm.validatePartDownload(
+          "bytes 10485760-13631480/13631488",
+          3,
+          partSize,
+        );
       }).toThrow("Expected part 3 to end at 13631487 but got 13631480");
     });
 
@@ -632,7 +691,11 @@ describe("S3TransferManager Unit Tests", () => {
       const partSize = 5242880;
 
       expect(() => {
-        tm.validatePartDownload("bytes 10485760-13631487/13631488", 3, partSize);
+        tm.validatePartDownload(
+          "bytes 10485760-13631487/13631488",
+          3,
+          partSize,
+        );
       }).not.toThrow();
     });
 
@@ -667,7 +730,10 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("Should pass when response range ends at total size", () => {
       expect(() => {
-        tm.validateRangeDownload("bytes=10485760-13631500", "bytes 10485760-13631487/13631488");
+        tm.validateRangeDownload(
+          "bytes=10485760-13631500",
+          "bytes 10485760-13631487/13631488",
+        );
       }).not.toThrow();
     });
 
@@ -757,7 +823,9 @@ describe("S3TransferManager Unit Tests", () => {
 
       expect(() => {
         tm.validateUploadPart(dataPart, partSize);
-      }).toThrow(`The byte size for part number 2, size ${7 * 1024 * 1024} does not match expected size ${partSize}`);
+      }).toThrow(
+        `The byte size for part number 2, size ${7 * 1024 * 1024} does not match expected size ${partSize}`,
+      );
     });
 
     it("should throw error when part has zero content length", () => {
@@ -770,7 +838,9 @@ describe("S3TransferManager Unit Tests", () => {
 
       expect(() => {
         tm.validateUploadPart(dataPart, partSize);
-      }).toThrow(`The byte size for part number 2, size 0 does not match expected size ${partSize}`);
+      }).toThrow(
+        `The byte size for part number 2, size 0 does not match expected size ${partSize}`,
+      );
     });
   });
 
@@ -782,7 +852,8 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("should use targetPartSizeBytes for small files", () => {
       const contentLength = 50 * 1024 * 1024; // 50MB
-      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
+      const { partSize, expectedPartsCount } =
+        tm.calculatePartSize(contentLength);
 
       expect(partSize).toBe(8 * 1024 * 1024); // Default 8MB
       expect(expectedPartsCount).toBe(7); // ceil(50/8) = 7
@@ -790,7 +861,8 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("should calculate larger part size for files approaching 10,000 parts limit", () => {
       const contentLength = 100 * 1024 * 1024 * 1024; // 100GB
-      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
+      const { partSize, expectedPartsCount } =
+        tm.calculatePartSize(contentLength);
 
       expect(partSize).toBeGreaterThan(8 * 1024 * 1024);
       expect(partSize).toBe(Math.ceil(contentLength / 10_000));
@@ -801,7 +873,8 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("should handle very large files correctly", () => {
       const contentLength = 5 * 1024 * 1024 * 1024 * 1024; // 5TB
-      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
+      const { partSize, expectedPartsCount } =
+        tm.calculatePartSize(contentLength);
 
       expect(partSize).toBe(Math.ceil(contentLength / 10_000));
       expect(expectedPartsCount).toBe(Math.ceil(contentLength / partSize));
@@ -812,7 +885,8 @@ describe("S3TransferManager Unit Tests", () => {
 
     it("should return correct values for minimum size file", () => {
       const contentLength = 8 * 1024 * 1024; // 8MB (one part)
-      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
+      const { partSize, expectedPartsCount } =
+        tm.calculatePartSize(contentLength);
 
       expect(partSize).toBe(8 * 1024 * 1024);
       expect(expectedPartsCount).toBe(1);
@@ -825,7 +899,8 @@ describe("S3TransferManager Unit Tests", () => {
         targetPartSizeBytes: customPartSize,
       }) as any;
 
-      const { partSize, expectedPartsCount } = tm.calculatePartSize(contentLength);
+      const { partSize, expectedPartsCount } =
+        tm.calculatePartSize(contentLength);
 
       expect(partSize).toBe(customPartSize);
       expect(expectedPartsCount).toBe(3); // 15MB / 5MB = 3 parts
@@ -866,7 +941,10 @@ describe("S3TransferManager Unit Tests", () => {
         });
       });
 
-      const { promises, onStreamConsumed } = tm.createConcurrentTaskPool(tasks, 2);
+      const { promises, onStreamConsumed } = tm.createConcurrentTaskPool(
+        tasks,
+        2,
+      );
       expect(launched).toBe(2);
 
       // Resolve first task and signal stream consumed
@@ -900,7 +978,10 @@ describe("S3TransferManager Unit Tests", () => {
         },
       ];
 
-      const { promises, onStreamConsumed } = tm.createConcurrentTaskPool(tasks, 2);
+      const { promises, onStreamConsumed } = tm.createConcurrentTaskPool(
+        tasks,
+        2,
+      );
       expect(launched).toBe(2);
 
       // Wait for the rejection to propagate
@@ -965,7 +1046,7 @@ describe("S3TransferManager Unit Tests", () => {
 
       await tm.upload(
         { Bucket: "test-bucket", Key: "file2.txt", Body: "content2" },
-        { eventListeners: { transferComplete: [requestLevelCallback] } }
+        { eventListeners: { transferComplete: [requestLevelCallback] } },
       );
 
       await tm.upload({
@@ -986,7 +1067,7 @@ describe("S3TransferManager Unit Tests", () => {
       await tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "a" });
       await tm.upload(
         { Bucket: "test-bucket", Key: "file2.txt", Body: "b" },
-        { eventListeners: { transferComplete: [requestCallback] } }
+        { eventListeners: { transferComplete: [requestCallback] } },
       );
       await tm.upload({ Bucket: "test-bucket", Key: "file3.txt", Body: "c" });
 
@@ -1026,9 +1107,9 @@ describe("S3TransferManager Unit Tests", () => {
 
       mockSend.mockRejectedValueOnce(new Error("Upload failed"));
 
-      await expect(tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" })).rejects.toThrow(
-        "Upload failed"
-      );
+      await expect(
+        tm.upload({ Bucket: "test-bucket", Key: "file1.txt", Body: "content" }),
+      ).rejects.toThrow("Upload failed");
 
       expect(failedCallback).toHaveBeenCalledTimes(1);
     });
@@ -1114,7 +1195,9 @@ describe("S3TransferManager Unit Tests", () => {
       expect(commandNames).toContain("CreateMultipartUploadCommand");
       expect(commandNames).toContain("UploadPartCommand");
       expect(commandNames).toContain("CompleteMultipartUploadCommand");
-      expect(commandNames.filter((n: string) => n === "UploadPartCommand").length).toBe(3);
+      expect(
+        commandNames.filter((n: string) => n === "UploadPartCommand").length,
+      ).toBe(3);
     });
 
     it("should route string body to threadedUploadInParts when workerThreadCount > 1", async () => {
@@ -1215,12 +1298,15 @@ describe("S3TransferManager Unit Tests", () => {
       const body = Buffer.alloc(24 * 1024 * 1024, "a");
 
       await expect(
-        tm.upload({ Bucket: "test-bucket", Key: "abort-test.bin", Body: body }, { abortSignal: controller.signal })
+        tm.upload(
+          { Bucket: "test-bucket", Key: "abort-test.bin", Body: body },
+          { abortSignal: controller.signal },
+        ),
       ).rejects.toThrow("Transfer aborted.");
 
       // Verify AbortMultipartUpload was called
       const abortCalls = mockClient.send.mock.calls.filter(
-        (c: any) => c[0].constructor?.name === "AbortMultipartUploadCommand"
+        (c: any) => c[0].constructor?.name === "AbortMultipartUploadCommand",
       );
       expect(abortCalls.length).toBe(1);
       expect(abortCalls[0][0].input.UploadId).toBe("abort-test-id");
@@ -1253,12 +1339,12 @@ describe("S3TransferManager Unit Tests", () => {
 
       const body = Buffer.alloc(20 * 1024 * 1024, "b");
 
-      await expect(tm.upload({ Bucket: "test-bucket", Key: "fail-test.bin", Body: body })).rejects.toThrow(
-        "Network error on part upload"
-      );
+      await expect(
+        tm.upload({ Bucket: "test-bucket", Key: "fail-test.bin", Body: body }),
+      ).rejects.toThrow("Network error on part upload");
 
       const abortCalls = mockClient.send.mock.calls.filter(
-        (c: any) => c[0].constructor?.name === "AbortMultipartUploadCommand"
+        (c: any) => c[0].constructor?.name === "AbortMultipartUploadCommand",
       );
       expect(abortCalls.length).toBe(1);
       expect(abortCalls[0][0].input.UploadId).toBe("fail-test-id");
@@ -1326,9 +1412,9 @@ describe("S3TransferManager Unit Tests", () => {
 
       const body = Buffer.alloc(20 * 1024 * 1024, "d");
 
-      await expect(tm.upload({ Bucket: "test-bucket", Key: "event-fail.bin", Body: body })).rejects.toThrow(
-        "Part failed"
-      );
+      await expect(
+        tm.upload({ Bucket: "test-bucket", Key: "event-fail.bin", Body: body }),
+      ).rejects.toThrow("Part failed");
 
       expect(failedCallback).toHaveBeenCalledTimes(1);
     });
@@ -1385,7 +1471,9 @@ describe("S3TransferManager Unit Tests", () => {
         Body: body,
       });
 
-      const completeCalls = sendCalls.filter((c: any) => c.constructor?.name === "CompleteMultipartUploadCommand");
+      const completeCalls = sendCalls.filter(
+        (c: any) => c.constructor?.name === "CompleteMultipartUploadCommand",
+      );
       expect(completeCalls.length).toBe(1);
 
       const parts = completeCalls[0].input.MultipartUpload.Parts;
@@ -1411,7 +1499,9 @@ describe("S3TransferManager Unit Tests", () => {
         Body: body,
       });
 
-      const createCalls = sendCalls.filter((c: any) => c.constructor?.name === "CreateMultipartUploadCommand");
+      const createCalls = sendCalls.filter(
+        (c: any) => c.constructor?.name === "CreateMultipartUploadCommand",
+      );
       expect(createCalls[0].input.ChecksumAlgorithm).toBe("CRC32");
     });
   });
@@ -1565,7 +1655,7 @@ describe("S3TransferManager Unit Tests", () => {
             bucket: "test-bucket",
             source: tmpDir,
             failurePolicy: "terminate" as CannedFailurePolicy,
-          })
+          }),
         ).rejects.toThrow("S3 error");
 
         expect(mockClient.send.mock.calls.length).toBeLessThanOrEqual(1);
@@ -1709,7 +1799,7 @@ describe("S3TransferManager Unit Tests", () => {
             source: tmpDir,
             failurePolicy: customPolicy,
             maxConcurrency: 1,
-          })
+          }),
         ).rejects.toThrow("Access Denied");
 
         // file1 and file2 succeeded, file3 failed with AccessDenied → terminate
@@ -1761,7 +1851,7 @@ describe("S3TransferManager Unit Tests", () => {
             uploadObjectRequestModifier: () => {
               throw new Error("uploadObjectRequestModifier failed");
             },
-          })
+          }),
         ).rejects.toThrow("uploadObjectRequestModifier failed");
 
         expect(mockClient.send).not.toHaveBeenCalled();
@@ -1778,7 +1868,7 @@ describe("S3TransferManager Unit Tests", () => {
         tm.uploadDirectory({
           bucket: "test-bucket",
           source: "/nonexistent/path/abc123",
-        })
+        }),
       ).rejects.toThrow("Cannot access directory at");
     });
 
@@ -1799,8 +1889,8 @@ describe("S3TransferManager Unit Tests", () => {
               bucket: "test-bucket",
               source: tmpDir,
             },
-            { abortSignal: ac.signal }
-          )
+            { abortSignal: ac.signal },
+          ),
         ).rejects.toThrow("Transfer aborted");
       } finally {
         await rm(tmpDir, { recursive: true });
@@ -1826,6 +1916,153 @@ describe("S3TransferManager Unit Tests", () => {
       } finally {
         await rm(tmpDir, { recursive: true });
       }
+    });
+  });
+
+  describe("downloadToFile", () => {
+    let mockSend: any;
+    let tmpDir: string;
+
+    function createMockClient() {
+      mockSend = vi.fn();
+      return { send: mockSend, config: {} } as any;
+    }
+
+    beforeEach(async () => {
+      tmpDir = await mkdtemp(join(tmpdir(), "tm-downloadToFile-test-"));
+    });
+
+    afterEach(async () => {
+      await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it("should throw when destination is an empty string", async () => {
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({
+        s3: mockClient,
+      });
+
+      await expect(
+        tm.downloadToFile({
+          Bucket: "test-bucket",
+          Key: "test-key",
+          destination: "",
+        }),
+      ).rejects.toThrow("destination must be a non-empty string");
+    });
+
+    it("should throw when failIfExists is true and destination file already exists", async () => {
+      const destination = join(tmpDir, "existing-file.txt");
+      await writeFile(destination, "existing content");
+
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({
+        s3: mockClient,
+      });
+
+      await expect(
+        tm.downloadToFile({
+          Bucket: "test-bucket",
+          Key: "test-key",
+          destination,
+          failIfExists: true,
+        }),
+      ).rejects.toThrow(/File already exists at destination/);
+    });
+
+    it("should overwrite existing file when failIfExists is false", async () => {
+      const destination = join(tmpDir, "existing-file.txt");
+      await writeFile(destination, "old content");
+
+      const mockClient = createMockClient();
+      const tm = new S3TransferManager({
+        s3: mockClient,
+      });
+
+      const body = Readable.from(Buffer.from("new content"));
+      mockSend.mockResolvedValueOnce({
+        Body: body,
+        ContentLength: 11,
+        ContentRange: "bytes 0-10/11",
+        PartsCount: 1,
+        ETag: '"mock-etag"',
+        $metadata: { httpStatusCode: 200 },
+      });
+
+      const response = await tm.downloadToFile({
+        Bucket: "test-bucket",
+        Key: "test-key",
+        destination,
+        failIfExists: false,
+      });
+
+      expect(response.bytesWritten).toBe(11);
+      expect(existsSync(destination)).toBe(true);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    describe("Temp File Lifecycle (Multipart/Part-Based Download)", () => {
+      it("should delete temp file and unregister cleanup handler on part failure", async () => {
+        const destination = join(tmpDir, "failed-multipart.bin");
+        const partSize = 10;
+        const totalSize = 20;
+
+        const mockClient = createMockClient();
+        const tm = new S3TransferManager({
+          s3: mockClient,
+          workerThreadCount: 1,
+        });
+
+        const exitListenersBefore = process.listenerCount("exit");
+        const sigintListenersBefore = process.listenerCount("SIGINT");
+
+        let tempFileExistedDuringDownload = false;
+        let exitListenersDuringDownload = 0;
+
+        // Part 1 succeeds
+        mockSend.mockResolvedValueOnce({
+          Body: Readable.from(Buffer.alloc(partSize, "A")),
+          ContentLength: partSize,
+          ContentRange: `bytes 0-9/${totalSize}`,
+          PartsCount: 2,
+          ETag: '"mock-etag"',
+          $metadata: { httpStatusCode: 200 },
+        });
+        // Part 2: observe temp file exists and cleanup handler is registered, then fail
+        mockSend.mockImplementationOnce(async () => {
+          const files = await readdir(tmpDir);
+          tempFileExistedDuringDownload = files.some((f) =>
+            f.includes(".s3tmp."),
+          );
+          exitListenersDuringDownload = process.listenerCount("exit");
+          throw new Error("S3 service error");
+        });
+
+        await expect(
+          tm.downloadToFile({
+            Bucket: "test-bucket",
+            Key: "fail-key",
+            destination,
+          }),
+        ).rejects.toThrow("S3 service error");
+
+        // Verify temp file DID exist before failure
+        expect(tempFileExistedDuringDownload).toBe(true);
+        expect(exitListenersDuringDownload).toBeGreaterThan(
+          exitListenersBefore,
+        );
+
+        // Verify temp file was cleaned up after failure
+        const files = await readdir(tmpDir);
+        expect(files.filter((f) => f.includes(".s3tmp."))).toHaveLength(0);
+
+        // Verify no final file was written
+        expect(existsSync(destination)).toBe(false);
+
+        // Verify cleanup handlers were unregistered
+        expect(process.listenerCount("exit")).toBe(exitListenersBefore);
+        expect(process.listenerCount("SIGINT")).toBe(sigintListenersBefore);
+      });
     });
   });
 });

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.spec.ts
@@ -908,9 +908,9 @@ describe("S3TransferManager Unit Tests", () => {
   });
 
   describe("createConcurrentTaskPool() concurrency", () => {
-    it("should default maxConcurrentDownloads to 8 when not provided", () => {
+    it("should default maxConcurrentDownloads to 32 when not provided", () => {
       const tm = new S3TransferManager() as any;
-      expect(tm.maxConcurrentDownloads).toBe(8);
+      expect(tm.maxConcurrentDownloads).toBe(32);
     });
 
     it("should use user-provided maxConcurrentDownloads", () => {
@@ -2019,7 +2019,7 @@ describe("S3TransferManager Unit Tests", () => {
         let tempFileExistedDuringDownload = false;
         let exitListenersDuringDownload = 0;
 
-        // Part 1 succeeds
+        // Part 1: succeeds
         mockSend.mockResolvedValueOnce({
           Body: Readable.from(Buffer.alloc(partSize, "A")),
           ContentLength: partSize,

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -1,5 +1,6 @@
 import type {
   AbortMultipartUploadCommandInput,
+  ChecksumAlgorithm,
   CompletedPart,
   CompleteMultipartUploadCommandInput,
   CompleteMultipartUploadCommandOutput,
@@ -399,54 +400,35 @@ export class S3TransferManager implements IS3TransferManager {
       }
     };
 
+    const resolvedTransferOptions = transferOptions ?? {};
+    const downloadArgs = [
+      request,
+      resolvedTransferOptions,
+      streams,
+      requests,
+      metadata,
+      checksumValidationEnabled,
+    ] as const;
+
     try {
+      let responseMetadata: { totalSize: number | undefined; onStreamConsumed?: (index: number) => void };
+
       if (this.multipartDownloadType === "PART") {
         if (this.workerHttpHandler) {
-          const responseMetadata = await this.downloadByPartWithWorkers(
-            request,
-            transferOptions ?? {},
-            streams,
-            requests,
-            metadata,
-            checksumValidationEnabled
-          );
-          totalSize = responseMetadata.totalSize;
+          responseMetadata = await this.downloadByPartWithWorkers(...downloadArgs);
         } else {
-          const responseMetadata = await this.downloadByPart(
-            request,
-            transferOptions ?? {},
-            streams,
-            requests,
-            metadata,
-            checksumValidationEnabled
-          );
-          totalSize = responseMetadata.totalSize;
-          onStreamConsumed = responseMetadata.onStreamConsumed;
+          responseMetadata = await this.downloadByPart(...downloadArgs);
         }
       } else if (this.multipartDownloadType === "RANGE") {
         if (this.workerHttpHandler && !request.Range) {
-          const responseMetadata = await this.downloadByRangeWithWorkers(
-            request,
-            transferOptions ?? {},
-            streams,
-            requests,
-            metadata,
-            checksumValidationEnabled
-          );
-          totalSize = responseMetadata.totalSize;
+          responseMetadata = await this.downloadByRangeWithWorkers(...downloadArgs);
         } else {
-          const responseMetadata = await this.downloadByRange(
-            request,
-            transferOptions ?? {},
-            streams,
-            requests,
-            metadata,
-            checksumValidationEnabled
-          );
-          totalSize = responseMetadata.totalSize;
-          onStreamConsumed = responseMetadata.onStreamConsumed;
+          responseMetadata = await this.downloadByRange(...downloadArgs);
         }
       }
+
+      totalSize = responseMetadata!.totalSize;
+      onStreamConsumed = responseMetadata!.onStreamConsumed;
     } catch (error) {
       // On failure or abort, response bodies that were already received but not
       // yet handed to joinStreams are orphaned. Destroy them (attaching a no-op
@@ -1717,6 +1699,9 @@ export class S3TransferManager implements IS3TransferManager {
     };
 
     const releaseSlot = (): void => {
+      if (inFlight <= 0) {
+        throw new Error("releaseSlot called with no in-flight requests");
+      }
       inFlight--;
       if (nextDispatchResolve && inFlight < this.maxConcurrentDownloads) {
         const resolve = nextDispatchResolve;
@@ -1724,9 +1709,6 @@ export class S3TransferManager implements IS3TransferManager {
         resolve();
       }
     };
-
-    // Dispatch part GET requests via the SDK pipeline (WorkerHttpHandler intercepts them).
-    // Concurrency limiter provides backpressure — waitForSlot blocks when all slots are in use.
     const dispatchPromise = (async () => {
       for (let partNumber = 2; partNumber <= partsCount; partNumber++) {
         if (abortController.signal.aborted || queue.hasError()) break;
@@ -1772,7 +1754,6 @@ export class S3TransferManager implements IS3TransferManager {
             if (!transferResult) {
               queue.setError(new Error(`Missing download result for part ${partNumber}`));
               abortController.abort();
-              releaseSlot();
               return;
             }
 
@@ -1790,11 +1771,12 @@ export class S3TransferManager implements IS3TransferManager {
                 },
               })
             );
-            releaseSlot();
           })
           .catch((error) => {
             queue.setError(error);
             abortController.abort();
+          })
+          .finally(() => {
             releaseSlot();
           });
       }
@@ -1808,11 +1790,15 @@ export class S3TransferManager implements IS3TransferManager {
 
     // Create a Readable stream that pulls parts sequentially from the ordered queue.
     // Each chunk is a zero-copy Buffer view into the transferred ArrayBuffer.
+    let reading = false;
     const transferStream = new Readable({
       read() {
+        if (reading) return;
+        reading = true;
         queue
           .dequeue()
           .then((item) => {
+            reading = false;
             if (item === null) {
               // null means either all parts delivered OR an error was set.
               // If an error was set, destroy the stream with that error so
@@ -1831,6 +1817,7 @@ export class S3TransferManager implements IS3TransferManager {
             this.push(buf);
           })
           .catch((err) => {
+            reading = false;
             this.destroy(err as Error);
           });
       },
@@ -1936,6 +1923,9 @@ export class S3TransferManager implements IS3TransferManager {
     };
 
     const releaseSlot = (): void => {
+      if (inFlight <= 0) {
+        throw new Error("releaseSlot called with no in-flight requests");
+      }
       inFlight--;
       if (nextDispatchResolve && inFlight < this.maxConcurrentDownloads) {
         const resolve = nextDispatchResolve;
@@ -1994,7 +1984,6 @@ export class S3TransferManager implements IS3TransferManager {
             if (!transferResult) {
               queue.setError(new Error(`Missing download result for range ${start}-${end}`));
               abortController.abort();
-              releaseSlot();
               return;
             }
 
@@ -2012,11 +2001,12 @@ export class S3TransferManager implements IS3TransferManager {
                 },
               })
             );
-            releaseSlot();
           })
           .catch((error) => {
             queue.setError(error);
             abortController.abort();
+          })
+          .finally(() => {
             releaseSlot();
           });
       }
@@ -2028,11 +2018,15 @@ export class S3TransferManager implements IS3TransferManager {
 
     // Create a Readable stream that pulls ranges sequentially from the ordered queue.
     // Each chunk is a zero-copy Buffer view into the transferred ArrayBuffer.
+    let reading = false;
     const transferStream = new Readable({
       read() {
+        if (reading) return;
+        reading = true;
         queue
           .dequeue()
           .then((item) => {
+            reading = false;
             if (item === null) {
               if (queue.hasError()) {
                 this.destroy(queue.getError() as Error);
@@ -2048,6 +2042,7 @@ export class S3TransferManager implements IS3TransferManager {
             this.push(buf);
           })
           .catch((err) => {
+            reading = false;
             this.destroy(err as Error);
           });
       },
@@ -2472,7 +2467,7 @@ export class S3TransferManager implements IS3TransferManager {
     const { partSize } = this.calculatePartSize(contentLength);
     const filePath = (request.Body as any).path as string;
 
-    const buildDataSource = (checksumAlgorithm?: string, checksumHeader?: string): DataSource => ({
+    const buildDataSource = (checksumAlgorithm?: ChecksumAlgorithm, checksumHeader?: string): DataSource => ({
       type: "file",
       filePath,
       partSize,
@@ -2501,7 +2496,7 @@ export class S3TransferManager implements IS3TransferManager {
     const sharedBuffer = new SharedArrayBuffer(body.byteLength);
     new Uint8Array(sharedBuffer).set(body);
 
-    const buildDataSource = (checksumAlgorithm?: string, checksumHeader?: string): DataSource => ({
+    const buildDataSource = (checksumAlgorithm?: ChecksumAlgorithm, checksumHeader?: string): DataSource => ({
       type: "sharedBuffer",
       sharedBuffer,
       partSize,
@@ -2522,7 +2517,7 @@ export class S3TransferManager implements IS3TransferManager {
   private async threadedMultipartUpload(
     request: UploadRequest,
     contentLength: number,
-    buildDataSource: (checksumAlgorithm?: string, checksumHeader?: string) => DataSource,
+    buildDataSource: (checksumAlgorithm?: ChecksumAlgorithm, checksumHeader?: string) => DataSource,
     transferOptions?: TransferOptions
   ): Promise<CompleteMultipartUploadCommandOutput> {
     const { partSize, expectedPartsCount } = this.calculatePartSize(contentLength);

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -21,13 +21,14 @@ import {
 } from "@aws-sdk/client-s3";
 import type { Logger } from "@smithy/types";
 import type { StreamingBlobPayloadOutputTypes } from "@smithy/types";
-import { createReadStream } from "node:fs";
-import { opendir, realpath, stat } from "node:fs/promises";
-import { join, relative, sep } from "node:path";
+import { createReadStream, existsSync } from "node:fs";
+import { open, opendir, realpath, stat } from "node:fs/promises";
+import { join, relative, resolve, sep } from "node:path";
 
 import { type RawDataPart, byteLength, getChunk } from "./chunker";
 import { handleFailure, Semaphore, validateDirectory } from "./directory-transfer-utils";
 import type { AddEventListenerOptions, EventListener, RemoveEventListenerOptions } from "./event-listener-types";
+import { FileManager } from "./file-manager";
 import { destroyStreams, joinStreams } from "./join-streams";
 import { LogLevel } from "./log-level";
 import type {
@@ -37,6 +38,8 @@ import type {
   DownloadDirectoryResponse,
   DownloadRequest,
   DownloadResponse,
+  DownloadToFileRequest,
+  DownloadToFileResponse,
   IS3TransferManager,
   S3TransferManagerConfig,
   TransferCompleteEvent,
@@ -48,7 +51,13 @@ import type {
   UploadRequest,
   UploadResponse,
 } from "./types";
-import { type DataSource, createEmptyReadable, defaultWorkerCount, WorkerHttpHandler } from "./worker-http-handler";
+import {
+  type DataSource,
+  type DownloadDataToFile,
+  createEmptyReadable,
+  defaultWorkerCount,
+  WorkerHttpHandler,
+} from "./worker-http-handler";
 
 /**
  * Client for efficient transfer of objects to and from Amazon S3.
@@ -460,6 +469,384 @@ export class S3TransferManager implements IS3TransferManager {
     };
 
     return response;
+  }
+
+  /**
+   * Downloads an S3 object to a local file.
+   *
+   * @param request - Download request including the local file destination path.
+   * @param transferOptions - Allows users to specify cancel functions for the request and a collection of callbacks for monitoring transfer lifecycle events.
+   *
+   * @returns the response containing bytes written, and object metadata.
+   *
+   * @alpha
+   */
+  public async downloadToFile(
+    request: DownloadToFileRequest,
+    transferOptions?: TransferOptions
+  ): Promise<DownloadToFileResponse> {
+
+    if (!request.destination || request.destination === "") {
+      throw new Error("destination must be a non-empty string");
+    }
+
+    const resolvedDestination = resolve(request.destination);
+
+    if (request.failIfExists && existsSync(resolvedDestination)) {
+      throw new Error(`File already exists at destination: ${resolvedDestination}`);
+    }
+
+    this.checkAborted(transferOptions);
+    this.addEventListeners(transferOptions?.eventListeners);
+
+    const removeLocalEventListeners = () => {
+      this.removeEventListeners(transferOptions?.eventListeners);
+      if (transferOptions?.abortSignal) {
+        this.abortCleanupFunctions.get(transferOptions.abortSignal as AbortSignal)?.();
+        this.abortCleanupFunctions.delete(transferOptions.abortSignal as AbortSignal);
+      }
+    };
+
+    const checksumValidationEnabled =
+      request.ChecksumMode === "ENABLED" || this.responseChecksumValidation === "WHEN_SUPPORTED";
+
+    const { destination, failIfExists, ...getObjectFields } = request;
+    const initialPartRequest: GetObjectCommandInput = {
+      ...getObjectFields,
+      PartNumber: 1,
+      ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+    };
+
+    let initialResponse: DownloadResponse;
+    try {
+      initialResponse = await this.s3.send(new GetObjectCommand(initialPartRequest), transferOptions);
+    } catch (error) {
+      removeLocalEventListeners();
+      throw error;
+    }
+
+    const totalSize = initialResponse.ContentRange
+      ? Number.parseInt(initialResponse.ContentRange.split("/")[1])
+      : initialResponse.ContentLength ?? 0;
+    const partsCount = initialResponse.PartsCount ?? 1;
+    const eTag = initialResponse.ETag ?? undefined;
+
+    this.dispatchTransferInitiatedEvent(request, totalSize);
+
+    const fileManager = new FileManager();
+    let tempFilePath: string | undefined;
+
+    try {
+      if (partsCount === 1) {
+      
+        tempFilePath = await fileManager.createTempFile(resolvedDestination, totalSize);
+        fileManager.registerCleanupHandler(tempFilePath);
+
+        // Write the whole object body, which starts at byte 0.
+        await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
+
+        // Atomic rename
+        await fileManager.atomicRename(tempFilePath, resolvedDestination);
+        fileManager.unregisterCleanupHandler(tempFilePath);
+
+        // Construct response
+        const metadata: Record<string, any> = {};
+        this.assignMetadata(metadata, initialResponse);
+        metadata.ContentLength = totalSize;
+        metadata.ContentRange = `bytes 0-${totalSize - 1}/${totalSize}`;
+
+        // Handle COMPOSITE checksum type
+        if (initialResponse.ChecksumType === "COMPOSITE") {
+          metadata.ChecksumCRC32 = undefined;
+          metadata.ChecksumCRC32C = undefined;
+          metadata.ChecksumSHA1 = undefined;
+          metadata.ChecksumSHA256 = undefined;
+        }
+
+        const response: DownloadToFileResponse = {
+          ...metadata,
+          bytesWritten: totalSize,
+        } as DownloadToFileResponse;
+
+        this.dispatchEvent(
+          Object.assign(new Event("transferComplete"), {
+            request,
+            response,
+            snapshot: {
+              transferredBytes: totalSize,
+              totalBytes: totalSize,
+            },
+          })
+        );
+        removeLocalEventListeners();
+        return response;
+      }
+
+      // Multipart download path when PartsCount > 1.
+      tempFilePath = await fileManager.createTempFile(resolvedDestination, totalSize);
+      fileManager.registerCleanupHandler(tempFilePath);
+
+      // Write Part 1 body, which starts at byte 0.
+      const partSize = initialResponse.ContentLength ?? 0;
+      await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
+
+      // TODO: Full-object CRC validation via CRC combination.
+      // S3 currently only returns full-object checksums in part GET responses for objects
+      // uploaded via single PutObject, making this path effectively unreachable for multipart
+      // downloads. Once S3 ships support for returning full-object checksums on MPU-uploaded
+      // objects (tracking: P320750170), implement CRC combination here to validate the
+      // combined per-part CRCs against the full-object checksum.
+
+      const partResults: Array<{ partNumber: number; bytesWritten: number }> = [];
+      partResults.push({ partNumber: 1, bytesWritten: partSize });
+
+      // Dispatch remaining Part GET requests with concurrency bounding
+      const semaphore = new Semaphore(this.maxConcurrentDownloads);
+      const abortController = new AbortController();
+      let failed = false;
+      let failureError: unknown;
+
+      // Listen to user abort
+      const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
+      if (userSignal) {
+        const onUserAbort = () => abortController.abort();
+        userSignal.addEventListener("abort", onUserAbort, { once: true });
+      }
+
+      const remainingPartTasks: Promise<void>[] = [];
+
+      for (let part = 2; part <= partsCount; part++) {
+        if (failed || abortController.signal.aborted) break;
+        this.checkAborted(transferOptions);
+
+        await semaphore.acquire();
+
+        if (failed || abortController.signal.aborted) {
+          semaphore.release();
+          break;
+        }
+
+        const partNumber = part;
+        // Calculate the expected offset and length from part boundaries
+        const partOffset = (partNumber - 1) * partSize;
+        // Last part might be smaller
+        const expectedLength = Math.min(partSize, totalSize - partOffset);
+
+        const partGetRequest: GetObjectCommandInput = {
+          ...getObjectFields,
+          PartNumber: partNumber,
+          IfMatch: eTag,
+          ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+        };
+
+        const task = (async () => {
+          try {
+            if (this.workerHttpHandler) {
+              // Worker-thread path: dispatch via WorkerHttpHandler for direct file-offset write
+              const resultToken = `download-${partNumber}-${Date.now()}`;
+              const downloadOptions: DownloadDataToFile = {
+                filePath: tempFilePath!,
+                offset: partOffset,
+                expectedLength,
+                resultToken,
+              };
+
+              // Send through S3Client with downloadDataToFile options.
+              // The WorkerHttpHandler intercepts requests with downloadDataToFile
+              // and dispatches them to worker threads for direct file writes.
+              // The handler returns a proper HttpResponse (with body omitted since
+              // it was written to disk) so the SDK middleware pipeline processes
+              // the response normally.
+              await this.s3.send(new GetObjectCommand(partGetRequest), {
+                ...transferOptions,
+                downloadDataToFile: downloadOptions,
+              } as any);
+
+              // Retrieve the download result from the WorkerHttpHandler's side-channel.
+              const downloadResult = this.workerHttpHandler.getDownloadResult(resultToken);
+              const bytesWritten = downloadResult?.bytesWritten ?? expectedLength;
+
+              partResults.push({
+                partNumber,
+                bytesWritten,
+              });
+            } else {
+              // Main-thread fallback (workerThreadCount === 1)
+              const partResponse = await this.s3.send(
+                new GetObjectCommand(partGetRequest),
+                transferOptions
+              );
+              await this.writeResponseBodyToFile(
+                partResponse.Body,
+                tempFilePath!,
+                partResponse.ContentRange,
+                partOffset
+              );
+
+              partResults.push({
+                partNumber,
+                bytesWritten: partResponse.ContentLength ?? expectedLength,
+              });
+            }
+
+            // Dispatch bytesTransferred event
+            this.dispatchEvent(
+              Object.assign(new Event("bytesTransferred"), {
+                request: partGetRequest,
+                snapshot: {
+                  transferredBytes: expectedLength,
+                  totalBytes: totalSize,
+                },
+              })
+            );
+          } catch (error) {
+            if (!failed) {
+              failed = true;
+              failureError = error;
+              abortController.abort();
+            }
+          } finally {
+            semaphore.release();
+          }
+        })();
+
+        remainingPartTasks.push(task);
+      }
+
+      await Promise.allSettled(remainingPartTasks);
+
+      // Handle abort: if the abort signal was triggered (either user or internal),
+      // reject with AbortError regardless of whether tasks have already failed.
+      if (abortController.signal.aborted && !failed) {
+        await fileManager.deleteTempFile(tempFilePath);
+        fileManager.unregisterCleanupHandler(tempFilePath);
+        const abortError = Object.assign(new Error("Transfer aborted."), { name: "AbortError" });
+        this.dispatchTransferFailedEvent(request, totalSize, abortError);
+        removeLocalEventListeners();
+        throw abortError;
+      }
+
+      // Handle failure
+      if (failed) {
+        await fileManager.deleteTempFile(tempFilePath);
+        fileManager.unregisterCleanupHandler(tempFilePath);
+        this.dispatchTransferFailedEvent(request, totalSize, failureError as Error);
+        removeLocalEventListeners();
+        throw failureError;
+      }
+
+      // Verify request count
+      if (partResults.length !== partsCount) {
+        await fileManager.deleteTempFile(tempFilePath);
+        fileManager.unregisterCleanupHandler(tempFilePath);
+        const error = new Error(
+          `The number of parts downloaded (${partResults.length}) does not match the expected number (${partsCount})`
+        );
+        this.dispatchTransferFailedEvent(request, totalSize, error);
+        removeLocalEventListeners();
+        throw error;
+      }
+
+      // Verify total bytes written matches expected object size
+      const totalBytesWritten = partResults.reduce((sum, p) => sum + p.bytesWritten, 0);
+      if (totalBytesWritten !== totalSize) {
+        await fileManager.deleteTempFile(tempFilePath);
+        fileManager.unregisterCleanupHandler(tempFilePath);
+        const error = new Error(
+          `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalSize})`
+        );
+        this.dispatchTransferFailedEvent(request, totalSize, error);
+        removeLocalEventListeners();
+        throw error;
+      }
+
+      // Atomic rename
+      await fileManager.atomicRename(tempFilePath, resolvedDestination);
+      fileManager.unregisterCleanupHandler(tempFilePath);
+
+      // Construct response metadata
+      const metadata: Record<string, any> = {};
+      this.assignMetadata(metadata, initialResponse);
+      metadata.ContentLength = totalSize;
+      metadata.ContentRange = `bytes 0-${totalSize - 1}/${totalSize}`;
+
+      // Handle COMPOSITE checksum type
+      if (initialResponse.ChecksumType === "COMPOSITE") {
+        metadata.ChecksumCRC32 = undefined;
+        metadata.ChecksumCRC32C = undefined;
+        metadata.ChecksumSHA1 = undefined;
+        metadata.ChecksumSHA256 = undefined;
+      }
+
+      const response: DownloadToFileResponse = {
+        ...metadata,
+        bytesWritten: totalSize,
+      } as DownloadToFileResponse;
+
+      this.dispatchEvent(
+        Object.assign(new Event("transferComplete"), {
+          request,
+          response,
+          snapshot: {
+            transferredBytes: totalSize,
+            totalBytes: totalSize,
+          },
+        })
+      );
+      removeLocalEventListeners();
+      return response;
+    } catch (error) {
+      // Ensure temp file cleanup on any unexpected error
+      if (tempFilePath) {
+        await fileManager.deleteTempFile(tempFilePath).catch(() => {});
+        fileManager.unregisterCleanupHandler(tempFilePath);
+      }
+      removeLocalEventListeners();
+      throw error;
+    }
+  }
+
+  /**
+   * Streams a GetObject response body into an already-created file, positioning
+   * each write explicitly at the offsets.
+   *
+   * The starting offset comes from the response's ContentRange header, which is
+   * authoritative: S3 permits multipart objects whose parts differ in size, so a
+   * caller-computed offset is only usable as a fallback when the header is
+   * absent or unparseable.
+   *
+   * @param body - The response body. A no-op when absent.
+   * @param filePath - Path to the existing file to write into.
+   * @param contentRange - The response's ContentRange header value, if any.
+   * @param fallbackOffset - Offset to use when ContentRange is unavailable.
+   * @returns The number of bytes written.
+   *
+   * @internal
+   */
+  private async writeResponseBodyToFile(
+    body: DownloadResponse["Body"],
+    filePath: string,
+    contentRange: string | undefined,
+    fallbackOffset: number
+  ): Promise<number> {
+    const start = parseContentRangeStart(contentRange) ?? fallbackOffset;
+    const fd = await open(filePath, "r+");
+    try {
+      let offset = start;
+      if (typeof (body as any)[Symbol.asyncIterator] === "function") {
+        for await (const chunk of body as AsyncIterable<Uint8Array>) {
+          await fd.write(chunk, 0, chunk.length, offset);
+          offset += chunk.length;
+        }
+      } else if (typeof (body as any).transformToByteArray === "function") {
+        const bytes: Uint8Array = await (body as any).transformToByteArray();
+        await fd.write(bytes, 0, bytes.length, offset);
+        offset += bytes.length;
+      }
+      return offset - start;
+    } finally {
+      await fd.close();
+    }
   }
 
   /**
@@ -1759,6 +2146,21 @@ export class S3TransferManager implements IS3TransferManager {
       );
     }
   }
+}
+
+/**
+ * Parses the starting byte offset from a ContentRange header value.
+ * Expected format: "bytes START-END/TOTAL".
+ *
+ * @param contentRange - The ContentRange header value.
+ * @returns The numeric START value, or undefined if absent or unparseable.
+ *
+ * @internal
+ */
+function parseContentRangeStart(contentRange: string | undefined): number | undefined {
+  if (!contentRange) return undefined;
+  const match = contentRange.match(/^bytes\s+(\d+)-/);
+  return match ? Number(match[1]) : undefined;
 }
 
 /**

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -27,16 +27,8 @@ import { join, relative, resolve, sep } from "node:path";
 import { Readable } from "node:stream";
 
 import { type RawDataPart, byteLength, getChunk } from "./chunker";
-import {
-  handleFailure,
-  Semaphore,
-  validateDirectory,
-} from "./directory-transfer-utils";
-import type {
-  AddEventListenerOptions,
-  EventListener,
-  RemoveEventListenerOptions,
-} from "./event-listener-types";
+import { handleFailure, Semaphore, validateDirectory } from "./directory-transfer-utils";
+import type { AddEventListenerOptions, EventListener, RemoveEventListenerOptions } from "./event-listener-types";
 import { FileManager } from "./file-manager";
 import { destroyStreams, joinStreams } from "./join-streams";
 import { LogLevel } from "./log-level";
@@ -87,18 +79,11 @@ export class S3TransferManager implements IS3TransferManager {
   private readonly s3: S3Client;
   private readonly targetPartSizeBytes: number;
   private readonly multipartUploadThresholdBytes: number;
-  private readonly requestChecksumCalculation:
-    | "WHEN_SUPPORTED"
-    | "WHEN_REQUIRED";
-  private readonly responseChecksumValidation:
-    | "WHEN_SUPPORTED"
-    | "WHEN_REQUIRED";
+  private readonly requestChecksumCalculation: "WHEN_SUPPORTED" | "WHEN_REQUIRED";
+  private readonly responseChecksumValidation: "WHEN_SUPPORTED" | "WHEN_REQUIRED";
   private readonly multipartDownloadType: "PART" | "RANGE";
   private readonly eventListeners: TransferEventListeners;
-  private readonly abortCleanupFunctions = new WeakMap<
-    AbortSignal,
-    () => void
-  >();
+  private readonly abortCleanupFunctions = new WeakMap<AbortSignal, () => void>();
   private readonly maxConcurrentDownloads: number;
   private readonly maxConcurrentUploads: number;
   private readonly workerThreadCount: number;
@@ -106,10 +91,8 @@ export class S3TransferManager implements IS3TransferManager {
   private readonly logger: Logger;
 
   public constructor(config: S3TransferManagerConfig = {}) {
-    this.requestChecksumCalculation =
-      config.requestChecksumCalculation ?? "WHEN_SUPPORTED";
-    this.responseChecksumValidation =
-      config.responseChecksumValidation ?? "WHEN_SUPPORTED";
+    this.requestChecksumCalculation = config.requestChecksumCalculation ?? "WHEN_SUPPORTED";
+    this.responseChecksumValidation = config.responseChecksumValidation ?? "WHEN_SUPPORTED";
     this.maxConcurrentUploads = config.maxConcurrentUploads ?? 32;
     this.workerThreadCount = config.workerThreadCount ?? defaultWorkerCount();
 
@@ -131,11 +114,10 @@ export class S3TransferManager implements IS3TransferManager {
     }
 
     this.targetPartSizeBytes = config.targetPartSizeBytes ?? 8 * 1024 * 1024; // 8 MB
-    this.multipartUploadThresholdBytes =
-      config.multipartUploadThresholdBytes ?? 16 * 1024 * 1024; // 16 MB
+    this.multipartUploadThresholdBytes = config.multipartUploadThresholdBytes ?? 16 * 1024 * 1024; // 16 MB
 
     this.multipartDownloadType = config.multipartDownloadType ?? "PART";
-    this.maxConcurrentDownloads = config.maxConcurrentDownloads ?? 8;
+    this.maxConcurrentDownloads = config.maxConcurrentDownloads ?? 32;
     this.logger = config.logger ?? new LogLevel("warn");
     this.eventListeners = {
       transferInitiated: config.eventListeners?.transferInitiated ?? [],
@@ -160,33 +142,25 @@ export class S3TransferManager implements IS3TransferManager {
   public addEventListener(
     type: "transferInitiated",
     callback: EventListener<TransferEvent>,
-    options?: AddEventListenerOptions | boolean,
+    options?: AddEventListenerOptions | boolean
   ): void;
   public addEventListener(
     type: "bytesTransferred",
     callback: EventListener<TransferEvent>,
-    options?: AddEventListenerOptions | boolean,
+    options?: AddEventListenerOptions | boolean
   ): void;
   public addEventListener(
     type: "transferComplete",
     callback: EventListener<TransferCompleteEvent>,
-    options?: AddEventListenerOptions | boolean,
+    options?: AddEventListenerOptions | boolean
   ): void;
   public addEventListener(
     type: "transferFailed",
     callback: EventListener<TransferEvent>,
-    options?: AddEventListenerOptions | boolean,
+    options?: AddEventListenerOptions | boolean
   ): void;
-  public addEventListener(
-    type: string,
-    callback: EventListener,
-    options?: AddEventListenerOptions | boolean,
-  ): void;
-  public addEventListener(
-    type: string,
-    callback: EventListener,
-    options?: AddEventListenerOptions | boolean,
-  ): void {
+  public addEventListener(type: string, callback: EventListener, options?: AddEventListenerOptions | boolean): void;
+  public addEventListener(type: string, callback: EventListener, options?: AddEventListenerOptions | boolean): void {
     const eventType = type as keyof TransferEventListeners;
     const listeners = this.eventListeners[eventType];
 
@@ -208,9 +182,7 @@ export class S3TransferManager implements IS3TransferManager {
         this.abortCleanupFunctions.delete(signal);
       };
 
-      this.abortCleanupFunctions.set(signal, () =>
-        signal.removeEventListener("abort", removeListenerAfterAbort),
-      );
+      this.abortCleanupFunctions.set(signal, () => signal.removeEventListener("abort", removeListenerAfterAbort));
       signal.addEventListener("abort", removeListenerAfterAbort, {
         once: true,
       });
@@ -243,9 +215,7 @@ export class S3TransferManager implements IS3TransferManager {
   public dispatchEvent(event: Event): boolean;
   public dispatchEvent(event: Event): boolean {
     const eventType = event.type;
-    const listeners = this.eventListeners[
-      eventType as keyof TransferEventListeners
-    ] as EventListener[];
+    const listeners = this.eventListeners[eventType as keyof TransferEventListeners] as EventListener[];
 
     if (listeners) {
       for (const listener of listeners) {
@@ -272,32 +242,32 @@ export class S3TransferManager implements IS3TransferManager {
   public removeEventListener(
     type: "transferInitiated",
     callback: EventListener<TransferEvent>,
-    options?: RemoveEventListenerOptions | boolean,
+    options?: RemoveEventListenerOptions | boolean
   ): void;
   public removeEventListener(
     type: "bytesTransferred",
     callback: EventListener<TransferEvent>,
-    options?: RemoveEventListenerOptions | boolean,
+    options?: RemoveEventListenerOptions | boolean
   ): void;
   public removeEventListener(
     type: "transferComplete",
     callback: EventListener<TransferCompleteEvent>,
-    options?: RemoveEventListenerOptions | boolean,
+    options?: RemoveEventListenerOptions | boolean
   ): void;
   public removeEventListener(
     type: "transferFailed",
     callback: EventListener<TransferEvent>,
-    options?: RemoveEventListenerOptions | boolean,
+    options?: RemoveEventListenerOptions | boolean
   ): void;
   public removeEventListener(
     type: string,
     callback: EventListener,
-    options?: RemoveEventListenerOptions | boolean,
+    options?: RemoveEventListenerOptions | boolean
   ): void;
   public removeEventListener(
     type: string,
     callback: EventListener,
-    options?: RemoveEventListenerOptions | boolean,
+    options?: RemoveEventListenerOptions | boolean
   ): void {
     const eventType = type as keyof TransferEventListeners;
     const listeners = this.eventListeners[eventType];
@@ -331,12 +301,8 @@ export class S3TransferManager implements IS3TransferManager {
    * @returns S3 PutObject or CompleteMultipartUpload response with transfer event dispatching.
    *
    */
-  public async upload(
-    request: UploadRequest,
-    transferOptions?: TransferOptions,
-  ): Promise<UploadResponse> {
-    const totalContentLength =
-      request.ContentLength ?? byteLength(request.Body);
+  public async upload(request: UploadRequest, transferOptions?: TransferOptions): Promise<UploadResponse> {
+    const totalContentLength = request.ContentLength ?? byteLength(request.Body);
 
     if (totalContentLength === undefined) {
       throw new Error("Unable to determine content length for upload");
@@ -349,12 +315,8 @@ export class S3TransferManager implements IS3TransferManager {
     const removeLocalEventListeners = () => {
       this.removeEventListeners(transferOptions?.eventListeners);
       if (transferOptions?.abortSignal) {
-        this.abortCleanupFunctions.get(
-          transferOptions.abortSignal as AbortSignal,
-        )?.();
-        this.abortCleanupFunctions.delete(
-          transferOptions.abortSignal as AbortSignal,
-        );
+        this.abortCleanupFunctions.get(transferOptions.abortSignal as AbortSignal)?.();
+        this.abortCleanupFunctions.delete(transferOptions.abortSignal as AbortSignal);
       }
     };
 
@@ -362,38 +324,19 @@ export class S3TransferManager implements IS3TransferManager {
       let response: UploadResponse;
 
       if (totalContentLength < this.multipartUploadThresholdBytes) {
-        response = await this.uploadSinglePart(
-          request,
-          totalContentLength,
-          transferOptions,
-        );
+        response = await this.uploadSinglePart(request, totalContentLength, transferOptions);
       } else if (this.workerThreadCount > 1 && this.isFileBody(request.Body)) {
-        response = await this.threadedUploadInPartsFromFile(
-          request,
-          totalContentLength,
-          transferOptions,
-        );
-      } else if (
-        this.workerThreadCount > 1 &&
-        this.isInMemoryBody(request.Body)
-      ) {
+        response = await this.threadedUploadInPartsFromFile(request, totalContentLength, transferOptions);
+      } else if (this.workerThreadCount > 1 && this.isInMemoryBody(request.Body)) {
         if (typeof request.Body === "string") {
           request = {
             ...request,
             Body: new TextEncoder().encode(request.Body),
           };
         }
-        response = await this.threadedUploadInParts(
-          request,
-          totalContentLength,
-          transferOptions,
-        );
+        response = await this.threadedUploadInParts(request, totalContentLength, transferOptions);
       } else {
-        response = await this.uploadInParts(
-          request,
-          totalContentLength,
-          transferOptions,
-        );
+        response = await this.uploadInParts(request, totalContentLength, transferOptions);
       }
 
       this.dispatchEvent(
@@ -404,16 +347,12 @@ export class S3TransferManager implements IS3TransferManager {
             transferredBytes: totalContentLength,
             totalBytes: totalContentLength,
           },
-        }),
+        })
       );
       removeLocalEventListeners();
       return response;
     } catch (error) {
-      this.dispatchTransferFailedEvent(
-        request,
-        totalContentLength,
-        error as Error,
-      );
+      this.dispatchTransferFailedEvent(request, totalContentLength, error as Error);
       removeLocalEventListeners();
       throw error;
     }
@@ -430,14 +369,11 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @alpha
    */
-  public async download(
-    request: DownloadRequest,
-    transferOptions?: TransferOptions,
-  ): Promise<DownloadResponse> {
+  public async download(request: DownloadRequest, transferOptions?: TransferOptions): Promise<DownloadResponse> {
     const partNumber = request.PartNumber;
     if (typeof partNumber === "number") {
       throw new Error(
-        "partNumber included: S3 Transfer Manager does not support downloads for specific parts. Use GetObjectCommand instead",
+        "partNumber included: S3 Transfer Manager does not support downloads for specific parts. Use GetObjectCommand instead"
       );
     }
 
@@ -451,20 +387,15 @@ export class S3TransferManager implements IS3TransferManager {
     this.addEventListeners(transferOptions?.eventListeners);
 
     const checksumValidationEnabled =
-      request.ChecksumMode === "ENABLED" ||
-      this.responseChecksumValidation === "WHEN_SUPPORTED";
+      request.ChecksumMode === "ENABLED" || this.responseChecksumValidation === "WHEN_SUPPORTED";
 
     let onStreamConsumed: ((index: number) => void) | undefined;
 
     const removeLocalEventListeners = () => {
       this.removeEventListeners(transferOptions?.eventListeners);
       if (transferOptions?.abortSignal) {
-        this.abortCleanupFunctions.get(
-          transferOptions.abortSignal as AbortSignal,
-        )?.();
-        this.abortCleanupFunctions.delete(
-          transferOptions.abortSignal as AbortSignal,
-        );
+        this.abortCleanupFunctions.get(transferOptions.abortSignal as AbortSignal)?.();
+        this.abortCleanupFunctions.delete(transferOptions.abortSignal as AbortSignal);
       }
     };
 
@@ -477,7 +408,7 @@ export class S3TransferManager implements IS3TransferManager {
             streams,
             requests,
             metadata,
-            checksumValidationEnabled,
+            checksumValidationEnabled
           );
           totalSize = responseMetadata.totalSize;
         } else {
@@ -487,7 +418,7 @@ export class S3TransferManager implements IS3TransferManager {
             streams,
             requests,
             metadata,
-            checksumValidationEnabled,
+            checksumValidationEnabled
           );
           totalSize = responseMetadata.totalSize;
           onStreamConsumed = responseMetadata.onStreamConsumed;
@@ -500,7 +431,7 @@ export class S3TransferManager implements IS3TransferManager {
             streams,
             requests,
             metadata,
-            checksumValidationEnabled,
+            checksumValidationEnabled
           );
           totalSize = responseMetadata.totalSize;
         } else {
@@ -510,7 +441,7 @@ export class S3TransferManager implements IS3TransferManager {
             streams,
             requests,
             metadata,
-            checksumValidationEnabled,
+            checksumValidationEnabled
           );
           totalSize = responseMetadata.totalSize;
           onStreamConsumed = responseMetadata.onStreamConsumed;
@@ -537,7 +468,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredBytes: byteLength,
                 totalBytes: totalSize,
               },
-            }),
+            })
           );
         },
         onCompletion: (byteLength: number, index) => {
@@ -549,7 +480,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredBytes: byteLength,
                 totalBytes: totalSize,
               },
-            }),
+            })
           );
           removeLocalEventListeners();
         },
@@ -561,7 +492,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredBytes: error,
                 totalBytes: totalSize,
               },
-            }),
+            })
           );
           removeLocalEventListeners();
         },
@@ -584,7 +515,7 @@ export class S3TransferManager implements IS3TransferManager {
    */
   public async downloadToFile(
     request: DownloadToFileRequest,
-    transferOptions?: TransferOptions,
+    transferOptions?: TransferOptions
   ): Promise<DownloadToFileResponse> {
     if (!request.destination || request.destination === "") {
       throw new Error("destination must be a non-empty string");
@@ -593,9 +524,7 @@ export class S3TransferManager implements IS3TransferManager {
     const resolvedDestination = resolve(request.destination);
 
     if (request.failIfExists && existsSync(resolvedDestination)) {
-      throw new Error(
-        `File already exists at destination: ${resolvedDestination}`,
-      );
+      throw new Error(`File already exists at destination: ${resolvedDestination}`);
     }
 
     this.checkAborted(transferOptions);
@@ -604,28 +533,19 @@ export class S3TransferManager implements IS3TransferManager {
     const removeLocalEventListeners = () => {
       this.removeEventListeners(transferOptions?.eventListeners);
       if (transferOptions?.abortSignal) {
-        this.abortCleanupFunctions.get(
-          transferOptions.abortSignal as AbortSignal,
-        )?.();
-        this.abortCleanupFunctions.delete(
-          transferOptions.abortSignal as AbortSignal,
-        );
+        this.abortCleanupFunctions.get(transferOptions.abortSignal as AbortSignal)?.();
+        this.abortCleanupFunctions.delete(transferOptions.abortSignal as AbortSignal);
       }
     };
 
     const checksumValidationEnabled =
-      request.ChecksumMode === "ENABLED" ||
-      this.responseChecksumValidation === "WHEN_SUPPORTED";
+      request.ChecksumMode === "ENABLED" || this.responseChecksumValidation === "WHEN_SUPPORTED";
 
     const { destination, failIfExists, ...getObjectFields } = request;
 
     if (this.multipartDownloadType === "RANGE") {
       try {
-        const result = await this.downloadToFileByRange(
-          request,
-          resolvedDestination,
-          transferOptions,
-        );
+        const result = await this.downloadToFileByRange(request, resolvedDestination, transferOptions);
         removeLocalEventListeners();
         return result;
       } catch (error) {
@@ -642,10 +562,7 @@ export class S3TransferManager implements IS3TransferManager {
 
     let initialResponse: DownloadResponse;
     try {
-      initialResponse = await this.s3.send(
-        new GetObjectCommand(initialPartRequest),
-        transferOptions,
-      );
+      initialResponse = await this.s3.send(new GetObjectCommand(initialPartRequest), transferOptions);
     } catch (error) {
       removeLocalEventListeners();
       throw error;
@@ -670,47 +587,47 @@ export class S3TransferManager implements IS3TransferManager {
 
     try {
       if (partsCount === 1) {
-        tempFilePath = await fileManager.createTempFile(
-          resolvedDestination,
-          totalSize,
-        );
+        tempFilePath = await fileManager.createTempFile(resolvedDestination, totalSize);
         fileManager.registerCleanupHandler(tempFilePath);
 
         // Write the whole object body, which starts at byte 0.
-        await this.writeResponseBodyToFile(
-          initialResponse.Body,
-          tempFilePath,
-          initialResponse.ContentRange,
-          0,
+        await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
+
+        this.dispatchEvent(
+          Object.assign(new Event("bytesTransferred"), {
+            request,
+            snapshot: {
+              transferredBytes: totalSize,
+              totalBytes: totalSize,
+            },
+          })
         );
 
         // Atomic rename
         await fileManager.atomicRename(tempFilePath, resolvedDestination);
         fileManager.unregisterCleanupHandler(tempFilePath);
 
-        const response = this.buildDownloadToFileResponse(
-          initialResponse,
-          totalSize,
-          request,
-        );
+        const response = this.buildDownloadToFileResponse(initialResponse, totalSize, request);
         removeLocalEventListeners();
         return response;
       }
 
       // Multipart download path when PartsCount > 1.
-      tempFilePath = await fileManager.createTempFile(
-        resolvedDestination,
-        totalSize,
-      );
+      tempFilePath = await fileManager.createTempFile(resolvedDestination, totalSize);
       fileManager.registerCleanupHandler(tempFilePath);
 
       // Write Part 1 body, which starts at byte 0.
       const partSize = initialResponse.ContentLength ?? 0;
-      await this.writeResponseBodyToFile(
-        initialResponse.Body,
-        tempFilePath,
-        initialResponse.ContentRange,
-        0,
+      await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
+
+      this.dispatchEvent(
+        Object.assign(new Event("bytesTransferred"), {
+          request,
+          snapshot: {
+            transferredBytes: partSize,
+            totalBytes: totalSize,
+          },
+        })
       );
 
       // TODO: Full-object CRC validation via CRC combination.
@@ -720,8 +637,7 @@ export class S3TransferManager implements IS3TransferManager {
       // objects (tracking: P320750170), implement CRC combination here to validate the
       // combined per-part CRCs against the full-object checksum.
 
-      const partResults: Array<{ partNumber: number; bytesWritten: number }> =
-        [];
+      const partResults: Array<{ partNumber: number; bytesWritten: number }> = [];
       partResults.push({ partNumber: 1, bytesWritten: partSize });
 
       // Dispatch remaining Part GET requests with concurrency bounding
@@ -731,9 +647,7 @@ export class S3TransferManager implements IS3TransferManager {
       let failureError: unknown;
 
       // Listen to user abort
-      const userSignal = transferOptions?.abortSignal as
-        | AbortSignal
-        | undefined;
+      const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
       if (userSignal) {
         const onUserAbort = () => abortController.abort();
         userSignal.addEventListener("abort", onUserAbort, { once: true });
@@ -791,30 +705,30 @@ export class S3TransferManager implements IS3TransferManager {
               } as any);
 
               // Retrieve the download result from the WorkerHttpHandler's side-channel.
-              const downloadResult = (
-                this.s3.config.requestHandler as unknown as WorkerHttpHandler
-              ).getDownloadResult(resultToken);
-              const bytesWritten =
-                downloadResult?.bytesWritten ?? expectedLength;
+              const downloadResult = (this.s3.config.requestHandler as unknown as WorkerHttpHandler).getDownloadResult(
+                resultToken
+              );
+              if (!downloadResult) {
+                throw new Error(`Missing download result for part ${partNumber}`);
+              }
 
               partResults.push({
                 partNumber,
-                bytesWritten,
+                bytesWritten: downloadResult.bytesWritten,
               });
             } else {
               // Main-thread fallback (workerThreadCount === 1)
-              const partResponse = await this.s3.send(
-                new GetObjectCommand(partGetRequest),
-                transferOptions,
-              );
+              const partResponse = await this.s3.send(new GetObjectCommand(partGetRequest), transferOptions);
               if (partResponse.Body && partResponse.Body instanceof Readable) {
                 partResponse.Body.on("error", () => {});
               }
+              // Validate ContentRange aligns with expected part boundaries
+              this.validatePartDownload(partResponse.ContentRange, partNumber, partSize);
               await this.writeResponseBodyToFile(
                 partResponse.Body,
                 tempFilePath!,
                 partResponse.ContentRange,
-                partOffset,
+                partOffset
               );
 
               partResults.push({
@@ -831,7 +745,7 @@ export class S3TransferManager implements IS3TransferManager {
                   transferredBytes: expectedLength,
                   totalBytes: totalSize,
                 },
-              }),
+              })
             );
           } catch (error) {
             if (!failed) {
@@ -855,26 +769,14 @@ export class S3TransferManager implements IS3TransferManager {
         const abortError = Object.assign(new Error("Transfer aborted."), {
           name: "AbortError",
         });
-        await this.handleDownloadCleanup(
-          fileManager,
-          tempFilePath,
-          request,
-          totalSize,
-          abortError,
-        );
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, abortError);
         removeLocalEventListeners();
         throw abortError;
       }
 
       // Handle failure
       if (failed) {
-        await this.handleDownloadCleanup(
-          fileManager,
-          tempFilePath,
-          request,
-          totalSize,
-          failureError,
-        );
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, failureError);
         removeLocalEventListeners();
         throw failureError;
       }
@@ -882,35 +784,20 @@ export class S3TransferManager implements IS3TransferManager {
       // Verify request count
       if (partResults.length !== partsCount) {
         const error = new Error(
-          `The number of parts downloaded (${partResults.length}) does not match the expected number (${partsCount})`,
+          `The number of parts downloaded (${partResults.length}) does not match the expected number (${partsCount})`
         );
-        await this.handleDownloadCleanup(
-          fileManager,
-          tempFilePath,
-          request,
-          totalSize,
-          error,
-        );
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, error);
         removeLocalEventListeners();
         throw error;
       }
 
       // Verify total bytes written matches expected object size
-      const totalBytesWritten = partResults.reduce(
-        (sum, p) => sum + p.bytesWritten,
-        0,
-      );
+      const totalBytesWritten = partResults.reduce((sum, p) => sum + p.bytesWritten, 0);
       if (totalBytesWritten !== totalSize) {
         const error = new Error(
-          `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalSize})`,
+          `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalSize})`
         );
-        await this.handleDownloadCleanup(
-          fileManager,
-          tempFilePath,
-          request,
-          totalSize,
-          error,
-        );
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, error);
         removeLocalEventListeners();
         throw error;
       }
@@ -919,11 +806,7 @@ export class S3TransferManager implements IS3TransferManager {
       await fileManager.atomicRename(tempFilePath, resolvedDestination);
       fileManager.unregisterCleanupHandler(tempFilePath);
 
-      const response = this.buildDownloadToFileResponse(
-        initialResponse,
-        totalSize,
-        request,
-      );
+      const response = this.buildDownloadToFileResponse(initialResponse, totalSize, request);
       removeLocalEventListeners();
       return response;
     } catch (error) {
@@ -939,17 +822,15 @@ export class S3TransferManager implements IS3TransferManager {
 
   /**
    * Downloads an S3 object to a local file using Range-based GET requests.
-   * @internal
    */
   private async downloadToFileByRange(
     request: DownloadToFileRequest,
     resolvedDestination: string,
-    transferOptions?: TransferOptions,
+    transferOptions?: TransferOptions
   ): Promise<DownloadToFileResponse> {
     const { destination, failIfExists, ...getObjectFields } = request;
     const checksumValidationEnabled =
-      request.ChecksumMode === "ENABLED" ||
-      this.responseChecksumValidation === "WHEN_SUPPORTED";
+      request.ChecksumMode === "ENABLED" || this.responseChecksumValidation === "WHEN_SUPPORTED";
 
     const fileManager = new FileManager();
     let tempFilePath: string | undefined;
@@ -963,10 +844,7 @@ export class S3TransferManager implements IS3TransferManager {
         ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
       };
 
-      const initialResponse = await this.s3.send(
-        new GetObjectCommand(initialRangeRequest),
-        transferOptions,
-      );
+      const initialResponse = await this.s3.send(new GetObjectCommand(initialRangeRequest), transferOptions);
 
       // Attach a no-op error handler to the initial response body to prevent
       // uncaught socket teardown errors if abort fires before the body is consumed.
@@ -975,42 +853,34 @@ export class S3TransferManager implements IS3TransferManager {
       }
 
       // Validate ContentRange matches the requested range (also validates presence and format)
-      this.validateRangeDownload(
-        `bytes=0-${rangeSize - 1}`,
-        initialResponse.ContentRange,
-      );
+      this.validateRangeDownload(`bytes=0-${rangeSize - 1}`, initialResponse.ContentRange);
 
       // Parse total content length from ContentRange: "bytes 0-N/TOTAL"
-      const totalContentLength = Number.parseInt(
-        initialResponse.ContentRange!.split("/")[1],
-      );
+      const totalContentLength = Number.parseInt(initialResponse.ContentRange!.split("/")[1]);
       const responseContentLength = initialResponse.ContentLength ?? 0;
 
       // Compare parsed total content length with ContentLength
       if (responseContentLength === totalContentLength) {
         // Single-part object — this response contains all the data
-        tempFilePath = await fileManager.createTempFile(
-          resolvedDestination,
-          totalContentLength,
-        );
+        tempFilePath = await fileManager.createTempFile(resolvedDestination, totalContentLength);
         fileManager.registerCleanupHandler(tempFilePath);
 
-        await this.writeResponseBodyToFile(
-          initialResponse.Body,
-          tempFilePath,
-          initialResponse.ContentRange,
-          0,
-        );
+        await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
 
         await fileManager.atomicRename(tempFilePath, resolvedDestination);
         fileManager.unregisterCleanupHandler(tempFilePath);
 
         this.dispatchTransferInitiatedEvent(request, totalContentLength);
-        return this.buildDownloadToFileResponse(
-          initialResponse,
-          totalContentLength,
-          request,
+        this.dispatchEvent(
+          Object.assign(new Event("bytesTransferred"), {
+            request,
+            snapshot: {
+              transferredBytes: totalContentLength,
+              totalBytes: totalContentLength,
+            },
+          })
         );
+        return this.buildDownloadToFileResponse(initialResponse, totalContentLength, request);
       }
 
       // Save ETag and calculate expected number of ranged GET requests
@@ -1020,18 +890,10 @@ export class S3TransferManager implements IS3TransferManager {
       this.dispatchTransferInitiatedEvent(request, totalContentLength);
 
       // Create temp file and write initial part
-      tempFilePath = await fileManager.createTempFile(
-        resolvedDestination,
-        totalContentLength,
-      );
+      tempFilePath = await fileManager.createTempFile(resolvedDestination, totalContentLength);
       fileManager.registerCleanupHandler(tempFilePath);
 
-      await this.writeResponseBodyToFile(
-        initialResponse.Body,
-        tempFilePath,
-        initialResponse.ContentRange,
-        0,
-      );
+      await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
 
       const rangeResults: Array<{ index: number; bytesWritten: number }> = [];
       rangeResults.push({ index: 0, bytesWritten: responseContentLength });
@@ -1043,7 +905,7 @@ export class S3TransferManager implements IS3TransferManager {
             transferredBytes: responseContentLength,
             totalBytes: totalContentLength,
           },
-        }),
+        })
       );
 
       // Construct and dispatch remaining range GET requests concurrently
@@ -1052,9 +914,7 @@ export class S3TransferManager implements IS3TransferManager {
       let failed = false;
       let failureError: unknown;
 
-      const userSignal = transferOptions?.abortSignal as
-        | AbortSignal
-        | undefined;
+      const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
       if (userSignal) {
         userSignal.addEventListener("abort", () => abortController.abort(), {
           once: true,
@@ -1064,11 +924,7 @@ export class S3TransferManager implements IS3TransferManager {
       const rangeTasks: Promise<void>[] = [];
       let rangeIndex = 1;
 
-      for (
-        let offset = rangeSize;
-        offset < totalContentLength;
-        offset += rangeSize
-      ) {
+      for (let offset = rangeSize; offset < totalContentLength; offset += rangeSize) {
         if (failed || abortController.signal.aborted) break;
         this.checkAborted(transferOptions);
 
@@ -1106,56 +962,37 @@ export class S3TransferManager implements IS3TransferManager {
                 resultToken,
               };
 
-              const rangeResponse = await this.s3.send(
-                new GetObjectCommand(rangeGetRequest),
-                {
-                  ...transferOptions,
-                  downloadDataToFile: downloadOptions,
-                } as any,
-              );
+              const rangeResponse = await this.s3.send(new GetObjectCommand(rangeGetRequest), {
+                ...transferOptions,
+                downloadDataToFile: downloadOptions,
+              } as any);
 
               // Validate ContentRange matches the requested range
-              this.validateRangeDownload(
-                `bytes=${start}-${end}`,
-                rangeResponse.ContentRange,
-              );
+              this.validateRangeDownload(`bytes=${start}-${end}`, rangeResponse.ContentRange);
 
               // Retrieve the download result from the WorkerHttpHandler's side-channel.
-              const downloadResult = (
-                this.s3.config.requestHandler as unknown as WorkerHttpHandler
-              ).getDownloadResult(resultToken);
-              const bytesWritten =
-                downloadResult?.bytesWritten ?? expectedLength;
+              const downloadResult = (this.s3.config.requestHandler as unknown as WorkerHttpHandler).getDownloadResult(
+                resultToken
+              );
+              if (!downloadResult) {
+                throw new Error(`Missing download result for range ${start}-${end}`);
+              }
 
               rangeResults.push({
                 index: currentIndex,
-                bytesWritten,
+                bytesWritten: downloadResult.bytesWritten,
               });
             } else {
               // Main-thread fallback (workerThreadCount === 1)
-              const rangeResponse = await this.s3.send(
-                new GetObjectCommand(rangeGetRequest),
-                transferOptions,
-              );
+              const rangeResponse = await this.s3.send(new GetObjectCommand(rangeGetRequest), transferOptions);
 
               // Validate ContentRange matches the requested range
-              this.validateRangeDownload(
-                `bytes=${start}-${end}`,
-                rangeResponse.ContentRange,
-              );
+              this.validateRangeDownload(`bytes=${start}-${end}`, rangeResponse.ContentRange);
 
-              if (
-                rangeResponse.Body &&
-                rangeResponse.Body instanceof Readable
-              ) {
+              if (rangeResponse.Body && rangeResponse.Body instanceof Readable) {
                 rangeResponse.Body.on("error", () => {});
               }
-              await this.writeResponseBodyToFile(
-                rangeResponse.Body,
-                tempFilePath!,
-                rangeResponse.ContentRange,
-                start,
-              );
+              await this.writeResponseBodyToFile(rangeResponse.Body, tempFilePath!, rangeResponse.ContentRange, start);
 
               rangeResults.push({
                 index: currentIndex,
@@ -1170,7 +1007,7 @@ export class S3TransferManager implements IS3TransferManager {
                   transferredBytes: end - start + 1,
                   totalBytes: totalContentLength,
                 },
-              }),
+              })
             );
           } catch (error) {
             if (!failed) {
@@ -1192,70 +1029,37 @@ export class S3TransferManager implements IS3TransferManager {
         const abortError = Object.assign(new Error("Transfer aborted."), {
           name: "AbortError",
         });
-        await this.handleDownloadCleanup(
-          fileManager,
-          tempFilePath,
-          request,
-          totalContentLength,
-          abortError,
-        );
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, abortError);
         throw abortError;
       }
 
       if (failed) {
-        await this.handleDownloadCleanup(
-          fileManager,
-          tempFilePath,
-          request,
-          totalContentLength,
-          failureError,
-        );
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, failureError);
         throw failureError;
       }
 
       // Validate total number of ranged GET requests matches expected count
       const actualRequestCount = rangeResults.length; // includes initial request
       if (actualRequestCount !== expectedRequestCount) {
-        const error = new Error(
-          `Expected ${expectedRequestCount} ranged GET requests but sent ${actualRequestCount}`,
-        );
-        await this.handleDownloadCleanup(
-          fileManager,
-          tempFilePath,
-          request,
-          totalContentLength,
-          error,
-        );
+        const error = new Error(`Expected ${expectedRequestCount} ranged GET requests but sent ${actualRequestCount}`);
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, error);
         throw error;
       }
 
       // Verify total bytes written matches expected object size
-      const totalBytesWritten = rangeResults.reduce(
-        (sum, r) => sum + r.bytesWritten,
-        0,
-      );
+      const totalBytesWritten = rangeResults.reduce((sum, r) => sum + r.bytesWritten, 0);
       if (totalBytesWritten !== totalContentLength) {
         const error = new Error(
-          `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalContentLength})`,
+          `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalContentLength})`
         );
-        await this.handleDownloadCleanup(
-          fileManager,
-          tempFilePath,
-          request,
-          totalContentLength,
-          error,
-        );
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, error);
         throw error;
       }
 
       await fileManager.atomicRename(tempFilePath, resolvedDestination);
       fileManager.unregisterCleanupHandler(tempFilePath);
 
-      return this.buildDownloadToFileResponse(
-        initialResponse,
-        totalContentLength,
-        request,
-      );
+      return this.buildDownloadToFileResponse(initialResponse, totalContentLength, request);
     } catch (error) {
       if (tempFilePath) {
         await fileManager.deleteTempFile(tempFilePath).catch(() => {});
@@ -1280,13 +1084,12 @@ export class S3TransferManager implements IS3TransferManager {
    * @param fallbackOffset - Offset to use when ContentRange is unavailable.
    * @returns The number of bytes written.
    *
-   * @internal
    */
   private async writeResponseBodyToFile(
     body: DownloadResponse["Body"],
     filePath: string,
     contentRange: string | undefined,
-    fallbackOffset: number,
+    fallbackOffset: number
   ): Promise<number> {
     const start = parseContentRangeStart(contentRange) ?? fallbackOffset;
     const fd = await open(filePath, "r+");
@@ -1321,12 +1124,11 @@ export class S3TransferManager implements IS3TransferManager {
    */
   public async uploadDirectory(
     request: UploadDirectoryRequest,
-    transferOptions?: TransferOptions,
+    transferOptions?: TransferOptions
   ): Promise<UploadDirectoryResponse> {
     const absoluteSource = await validateDirectory(request.source);
     const maxConcurrency = request.maxConcurrency ?? 100;
-    const failurePolicy =
-      request.failurePolicy ?? ("terminate" as CannedFailurePolicy);
+    const failurePolicy = request.failurePolicy ?? ("terminate" as CannedFailurePolicy);
     const semaphore = new Semaphore(maxConcurrency);
     const abortController = new AbortController();
     const inFlight = new Set<Promise<void>>();
@@ -1358,7 +1160,7 @@ export class S3TransferManager implements IS3TransferManager {
           transferredFiles: 0,
           totalFiles: undefined,
         },
-      }),
+      })
     );
 
     const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
@@ -1379,10 +1181,7 @@ export class S3TransferManager implements IS3TransferManager {
       this.checkAborted(transferOptions);
 
       if (request.filter) {
-        const include =
-          request.filter instanceof RegExp
-            ? request.filter.test(filePath)
-            : request.filter(filePath);
+        const include = request.filter instanceof RegExp ? request.filter.test(filePath) : request.filter(filePath);
         if (!include) continue;
       }
 
@@ -1392,10 +1191,7 @@ export class S3TransferManager implements IS3TransferManager {
 
       const count =
         fileStat.size >= this.multipartUploadThresholdBytes
-          ? Math.min(
-              Math.ceil(fileStat.size / this.targetPartSizeBytes),
-              this.maxConcurrentUploads,
-            )
+          ? Math.min(Math.ceil(fileStat.size / this.targetPartSizeBytes), this.maxConcurrentUploads)
           : 1;
 
       await semaphore.acquire(count);
@@ -1407,11 +1203,7 @@ export class S3TransferManager implements IS3TransferManager {
 
       const task = (async () => {
         try {
-          const key = this.deriveS3Key(
-            absoluteSource,
-            filePath,
-            request.s3Prefix,
-          );
+          const key = this.deriveS3Key(absoluteSource, filePath, request.s3Prefix);
 
           let putRequest: PutObjectCommandInput = {
             Bucket: request.bucket,
@@ -1440,7 +1232,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredFiles,
                 totalFiles: traversalComplete ? totalFiles : undefined,
               },
-            }),
+            })
           );
         } catch (error) {
           if (terminated || abortController.signal.aborted) {
@@ -1455,11 +1247,7 @@ export class S3TransferManager implements IS3TransferManager {
             },
             error,
           };
-          const result = await handleFailure(
-            failurePolicy,
-            context,
-            abortController,
-          );
+          const result = await handleFailure(failurePolicy, context, abortController);
           if (result === "terminate") {
             terminated = true;
             if (!terminationError) {
@@ -1492,7 +1280,7 @@ export class S3TransferManager implements IS3TransferManager {
             transferredFiles,
             totalFiles,
           },
-        }),
+        })
       );
       removeLocalEventListeners();
       throw terminationError;
@@ -1508,7 +1296,7 @@ export class S3TransferManager implements IS3TransferManager {
           transferredFiles,
           totalFiles,
         },
-      }),
+      })
     );
     removeLocalEventListeners();
     return { objectsUploaded, objectsFailed };
@@ -1526,7 +1314,7 @@ export class S3TransferManager implements IS3TransferManager {
    */
   public downloadDirectory(
     request: DownloadDirectoryRequest,
-    transferOptions?: TransferOptions,
+    transferOptions?: TransferOptions
   ): Promise<DownloadDirectoryResponse> {
     throw new Error("Method not implemented.");
   }
@@ -1544,7 +1332,7 @@ export class S3TransferManager implements IS3TransferManager {
     streams: Promise<StreamingBlobPayloadOutputTypes>[],
     requests: GetObjectCommandInput[],
     metadata: Omit<DownloadResponse, "Body">,
-    checksumValidationEnabled: boolean,
+    checksumValidationEnabled: boolean
   ): Promise<{
     totalSize: number | undefined;
     onStreamConsumed?: (index: number) => void;
@@ -1560,22 +1348,14 @@ export class S3TransferManager implements IS3TransferManager {
         ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
       };
       try {
-        const initialPart = await this.s3.send(
-          new GetObjectCommand(initialPartRequest),
-          transferOptions,
-        );
+        const initialPart = await this.s3.send(new GetObjectCommand(initialPartRequest), transferOptions);
         await internalEventHandler.afterInitialGetObject();
         const partSize = initialPart.ContentLength;
         const initialETag = initialPart.ETag ?? undefined;
-        totalSize = initialPart.ContentRange
-          ? Number.parseInt(initialPart.ContentRange.split("/")[1])
-          : 0;
+        totalSize = initialPart.ContentRange ? Number.parseInt(initialPart.ContentRange.split("/")[1]) : 0;
         this.dispatchTransferInitiatedEvent(request, totalSize);
         if (initialPart.Body) {
-          if (
-            initialPart.Body &&
-            typeof (initialPart.Body as any).getReader === "function"
-          ) {
+          if (initialPart.Body && typeof (initialPart.Body as any).getReader === "function") {
             const reader = (initialPart.Body as any).getReader();
             (initialPart.Body as any).getReader = function () {
               return reader;
@@ -1589,8 +1369,7 @@ export class S3TransferManager implements IS3TransferManager {
 
         let partCount = 1;
         if (initialPart.PartsCount! > 1) {
-          const partTasks: (() => Promise<StreamingBlobPayloadOutputTypes>)[] =
-            [];
+          const partTasks: (() => Promise<StreamingBlobPayloadOutputTypes>)[] = [];
           const partRequests: GetObjectCommandInput[] = [];
 
           for (let part = 2; part <= initialPart.PartsCount!; part++) {
@@ -1609,15 +1388,8 @@ export class S3TransferManager implements IS3TransferManager {
               return this.s3
                 .send(new GetObjectCommand(getObjectRequest), transferOptions)
                 .then((response) => {
-                  this.validatePartDownload(
-                    response.ContentRange,
-                    part,
-                    partSize ?? 0,
-                  );
-                  if (
-                    response.Body &&
-                    typeof (response.Body as any).getReader === "function"
-                  ) {
+                  this.validatePartDownload(response.ContentRange, part, partSize ?? 0);
+                  if (response.Body && typeof (response.Body as any).getReader === "function") {
                     const reader = (response.Body as any).getReader();
                     (response.Body as any).getReader = function () {
                       return reader;
@@ -1626,11 +1398,7 @@ export class S3TransferManager implements IS3TransferManager {
                   return response.Body!;
                 })
                 .catch((error) => {
-                  this.dispatchTransferFailedEvent(
-                    getObjectRequest,
-                    totalSize,
-                    error as Error,
-                  );
+                  this.dispatchTransferFailedEvent(getObjectRequest, totalSize, error as Error);
                   throw error;
                 });
             });
@@ -1639,11 +1407,10 @@ export class S3TransferManager implements IS3TransferManager {
           // Lazily prefetch streams — only maxConcurrentDownloads requests in-flight.
           // New requests fire as previous ones complete, and joinStreams can start
           // consuming immediately without waiting for all parts to be fetched.
-          const { promises: pendingStreams, onStreamConsumed } =
-            this.createConcurrentTaskPool(
-              partTasks,
-              this.maxConcurrentDownloads,
-            );
+          const { promises: pendingStreams, onStreamConsumed } = this.createConcurrentTaskPool(
+            partTasks,
+            this.maxConcurrentDownloads
+          );
           streams.push(...pendingStreams);
           requests.push(...partRequests);
           streamConsumedCallback = onStreamConsumed;
@@ -1651,7 +1418,7 @@ export class S3TransferManager implements IS3TransferManager {
 
           if (partCount !== initialPart.PartsCount) {
             throw new Error(
-              `The number of parts downloaded (${partCount}) does not match the expected number (${initialPart.PartsCount})`,
+              `The number of parts downloaded (${partCount}) does not match the expected number (${initialPart.PartsCount})`
             );
           }
         }
@@ -1670,13 +1437,8 @@ export class S3TransferManager implements IS3TransferManager {
           }),
         };
 
-        const getObject = await this.s3.send(
-          new GetObjectCommand(getObjectRequest),
-          transferOptions,
-        );
-        totalSize = getObject.ContentRange
-          ? Number.parseInt(getObject.ContentRange.split("/")[1])
-          : 0;
+        const getObject = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
+        totalSize = getObject.ContentRange ? Number.parseInt(getObject.ContentRange.split("/")[1]) : 0;
 
         this.dispatchTransferInitiatedEvent(request, totalSize);
         if (getObject.Body) {
@@ -1709,7 +1471,7 @@ export class S3TransferManager implements IS3TransferManager {
     streams: Promise<StreamingBlobPayloadOutputTypes>[],
     requests: GetObjectCommandInput[],
     metadata: Omit<DownloadResponse, "Body">,
-    checksumValidationEnabled: boolean,
+    checksumValidationEnabled: boolean
   ): Promise<{
     totalSize: number | undefined;
     onStreamConsumed?: (index: number) => void;
@@ -1719,7 +1481,7 @@ export class S3TransferManager implements IS3TransferManager {
 
     const headResponse = await this.s3.send(
       new HeadObjectCommand({ Bucket: request.Bucket, Key: request.Key }),
-      transferOptions,
+      transferOptions
     );
 
     if (headResponse.ContentLength === 0) {
@@ -1727,10 +1489,7 @@ export class S3TransferManager implements IS3TransferManager {
         ...request,
         ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
       };
-      const response = await this.s3.send(
-        new GetObjectCommand(getObjectRequest),
-        transferOptions,
-      );
+      const response = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
 
       this.dispatchTransferInitiatedEvent(request, 0);
       if (response.Body) streams.push(Promise.resolve(response.Body));
@@ -1748,18 +1507,10 @@ export class S3TransferManager implements IS3TransferManager {
     let initialETag: string | undefined;
 
     if (request.Range != null) {
-      const [userRangeLeft, userRangeRight] = request.Range.replace(
-        "bytes=",
-        "",
-      )
-        .split("-")
-        .map(Number);
+      const [userRangeLeft, userRangeRight] = request.Range.replace("bytes=", "").split("-").map(Number);
       maxRange = userRangeRight;
       left = userRangeLeft;
-      right = Math.min(
-        userRangeRight,
-        left + S3TransferManager.MIN_PART_SIZE - 1,
-      );
+      right = Math.min(userRangeRight, left + S3TransferManager.MIN_PART_SIZE - 1);
       totalSize = userRangeRight + 1;
     }
 
@@ -1769,15 +1520,9 @@ export class S3TransferManager implements IS3TransferManager {
         Range: `bytes=${left}-${right}`,
         ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
       };
-      const initialRangeGet = await this.s3.send(
-        new GetObjectCommand(getObjectRequest),
-        transferOptions,
-      );
+      const initialRangeGet = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
       await internalEventHandler.afterInitialGetObject();
-      this.validateRangeDownload(
-        `bytes=${left}-${right}`,
-        initialRangeGet.ContentRange,
-      );
+      this.validateRangeDownload(`bytes=${left}-${right}`, initialRangeGet.ContentRange);
       initialETag = initialRangeGet.ETag ?? undefined;
       if (!totalSize) {
         totalSize = initialRangeGet.ContentRange
@@ -1785,10 +1530,7 @@ export class S3TransferManager implements IS3TransferManager {
           : undefined;
       }
 
-      if (
-        initialRangeGet.Body &&
-        typeof (initialRangeGet.Body as any).getReader === "function"
-      ) {
+      if (initialRangeGet.Body && typeof (initialRangeGet.Body as any).getReader === "function") {
         const reader = (initialRangeGet.Body as any).getReader();
         (initialRangeGet.Body as any).getReader = function () {
           return reader;
@@ -1808,17 +1550,13 @@ export class S3TransferManager implements IS3TransferManager {
     if (totalSize) {
       const contentLength = totalSize;
       const remainingBytes = Math.max(0, contentLength - (right - left + 1));
-      const additionalRequests = Math.ceil(
-        remainingBytes / S3TransferManager.MIN_PART_SIZE,
-      );
+      const additionalRequests = Math.ceil(remainingBytes / S3TransferManager.MIN_PART_SIZE);
       expectedRequestCount += additionalRequests;
     }
 
     left = right + 1;
     right = Math.min(left + S3TransferManager.MIN_PART_SIZE - 1, maxRange);
-    remainingLength = totalSize
-      ? Math.min(right - left + 1, Math.max(0, totalSize - left))
-      : 0;
+    remainingLength = totalSize ? Math.min(right - left + 1, Math.max(0, totalSize - left)) : 0;
     const rangeTasks: (() => Promise<StreamingBlobPayloadOutputTypes>)[] = [];
     const rangeRequests: GetObjectCommandInput[] = [];
 
@@ -1838,10 +1576,7 @@ export class S3TransferManager implements IS3TransferManager {
           .send(new GetObjectCommand(getObjectRequest), transferOptions)
           .then((response) => {
             this.validateRangeDownload(range, response.ContentRange);
-            if (
-              response.Body &&
-              typeof (response.Body as any).getReader === "function"
-            ) {
+            if (response.Body && typeof (response.Body as any).getReader === "function") {
               const reader = (response.Body as any).getReader();
               (response.Body as any).getReader = function () {
                 return reader;
@@ -1850,28 +1585,24 @@ export class S3TransferManager implements IS3TransferManager {
             return response.Body!;
           })
           .catch((error) => {
-            this.dispatchTransferFailedEvent(
-              getObjectRequest,
-              totalSize,
-              error,
-            );
+            this.dispatchTransferFailedEvent(getObjectRequest, totalSize, error);
             throw error;
           });
       });
 
       left = right + 1;
       right = Math.min(left + S3TransferManager.MIN_PART_SIZE - 1, maxRange);
-      remainingLength = totalSize
-        ? Math.min(right - left + 1, Math.max(0, totalSize - left))
-        : 0;
+      remainingLength = totalSize ? Math.min(right - left + 1, Math.max(0, totalSize - left)) : 0;
     }
 
     if (rangeTasks.length > 0) {
       // Lazily prefetch streams — only maxConcurrentDownloads requests in-flight.
       // New requests fire as previous ones complete, and joinStreams can start
       // consuming immediately without waiting for all ranges to be fetched.
-      const { promises: pendingStreams, onStreamConsumed } =
-        this.createConcurrentTaskPool(rangeTasks, this.maxConcurrentDownloads);
+      const { promises: pendingStreams, onStreamConsumed } = this.createConcurrentTaskPool(
+        rangeTasks,
+        this.maxConcurrentDownloads
+      );
       streams.push(...pendingStreams);
       requests.push(...rangeRequests);
       streamConsumedCallback = onStreamConsumed;
@@ -1880,7 +1611,7 @@ export class S3TransferManager implements IS3TransferManager {
     const actualRequestCount = 1 + rangeTasks.length;
     if (expectedRequestCount !== actualRequestCount) {
       throw new Error(
-        `The number of ranged GET requests sent (${actualRequestCount}) does not match the expected number (${expectedRequestCount})`,
+        `The number of ranged GET requests sent (${actualRequestCount}) does not match the expected number (${expectedRequestCount})`
       );
     }
 
@@ -1900,7 +1631,6 @@ export class S3TransferManager implements IS3TransferManager {
    * and transfer ownership back to main (zero-copy). The OrderedPartQueue delivers
    * parts sequentially to the consumer stream regardless of arrival order.
    *
-   * @internal
    */
   private async downloadByPartWithWorkers(
     request: DownloadRequest,
@@ -1908,7 +1638,7 @@ export class S3TransferManager implements IS3TransferManager {
     streams: Promise<StreamingBlobPayloadOutputTypes>[],
     requests: GetObjectCommandInput[],
     metadata: Omit<DownloadResponse, "Body">,
-    checksumValidationEnabled: boolean,
+    checksumValidationEnabled: boolean
   ): Promise<{
     totalSize: number | undefined;
     onStreamConsumed?: (index: number) => void;
@@ -1924,10 +1654,7 @@ export class S3TransferManager implements IS3TransferManager {
       ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
     };
 
-    const initialPart = await this.s3.send(
-      new GetObjectCommand(initialPartRequest),
-      transferOptions,
-    );
+    const initialPart = await this.s3.send(new GetObjectCommand(initialPartRequest), transferOptions);
     await internalEventHandler.afterInitialGetObject();
 
     const partSize = initialPart.ContentLength!;
@@ -2042,23 +1769,27 @@ export class S3TransferManager implements IS3TransferManager {
             const transferResult = (
               this.s3.config.requestHandler as unknown as WorkerHttpHandler
             ).getStreamDownloadResult(resultToken);
-            if (transferResult) {
-              queue.enqueue(
-                rangeIndex,
-                transferResult.buffer,
-                transferResult.byteLength,
-              );
-
-              this.dispatchEvent(
-                Object.assign(new Event("bytesTransferred"), {
-                  request: partGetRequest,
-                  snapshot: {
-                    transferredBytes: transferResult.byteLength,
-                    totalBytes: totalSize,
-                  },
-                }),
-              );
+            if (!transferResult) {
+              queue.setError(new Error(`Missing download result for part ${partNumber}`));
+              abortController.abort();
+              releaseSlot();
+              return;
             }
+
+            // Validate ContentRange matches expected part boundaries
+            this.validatePartDownload(transferResult.headers["content-range"], partNumber, partSize);
+
+            queue.enqueue(rangeIndex, transferResult.buffer, transferResult.byteLength);
+
+            this.dispatchEvent(
+              Object.assign(new Event("bytesTransferred"), {
+                request: partGetRequest,
+                snapshot: {
+                  transferredBytes: transferResult.byteLength,
+                  totalBytes: totalSize,
+                },
+              })
+            );
             releaseSlot();
           })
           .catch((error) => {
@@ -2113,11 +1844,7 @@ export class S3TransferManager implements IS3TransferManager {
       },
     });
 
-    streams.push(
-      Promise.resolve(
-        transferStream as unknown as StreamingBlobPayloadOutputTypes,
-      ),
-    );
+    streams.push(Promise.resolve(transferStream as unknown as StreamingBlobPayloadOutputTypes));
 
     return { totalSize };
   }
@@ -2131,8 +1858,6 @@ export class S3TransferManager implements IS3TransferManager {
    * Memory is bounded by maxConcurrentDownloads in-flight buffers plus the
    * reorder window in the queue. Backpressure is applied via a concurrency
    * limiter — dispatch blocks when all slots are in use.
-   *
-   * @internal
    */
   private async downloadByRangeWithWorkers(
     request: DownloadRequest,
@@ -2140,7 +1865,7 @@ export class S3TransferManager implements IS3TransferManager {
     streams: Promise<StreamingBlobPayloadOutputTypes>[],
     requests: GetObjectCommandInput[],
     metadata: Omit<DownloadResponse, "Body">,
-    checksumValidationEnabled: boolean,
+    checksumValidationEnabled: boolean
   ): Promise<{
     totalSize: number | undefined;
     onStreamConsumed?: (index: number) => void;
@@ -2149,7 +1874,7 @@ export class S3TransferManager implements IS3TransferManager {
 
     const headResponse = await this.s3.send(
       new HeadObjectCommand({ Bucket: request.Bucket, Key: request.Key }),
-      transferOptions,
+      transferOptions
     );
     await internalEventHandler.afterInitialGetObject();
 
@@ -2158,10 +1883,7 @@ export class S3TransferManager implements IS3TransferManager {
         ...request,
         ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
       };
-      const response = await this.s3.send(
-        new GetObjectCommand(getObjectRequest),
-        transferOptions,
-      );
+      const response = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
 
       this.dispatchTransferInitiatedEvent(request, 0);
       if (response.Body) streams.push(Promise.resolve(response.Body));
@@ -2222,7 +1944,7 @@ export class S3TransferManager implements IS3TransferManager {
       }
     };
 
-    // Dispatch all range requests via the SDK pipeline (WorkerHttpHandler intercepts them).
+    // Dispatch remaining range requests via the SDK pipeline (WorkerHttpHandler intercepts them).
     // Concurrency limiter provides backpressure — waitForSlot blocks when all slots are in use.
     const dispatchPromise = (async () => {
       for (let rangeIndex = 0; rangeIndex < totalParts; rangeIndex++) {
@@ -2269,23 +1991,27 @@ export class S3TransferManager implements IS3TransferManager {
             const transferResult = (
               this.s3.config.requestHandler as unknown as WorkerHttpHandler
             ).getStreamDownloadResult(resultToken);
-            if (transferResult) {
-              queue.enqueue(
-                rangeIndex,
-                transferResult.buffer,
-                transferResult.byteLength,
-              );
-
-              this.dispatchEvent(
-                Object.assign(new Event("bytesTransferred"), {
-                  request: rangeGetRequest,
-                  snapshot: {
-                    transferredBytes: transferResult.byteLength,
-                    totalBytes: totalSize,
-                  },
-                }),
-              );
+            if (!transferResult) {
+              queue.setError(new Error(`Missing download result for range ${start}-${end}`));
+              abortController.abort();
+              releaseSlot();
+              return;
             }
+
+            // Validate ContentRange matches the requested byte range
+            this.validateRangeDownload(`bytes=${start}-${end}`, transferResult.headers["content-range"]);
+
+            queue.enqueue(rangeIndex, transferResult.buffer, transferResult.byteLength);
+
+            this.dispatchEvent(
+              Object.assign(new Event("bytesTransferred"), {
+                request: rangeGetRequest,
+                snapshot: {
+                  transferredBytes: transferResult.byteLength,
+                  totalBytes: totalSize,
+                },
+              })
+            );
             releaseSlot();
           })
           .catch((error) => {
@@ -2335,51 +2061,35 @@ export class S3TransferManager implements IS3TransferManager {
       },
     });
 
-    streams.push(
-      Promise.resolve(
-        transferStream as unknown as StreamingBlobPayloadOutputTypes,
-      ),
-    );
+    streams.push(Promise.resolve(transferStream as unknown as StreamingBlobPayloadOutputTypes));
 
     return { totalSize };
   }
 
   /**
    * Adds all event listeners from provided collection to the transfer manager.
-   *
-   * @internal
    */
   private addEventListeners(eventListeners?: TransferEventListeners): void {
     for (const listeners of this.iterateListeners(eventListeners)) {
       for (const listener of listeners) {
-        this.addEventListener(
-          listener.eventType,
-          listener.callback as EventListener,
-        );
+        this.addEventListener(listener.eventType, listener.callback as EventListener);
       }
     }
   }
 
   /**
-   * Removes event listeners from provided collection from the transfer manager.
    *
-   * @internal
    */
   private removeEventListeners(eventListeners?: TransferEventListeners): void {
     for (const listeners of this.iterateListeners(eventListeners)) {
       for (const listener of listeners) {
-        this.removeEventListener(
-          listener.eventType,
-          listener.callback as EventListener,
-        );
+        this.removeEventListener(listener.eventType, listener.callback as EventListener);
       }
     }
   }
 
   /**
    * Copies all response properties except Body to the container object.
-   *
-   * @internal
    */
   private assignMetadata(container: any, response: any) {
     for (const key in response) {
@@ -2392,15 +2102,13 @@ export class S3TransferManager implements IS3TransferManager {
 
   /**
    * Builds the final DownloadToFileResponse from the initial response metadata.
-   * Copies all metadata fields, overrides ContentLength/ContentRange for the full object,
    * nulls checksum fields for COMPOSITE types, and dispatches the transferComplete event.
    *
-   * @internal
    */
   private buildDownloadToFileResponse(
     initialResponse: DownloadResponse,
     totalSize: number,
-    request: DownloadToFileRequest,
+    request: DownloadToFileRequest
   ): DownloadToFileResponse {
     const metadata: Record<string, any> = {};
     this.assignMetadata(metadata, initialResponse);
@@ -2427,24 +2135,22 @@ export class S3TransferManager implements IS3TransferManager {
           transferredBytes: totalSize,
           totalBytes: totalSize,
         },
-      }),
+      })
     );
 
     return response;
   }
 
   /**
-   * Handles cleanup on download failure: deletes the temp file,
    * unregisters process handlers, and dispatches transferFailed event.
    *
-   * @internal
    */
   private async handleDownloadCleanup(
     fileManager: FileManager,
     tempFilePath: string,
     request: DownloadToFileRequest,
     totalSize: number,
-    error: unknown,
+    error: unknown
   ): Promise<void> {
     await fileManager.deleteTempFile(tempFilePath);
     fileManager.unregisterCleanupHandler(tempFilePath);
@@ -2454,12 +2160,8 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Updates response ContentLength and ContentRange based on total object size.
    *
-   * @internal
    */
-  private updateResponseLengthAndRange(
-    response: DownloadResponse,
-    totalSize: number | undefined,
-  ): void {
+  private updateResponseLengthAndRange(response: DownloadResponse, totalSize: number | undefined): void {
     if (totalSize !== undefined) {
       response.ContentLength = totalSize;
       response.ContentRange = `bytes 0-${totalSize - 1}/${totalSize}`;
@@ -2469,12 +2171,8 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Clears checksum values for composite multipart downloads.
    *
-   * @internal
    */
-  private updateChecksumValues(
-    initialPart: DownloadResponse,
-    metadata: Omit<DownloadResponse, "Body">,
-  ) {
+  private updateChecksumValues(initialPart: DownloadResponse, metadata: Omit<DownloadResponse, "Body">) {
     if (initialPart.ChecksumType === "COMPOSITE") {
       metadata.ChecksumCRC32 = undefined;
       metadata.ChecksumCRC32C = undefined;
@@ -2486,12 +2184,11 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Processes response metadata by updating length, copying properties, and handling checksums.
    *
-   * @internal
    */
   private processResponseMetadata(
     response: DownloadResponse,
     metadata: Omit<DownloadResponse, "Body">,
-    totalSize: number | undefined,
+    totalSize: number | undefined
   ): void {
     this.updateResponseLengthAndRange(response, totalSize);
     this.assignMetadata(metadata, response);
@@ -2501,7 +2198,6 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Throws AbortError if the transfer has been aborted via signal.
    *
-   * @internal
    */
   private checkAborted(transferOptions?: TransferOptions): void {
     if (transferOptions?.abortSignal?.aborted) {
@@ -2514,25 +2210,18 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Validates if configuration parameters meets minimum requirements.
    *
-   * @internal
    */
   private validateConfig(): void {
     if (this.targetPartSizeBytes < S3TransferManager.MIN_PART_SIZE) {
-      throw new Error(
-        `targetPartSizeBytes must be at least ${S3TransferManager.MIN_PART_SIZE} bytes`,
-      );
+      throw new Error(`targetPartSizeBytes must be at least ${S3TransferManager.MIN_PART_SIZE} bytes`);
     }
   }
 
   /**
    * Dispatches transferInitiated event with initial progress snapshot.
    *
-   * @internal
    */
-  private dispatchTransferInitiatedEvent(
-    request: DownloadRequest | UploadRequest,
-    totalSize?: number,
-  ): boolean {
+  private dispatchTransferInitiatedEvent(request: DownloadRequest | UploadRequest, totalSize?: number): boolean {
     this.dispatchEvent(
       Object.assign(new Event("transferInitiated"), {
         request,
@@ -2540,7 +2229,7 @@ export class S3TransferManager implements IS3TransferManager {
           transferredBytes: 0,
           totalBytes: totalSize,
         },
-      }),
+      })
     );
     return true;
   }
@@ -2548,12 +2237,11 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Dispatches transferFailed event with error details and progress snapshot.
    *
-   * @internal
    */
   private dispatchTransferFailedEvent(
     request: DownloadRequest | UploadRequest,
     totalSize?: number,
-    error?: Error,
+    error?: Error
   ): boolean {
     this.dispatchEvent(
       Object.assign(new Event("transferFailed"), {
@@ -2563,7 +2251,7 @@ export class S3TransferManager implements IS3TransferManager {
           transferredBytes: 0,
           totalBytes: totalSize,
         },
-      }),
+      })
     );
     return true;
   }
@@ -2571,13 +2259,11 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Generator that yields event listeners from the provided collection for iteration.
    *
-   * @internal
    */
   private *iterateListeners(eventListeners: TransferEventListeners = {}) {
     for (const key in eventListeners) {
       const eventType = key as keyof TransferEventListeners;
-      const listeners =
-        eventListeners[eventType as keyof TransferEventListeners];
+      const listeners = eventListeners[eventType as keyof TransferEventListeners];
       if (Array.isArray(listeners)) {
         for (const callback of listeners) {
           yield [
@@ -2600,14 +2286,12 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @param tasks - Array of deferred task functions, each returning a promise.
    * @param maxConcurrent - Maximum number of HTTP requests in-flight at any time.
-   * @returns An object containing the array of promises (one per task) and an `onStreamConsumed` callback
    *          to signal that a stream has been consumed and the next task can be launched.
    *
-   * @internal
    */
   private createConcurrentTaskPool<T>(
     tasks: (() => Promise<T>)[],
-    maxConcurrent: number,
+    maxConcurrent: number
   ): {
     promises: Promise<T>[];
     onStreamConsumed: (index: number) => void;
@@ -2640,7 +2324,7 @@ export class S3TransferManager implements IS3TransferManager {
         (error) => {
           failed = true;
           resolvers[index].reject(error);
-        },
+        }
       );
     };
 
@@ -2661,13 +2345,8 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Validates part download ContentRange matches expected part boundaries.
    *
-   * @internal
    */
-  private validatePartDownload(
-    contentRange: string | undefined,
-    partNumber: number,
-    partSize: number,
-  ) {
+  private validatePartDownload(contentRange: string | undefined, partNumber: number, partSize: number) {
     if (!contentRange) {
       throw new Error(`Missing ContentRange for part ${partNumber}.`);
     }
@@ -2683,34 +2362,25 @@ export class S3TransferManager implements IS3TransferManager {
     const expectedEnd = Math.min(expectedStart + partSize - 1, total);
 
     if (start !== expectedStart) {
-      throw new Error(
-        `Expected part ${partNumber} to start at ${expectedStart} but got ${start}`,
-      );
+      throw new Error(`Expected part ${partNumber} to start at ${expectedStart} but got ${start}`);
     }
 
     if (end !== expectedEnd) {
-      throw new Error(
-        `Expected part ${partNumber} to end at ${expectedEnd} but got ${end}`,
-      );
+      throw new Error(`Expected part ${partNumber} to end at ${expectedEnd} but got ${end}`);
     }
   }
 
   /**
    * Validates range download ContentRange matches requested byte range.
    *
-   * @internal
    */
-  private validateRangeDownload(
-    requestRange: string,
-    responseRange: string | undefined,
-  ) {
+  private validateRangeDownload(requestRange: string, responseRange: string | undefined) {
     if (!responseRange) {
       throw new Error(`Missing ContentRange for range ${requestRange}.`);
     }
 
     const match = responseRange.match(/bytes (\d+)-(\d+)\/(\d+)/);
-    if (!match)
-      throw new Error(`Invalid ContentRange format: ${responseRange}`);
+    if (!match) throw new Error(`Invalid ContentRange format: ${responseRange}`);
 
     const start = Number.parseInt(match[1]);
     const end = Number.parseInt(match[2]);
@@ -2723,9 +2393,7 @@ export class S3TransferManager implements IS3TransferManager {
     const expectedEnd = Number.parseInt(rangeMatch[2]);
 
     if (start !== expectedStart) {
-      throw new Error(
-        `Expected range to start at ${expectedStart} but got ${start}`,
-      );
+      throw new Error(`Expected range to start at ${expectedStart} but got ${start}`);
     }
 
     if (end === expectedEnd) {
@@ -2740,23 +2408,18 @@ export class S3TransferManager implements IS3TransferManager {
   }
 
   /**
-   * Uploads a single object to S3 using PutObject operation.
    * Used when content length is below the multipart upload threshold.
    *
-   * @internal
    */
   private async uploadSinglePart(
     request: UploadRequest,
     contentLength: number,
-    transferOptions?: TransferOptions,
+    transferOptions?: TransferOptions
   ): Promise<PutObjectCommandOutput> {
     const putObjectRequest: PutObjectCommandInput = { ...request };
 
     this.checkAborted(transferOptions);
-    const response = await this.s3.send(
-      new PutObjectCommand(putObjectRequest),
-      transferOptions,
-    );
+    const response = await this.s3.send(new PutObjectCommand(putObjectRequest), transferOptions);
 
     this.dispatchEvent(
       Object.assign(new Event("bytesTransferred"), {
@@ -2765,7 +2428,7 @@ export class S3TransferManager implements IS3TransferManager {
           transferredBytes: contentLength,
           totalBytes: contentLength,
         },
-      }),
+      })
     );
 
     return response;
@@ -2774,33 +2437,23 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Calculates part size and expected parts count.
    *
-   * @internal
    */
   private calculatePartSize(contentLength: number): {
     partSize: number;
     expectedPartsCount: number;
   } {
-    const partSize = Math.max(
-      this.targetPartSizeBytes,
-      Math.ceil(contentLength / 10_000),
-    );
+    const partSize = Math.max(this.targetPartSizeBytes, Math.ceil(contentLength / 10_000));
     const expectedPartsCount = Math.ceil(contentLength / partSize);
     return { partSize, expectedPartsCount };
   }
-
   /**
    * Checks if the body is a file read stream with a .path property.
-   * @internal
    */
   private isFileBody(body: any): boolean {
-    return (
-      typeof body?.pipe === "function" && typeof (body as any).path === "string"
-    );
+    return typeof body?.pipe === "function" && typeof (body as any).path === "string";
   }
-
   /**
    * Checks if the body is fully in memory (Buffer, Uint8Array, or string).
-   * @internal
    */
   private isInMemoryBody(body: any): body is Uint8Array | string {
     return body instanceof Uint8Array || typeof body === "string";
@@ -2808,23 +2461,18 @@ export class S3TransferManager implements IS3TransferManager {
 
   /**
    * Uploads using worker threads from a file source. Workers read file slices
-   * directly from disk, compute checksum, and send data in aws-chunked format
    * with trailing checksums.
    *
-   * @internal
    */
   private async threadedUploadInPartsFromFile(
     request: UploadRequest,
     contentLength: number,
-    transferOptions?: TransferOptions,
+    transferOptions?: TransferOptions
   ): Promise<CompleteMultipartUploadCommandOutput> {
     const { partSize } = this.calculatePartSize(contentLength);
     const filePath = (request.Body as any).path as string;
 
-    const buildDataSource = (
-      checksumAlgorithm?: string,
-      checksumHeader?: string,
-    ): DataSource => ({
+    const buildDataSource = (checksumAlgorithm?: string, checksumHeader?: string): DataSource => ({
       type: "file",
       filePath,
       partSize,
@@ -2833,25 +2481,18 @@ export class S3TransferManager implements IS3TransferManager {
       checksumHeader,
     });
 
-    return this.threadedMultipartUpload(
-      request,
-      contentLength,
-      buildDataSource,
-      transferOptions,
-    );
+    return this.threadedMultipartUpload(request, contentLength, buildDataSource, transferOptions);
   }
 
   /**
    * Uploads using worker threads with in-memory data. Copies the user's Buffer
-   * into a SharedArrayBuffer once, then workers read slices by offset —
    * zero-copy per part.
    *
-   * @internal
    */
   private async threadedUploadInParts(
     request: UploadRequest,
     contentLength: number,
-    transferOptions?: TransferOptions,
+    transferOptions?: TransferOptions
   ): Promise<CompleteMultipartUploadCommandOutput> {
     const { partSize } = this.calculatePartSize(contentLength);
     const body = request.Body as Uint8Array;
@@ -2860,10 +2501,7 @@ export class S3TransferManager implements IS3TransferManager {
     const sharedBuffer = new SharedArrayBuffer(body.byteLength);
     new Uint8Array(sharedBuffer).set(body);
 
-    const buildDataSource = (
-      checksumAlgorithm?: string,
-      checksumHeader?: string,
-    ): DataSource => ({
+    const buildDataSource = (checksumAlgorithm?: string, checksumHeader?: string): DataSource => ({
       type: "sharedBuffer",
       sharedBuffer,
       partSize,
@@ -2872,33 +2510,22 @@ export class S3TransferManager implements IS3TransferManager {
       checksumHeader,
     });
 
-    return this.threadedMultipartUpload(
-      request,
-      contentLength,
-      buildDataSource,
-      transferOptions,
-    );
+    return this.threadedMultipartUpload(request, contentLength, buildDataSource, transferOptions);
   }
 
   /**
    * Common implementation for threaded multipart uploads.
    * Handles CreateMPU, concurrent UploadPart dispatch, and CompleteMPU/AbortMPU.
-   * The buildDataSource factory is called with checksum info to produce the
    * per-request data source passed to the WorkerHttpHandler.
    *
-   * @internal
    */
   private async threadedMultipartUpload(
     request: UploadRequest,
     contentLength: number,
-    buildDataSource: (
-      checksumAlgorithm?: string,
-      checksumHeader?: string,
-    ) => DataSource,
-    transferOptions?: TransferOptions,
+    buildDataSource: (checksumAlgorithm?: string, checksumHeader?: string) => DataSource,
+    transferOptions?: TransferOptions
   ): Promise<CompleteMultipartUploadCommandOutput> {
-    const { partSize, expectedPartsCount } =
-      this.calculatePartSize(contentLength);
+    const { partSize, expectedPartsCount } = this.calculatePartSize(contentLength);
 
     this.checkAborted(transferOptions);
 
@@ -2914,23 +2541,15 @@ export class S3TransferManager implements IS3TransferManager {
     if (hasFullObjectChecksum) {
       createMpuRequest.ChecksumType = "FULL_OBJECT";
     }
-    if (
-      !createMpuRequest.ChecksumAlgorithm &&
-      this.requestChecksumCalculation === "WHEN_SUPPORTED"
-    ) {
+    if (!createMpuRequest.ChecksumAlgorithm && this.requestChecksumCalculation === "WHEN_SUPPORTED") {
       createMpuRequest.ChecksumAlgorithm = request.ChecksumAlgorithm ?? "CRC32";
     }
 
-    const createMpuResponse = await this.s3.send(
-      new CreateMultipartUploadCommand(createMpuRequest),
-      transferOptions,
-    );
+    const createMpuResponse = await this.s3.send(new CreateMultipartUploadCommand(createMpuRequest), transferOptions);
     const uploadId = createMpuResponse.UploadId!;
 
     const checksumAlgorithm = createMpuRequest.ChecksumAlgorithm;
-    const checksumHeader = checksumAlgorithm
-      ? `x-amz-checksum-${checksumAlgorithm.toLowerCase()}`
-      : undefined;
+    const checksumHeader = checksumAlgorithm ? `x-amz-checksum-${checksumAlgorithm.toLowerCase()}` : undefined;
     const dataSource = buildDataSource(checksumAlgorithm, checksumHeader);
 
     const abortController = new AbortController();
@@ -2947,10 +2566,7 @@ export class S3TransferManager implements IS3TransferManager {
           if (partNumber > expectedPartsCount) return;
 
           if (uploadAbortSignal.aborted) {
-            throw Object.assign(
-              new Error("Upload aborted due to part failure."),
-              { name: "AbortError" },
-            );
+            throw Object.assign(new Error("Upload aborted due to part failure."), { name: "AbortError" });
           }
           this.checkAborted(transferOptions);
 
@@ -2973,28 +2589,20 @@ export class S3TransferManager implements IS3TransferManager {
             }),
           };
 
-          const partResponse = await this.s3.send(
-            new UploadPartCommand(partRequest),
-            {
-              ...transferOptions,
-              dataSource,
-            } as any,
-          );
+          const partResponse = await this.s3.send(new UploadPartCommand(partRequest), {
+            ...transferOptions,
+            dataSource,
+          } as any);
 
           const completedPart: CompletedPart = {
             PartNumber: partNumber,
             ETag: partResponse.ETag,
           };
-          if (partResponse.ChecksumCRC32)
-            completedPart.ChecksumCRC32 = partResponse.ChecksumCRC32;
-          if (partResponse.ChecksumCRC32C)
-            completedPart.ChecksumCRC32C = partResponse.ChecksumCRC32C;
-          if (partResponse.ChecksumCRC64NVME)
-            completedPart.ChecksumCRC64NVME = partResponse.ChecksumCRC64NVME;
-          if (partResponse.ChecksumSHA1)
-            completedPart.ChecksumSHA1 = partResponse.ChecksumSHA1;
-          if (partResponse.ChecksumSHA256)
-            completedPart.ChecksumSHA256 = partResponse.ChecksumSHA256;
+          if (partResponse.ChecksumCRC32) completedPart.ChecksumCRC32 = partResponse.ChecksumCRC32;
+          if (partResponse.ChecksumCRC32C) completedPart.ChecksumCRC32C = partResponse.ChecksumCRC32C;
+          if (partResponse.ChecksumCRC64NVME) completedPart.ChecksumCRC64NVME = partResponse.ChecksumCRC64NVME;
+          if (partResponse.ChecksumSHA1) completedPart.ChecksumSHA1 = partResponse.ChecksumSHA1;
+          if (partResponse.ChecksumSHA256) completedPart.ChecksumSHA256 = partResponse.ChecksumSHA256;
 
           completedParts.push(completedPart);
           bytesUploaded += length;
@@ -3006,7 +2614,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredBytes: bytesUploaded,
                 totalBytes: contentLength,
               },
-            }),
+            })
           );
         }
       };
@@ -3017,16 +2625,14 @@ export class S3TransferManager implements IS3TransferManager {
           uploadPart().catch((error) => {
             abortController.abort();
             throw error;
-          }),
+          })
         );
       }
 
       await Promise.all(partUploads);
 
       if (completedParts.length !== expectedPartsCount) {
-        throw new Error(
-          `Expected ${expectedPartsCount} parts but uploaded ${completedParts.length} parts`,
-        );
+        throw new Error(`Expected ${expectedPartsCount} parts but uploaded ${completedParts.length} parts`);
       }
 
       completedParts.sort((a, b) => a.PartNumber! - b.PartNumber!);
@@ -3042,22 +2648,16 @@ export class S3TransferManager implements IS3TransferManager {
 
       if (hasFullObjectChecksum) {
         completeRequest.ChecksumType = "FULL_OBJECT";
-        if (request.ChecksumCRC32)
-          completeRequest.ChecksumCRC32 = request.ChecksumCRC32;
-        if (request.ChecksumCRC32C)
-          completeRequest.ChecksumCRC32C = request.ChecksumCRC32C;
-        if (request.ChecksumCRC64NVME)
-          completeRequest.ChecksumCRC64NVME = request.ChecksumCRC64NVME;
+        if (request.ChecksumCRC32) completeRequest.ChecksumCRC32 = request.ChecksumCRC32;
+        if (request.ChecksumCRC32C) completeRequest.ChecksumCRC32C = request.ChecksumCRC32C;
+        if (request.ChecksumCRC64NVME) completeRequest.ChecksumCRC64NVME = request.ChecksumCRC64NVME;
       }
 
       try {
-        return await this.s3.send(
-          new CompleteMultipartUploadCommand(completeRequest),
-          transferOptions,
-        );
+        return await this.s3.send(new CompleteMultipartUploadCommand(completeRequest), transferOptions);
       } catch (completeMpuError) {
         this.logger.warn(
-          `CompleteMultipartUpload failed for upload ID ${uploadId}: ${(completeMpuError as Error).message}`,
+          `CompleteMultipartUpload failed for upload ID ${uploadId}: ${(completeMpuError as Error).message}`
         );
         throw completeMpuError;
       }
@@ -3069,15 +2669,9 @@ export class S3TransferManager implements IS3TransferManager {
       };
 
       try {
-        await this.s3.send(
-          new AbortMultipartUploadCommand(abortRequest),
-          transferOptions,
-        );
+        await this.s3.send(new AbortMultipartUploadCommand(abortRequest), transferOptions);
       } catch (abortError) {
-        this.logger.warn(
-          `Failed to abort multipart upload ${uploadId}:`,
-          abortError,
-        );
+        this.logger.warn(`Failed to abort multipart upload ${uploadId}:`, abortError);
       }
       throw error;
     }
@@ -3086,18 +2680,15 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Uploads an object to S3 using multipart upload operation.
    * Used when content length exceeds the multipart upload threshold.
-   * Streams the body chunk-by-chunk via getChunk without buffering
    * the entire content into memory.
    *
-   * @internal
    */
   private async uploadInParts(
     request: UploadRequest,
     contentLength: number,
-    transferOptions?: TransferOptions,
+    transferOptions?: TransferOptions
   ): Promise<CompleteMultipartUploadCommandOutput> {
-    const { partSize, expectedPartsCount } =
-      this.calculatePartSize(contentLength);
+    const { partSize, expectedPartsCount } = this.calculatePartSize(contentLength);
 
     this.checkAborted(transferOptions);
 
@@ -3114,16 +2705,10 @@ export class S3TransferManager implements IS3TransferManager {
     if (hasFullObjectChecksum) {
       createMpuRequest.ChecksumType = "FULL_OBJECT";
     }
-    if (
-      !createMpuRequest.ChecksumAlgorithm &&
-      this.requestChecksumCalculation === "WHEN_SUPPORTED"
-    ) {
+    if (!createMpuRequest.ChecksumAlgorithm && this.requestChecksumCalculation === "WHEN_SUPPORTED") {
       createMpuRequest.ChecksumAlgorithm = request.ChecksumAlgorithm ?? "CRC32";
     }
-    const createMpuResponse = await this.s3.send(
-      new CreateMultipartUploadCommand(createMpuRequest),
-      transferOptions,
-    );
+    const createMpuResponse = await this.s3.send(new CreateMultipartUploadCommand(createMpuRequest), transferOptions);
     const uploadId = createMpuResponse.UploadId!;
 
     const abortController = new AbortController();
@@ -3134,15 +2719,10 @@ export class S3TransferManager implements IS3TransferManager {
       const dataFeeder = getChunk(request.Body, partSize);
       let bytesUploaded = 0;
 
-      const uploadPart = async (
-        dataFeeder: AsyncGenerator<RawDataPart, void, undefined>,
-      ) => {
+      const uploadPart = async (dataFeeder: AsyncGenerator<RawDataPart, void, undefined>) => {
         for await (const dataPart of dataFeeder) {
           if (uploadAbortSignal.aborted) {
-            throw Object.assign(
-              new Error("Upload aborted due to part failure."),
-              { name: "AbortError" },
-            );
+            throw Object.assign(new Error("Upload aborted due to part failure."), { name: "AbortError" });
           }
           this.checkAborted(transferOptions);
 
@@ -3159,10 +2739,7 @@ export class S3TransferManager implements IS3TransferManager {
             }),
           };
 
-          const partResponse = await this.s3.send(
-            new UploadPartCommand(partRequest),
-            transferOptions,
-          );
+          const partResponse = await this.s3.send(new UploadPartCommand(partRequest), transferOptions);
 
           const checksumAlgorithm = partRequest.ChecksumAlgorithm;
           if (
@@ -3175,7 +2752,7 @@ export class S3TransferManager implements IS3TransferManager {
           ) {
             throw new Error(
               `Checksum was requested for part ${dataPart.partNumber} using ${checksumAlgorithm}, but no checksum was returned in the response. ` +
-                `If running in a browser, ensure your S3 bucket CORS configuration is enabled. `,
+                `If running in a browser, ensure your S3 bucket CORS configuration is enabled. `
             );
           }
 
@@ -3183,16 +2760,11 @@ export class S3TransferManager implements IS3TransferManager {
             PartNumber: dataPart.partNumber,
             ETag: partResponse.ETag,
           };
-          if (partResponse.ChecksumCRC32)
-            completedPart.ChecksumCRC32 = partResponse.ChecksumCRC32;
-          if (partResponse.ChecksumCRC32C)
-            completedPart.ChecksumCRC32C = partResponse.ChecksumCRC32C;
-          if (partResponse.ChecksumCRC64NVME)
-            completedPart.ChecksumCRC64NVME = partResponse.ChecksumCRC64NVME;
-          if (partResponse.ChecksumSHA1)
-            completedPart.ChecksumSHA1 = partResponse.ChecksumSHA1;
-          if (partResponse.ChecksumSHA256)
-            completedPart.ChecksumSHA256 = partResponse.ChecksumSHA256;
+          if (partResponse.ChecksumCRC32) completedPart.ChecksumCRC32 = partResponse.ChecksumCRC32;
+          if (partResponse.ChecksumCRC32C) completedPart.ChecksumCRC32C = partResponse.ChecksumCRC32C;
+          if (partResponse.ChecksumCRC64NVME) completedPart.ChecksumCRC64NVME = partResponse.ChecksumCRC64NVME;
+          if (partResponse.ChecksumSHA1) completedPart.ChecksumSHA1 = partResponse.ChecksumSHA1;
+          if (partResponse.ChecksumSHA256) completedPart.ChecksumSHA256 = partResponse.ChecksumSHA256;
 
           completedParts.push(completedPart);
 
@@ -3206,7 +2778,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredBytes: bytesUploaded,
                 totalBytes: contentLength,
               },
-            }),
+            })
           );
         }
       };
@@ -3217,16 +2789,14 @@ export class S3TransferManager implements IS3TransferManager {
           uploadPart(dataFeeder).catch((error) => {
             abortController.abort();
             throw error;
-          }),
+          })
         );
       }
 
       await Promise.all(partUploads);
 
       if (completedParts.length !== expectedPartsCount) {
-        throw new Error(
-          `Expected ${expectedPartsCount} parts but uploaded ${completedParts.length} parts`,
-        );
+        throw new Error(`Expected ${expectedPartsCount} parts but uploaded ${completedParts.length} parts`);
       }
 
       completedParts.sort((a, b) => a.PartNumber! - b.PartNumber!);
@@ -3242,22 +2812,16 @@ export class S3TransferManager implements IS3TransferManager {
 
       if (hasFullObjectChecksum) {
         completeRequest.ChecksumType = "FULL_OBJECT";
-        if (request.ChecksumCRC32)
-          completeRequest.ChecksumCRC32 = request.ChecksumCRC32;
-        if (request.ChecksumCRC32C)
-          completeRequest.ChecksumCRC32C = request.ChecksumCRC32C;
-        if (request.ChecksumCRC64NVME)
-          completeRequest.ChecksumCRC64NVME = request.ChecksumCRC64NVME;
+        if (request.ChecksumCRC32) completeRequest.ChecksumCRC32 = request.ChecksumCRC32;
+        if (request.ChecksumCRC32C) completeRequest.ChecksumCRC32C = request.ChecksumCRC32C;
+        if (request.ChecksumCRC64NVME) completeRequest.ChecksumCRC64NVME = request.ChecksumCRC64NVME;
       }
 
       try {
-        return await this.s3.send(
-          new CompleteMultipartUploadCommand(completeRequest),
-          transferOptions,
-        );
+        return await this.s3.send(new CompleteMultipartUploadCommand(completeRequest), transferOptions);
       } catch (completeMpuError) {
         this.logger.warn(
-          `CompleteMultipartUpload failed for upload ID ${uploadId}: ${(completeMpuError as Error).message}`,
+          `CompleteMultipartUpload failed for upload ID ${uploadId}: ${(completeMpuError as Error).message}`
         );
         throw completeMpuError;
       }
@@ -3269,15 +2833,9 @@ export class S3TransferManager implements IS3TransferManager {
       };
 
       try {
-        await this.s3.send(
-          new AbortMultipartUploadCommand(abortRequest),
-          transferOptions,
-        );
+        await this.s3.send(new AbortMultipartUploadCommand(abortRequest), transferOptions);
       } catch (abortError) {
-        this.logger.warn(
-          `Failed to abort multipart upload ${uploadId}:`,
-          abortError,
-        );
+        this.logger.warn(`Failed to abort multipart upload ${uploadId}:`, abortError);
       }
       throw error;
     }
@@ -3285,22 +2843,17 @@ export class S3TransferManager implements IS3TransferManager {
 
   /**
    * Async generator that yields file paths from the source directory.
-   * Uses fs.opendir with recursive option (Node 20+).
    * Handles symlink cycle detection when followSymbolicLinks is true.
    *
-   * @internal
    */
   private async *traverseDirectory(
     source: string,
-    options: { recursive: boolean; followSymbolicLinks: boolean },
+    options: { recursive: boolean; followSymbolicLinks: boolean }
   ): AsyncGenerator<string> {
     const visited = new Set<string>();
     const dir = await opendir(source, { recursive: options.recursive });
     for await (const entry of dir) {
-      const fullPath = join(
-        (entry as any).parentPath ?? (entry as any).path ?? source,
-        entry.name,
-      );
+      const fullPath = join((entry as any).parentPath ?? (entry as any).path ?? source, entry.name);
 
       if (entry.isSymbolicLink()) {
         if (!options.followSymbolicLinks) continue;
@@ -3308,9 +2861,7 @@ export class S3TransferManager implements IS3TransferManager {
         const linkStat = await stat(realPath);
         if (linkStat.isDirectory()) {
           if (visited.has(realPath)) {
-            throw new Error(
-              `Circular symbolic link detected: ${fullPath} -> ${realPath}`,
-            );
+            throw new Error(`Circular symbolic link detected: ${fullPath} -> ${realPath}`);
           }
           visited.add(realPath);
           yield* this.traverseDirectory(realPath, options);
@@ -3327,16 +2878,10 @@ export class S3TransferManager implements IS3TransferManager {
 
   /**
    * Derives the S3 object key from local file path.
-   * Computes relative path from source, normalizes separators to "/",
    * and prepends s3Prefix if provided.
    *
-   * @internal
    */
-  private deriveS3Key(
-    source: string,
-    filePath: string,
-    s3Prefix?: string,
-  ): string {
+  private deriveS3Key(source: string, filePath: string, s3Prefix?: string): string {
     let relativePath = relative(source, filePath);
     if (sep !== "/") {
       relativePath = relativePath.split(sep).join("/");
@@ -3349,14 +2894,13 @@ export class S3TransferManager implements IS3TransferManager {
   /**
    * Validates that a data part has a measurable size and matches the expected part size.
    *
-   * @internal
    */
   private validateUploadPart(dataPart: RawDataPart, partSize: number): void {
     const actualPartSize = byteLength(dataPart.data);
 
     if (actualPartSize === undefined) {
       throw new Error(
-        `A dataPart was generated without a measurable data chunk size for part number ${dataPart.partNumber}`,
+        `A dataPart was generated without a measurable data chunk size for part number ${dataPart.partNumber}`
       );
     }
 
@@ -3366,7 +2910,7 @@ export class S3TransferManager implements IS3TransferManager {
 
     if (!dataPart.lastPart && actualPartSize !== partSize) {
       throw new Error(
-        `The byte size for part number ${dataPart.partNumber}, size ${actualPartSize} does not match expected size ${partSize}`,
+        `The byte size for part number ${dataPart.partNumber}, size ${actualPartSize} does not match expected size ${partSize}`
       );
     }
   }
@@ -3381,9 +2925,7 @@ export class S3TransferManager implements IS3TransferManager {
  *
  * @internal
  */
-function parseContentRangeStart(
-  contentRange: string | undefined,
-): number | undefined {
+function parseContentRangeStart(contentRange: string | undefined): number | undefined {
   if (!contentRange) return undefined;
   const match = contentRange.match(/^bytes\s+(\d+)-/);
   return match ? Number(match[1]) : undefined;

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -27,8 +27,16 @@ import { join, relative, resolve, sep } from "node:path";
 import { Readable } from "node:stream";
 
 import { type RawDataPart, byteLength, getChunk } from "./chunker";
-import { handleFailure, Semaphore, validateDirectory } from "./directory-transfer-utils";
-import type { AddEventListenerOptions, EventListener, RemoveEventListenerOptions } from "./event-listener-types";
+import {
+  handleFailure,
+  Semaphore,
+  validateDirectory,
+} from "./directory-transfer-utils";
+import type {
+  AddEventListenerOptions,
+  EventListener,
+  RemoveEventListenerOptions,
+} from "./event-listener-types";
 import { FileManager } from "./file-manager";
 import { destroyStreams, joinStreams } from "./join-streams";
 import { LogLevel } from "./log-level";
@@ -79,11 +87,18 @@ export class S3TransferManager implements IS3TransferManager {
   private readonly s3: S3Client;
   private readonly targetPartSizeBytes: number;
   private readonly multipartUploadThresholdBytes: number;
-  private readonly requestChecksumCalculation: "WHEN_SUPPORTED" | "WHEN_REQUIRED";
-  private readonly responseChecksumValidation: "WHEN_SUPPORTED" | "WHEN_REQUIRED";
+  private readonly requestChecksumCalculation:
+    | "WHEN_SUPPORTED"
+    | "WHEN_REQUIRED";
+  private readonly responseChecksumValidation:
+    | "WHEN_SUPPORTED"
+    | "WHEN_REQUIRED";
   private readonly multipartDownloadType: "PART" | "RANGE";
   private readonly eventListeners: TransferEventListeners;
-  private readonly abortCleanupFunctions = new WeakMap<AbortSignal, () => void>();
+  private readonly abortCleanupFunctions = new WeakMap<
+    AbortSignal,
+    () => void
+  >();
   private readonly maxConcurrentDownloads: number;
   private readonly maxConcurrentUploads: number;
   private readonly workerThreadCount: number;
@@ -91,8 +106,10 @@ export class S3TransferManager implements IS3TransferManager {
   private readonly logger: Logger;
 
   public constructor(config: S3TransferManagerConfig = {}) {
-    this.requestChecksumCalculation = config.requestChecksumCalculation ?? "WHEN_SUPPORTED";
-    this.responseChecksumValidation = config.responseChecksumValidation ?? "WHEN_SUPPORTED";
+    this.requestChecksumCalculation =
+      config.requestChecksumCalculation ?? "WHEN_SUPPORTED";
+    this.responseChecksumValidation =
+      config.responseChecksumValidation ?? "WHEN_SUPPORTED";
     this.maxConcurrentUploads = config.maxConcurrentUploads ?? 32;
     this.workerThreadCount = config.workerThreadCount ?? defaultWorkerCount();
 
@@ -114,7 +131,8 @@ export class S3TransferManager implements IS3TransferManager {
     }
 
     this.targetPartSizeBytes = config.targetPartSizeBytes ?? 8 * 1024 * 1024; // 8 MB
-    this.multipartUploadThresholdBytes = config.multipartUploadThresholdBytes ?? 16 * 1024 * 1024; // 16 MB
+    this.multipartUploadThresholdBytes =
+      config.multipartUploadThresholdBytes ?? 16 * 1024 * 1024; // 16 MB
 
     this.multipartDownloadType = config.multipartDownloadType ?? "PART";
     this.maxConcurrentDownloads = config.maxConcurrentDownloads ?? 8;
@@ -142,25 +160,33 @@ export class S3TransferManager implements IS3TransferManager {
   public addEventListener(
     type: "transferInitiated",
     callback: EventListener<TransferEvent>,
-    options?: AddEventListenerOptions | boolean
+    options?: AddEventListenerOptions | boolean,
   ): void;
   public addEventListener(
     type: "bytesTransferred",
     callback: EventListener<TransferEvent>,
-    options?: AddEventListenerOptions | boolean
+    options?: AddEventListenerOptions | boolean,
   ): void;
   public addEventListener(
     type: "transferComplete",
     callback: EventListener<TransferCompleteEvent>,
-    options?: AddEventListenerOptions | boolean
+    options?: AddEventListenerOptions | boolean,
   ): void;
   public addEventListener(
     type: "transferFailed",
     callback: EventListener<TransferEvent>,
-    options?: AddEventListenerOptions | boolean
+    options?: AddEventListenerOptions | boolean,
   ): void;
-  public addEventListener(type: string, callback: EventListener, options?: AddEventListenerOptions | boolean): void;
-  public addEventListener(type: string, callback: EventListener, options?: AddEventListenerOptions | boolean): void {
+  public addEventListener(
+    type: string,
+    callback: EventListener,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+  public addEventListener(
+    type: string,
+    callback: EventListener,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
     const eventType = type as keyof TransferEventListeners;
     const listeners = this.eventListeners[eventType];
 
@@ -182,8 +208,12 @@ export class S3TransferManager implements IS3TransferManager {
         this.abortCleanupFunctions.delete(signal);
       };
 
-      this.abortCleanupFunctions.set(signal, () => signal.removeEventListener("abort", removeListenerAfterAbort));
-      signal.addEventListener("abort", removeListenerAfterAbort, { once: true });
+      this.abortCleanupFunctions.set(signal, () =>
+        signal.removeEventListener("abort", removeListenerAfterAbort),
+      );
+      signal.addEventListener("abort", removeListenerAfterAbort, {
+        once: true,
+      });
     }
 
     if (once) {
@@ -213,7 +243,9 @@ export class S3TransferManager implements IS3TransferManager {
   public dispatchEvent(event: Event): boolean;
   public dispatchEvent(event: Event): boolean {
     const eventType = event.type;
-    const listeners = this.eventListeners[eventType as keyof TransferEventListeners] as EventListener[];
+    const listeners = this.eventListeners[
+      eventType as keyof TransferEventListeners
+    ] as EventListener[];
 
     if (listeners) {
       for (const listener of listeners) {
@@ -240,32 +272,32 @@ export class S3TransferManager implements IS3TransferManager {
   public removeEventListener(
     type: "transferInitiated",
     callback: EventListener<TransferEvent>,
-    options?: RemoveEventListenerOptions | boolean
+    options?: RemoveEventListenerOptions | boolean,
   ): void;
   public removeEventListener(
     type: "bytesTransferred",
     callback: EventListener<TransferEvent>,
-    options?: RemoveEventListenerOptions | boolean
+    options?: RemoveEventListenerOptions | boolean,
   ): void;
   public removeEventListener(
     type: "transferComplete",
     callback: EventListener<TransferCompleteEvent>,
-    options?: RemoveEventListenerOptions | boolean
+    options?: RemoveEventListenerOptions | boolean,
   ): void;
   public removeEventListener(
     type: "transferFailed",
     callback: EventListener<TransferEvent>,
-    options?: RemoveEventListenerOptions | boolean
+    options?: RemoveEventListenerOptions | boolean,
   ): void;
   public removeEventListener(
     type: string,
     callback: EventListener,
-    options?: RemoveEventListenerOptions | boolean
+    options?: RemoveEventListenerOptions | boolean,
   ): void;
   public removeEventListener(
     type: string,
     callback: EventListener,
-    options?: RemoveEventListenerOptions | boolean
+    options?: RemoveEventListenerOptions | boolean,
   ): void {
     const eventType = type as keyof TransferEventListeners;
     const listeners = this.eventListeners[eventType];
@@ -299,8 +331,12 @@ export class S3TransferManager implements IS3TransferManager {
    * @returns S3 PutObject or CompleteMultipartUpload response with transfer event dispatching.
    *
    */
-  public async upload(request: UploadRequest, transferOptions?: TransferOptions): Promise<UploadResponse> {
-    const totalContentLength = request.ContentLength ?? byteLength(request.Body);
+  public async upload(
+    request: UploadRequest,
+    transferOptions?: TransferOptions,
+  ): Promise<UploadResponse> {
+    const totalContentLength =
+      request.ContentLength ?? byteLength(request.Body);
 
     if (totalContentLength === undefined) {
       throw new Error("Unable to determine content length for upload");
@@ -313,8 +349,12 @@ export class S3TransferManager implements IS3TransferManager {
     const removeLocalEventListeners = () => {
       this.removeEventListeners(transferOptions?.eventListeners);
       if (transferOptions?.abortSignal) {
-        this.abortCleanupFunctions.get(transferOptions.abortSignal as AbortSignal)?.();
-        this.abortCleanupFunctions.delete(transferOptions.abortSignal as AbortSignal);
+        this.abortCleanupFunctions.get(
+          transferOptions.abortSignal as AbortSignal,
+        )?.();
+        this.abortCleanupFunctions.delete(
+          transferOptions.abortSignal as AbortSignal,
+        );
       }
     };
 
@@ -322,16 +362,38 @@ export class S3TransferManager implements IS3TransferManager {
       let response: UploadResponse;
 
       if (totalContentLength < this.multipartUploadThresholdBytes) {
-        response = await this.uploadSinglePart(request, totalContentLength, transferOptions);
+        response = await this.uploadSinglePart(
+          request,
+          totalContentLength,
+          transferOptions,
+        );
       } else if (this.workerThreadCount > 1 && this.isFileBody(request.Body)) {
-        response = await this.threadedUploadInPartsFromFile(request, totalContentLength, transferOptions);
-      } else if (this.workerThreadCount > 1 && this.isInMemoryBody(request.Body)) {
+        response = await this.threadedUploadInPartsFromFile(
+          request,
+          totalContentLength,
+          transferOptions,
+        );
+      } else if (
+        this.workerThreadCount > 1 &&
+        this.isInMemoryBody(request.Body)
+      ) {
         if (typeof request.Body === "string") {
-          request = { ...request, Body: new TextEncoder().encode(request.Body) };
+          request = {
+            ...request,
+            Body: new TextEncoder().encode(request.Body),
+          };
         }
-        response = await this.threadedUploadInParts(request, totalContentLength, transferOptions);
+        response = await this.threadedUploadInParts(
+          request,
+          totalContentLength,
+          transferOptions,
+        );
       } else {
-        response = await this.uploadInParts(request, totalContentLength, transferOptions);
+        response = await this.uploadInParts(
+          request,
+          totalContentLength,
+          transferOptions,
+        );
       }
 
       this.dispatchEvent(
@@ -342,12 +404,16 @@ export class S3TransferManager implements IS3TransferManager {
             transferredBytes: totalContentLength,
             totalBytes: totalContentLength,
           },
-        })
+        }),
       );
       removeLocalEventListeners();
       return response;
     } catch (error) {
-      this.dispatchTransferFailedEvent(request, totalContentLength, error as Error);
+      this.dispatchTransferFailedEvent(
+        request,
+        totalContentLength,
+        error as Error,
+      );
       removeLocalEventListeners();
       throw error;
     }
@@ -364,11 +430,14 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @alpha
    */
-  public async download(request: DownloadRequest, transferOptions?: TransferOptions): Promise<DownloadResponse> {
+  public async download(
+    request: DownloadRequest,
+    transferOptions?: TransferOptions,
+  ): Promise<DownloadResponse> {
     const partNumber = request.PartNumber;
     if (typeof partNumber === "number") {
       throw new Error(
-        "partNumber included: S3 Transfer Manager does not support downloads for specific parts. Use GetObjectCommand instead"
+        "partNumber included: S3 Transfer Manager does not support downloads for specific parts. Use GetObjectCommand instead",
       );
     }
 
@@ -382,15 +451,20 @@ export class S3TransferManager implements IS3TransferManager {
     this.addEventListeners(transferOptions?.eventListeners);
 
     const checksumValidationEnabled =
-      request.ChecksumMode === "ENABLED" || this.responseChecksumValidation === "WHEN_SUPPORTED";
+      request.ChecksumMode === "ENABLED" ||
+      this.responseChecksumValidation === "WHEN_SUPPORTED";
 
     let onStreamConsumed: ((index: number) => void) | undefined;
 
     const removeLocalEventListeners = () => {
       this.removeEventListeners(transferOptions?.eventListeners);
       if (transferOptions?.abortSignal) {
-        this.abortCleanupFunctions.get(transferOptions.abortSignal as AbortSignal)?.();
-        this.abortCleanupFunctions.delete(transferOptions.abortSignal as AbortSignal);
+        this.abortCleanupFunctions.get(
+          transferOptions.abortSignal as AbortSignal,
+        )?.();
+        this.abortCleanupFunctions.delete(
+          transferOptions.abortSignal as AbortSignal,
+        );
       }
     };
 
@@ -403,7 +477,7 @@ export class S3TransferManager implements IS3TransferManager {
             streams,
             requests,
             metadata,
-            checksumValidationEnabled
+            checksumValidationEnabled,
           );
           totalSize = responseMetadata.totalSize;
         } else {
@@ -413,7 +487,7 @@ export class S3TransferManager implements IS3TransferManager {
             streams,
             requests,
             metadata,
-            checksumValidationEnabled
+            checksumValidationEnabled,
           );
           totalSize = responseMetadata.totalSize;
           onStreamConsumed = responseMetadata.onStreamConsumed;
@@ -426,7 +500,7 @@ export class S3TransferManager implements IS3TransferManager {
             streams,
             requests,
             metadata,
-            checksumValidationEnabled
+            checksumValidationEnabled,
           );
           totalSize = responseMetadata.totalSize;
         } else {
@@ -436,7 +510,7 @@ export class S3TransferManager implements IS3TransferManager {
             streams,
             requests,
             metadata,
-            checksumValidationEnabled
+            checksumValidationEnabled,
           );
           totalSize = responseMetadata.totalSize;
           onStreamConsumed = responseMetadata.onStreamConsumed;
@@ -463,7 +537,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredBytes: byteLength,
                 totalBytes: totalSize,
               },
-            })
+            }),
           );
         },
         onCompletion: (byteLength: number, index) => {
@@ -475,7 +549,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredBytes: byteLength,
                 totalBytes: totalSize,
               },
-            })
+            }),
           );
           removeLocalEventListeners();
         },
@@ -487,7 +561,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredBytes: error,
                 totalBytes: totalSize,
               },
-            })
+            }),
           );
           removeLocalEventListeners();
         },
@@ -510,7 +584,7 @@ export class S3TransferManager implements IS3TransferManager {
    */
   public async downloadToFile(
     request: DownloadToFileRequest,
-    transferOptions?: TransferOptions
+    transferOptions?: TransferOptions,
   ): Promise<DownloadToFileResponse> {
     if (!request.destination || request.destination === "") {
       throw new Error("destination must be a non-empty string");
@@ -519,7 +593,9 @@ export class S3TransferManager implements IS3TransferManager {
     const resolvedDestination = resolve(request.destination);
 
     if (request.failIfExists && existsSync(resolvedDestination)) {
-      throw new Error(`File already exists at destination: ${resolvedDestination}`);
+      throw new Error(
+        `File already exists at destination: ${resolvedDestination}`,
+      );
     }
 
     this.checkAborted(transferOptions);
@@ -528,19 +604,28 @@ export class S3TransferManager implements IS3TransferManager {
     const removeLocalEventListeners = () => {
       this.removeEventListeners(transferOptions?.eventListeners);
       if (transferOptions?.abortSignal) {
-        this.abortCleanupFunctions.get(transferOptions.abortSignal as AbortSignal)?.();
-        this.abortCleanupFunctions.delete(transferOptions.abortSignal as AbortSignal);
+        this.abortCleanupFunctions.get(
+          transferOptions.abortSignal as AbortSignal,
+        )?.();
+        this.abortCleanupFunctions.delete(
+          transferOptions.abortSignal as AbortSignal,
+        );
       }
     };
 
     const checksumValidationEnabled =
-      request.ChecksumMode === "ENABLED" || this.responseChecksumValidation === "WHEN_SUPPORTED";
+      request.ChecksumMode === "ENABLED" ||
+      this.responseChecksumValidation === "WHEN_SUPPORTED";
 
     const { destination, failIfExists, ...getObjectFields } = request;
 
     if (this.multipartDownloadType === "RANGE") {
       try {
-        const result = await this.downloadToFileByRange(request, resolvedDestination, transferOptions);
+        const result = await this.downloadToFileByRange(
+          request,
+          resolvedDestination,
+          transferOptions,
+        );
         removeLocalEventListeners();
         return result;
       } catch (error) {
@@ -557,10 +642,19 @@ export class S3TransferManager implements IS3TransferManager {
 
     let initialResponse: DownloadResponse;
     try {
-      initialResponse = await this.s3.send(new GetObjectCommand(initialPartRequest), transferOptions);
+      initialResponse = await this.s3.send(
+        new GetObjectCommand(initialPartRequest),
+        transferOptions,
+      );
     } catch (error) {
       removeLocalEventListeners();
       throw error;
+    }
+
+    // Attach a no-op error handler to the initial response body to prevent
+    // uncaught socket teardown errors if abort fires before the body is consumed.
+    if (initialResponse.Body && initialResponse.Body instanceof Readable) {
+      initialResponse.Body.on("error", () => {});
     }
 
     const totalSize = initialResponse.ContentRange
@@ -576,28 +670,48 @@ export class S3TransferManager implements IS3TransferManager {
 
     try {
       if (partsCount === 1) {
-        tempFilePath = await fileManager.createTempFile(resolvedDestination, totalSize);
+        tempFilePath = await fileManager.createTempFile(
+          resolvedDestination,
+          totalSize,
+        );
         fileManager.registerCleanupHandler(tempFilePath);
 
         // Write the whole object body, which starts at byte 0.
-        await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
+        await this.writeResponseBodyToFile(
+          initialResponse.Body,
+          tempFilePath,
+          initialResponse.ContentRange,
+          0,
+        );
 
         // Atomic rename
         await fileManager.atomicRename(tempFilePath, resolvedDestination);
         fileManager.unregisterCleanupHandler(tempFilePath);
 
-        const response = this.buildDownloadToFileResponse(initialResponse, totalSize, request);
+        const response = this.buildDownloadToFileResponse(
+          initialResponse,
+          totalSize,
+          request,
+        );
         removeLocalEventListeners();
         return response;
       }
 
       // Multipart download path when PartsCount > 1.
-      tempFilePath = await fileManager.createTempFile(resolvedDestination, totalSize);
+      tempFilePath = await fileManager.createTempFile(
+        resolvedDestination,
+        totalSize,
+      );
       fileManager.registerCleanupHandler(tempFilePath);
 
       // Write Part 1 body, which starts at byte 0.
       const partSize = initialResponse.ContentLength ?? 0;
-      await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
+      await this.writeResponseBodyToFile(
+        initialResponse.Body,
+        tempFilePath,
+        initialResponse.ContentRange,
+        0,
+      );
 
       // TODO: Full-object CRC validation via CRC combination.
       // S3 currently only returns full-object checksums in part GET responses for objects
@@ -606,7 +720,8 @@ export class S3TransferManager implements IS3TransferManager {
       // objects (tracking: P320750170), implement CRC combination here to validate the
       // combined per-part CRCs against the full-object checksum.
 
-      const partResults: Array<{ partNumber: number; bytesWritten: number }> = [];
+      const partResults: Array<{ partNumber: number; bytesWritten: number }> =
+        [];
       partResults.push({ partNumber: 1, bytesWritten: partSize });
 
       // Dispatch remaining Part GET requests with concurrency bounding
@@ -616,7 +731,9 @@ export class S3TransferManager implements IS3TransferManager {
       let failureError: unknown;
 
       // Listen to user abort
-      const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
+      const userSignal = transferOptions?.abortSignal as
+        | AbortSignal
+        | undefined;
       if (userSignal) {
         const onUserAbort = () => abortController.abort();
         userSignal.addEventListener("abort", onUserAbort, { once: true });
@@ -645,7 +762,9 @@ export class S3TransferManager implements IS3TransferManager {
           ...getObjectFields,
           PartNumber: partNumber,
           IfMatch: eTag,
-          ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+          ...(checksumValidationEnabled && {
+            ChecksumMode: "ENABLED" as const,
+          }),
         };
 
         const task = (async () => {
@@ -672,10 +791,11 @@ export class S3TransferManager implements IS3TransferManager {
               } as any);
 
               // Retrieve the download result from the WorkerHttpHandler's side-channel.
-              const downloadResult = (this.s3.config.requestHandler as unknown as WorkerHttpHandler).getDownloadResult(
-                resultToken
-              );
-              const bytesWritten = downloadResult?.bytesWritten ?? expectedLength;
+              const downloadResult = (
+                this.s3.config.requestHandler as unknown as WorkerHttpHandler
+              ).getDownloadResult(resultToken);
+              const bytesWritten =
+                downloadResult?.bytesWritten ?? expectedLength;
 
               partResults.push({
                 partNumber,
@@ -683,12 +803,18 @@ export class S3TransferManager implements IS3TransferManager {
               });
             } else {
               // Main-thread fallback (workerThreadCount === 1)
-              const partResponse = await this.s3.send(new GetObjectCommand(partGetRequest), transferOptions);
+              const partResponse = await this.s3.send(
+                new GetObjectCommand(partGetRequest),
+                transferOptions,
+              );
+              if (partResponse.Body && partResponse.Body instanceof Readable) {
+                partResponse.Body.on("error", () => {});
+              }
               await this.writeResponseBodyToFile(
                 partResponse.Body,
                 tempFilePath!,
                 partResponse.ContentRange,
-                partOffset
+                partOffset,
               );
 
               partResults.push({
@@ -705,7 +831,7 @@ export class S3TransferManager implements IS3TransferManager {
                   transferredBytes: expectedLength,
                   totalBytes: totalSize,
                 },
-              })
+              }),
             );
           } catch (error) {
             if (!failed) {
@@ -726,15 +852,29 @@ export class S3TransferManager implements IS3TransferManager {
       // Handle abort: if the abort signal was triggered (either user or internal),
       // reject with AbortError regardless of whether tasks have already failed.
       if (abortController.signal.aborted && !failed) {
-        const abortError = Object.assign(new Error("Transfer aborted."), { name: "AbortError" });
-        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, abortError);
+        const abortError = Object.assign(new Error("Transfer aborted."), {
+          name: "AbortError",
+        });
+        await this.handleDownloadCleanup(
+          fileManager,
+          tempFilePath,
+          request,
+          totalSize,
+          abortError,
+        );
         removeLocalEventListeners();
         throw abortError;
       }
 
       // Handle failure
       if (failed) {
-        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, failureError);
+        await this.handleDownloadCleanup(
+          fileManager,
+          tempFilePath,
+          request,
+          totalSize,
+          failureError,
+        );
         removeLocalEventListeners();
         throw failureError;
       }
@@ -742,20 +882,35 @@ export class S3TransferManager implements IS3TransferManager {
       // Verify request count
       if (partResults.length !== partsCount) {
         const error = new Error(
-          `The number of parts downloaded (${partResults.length}) does not match the expected number (${partsCount})`
+          `The number of parts downloaded (${partResults.length}) does not match the expected number (${partsCount})`,
         );
-        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, error);
+        await this.handleDownloadCleanup(
+          fileManager,
+          tempFilePath,
+          request,
+          totalSize,
+          error,
+        );
         removeLocalEventListeners();
         throw error;
       }
 
       // Verify total bytes written matches expected object size
-      const totalBytesWritten = partResults.reduce((sum, p) => sum + p.bytesWritten, 0);
+      const totalBytesWritten = partResults.reduce(
+        (sum, p) => sum + p.bytesWritten,
+        0,
+      );
       if (totalBytesWritten !== totalSize) {
         const error = new Error(
-          `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalSize})`
+          `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalSize})`,
         );
-        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, error);
+        await this.handleDownloadCleanup(
+          fileManager,
+          tempFilePath,
+          request,
+          totalSize,
+          error,
+        );
         removeLocalEventListeners();
         throw error;
       }
@@ -764,7 +919,11 @@ export class S3TransferManager implements IS3TransferManager {
       await fileManager.atomicRename(tempFilePath, resolvedDestination);
       fileManager.unregisterCleanupHandler(tempFilePath);
 
-      const response = this.buildDownloadToFileResponse(initialResponse, totalSize, request);
+      const response = this.buildDownloadToFileResponse(
+        initialResponse,
+        totalSize,
+        request,
+      );
       removeLocalEventListeners();
       return response;
     } catch (error) {
@@ -785,11 +944,12 @@ export class S3TransferManager implements IS3TransferManager {
   private async downloadToFileByRange(
     request: DownloadToFileRequest,
     resolvedDestination: string,
-    transferOptions?: TransferOptions
+    transferOptions?: TransferOptions,
   ): Promise<DownloadToFileResponse> {
     const { destination, failIfExists, ...getObjectFields } = request;
     const checksumValidationEnabled =
-      request.ChecksumMode === "ENABLED" || this.responseChecksumValidation === "WHEN_SUPPORTED";
+      request.ChecksumMode === "ENABLED" ||
+      this.responseChecksumValidation === "WHEN_SUPPORTED";
 
     const fileManager = new FileManager();
     let tempFilePath: string | undefined;
@@ -803,28 +963,54 @@ export class S3TransferManager implements IS3TransferManager {
         ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
       };
 
-      const initialResponse = await this.s3.send(new GetObjectCommand(initialRangeRequest), transferOptions);
+      const initialResponse = await this.s3.send(
+        new GetObjectCommand(initialRangeRequest),
+        transferOptions,
+      );
+
+      // Attach a no-op error handler to the initial response body to prevent
+      // uncaught socket teardown errors if abort fires before the body is consumed.
+      if (initialResponse.Body && initialResponse.Body instanceof Readable) {
+        initialResponse.Body.on("error", () => {});
+      }
 
       // Validate ContentRange matches the requested range (also validates presence and format)
-      this.validateRangeDownload(`bytes=0-${rangeSize - 1}`, initialResponse.ContentRange);
+      this.validateRangeDownload(
+        `bytes=0-${rangeSize - 1}`,
+        initialResponse.ContentRange,
+      );
 
       // Parse total content length from ContentRange: "bytes 0-N/TOTAL"
-      const totalContentLength = Number.parseInt(initialResponse.ContentRange!.split("/")[1]);
+      const totalContentLength = Number.parseInt(
+        initialResponse.ContentRange!.split("/")[1],
+      );
       const responseContentLength = initialResponse.ContentLength ?? 0;
 
       // Compare parsed total content length with ContentLength
       if (responseContentLength === totalContentLength) {
         // Single-part object — this response contains all the data
-        tempFilePath = await fileManager.createTempFile(resolvedDestination, totalContentLength);
+        tempFilePath = await fileManager.createTempFile(
+          resolvedDestination,
+          totalContentLength,
+        );
         fileManager.registerCleanupHandler(tempFilePath);
 
-        await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
+        await this.writeResponseBodyToFile(
+          initialResponse.Body,
+          tempFilePath,
+          initialResponse.ContentRange,
+          0,
+        );
 
         await fileManager.atomicRename(tempFilePath, resolvedDestination);
         fileManager.unregisterCleanupHandler(tempFilePath);
 
         this.dispatchTransferInitiatedEvent(request, totalContentLength);
-        return this.buildDownloadToFileResponse(initialResponse, totalContentLength, request);
+        return this.buildDownloadToFileResponse(
+          initialResponse,
+          totalContentLength,
+          request,
+        );
       }
 
       // Save ETag and calculate expected number of ranged GET requests
@@ -834,10 +1020,18 @@ export class S3TransferManager implements IS3TransferManager {
       this.dispatchTransferInitiatedEvent(request, totalContentLength);
 
       // Create temp file and write initial part
-      tempFilePath = await fileManager.createTempFile(resolvedDestination, totalContentLength);
+      tempFilePath = await fileManager.createTempFile(
+        resolvedDestination,
+        totalContentLength,
+      );
       fileManager.registerCleanupHandler(tempFilePath);
 
-      await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
+      await this.writeResponseBodyToFile(
+        initialResponse.Body,
+        tempFilePath,
+        initialResponse.ContentRange,
+        0,
+      );
 
       const rangeResults: Array<{ index: number; bytesWritten: number }> = [];
       rangeResults.push({ index: 0, bytesWritten: responseContentLength });
@@ -845,8 +1039,11 @@ export class S3TransferManager implements IS3TransferManager {
       this.dispatchEvent(
         Object.assign(new Event("bytesTransferred"), {
           request: initialRangeRequest,
-          snapshot: { transferredBytes: responseContentLength, totalBytes: totalContentLength },
-        })
+          snapshot: {
+            transferredBytes: responseContentLength,
+            totalBytes: totalContentLength,
+          },
+        }),
       );
 
       // Construct and dispatch remaining range GET requests concurrently
@@ -855,15 +1052,23 @@ export class S3TransferManager implements IS3TransferManager {
       let failed = false;
       let failureError: unknown;
 
-      const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
+      const userSignal = transferOptions?.abortSignal as
+        | AbortSignal
+        | undefined;
       if (userSignal) {
-        userSignal.addEventListener("abort", () => abortController.abort(), { once: true });
+        userSignal.addEventListener("abort", () => abortController.abort(), {
+          once: true,
+        });
       }
 
       const rangeTasks: Promise<void>[] = [];
       let rangeIndex = 1;
 
-      for (let offset = rangeSize; offset < totalContentLength; offset += rangeSize) {
+      for (
+        let offset = rangeSize;
+        offset < totalContentLength;
+        offset += rangeSize
+      ) {
         if (failed || abortController.signal.aborted) break;
         this.checkAborted(transferOptions);
 
@@ -882,7 +1087,9 @@ export class S3TransferManager implements IS3TransferManager {
           ...getObjectFields,
           Range: `bytes=${start}-${end}`,
           IfMatch: eTag,
-          ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+          ...(checksumValidationEnabled && {
+            ChecksumMode: "ENABLED" as const,
+          }),
         };
 
         const task = (async () => {
@@ -899,19 +1106,26 @@ export class S3TransferManager implements IS3TransferManager {
                 resultToken,
               };
 
-              const rangeResponse = await this.s3.send(new GetObjectCommand(rangeGetRequest), {
-                ...transferOptions,
-                downloadDataToFile: downloadOptions,
-              } as any);
+              const rangeResponse = await this.s3.send(
+                new GetObjectCommand(rangeGetRequest),
+                {
+                  ...transferOptions,
+                  downloadDataToFile: downloadOptions,
+                } as any,
+              );
 
               // Validate ContentRange matches the requested range
-              this.validateRangeDownload(`bytes=${start}-${end}`, rangeResponse.ContentRange);
+              this.validateRangeDownload(
+                `bytes=${start}-${end}`,
+                rangeResponse.ContentRange,
+              );
 
               // Retrieve the download result from the WorkerHttpHandler's side-channel.
-              const downloadResult = (this.s3.config.requestHandler as unknown as WorkerHttpHandler).getDownloadResult(
-                resultToken
-              );
-              const bytesWritten = downloadResult?.bytesWritten ?? expectedLength;
+              const downloadResult = (
+                this.s3.config.requestHandler as unknown as WorkerHttpHandler
+              ).getDownloadResult(resultToken);
+              const bytesWritten =
+                downloadResult?.bytesWritten ?? expectedLength;
 
               rangeResults.push({
                 index: currentIndex,
@@ -919,12 +1133,29 @@ export class S3TransferManager implements IS3TransferManager {
               });
             } else {
               // Main-thread fallback (workerThreadCount === 1)
-              const rangeResponse = await this.s3.send(new GetObjectCommand(rangeGetRequest), transferOptions);
+              const rangeResponse = await this.s3.send(
+                new GetObjectCommand(rangeGetRequest),
+                transferOptions,
+              );
 
               // Validate ContentRange matches the requested range
-              this.validateRangeDownload(`bytes=${start}-${end}`, rangeResponse.ContentRange);
+              this.validateRangeDownload(
+                `bytes=${start}-${end}`,
+                rangeResponse.ContentRange,
+              );
 
-              await this.writeResponseBodyToFile(rangeResponse.Body, tempFilePath!, rangeResponse.ContentRange, start);
+              if (
+                rangeResponse.Body &&
+                rangeResponse.Body instanceof Readable
+              ) {
+                rangeResponse.Body.on("error", () => {});
+              }
+              await this.writeResponseBodyToFile(
+                rangeResponse.Body,
+                tempFilePath!,
+                rangeResponse.ContentRange,
+                start,
+              );
 
               rangeResults.push({
                 index: currentIndex,
@@ -935,8 +1166,11 @@ export class S3TransferManager implements IS3TransferManager {
             this.dispatchEvent(
               Object.assign(new Event("bytesTransferred"), {
                 request: rangeGetRequest,
-                snapshot: { transferredBytes: end - start + 1, totalBytes: totalContentLength },
-              })
+                snapshot: {
+                  transferredBytes: end - start + 1,
+                  totalBytes: totalContentLength,
+                },
+              }),
             );
           } catch (error) {
             if (!failed) {
@@ -955,38 +1189,73 @@ export class S3TransferManager implements IS3TransferManager {
       await Promise.allSettled(rangeTasks);
 
       if (abortController.signal.aborted && !failed) {
-        const abortError = Object.assign(new Error("Transfer aborted."), { name: "AbortError" });
-        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, abortError);
+        const abortError = Object.assign(new Error("Transfer aborted."), {
+          name: "AbortError",
+        });
+        await this.handleDownloadCleanup(
+          fileManager,
+          tempFilePath,
+          request,
+          totalContentLength,
+          abortError,
+        );
         throw abortError;
       }
 
       if (failed) {
-        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, failureError);
+        await this.handleDownloadCleanup(
+          fileManager,
+          tempFilePath,
+          request,
+          totalContentLength,
+          failureError,
+        );
         throw failureError;
       }
 
       // Validate total number of ranged GET requests matches expected count
       const actualRequestCount = rangeResults.length; // includes initial request
       if (actualRequestCount !== expectedRequestCount) {
-        const error = new Error(`Expected ${expectedRequestCount} ranged GET requests but sent ${actualRequestCount}`);
-        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, error);
+        const error = new Error(
+          `Expected ${expectedRequestCount} ranged GET requests but sent ${actualRequestCount}`,
+        );
+        await this.handleDownloadCleanup(
+          fileManager,
+          tempFilePath,
+          request,
+          totalContentLength,
+          error,
+        );
         throw error;
       }
 
       // Verify total bytes written matches expected object size
-      const totalBytesWritten = rangeResults.reduce((sum, r) => sum + r.bytesWritten, 0);
+      const totalBytesWritten = rangeResults.reduce(
+        (sum, r) => sum + r.bytesWritten,
+        0,
+      );
       if (totalBytesWritten !== totalContentLength) {
         const error = new Error(
-          `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalContentLength})`
+          `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalContentLength})`,
         );
-        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, error);
+        await this.handleDownloadCleanup(
+          fileManager,
+          tempFilePath,
+          request,
+          totalContentLength,
+          error,
+        );
         throw error;
       }
 
       await fileManager.atomicRename(tempFilePath, resolvedDestination);
       fileManager.unregisterCleanupHandler(tempFilePath);
 
-      return this.buildDownloadToFileResponse(initialResponse, totalContentLength, request);
+      return this.buildDownloadToFileResponse(
+        initialResponse,
+        totalContentLength,
+        request,
+      );
     } catch (error) {
       if (tempFilePath) {
         await fileManager.deleteTempFile(tempFilePath).catch(() => {});
@@ -1017,7 +1286,7 @@ export class S3TransferManager implements IS3TransferManager {
     body: DownloadResponse["Body"],
     filePath: string,
     contentRange: string | undefined,
-    fallbackOffset: number
+    fallbackOffset: number,
   ): Promise<number> {
     const start = parseContentRangeStart(contentRange) ?? fallbackOffset;
     const fd = await open(filePath, "r+");
@@ -1052,11 +1321,12 @@ export class S3TransferManager implements IS3TransferManager {
    */
   public async uploadDirectory(
     request: UploadDirectoryRequest,
-    transferOptions?: TransferOptions
+    transferOptions?: TransferOptions,
   ): Promise<UploadDirectoryResponse> {
     const absoluteSource = await validateDirectory(request.source);
     const maxConcurrency = request.maxConcurrency ?? 100;
-    const failurePolicy = request.failurePolicy ?? ("terminate" as CannedFailurePolicy);
+    const failurePolicy =
+      request.failurePolicy ?? ("terminate" as CannedFailurePolicy);
     const semaphore = new Semaphore(maxConcurrency);
     const abortController = new AbortController();
     const inFlight = new Set<Promise<void>>();
@@ -1082,13 +1352,20 @@ export class S3TransferManager implements IS3TransferManager {
     this.dispatchEvent(
       Object.assign(new Event("transferInitiated"), {
         request,
-        snapshot: { transferredBytes: 0, totalBytes: undefined, transferredFiles: 0, totalFiles: undefined },
-      })
+        snapshot: {
+          transferredBytes: 0,
+          totalBytes: undefined,
+          transferredFiles: 0,
+          totalFiles: undefined,
+        },
+      }),
     );
 
     const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
     if (userSignal) {
-      userSignal.addEventListener("abort", () => abortController.abort(), { once: true });
+      userSignal.addEventListener("abort", () => abortController.abort(), {
+        once: true,
+      });
     }
 
     let discoveredFiles = 0;
@@ -1102,7 +1379,10 @@ export class S3TransferManager implements IS3TransferManager {
       this.checkAborted(transferOptions);
 
       if (request.filter) {
-        const include = request.filter instanceof RegExp ? request.filter.test(filePath) : request.filter(filePath);
+        const include =
+          request.filter instanceof RegExp
+            ? request.filter.test(filePath)
+            : request.filter(filePath);
         if (!include) continue;
       }
 
@@ -1112,7 +1392,10 @@ export class S3TransferManager implements IS3TransferManager {
 
       const count =
         fileStat.size >= this.multipartUploadThresholdBytes
-          ? Math.min(Math.ceil(fileStat.size / this.targetPartSizeBytes), this.maxConcurrentUploads)
+          ? Math.min(
+              Math.ceil(fileStat.size / this.targetPartSizeBytes),
+              this.maxConcurrentUploads,
+            )
           : 1;
 
       await semaphore.acquire(count);
@@ -1124,7 +1407,11 @@ export class S3TransferManager implements IS3TransferManager {
 
       const task = (async () => {
         try {
-          const key = this.deriveS3Key(absoluteSource, filePath, request.s3Prefix);
+          const key = this.deriveS3Key(
+            absoluteSource,
+            filePath,
+            request.s3Prefix,
+          );
 
           let putRequest: PutObjectCommandInput = {
             Bucket: request.bucket,
@@ -1137,7 +1424,9 @@ export class S3TransferManager implements IS3TransferManager {
             putRequest = request.uploadObjectRequestModifier(putRequest);
           }
 
-          await this.upload(putRequest, { abortSignal: abortController.signal });
+          await this.upload(putRequest, {
+            abortSignal: abortController.signal,
+          });
           objectsUploaded++;
           transferredFiles++;
           transferredBytes += fileStat.size;
@@ -1151,7 +1440,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredFiles,
                 totalFiles: traversalComplete ? totalFiles : undefined,
               },
-            })
+            }),
           );
         } catch (error) {
           if (terminated || abortController.signal.aborted) {
@@ -1166,7 +1455,11 @@ export class S3TransferManager implements IS3TransferManager {
             },
             error,
           };
-          const result = await handleFailure(failurePolicy, context, abortController);
+          const result = await handleFailure(
+            failurePolicy,
+            context,
+            abortController,
+          );
           if (result === "terminate") {
             terminated = true;
             if (!terminationError) {
@@ -1193,8 +1486,13 @@ export class S3TransferManager implements IS3TransferManager {
       this.dispatchEvent(
         Object.assign(new Event("transferFailed"), {
           request,
-          snapshot: { transferredBytes, totalBytes, transferredFiles, totalFiles },
-        })
+          snapshot: {
+            transferredBytes,
+            totalBytes,
+            transferredFiles,
+            totalFiles,
+          },
+        }),
       );
       removeLocalEventListeners();
       throw terminationError;
@@ -1204,8 +1502,13 @@ export class S3TransferManager implements IS3TransferManager {
       Object.assign(new Event("transferComplete"), {
         request,
         response: { objectsUploaded, objectsFailed },
-        snapshot: { transferredBytes, totalBytes, transferredFiles, totalFiles },
-      })
+        snapshot: {
+          transferredBytes,
+          totalBytes,
+          transferredFiles,
+          totalFiles,
+        },
+      }),
     );
     removeLocalEventListeners();
     return { objectsUploaded, objectsFailed };
@@ -1223,7 +1526,7 @@ export class S3TransferManager implements IS3TransferManager {
    */
   public downloadDirectory(
     request: DownloadDirectoryRequest,
-    transferOptions?: TransferOptions
+    transferOptions?: TransferOptions,
   ): Promise<DownloadDirectoryResponse> {
     throw new Error("Method not implemented.");
   }
@@ -1241,8 +1544,11 @@ export class S3TransferManager implements IS3TransferManager {
     streams: Promise<StreamingBlobPayloadOutputTypes>[],
     requests: GetObjectCommandInput[],
     metadata: Omit<DownloadResponse, "Body">,
-    checksumValidationEnabled: boolean
-  ): Promise<{ totalSize: number | undefined; onStreamConsumed?: (index: number) => void }> {
+    checksumValidationEnabled: boolean,
+  ): Promise<{
+    totalSize: number | undefined;
+    onStreamConsumed?: (index: number) => void;
+  }> {
     let totalSize: number | undefined;
     let streamConsumedCallback: ((index: number) => void) | undefined;
     this.checkAborted(transferOptions);
@@ -1254,14 +1560,22 @@ export class S3TransferManager implements IS3TransferManager {
         ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
       };
       try {
-        const initialPart = await this.s3.send(new GetObjectCommand(initialPartRequest), transferOptions);
+        const initialPart = await this.s3.send(
+          new GetObjectCommand(initialPartRequest),
+          transferOptions,
+        );
         await internalEventHandler.afterInitialGetObject();
         const partSize = initialPart.ContentLength;
         const initialETag = initialPart.ETag ?? undefined;
-        totalSize = initialPart.ContentRange ? Number.parseInt(initialPart.ContentRange.split("/")[1]) : 0;
+        totalSize = initialPart.ContentRange
+          ? Number.parseInt(initialPart.ContentRange.split("/")[1])
+          : 0;
         this.dispatchTransferInitiatedEvent(request, totalSize);
         if (initialPart.Body) {
-          if (initialPart.Body && typeof (initialPart.Body as any).getReader === "function") {
+          if (
+            initialPart.Body &&
+            typeof (initialPart.Body as any).getReader === "function"
+          ) {
             const reader = (initialPart.Body as any).getReader();
             (initialPart.Body as any).getReader = function () {
               return reader;
@@ -1275,7 +1589,8 @@ export class S3TransferManager implements IS3TransferManager {
 
         let partCount = 1;
         if (initialPart.PartsCount! > 1) {
-          const partTasks: (() => Promise<StreamingBlobPayloadOutputTypes>)[] = [];
+          const partTasks: (() => Promise<StreamingBlobPayloadOutputTypes>)[] =
+            [];
           const partRequests: GetObjectCommandInput[] = [];
 
           for (let part = 2; part <= initialPart.PartsCount!; part++) {
@@ -1283,7 +1598,9 @@ export class S3TransferManager implements IS3TransferManager {
               ...request,
               PartNumber: part,
               IfMatch: initialETag,
-              ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+              ...(checksumValidationEnabled && {
+                ChecksumMode: "ENABLED" as const,
+              }),
             };
             partRequests.push(getObjectRequest);
 
@@ -1292,8 +1609,15 @@ export class S3TransferManager implements IS3TransferManager {
               return this.s3
                 .send(new GetObjectCommand(getObjectRequest), transferOptions)
                 .then((response) => {
-                  this.validatePartDownload(response.ContentRange, part, partSize ?? 0);
-                  if (response.Body && typeof (response.Body as any).getReader === "function") {
+                  this.validatePartDownload(
+                    response.ContentRange,
+                    part,
+                    partSize ?? 0,
+                  );
+                  if (
+                    response.Body &&
+                    typeof (response.Body as any).getReader === "function"
+                  ) {
                     const reader = (response.Body as any).getReader();
                     (response.Body as any).getReader = function () {
                       return reader;
@@ -1302,7 +1626,11 @@ export class S3TransferManager implements IS3TransferManager {
                   return response.Body!;
                 })
                 .catch((error) => {
-                  this.dispatchTransferFailedEvent(getObjectRequest, totalSize, error as Error);
+                  this.dispatchTransferFailedEvent(
+                    getObjectRequest,
+                    totalSize,
+                    error as Error,
+                  );
                   throw error;
                 });
             });
@@ -1311,10 +1639,11 @@ export class S3TransferManager implements IS3TransferManager {
           // Lazily prefetch streams — only maxConcurrentDownloads requests in-flight.
           // New requests fire as previous ones complete, and joinStreams can start
           // consuming immediately without waiting for all parts to be fetched.
-          const { promises: pendingStreams, onStreamConsumed } = this.createConcurrentTaskPool(
-            partTasks,
-            this.maxConcurrentDownloads
-          );
+          const { promises: pendingStreams, onStreamConsumed } =
+            this.createConcurrentTaskPool(
+              partTasks,
+              this.maxConcurrentDownloads,
+            );
           streams.push(...pendingStreams);
           requests.push(...partRequests);
           streamConsumedCallback = onStreamConsumed;
@@ -1322,7 +1651,7 @@ export class S3TransferManager implements IS3TransferManager {
 
           if (partCount !== initialPart.PartsCount) {
             throw new Error(
-              `The number of parts downloaded (${partCount}) does not match the expected number (${initialPart.PartsCount})`
+              `The number of parts downloaded (${partCount}) does not match the expected number (${initialPart.PartsCount})`,
             );
           }
         }
@@ -1336,11 +1665,18 @@ export class S3TransferManager implements IS3TransferManager {
       try {
         const getObjectRequest = {
           ...request,
-          ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+          ...(checksumValidationEnabled && {
+            ChecksumMode: "ENABLED" as const,
+          }),
         };
 
-        const getObject = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
-        totalSize = getObject.ContentRange ? Number.parseInt(getObject.ContentRange.split("/")[1]) : 0;
+        const getObject = await this.s3.send(
+          new GetObjectCommand(getObjectRequest),
+          transferOptions,
+        );
+        totalSize = getObject.ContentRange
+          ? Number.parseInt(getObject.ContentRange.split("/")[1])
+          : 0;
 
         this.dispatchTransferInitiatedEvent(request, totalSize);
         if (getObject.Body) {
@@ -1373,19 +1709,28 @@ export class S3TransferManager implements IS3TransferManager {
     streams: Promise<StreamingBlobPayloadOutputTypes>[],
     requests: GetObjectCommandInput[],
     metadata: Omit<DownloadResponse, "Body">,
-    checksumValidationEnabled: boolean
-  ): Promise<{ totalSize: number | undefined; onStreamConsumed?: (index: number) => void }> {
+    checksumValidationEnabled: boolean,
+  ): Promise<{
+    totalSize: number | undefined;
+    onStreamConsumed?: (index: number) => void;
+  }> {
     let streamConsumedCallback: ((index: number) => void) | undefined;
     this.checkAborted(transferOptions);
 
     const headResponse = await this.s3.send(
       new HeadObjectCommand({ Bucket: request.Bucket, Key: request.Key }),
-      transferOptions
+      transferOptions,
     );
 
     if (headResponse.ContentLength === 0) {
-      const getObjectRequest = { ...request, ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }) };
-      const response = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
+      const getObjectRequest = {
+        ...request,
+        ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+      };
+      const response = await this.s3.send(
+        new GetObjectCommand(getObjectRequest),
+        transferOptions,
+      );
 
       this.dispatchTransferInitiatedEvent(request, 0);
       if (response.Body) streams.push(Promise.resolve(response.Body));
@@ -1403,10 +1748,18 @@ export class S3TransferManager implements IS3TransferManager {
     let initialETag: string | undefined;
 
     if (request.Range != null) {
-      const [userRangeLeft, userRangeRight] = request.Range.replace("bytes=", "").split("-").map(Number);
+      const [userRangeLeft, userRangeRight] = request.Range.replace(
+        "bytes=",
+        "",
+      )
+        .split("-")
+        .map(Number);
       maxRange = userRangeRight;
       left = userRangeLeft;
-      right = Math.min(userRangeRight, left + S3TransferManager.MIN_PART_SIZE - 1);
+      right = Math.min(
+        userRangeRight,
+        left + S3TransferManager.MIN_PART_SIZE - 1,
+      );
       totalSize = userRangeRight + 1;
     }
 
@@ -1416,9 +1769,15 @@ export class S3TransferManager implements IS3TransferManager {
         Range: `bytes=${left}-${right}`,
         ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
       };
-      const initialRangeGet = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
+      const initialRangeGet = await this.s3.send(
+        new GetObjectCommand(getObjectRequest),
+        transferOptions,
+      );
       await internalEventHandler.afterInitialGetObject();
-      this.validateRangeDownload(`bytes=${left}-${right}`, initialRangeGet.ContentRange);
+      this.validateRangeDownload(
+        `bytes=${left}-${right}`,
+        initialRangeGet.ContentRange,
+      );
       initialETag = initialRangeGet.ETag ?? undefined;
       if (!totalSize) {
         totalSize = initialRangeGet.ContentRange
@@ -1426,7 +1785,10 @@ export class S3TransferManager implements IS3TransferManager {
           : undefined;
       }
 
-      if (initialRangeGet.Body && typeof (initialRangeGet.Body as any).getReader === "function") {
+      if (
+        initialRangeGet.Body &&
+        typeof (initialRangeGet.Body as any).getReader === "function"
+      ) {
         const reader = (initialRangeGet.Body as any).getReader();
         (initialRangeGet.Body as any).getReader = function () {
           return reader;
@@ -1446,13 +1808,17 @@ export class S3TransferManager implements IS3TransferManager {
     if (totalSize) {
       const contentLength = totalSize;
       const remainingBytes = Math.max(0, contentLength - (right - left + 1));
-      const additionalRequests = Math.ceil(remainingBytes / S3TransferManager.MIN_PART_SIZE);
+      const additionalRequests = Math.ceil(
+        remainingBytes / S3TransferManager.MIN_PART_SIZE,
+      );
       expectedRequestCount += additionalRequests;
     }
 
     left = right + 1;
     right = Math.min(left + S3TransferManager.MIN_PART_SIZE - 1, maxRange);
-    remainingLength = totalSize ? Math.min(right - left + 1, Math.max(0, totalSize - left)) : 0;
+    remainingLength = totalSize
+      ? Math.min(right - left + 1, Math.max(0, totalSize - left))
+      : 0;
     const rangeTasks: (() => Promise<StreamingBlobPayloadOutputTypes>)[] = [];
     const rangeRequests: GetObjectCommandInput[] = [];
 
@@ -1472,7 +1838,10 @@ export class S3TransferManager implements IS3TransferManager {
           .send(new GetObjectCommand(getObjectRequest), transferOptions)
           .then((response) => {
             this.validateRangeDownload(range, response.ContentRange);
-            if (response.Body && typeof (response.Body as any).getReader === "function") {
+            if (
+              response.Body &&
+              typeof (response.Body as any).getReader === "function"
+            ) {
               const reader = (response.Body as any).getReader();
               (response.Body as any).getReader = function () {
                 return reader;
@@ -1481,24 +1850,28 @@ export class S3TransferManager implements IS3TransferManager {
             return response.Body!;
           })
           .catch((error) => {
-            this.dispatchTransferFailedEvent(getObjectRequest, totalSize, error);
+            this.dispatchTransferFailedEvent(
+              getObjectRequest,
+              totalSize,
+              error,
+            );
             throw error;
           });
       });
 
       left = right + 1;
       right = Math.min(left + S3TransferManager.MIN_PART_SIZE - 1, maxRange);
-      remainingLength = totalSize ? Math.min(right - left + 1, Math.max(0, totalSize - left)) : 0;
+      remainingLength = totalSize
+        ? Math.min(right - left + 1, Math.max(0, totalSize - left))
+        : 0;
     }
 
     if (rangeTasks.length > 0) {
       // Lazily prefetch streams — only maxConcurrentDownloads requests in-flight.
       // New requests fire as previous ones complete, and joinStreams can start
       // consuming immediately without waiting for all ranges to be fetched.
-      const { promises: pendingStreams, onStreamConsumed } = this.createConcurrentTaskPool(
-        rangeTasks,
-        this.maxConcurrentDownloads
-      );
+      const { promises: pendingStreams, onStreamConsumed } =
+        this.createConcurrentTaskPool(rangeTasks, this.maxConcurrentDownloads);
       streams.push(...pendingStreams);
       requests.push(...rangeRequests);
       streamConsumedCallback = onStreamConsumed;
@@ -1507,7 +1880,7 @@ export class S3TransferManager implements IS3TransferManager {
     const actualRequestCount = 1 + rangeTasks.length;
     if (expectedRequestCount !== actualRequestCount) {
       throw new Error(
-        `The number of ranged GET requests sent (${actualRequestCount}) does not match the expected number (${expectedRequestCount})`
+        `The number of ranged GET requests sent (${actualRequestCount}) does not match the expected number (${expectedRequestCount})`,
       );
     }
 
@@ -1535,8 +1908,11 @@ export class S3TransferManager implements IS3TransferManager {
     streams: Promise<StreamingBlobPayloadOutputTypes>[],
     requests: GetObjectCommandInput[],
     metadata: Omit<DownloadResponse, "Body">,
-    checksumValidationEnabled: boolean
-  ): Promise<{ totalSize: number | undefined; onStreamConsumed?: (index: number) => void }> {
+    checksumValidationEnabled: boolean,
+  ): Promise<{
+    totalSize: number | undefined;
+    onStreamConsumed?: (index: number) => void;
+  }> {
     this.checkAborted(transferOptions);
 
     // Fetch Part 1 to discover metadata: PartsCount, part size, ETag, total object size.
@@ -1548,7 +1924,10 @@ export class S3TransferManager implements IS3TransferManager {
       ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
     };
 
-    const initialPart = await this.s3.send(new GetObjectCommand(initialPartRequest), transferOptions);
+    const initialPart = await this.s3.send(
+      new GetObjectCommand(initialPartRequest),
+      transferOptions,
+    );
     await internalEventHandler.afterInitialGetObject();
 
     const partSize = initialPart.ContentLength!;
@@ -1591,7 +1970,9 @@ export class S3TransferManager implements IS3TransferManager {
     const abortController = new AbortController();
     const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
     if (userSignal) {
-      userSignal.addEventListener("abort", () => abortController.abort(), { once: true });
+      userSignal.addEventListener("abort", () => abortController.abort(), {
+        once: true,
+      });
     }
 
     // Concurrency limiter: bound in-flight requests to maxConcurrentDownloads.
@@ -1634,7 +2015,9 @@ export class S3TransferManager implements IS3TransferManager {
           ...requestWithoutRange,
           PartNumber: partNumber,
           IfMatch: initialETag,
-          ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+          ...(checksumValidationEnabled && {
+            ChecksumMode: "ENABLED" as const,
+          }),
         };
 
         requests.push(partGetRequest);
@@ -1660,13 +2043,20 @@ export class S3TransferManager implements IS3TransferManager {
               this.s3.config.requestHandler as unknown as WorkerHttpHandler
             ).getStreamDownloadResult(resultToken);
             if (transferResult) {
-              queue.enqueue(rangeIndex, transferResult.buffer, transferResult.byteLength);
+              queue.enqueue(
+                rangeIndex,
+                transferResult.buffer,
+                transferResult.byteLength,
+              );
 
               this.dispatchEvent(
                 Object.assign(new Event("bytesTransferred"), {
                   request: partGetRequest,
-                  snapshot: { transferredBytes: transferResult.byteLength, totalBytes: totalSize },
-                })
+                  snapshot: {
+                    transferredBytes: transferResult.byteLength,
+                    totalBytes: totalSize,
+                  },
+                }),
               );
             }
             releaseSlot();
@@ -1723,7 +2113,11 @@ export class S3TransferManager implements IS3TransferManager {
       },
     });
 
-    streams.push(Promise.resolve(transferStream as unknown as StreamingBlobPayloadOutputTypes));
+    streams.push(
+      Promise.resolve(
+        transferStream as unknown as StreamingBlobPayloadOutputTypes,
+      ),
+    );
 
     return { totalSize };
   }
@@ -1746,19 +2140,28 @@ export class S3TransferManager implements IS3TransferManager {
     streams: Promise<StreamingBlobPayloadOutputTypes>[],
     requests: GetObjectCommandInput[],
     metadata: Omit<DownloadResponse, "Body">,
-    checksumValidationEnabled: boolean
-  ): Promise<{ totalSize: number | undefined; onStreamConsumed?: (index: number) => void }> {
+    checksumValidationEnabled: boolean,
+  ): Promise<{
+    totalSize: number | undefined;
+    onStreamConsumed?: (index: number) => void;
+  }> {
     this.checkAborted(transferOptions);
 
     const headResponse = await this.s3.send(
       new HeadObjectCommand({ Bucket: request.Bucket, Key: request.Key }),
-      transferOptions
+      transferOptions,
     );
     await internalEventHandler.afterInitialGetObject();
 
     if (headResponse.ContentLength === 0) {
-      const getObjectRequest = { ...request, ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }) };
-      const response = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
+      const getObjectRequest = {
+        ...request,
+        ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+      };
+      const response = await this.s3.send(
+        new GetObjectCommand(getObjectRequest),
+        transferOptions,
+      );
 
       this.dispatchTransferInitiatedEvent(request, 0);
       if (response.Body) streams.push(Promise.resolve(response.Body));
@@ -1792,7 +2195,9 @@ export class S3TransferManager implements IS3TransferManager {
     const abortController = new AbortController();
     const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
     if (userSignal) {
-      userSignal.addEventListener("abort", () => abortController.abort(), { once: true });
+      userSignal.addEventListener("abort", () => abortController.abort(), {
+        once: true,
+      });
     }
 
     // Concurrency limiter: bound in-flight requests to maxConcurrentDownloads.
@@ -1837,7 +2242,9 @@ export class S3TransferManager implements IS3TransferManager {
           ...request,
           Range: `bytes=${start}-${end}`,
           IfMatch: eTag,
-          ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+          ...(checksumValidationEnabled && {
+            ChecksumMode: "ENABLED" as const,
+          }),
         };
 
         requests.push(rangeGetRequest);
@@ -1863,13 +2270,20 @@ export class S3TransferManager implements IS3TransferManager {
               this.s3.config.requestHandler as unknown as WorkerHttpHandler
             ).getStreamDownloadResult(resultToken);
             if (transferResult) {
-              queue.enqueue(rangeIndex, transferResult.buffer, transferResult.byteLength);
+              queue.enqueue(
+                rangeIndex,
+                transferResult.buffer,
+                transferResult.byteLength,
+              );
 
               this.dispatchEvent(
                 Object.assign(new Event("bytesTransferred"), {
                   request: rangeGetRequest,
-                  snapshot: { transferredBytes: transferResult.byteLength, totalBytes: totalSize },
-                })
+                  snapshot: {
+                    transferredBytes: transferResult.byteLength,
+                    totalBytes: totalSize,
+                  },
+                }),
               );
             }
             releaseSlot();
@@ -1921,7 +2335,11 @@ export class S3TransferManager implements IS3TransferManager {
       },
     });
 
-    streams.push(Promise.resolve(transferStream as unknown as StreamingBlobPayloadOutputTypes));
+    streams.push(
+      Promise.resolve(
+        transferStream as unknown as StreamingBlobPayloadOutputTypes,
+      ),
+    );
 
     return { totalSize };
   }
@@ -1934,7 +2352,10 @@ export class S3TransferManager implements IS3TransferManager {
   private addEventListeners(eventListeners?: TransferEventListeners): void {
     for (const listeners of this.iterateListeners(eventListeners)) {
       for (const listener of listeners) {
-        this.addEventListener(listener.eventType, listener.callback as EventListener);
+        this.addEventListener(
+          listener.eventType,
+          listener.callback as EventListener,
+        );
       }
     }
   }
@@ -1947,7 +2368,10 @@ export class S3TransferManager implements IS3TransferManager {
   private removeEventListeners(eventListeners?: TransferEventListeners): void {
     for (const listeners of this.iterateListeners(eventListeners)) {
       for (const listener of listeners) {
-        this.removeEventListener(listener.eventType, listener.callback as EventListener);
+        this.removeEventListener(
+          listener.eventType,
+          listener.callback as EventListener,
+        );
       }
     }
   }
@@ -1976,7 +2400,7 @@ export class S3TransferManager implements IS3TransferManager {
   private buildDownloadToFileResponse(
     initialResponse: DownloadResponse,
     totalSize: number,
-    request: DownloadToFileRequest
+    request: DownloadToFileRequest,
   ): DownloadToFileResponse {
     const metadata: Record<string, any> = {};
     this.assignMetadata(metadata, initialResponse);
@@ -2003,7 +2427,7 @@ export class S3TransferManager implements IS3TransferManager {
           transferredBytes: totalSize,
           totalBytes: totalSize,
         },
-      })
+      }),
     );
 
     return response;
@@ -2020,7 +2444,7 @@ export class S3TransferManager implements IS3TransferManager {
     tempFilePath: string,
     request: DownloadToFileRequest,
     totalSize: number,
-    error: unknown
+    error: unknown,
   ): Promise<void> {
     await fileManager.deleteTempFile(tempFilePath);
     fileManager.unregisterCleanupHandler(tempFilePath);
@@ -2032,7 +2456,10 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @internal
    */
-  private updateResponseLengthAndRange(response: DownloadResponse, totalSize: number | undefined): void {
+  private updateResponseLengthAndRange(
+    response: DownloadResponse,
+    totalSize: number | undefined,
+  ): void {
     if (totalSize !== undefined) {
       response.ContentLength = totalSize;
       response.ContentRange = `bytes 0-${totalSize - 1}/${totalSize}`;
@@ -2044,7 +2471,10 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @internal
    */
-  private updateChecksumValues(initialPart: DownloadResponse, metadata: Omit<DownloadResponse, "Body">) {
+  private updateChecksumValues(
+    initialPart: DownloadResponse,
+    metadata: Omit<DownloadResponse, "Body">,
+  ) {
     if (initialPart.ChecksumType === "COMPOSITE") {
       metadata.ChecksumCRC32 = undefined;
       metadata.ChecksumCRC32C = undefined;
@@ -2061,7 +2491,7 @@ export class S3TransferManager implements IS3TransferManager {
   private processResponseMetadata(
     response: DownloadResponse,
     metadata: Omit<DownloadResponse, "Body">,
-    totalSize: number | undefined
+    totalSize: number | undefined,
   ): void {
     this.updateResponseLengthAndRange(response, totalSize);
     this.assignMetadata(metadata, response);
@@ -2075,7 +2505,9 @@ export class S3TransferManager implements IS3TransferManager {
    */
   private checkAborted(transferOptions?: TransferOptions): void {
     if (transferOptions?.abortSignal?.aborted) {
-      throw Object.assign(new Error("Transfer aborted."), { name: "AbortError" });
+      throw Object.assign(new Error("Transfer aborted."), {
+        name: "AbortError",
+      });
     }
   }
 
@@ -2086,7 +2518,9 @@ export class S3TransferManager implements IS3TransferManager {
    */
   private validateConfig(): void {
     if (this.targetPartSizeBytes < S3TransferManager.MIN_PART_SIZE) {
-      throw new Error(`targetPartSizeBytes must be at least ${S3TransferManager.MIN_PART_SIZE} bytes`);
+      throw new Error(
+        `targetPartSizeBytes must be at least ${S3TransferManager.MIN_PART_SIZE} bytes`,
+      );
     }
   }
 
@@ -2095,7 +2529,10 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @internal
    */
-  private dispatchTransferInitiatedEvent(request: DownloadRequest | UploadRequest, totalSize?: number): boolean {
+  private dispatchTransferInitiatedEvent(
+    request: DownloadRequest | UploadRequest,
+    totalSize?: number,
+  ): boolean {
     this.dispatchEvent(
       Object.assign(new Event("transferInitiated"), {
         request,
@@ -2103,7 +2540,7 @@ export class S3TransferManager implements IS3TransferManager {
           transferredBytes: 0,
           totalBytes: totalSize,
         },
-      })
+      }),
     );
     return true;
   }
@@ -2116,7 +2553,7 @@ export class S3TransferManager implements IS3TransferManager {
   private dispatchTransferFailedEvent(
     request: DownloadRequest | UploadRequest,
     totalSize?: number,
-    error?: Error
+    error?: Error,
   ): boolean {
     this.dispatchEvent(
       Object.assign(new Event("transferFailed"), {
@@ -2126,7 +2563,7 @@ export class S3TransferManager implements IS3TransferManager {
           transferredBytes: 0,
           totalBytes: totalSize,
         },
-      })
+      }),
     );
     return true;
   }
@@ -2139,7 +2576,8 @@ export class S3TransferManager implements IS3TransferManager {
   private *iterateListeners(eventListeners: TransferEventListeners = {}) {
     for (const key in eventListeners) {
       const eventType = key as keyof TransferEventListeners;
-      const listeners = eventListeners[eventType as keyof TransferEventListeners];
+      const listeners =
+        eventListeners[eventType as keyof TransferEventListeners];
       if (Array.isArray(listeners)) {
         for (const callback of listeners) {
           yield [
@@ -2169,14 +2607,17 @@ export class S3TransferManager implements IS3TransferManager {
    */
   private createConcurrentTaskPool<T>(
     tasks: (() => Promise<T>)[],
-    maxConcurrent: number
+    maxConcurrent: number,
   ): {
     promises: Promise<T>[];
     onStreamConsumed: (index: number) => void;
   } {
     if (tasks.length === 0) return { promises: [], onStreamConsumed: () => {} };
 
-    const resolvers: Array<{ resolve: (value: T) => void; reject: (error: unknown) => void }> = [];
+    const resolvers: Array<{
+      resolve: (value: T) => void;
+      reject: (error: unknown) => void;
+    }> = [];
     const promises: Promise<T>[] = tasks.map(() => {
       let resolve!: (value: T) => void;
       let reject!: (error: unknown) => void;
@@ -2199,7 +2640,7 @@ export class S3TransferManager implements IS3TransferManager {
         (error) => {
           failed = true;
           resolvers[index].reject(error);
-        }
+        },
       );
     };
 
@@ -2222,7 +2663,11 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @internal
    */
-  private validatePartDownload(contentRange: string | undefined, partNumber: number, partSize: number) {
+  private validatePartDownload(
+    contentRange: string | undefined,
+    partNumber: number,
+    partSize: number,
+  ) {
     if (!contentRange) {
       throw new Error(`Missing ContentRange for part ${partNumber}.`);
     }
@@ -2238,11 +2683,15 @@ export class S3TransferManager implements IS3TransferManager {
     const expectedEnd = Math.min(expectedStart + partSize - 1, total);
 
     if (start !== expectedStart) {
-      throw new Error(`Expected part ${partNumber} to start at ${expectedStart} but got ${start}`);
+      throw new Error(
+        `Expected part ${partNumber} to start at ${expectedStart} but got ${start}`,
+      );
     }
 
     if (end !== expectedEnd) {
-      throw new Error(`Expected part ${partNumber} to end at ${expectedEnd} but got ${end}`);
+      throw new Error(
+        `Expected part ${partNumber} to end at ${expectedEnd} but got ${end}`,
+      );
     }
   }
 
@@ -2251,13 +2700,17 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @internal
    */
-  private validateRangeDownload(requestRange: string, responseRange: string | undefined) {
+  private validateRangeDownload(
+    requestRange: string,
+    responseRange: string | undefined,
+  ) {
     if (!responseRange) {
       throw new Error(`Missing ContentRange for range ${requestRange}.`);
     }
 
     const match = responseRange.match(/bytes (\d+)-(\d+)\/(\d+)/);
-    if (!match) throw new Error(`Invalid ContentRange format: ${responseRange}`);
+    if (!match)
+      throw new Error(`Invalid ContentRange format: ${responseRange}`);
 
     const start = Number.parseInt(match[1]);
     const end = Number.parseInt(match[2]);
@@ -2270,7 +2723,9 @@ export class S3TransferManager implements IS3TransferManager {
     const expectedEnd = Number.parseInt(rangeMatch[2]);
 
     if (start !== expectedStart) {
-      throw new Error(`Expected range to start at ${expectedStart} but got ${start}`);
+      throw new Error(
+        `Expected range to start at ${expectedStart} but got ${start}`,
+      );
     }
 
     if (end === expectedEnd) {
@@ -2293,12 +2748,15 @@ export class S3TransferManager implements IS3TransferManager {
   private async uploadSinglePart(
     request: UploadRequest,
     contentLength: number,
-    transferOptions?: TransferOptions
+    transferOptions?: TransferOptions,
   ): Promise<PutObjectCommandOutput> {
     const putObjectRequest: PutObjectCommandInput = { ...request };
 
     this.checkAborted(transferOptions);
-    const response = await this.s3.send(new PutObjectCommand(putObjectRequest), transferOptions);
+    const response = await this.s3.send(
+      new PutObjectCommand(putObjectRequest),
+      transferOptions,
+    );
 
     this.dispatchEvent(
       Object.assign(new Event("bytesTransferred"), {
@@ -2307,7 +2765,7 @@ export class S3TransferManager implements IS3TransferManager {
           transferredBytes: contentLength,
           totalBytes: contentLength,
         },
-      })
+      }),
     );
 
     return response;
@@ -2318,8 +2776,14 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @internal
    */
-  private calculatePartSize(contentLength: number): { partSize: number; expectedPartsCount: number } {
-    const partSize = Math.max(this.targetPartSizeBytes, Math.ceil(contentLength / 10_000));
+  private calculatePartSize(contentLength: number): {
+    partSize: number;
+    expectedPartsCount: number;
+  } {
+    const partSize = Math.max(
+      this.targetPartSizeBytes,
+      Math.ceil(contentLength / 10_000),
+    );
     const expectedPartsCount = Math.ceil(contentLength / partSize);
     return { partSize, expectedPartsCount };
   }
@@ -2329,7 +2793,9 @@ export class S3TransferManager implements IS3TransferManager {
    * @internal
    */
   private isFileBody(body: any): boolean {
-    return typeof body?.pipe === "function" && typeof (body as any).path === "string";
+    return (
+      typeof body?.pipe === "function" && typeof (body as any).path === "string"
+    );
   }
 
   /**
@@ -2350,12 +2816,15 @@ export class S3TransferManager implements IS3TransferManager {
   private async threadedUploadInPartsFromFile(
     request: UploadRequest,
     contentLength: number,
-    transferOptions?: TransferOptions
+    transferOptions?: TransferOptions,
   ): Promise<CompleteMultipartUploadCommandOutput> {
     const { partSize } = this.calculatePartSize(contentLength);
     const filePath = (request.Body as any).path as string;
 
-    const buildDataSource = (checksumAlgorithm?: string, checksumHeader?: string): DataSource => ({
+    const buildDataSource = (
+      checksumAlgorithm?: string,
+      checksumHeader?: string,
+    ): DataSource => ({
       type: "file",
       filePath,
       partSize,
@@ -2364,7 +2833,12 @@ export class S3TransferManager implements IS3TransferManager {
       checksumHeader,
     });
 
-    return this.threadedMultipartUpload(request, contentLength, buildDataSource, transferOptions);
+    return this.threadedMultipartUpload(
+      request,
+      contentLength,
+      buildDataSource,
+      transferOptions,
+    );
   }
 
   /**
@@ -2377,7 +2851,7 @@ export class S3TransferManager implements IS3TransferManager {
   private async threadedUploadInParts(
     request: UploadRequest,
     contentLength: number,
-    transferOptions?: TransferOptions
+    transferOptions?: TransferOptions,
   ): Promise<CompleteMultipartUploadCommandOutput> {
     const { partSize } = this.calculatePartSize(contentLength);
     const body = request.Body as Uint8Array;
@@ -2386,7 +2860,10 @@ export class S3TransferManager implements IS3TransferManager {
     const sharedBuffer = new SharedArrayBuffer(body.byteLength);
     new Uint8Array(sharedBuffer).set(body);
 
-    const buildDataSource = (checksumAlgorithm?: string, checksumHeader?: string): DataSource => ({
+    const buildDataSource = (
+      checksumAlgorithm?: string,
+      checksumHeader?: string,
+    ): DataSource => ({
       type: "sharedBuffer",
       sharedBuffer,
       partSize,
@@ -2395,7 +2872,12 @@ export class S3TransferManager implements IS3TransferManager {
       checksumHeader,
     });
 
-    return this.threadedMultipartUpload(request, contentLength, buildDataSource, transferOptions);
+    return this.threadedMultipartUpload(
+      request,
+      contentLength,
+      buildDataSource,
+      transferOptions,
+    );
   }
 
   /**
@@ -2409,10 +2891,14 @@ export class S3TransferManager implements IS3TransferManager {
   private async threadedMultipartUpload(
     request: UploadRequest,
     contentLength: number,
-    buildDataSource: (checksumAlgorithm?: string, checksumHeader?: string) => DataSource,
-    transferOptions?: TransferOptions
+    buildDataSource: (
+      checksumAlgorithm?: string,
+      checksumHeader?: string,
+    ) => DataSource,
+    transferOptions?: TransferOptions,
   ): Promise<CompleteMultipartUploadCommandOutput> {
-    const { partSize, expectedPartsCount } = this.calculatePartSize(contentLength);
+    const { partSize, expectedPartsCount } =
+      this.calculatePartSize(contentLength);
 
     this.checkAborted(transferOptions);
 
@@ -2428,15 +2914,23 @@ export class S3TransferManager implements IS3TransferManager {
     if (hasFullObjectChecksum) {
       createMpuRequest.ChecksumType = "FULL_OBJECT";
     }
-    if (!createMpuRequest.ChecksumAlgorithm && this.requestChecksumCalculation === "WHEN_SUPPORTED") {
+    if (
+      !createMpuRequest.ChecksumAlgorithm &&
+      this.requestChecksumCalculation === "WHEN_SUPPORTED"
+    ) {
       createMpuRequest.ChecksumAlgorithm = request.ChecksumAlgorithm ?? "CRC32";
     }
 
-    const createMpuResponse = await this.s3.send(new CreateMultipartUploadCommand(createMpuRequest), transferOptions);
+    const createMpuResponse = await this.s3.send(
+      new CreateMultipartUploadCommand(createMpuRequest),
+      transferOptions,
+    );
     const uploadId = createMpuResponse.UploadId!;
 
     const checksumAlgorithm = createMpuRequest.ChecksumAlgorithm;
-    const checksumHeader = checksumAlgorithm ? `x-amz-checksum-${checksumAlgorithm.toLowerCase()}` : undefined;
+    const checksumHeader = checksumAlgorithm
+      ? `x-amz-checksum-${checksumAlgorithm.toLowerCase()}`
+      : undefined;
     const dataSource = buildDataSource(checksumAlgorithm, checksumHeader);
 
     const abortController = new AbortController();
@@ -2453,7 +2947,10 @@ export class S3TransferManager implements IS3TransferManager {
           if (partNumber > expectedPartsCount) return;
 
           if (uploadAbortSignal.aborted) {
-            throw Object.assign(new Error("Upload aborted due to part failure."), { name: "AbortError" });
+            throw Object.assign(
+              new Error("Upload aborted due to part failure."),
+              { name: "AbortError" },
+            );
           }
           this.checkAborted(transferOptions);
 
@@ -2471,23 +2968,33 @@ export class S3TransferManager implements IS3TransferManager {
             UploadId: uploadId,
             PartNumber: partNumber,
             ContentLength: length,
-            ...(checksumAlgorithm && { ChecksumAlgorithm: checksumAlgorithm as any }),
+            ...(checksumAlgorithm && {
+              ChecksumAlgorithm: checksumAlgorithm as any,
+            }),
           };
 
-          const partResponse = await this.s3.send(new UploadPartCommand(partRequest), {
-            ...transferOptions,
-            dataSource,
-          } as any);
+          const partResponse = await this.s3.send(
+            new UploadPartCommand(partRequest),
+            {
+              ...transferOptions,
+              dataSource,
+            } as any,
+          );
 
           const completedPart: CompletedPart = {
             PartNumber: partNumber,
             ETag: partResponse.ETag,
           };
-          if (partResponse.ChecksumCRC32) completedPart.ChecksumCRC32 = partResponse.ChecksumCRC32;
-          if (partResponse.ChecksumCRC32C) completedPart.ChecksumCRC32C = partResponse.ChecksumCRC32C;
-          if (partResponse.ChecksumCRC64NVME) completedPart.ChecksumCRC64NVME = partResponse.ChecksumCRC64NVME;
-          if (partResponse.ChecksumSHA1) completedPart.ChecksumSHA1 = partResponse.ChecksumSHA1;
-          if (partResponse.ChecksumSHA256) completedPart.ChecksumSHA256 = partResponse.ChecksumSHA256;
+          if (partResponse.ChecksumCRC32)
+            completedPart.ChecksumCRC32 = partResponse.ChecksumCRC32;
+          if (partResponse.ChecksumCRC32C)
+            completedPart.ChecksumCRC32C = partResponse.ChecksumCRC32C;
+          if (partResponse.ChecksumCRC64NVME)
+            completedPart.ChecksumCRC64NVME = partResponse.ChecksumCRC64NVME;
+          if (partResponse.ChecksumSHA1)
+            completedPart.ChecksumSHA1 = partResponse.ChecksumSHA1;
+          if (partResponse.ChecksumSHA256)
+            completedPart.ChecksumSHA256 = partResponse.ChecksumSHA256;
 
           completedParts.push(completedPart);
           bytesUploaded += length;
@@ -2499,7 +3006,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredBytes: bytesUploaded,
                 totalBytes: contentLength,
               },
-            })
+            }),
           );
         }
       };
@@ -2510,14 +3017,16 @@ export class S3TransferManager implements IS3TransferManager {
           uploadPart().catch((error) => {
             abortController.abort();
             throw error;
-          })
+          }),
         );
       }
 
       await Promise.all(partUploads);
 
       if (completedParts.length !== expectedPartsCount) {
-        throw new Error(`Expected ${expectedPartsCount} parts but uploaded ${completedParts.length} parts`);
+        throw new Error(
+          `Expected ${expectedPartsCount} parts but uploaded ${completedParts.length} parts`,
+        );
       }
 
       completedParts.sort((a, b) => a.PartNumber! - b.PartNumber!);
@@ -2533,16 +3042,22 @@ export class S3TransferManager implements IS3TransferManager {
 
       if (hasFullObjectChecksum) {
         completeRequest.ChecksumType = "FULL_OBJECT";
-        if (request.ChecksumCRC32) completeRequest.ChecksumCRC32 = request.ChecksumCRC32;
-        if (request.ChecksumCRC32C) completeRequest.ChecksumCRC32C = request.ChecksumCRC32C;
-        if (request.ChecksumCRC64NVME) completeRequest.ChecksumCRC64NVME = request.ChecksumCRC64NVME;
+        if (request.ChecksumCRC32)
+          completeRequest.ChecksumCRC32 = request.ChecksumCRC32;
+        if (request.ChecksumCRC32C)
+          completeRequest.ChecksumCRC32C = request.ChecksumCRC32C;
+        if (request.ChecksumCRC64NVME)
+          completeRequest.ChecksumCRC64NVME = request.ChecksumCRC64NVME;
       }
 
       try {
-        return await this.s3.send(new CompleteMultipartUploadCommand(completeRequest), transferOptions);
+        return await this.s3.send(
+          new CompleteMultipartUploadCommand(completeRequest),
+          transferOptions,
+        );
       } catch (completeMpuError) {
         this.logger.warn(
-          `CompleteMultipartUpload failed for upload ID ${uploadId}: ${(completeMpuError as Error).message}`
+          `CompleteMultipartUpload failed for upload ID ${uploadId}: ${(completeMpuError as Error).message}`,
         );
         throw completeMpuError;
       }
@@ -2554,9 +3069,15 @@ export class S3TransferManager implements IS3TransferManager {
       };
 
       try {
-        await this.s3.send(new AbortMultipartUploadCommand(abortRequest), transferOptions);
+        await this.s3.send(
+          new AbortMultipartUploadCommand(abortRequest),
+          transferOptions,
+        );
       } catch (abortError) {
-        this.logger.warn(`Failed to abort multipart upload ${uploadId}:`, abortError);
+        this.logger.warn(
+          `Failed to abort multipart upload ${uploadId}:`,
+          abortError,
+        );
       }
       throw error;
     }
@@ -2573,9 +3094,10 @@ export class S3TransferManager implements IS3TransferManager {
   private async uploadInParts(
     request: UploadRequest,
     contentLength: number,
-    transferOptions?: TransferOptions
+    transferOptions?: TransferOptions,
   ): Promise<CompleteMultipartUploadCommandOutput> {
-    const { partSize, expectedPartsCount } = this.calculatePartSize(contentLength);
+    const { partSize, expectedPartsCount } =
+      this.calculatePartSize(contentLength);
 
     this.checkAborted(transferOptions);
 
@@ -2592,10 +3114,16 @@ export class S3TransferManager implements IS3TransferManager {
     if (hasFullObjectChecksum) {
       createMpuRequest.ChecksumType = "FULL_OBJECT";
     }
-    if (!createMpuRequest.ChecksumAlgorithm && this.requestChecksumCalculation === "WHEN_SUPPORTED") {
+    if (
+      !createMpuRequest.ChecksumAlgorithm &&
+      this.requestChecksumCalculation === "WHEN_SUPPORTED"
+    ) {
       createMpuRequest.ChecksumAlgorithm = request.ChecksumAlgorithm ?? "CRC32";
     }
-    const createMpuResponse = await this.s3.send(new CreateMultipartUploadCommand(createMpuRequest), transferOptions);
+    const createMpuResponse = await this.s3.send(
+      new CreateMultipartUploadCommand(createMpuRequest),
+      transferOptions,
+    );
     const uploadId = createMpuResponse.UploadId!;
 
     const abortController = new AbortController();
@@ -2606,10 +3134,15 @@ export class S3TransferManager implements IS3TransferManager {
       const dataFeeder = getChunk(request.Body, partSize);
       let bytesUploaded = 0;
 
-      const uploadPart = async (dataFeeder: AsyncGenerator<RawDataPart, void, undefined>) => {
+      const uploadPart = async (
+        dataFeeder: AsyncGenerator<RawDataPart, void, undefined>,
+      ) => {
         for await (const dataPart of dataFeeder) {
           if (uploadAbortSignal.aborted) {
-            throw Object.assign(new Error("Upload aborted due to part failure."), { name: "AbortError" });
+            throw Object.assign(
+              new Error("Upload aborted due to part failure."),
+              { name: "AbortError" },
+            );
           }
           this.checkAborted(transferOptions);
 
@@ -2626,7 +3159,10 @@ export class S3TransferManager implements IS3TransferManager {
             }),
           };
 
-          const partResponse = await this.s3.send(new UploadPartCommand(partRequest), transferOptions);
+          const partResponse = await this.s3.send(
+            new UploadPartCommand(partRequest),
+            transferOptions,
+          );
 
           const checksumAlgorithm = partRequest.ChecksumAlgorithm;
           if (
@@ -2639,7 +3175,7 @@ export class S3TransferManager implements IS3TransferManager {
           ) {
             throw new Error(
               `Checksum was requested for part ${dataPart.partNumber} using ${checksumAlgorithm}, but no checksum was returned in the response. ` +
-                `If running in a browser, ensure your S3 bucket CORS configuration is enabled. `
+                `If running in a browser, ensure your S3 bucket CORS configuration is enabled. `,
             );
           }
 
@@ -2647,11 +3183,16 @@ export class S3TransferManager implements IS3TransferManager {
             PartNumber: dataPart.partNumber,
             ETag: partResponse.ETag,
           };
-          if (partResponse.ChecksumCRC32) completedPart.ChecksumCRC32 = partResponse.ChecksumCRC32;
-          if (partResponse.ChecksumCRC32C) completedPart.ChecksumCRC32C = partResponse.ChecksumCRC32C;
-          if (partResponse.ChecksumCRC64NVME) completedPart.ChecksumCRC64NVME = partResponse.ChecksumCRC64NVME;
-          if (partResponse.ChecksumSHA1) completedPart.ChecksumSHA1 = partResponse.ChecksumSHA1;
-          if (partResponse.ChecksumSHA256) completedPart.ChecksumSHA256 = partResponse.ChecksumSHA256;
+          if (partResponse.ChecksumCRC32)
+            completedPart.ChecksumCRC32 = partResponse.ChecksumCRC32;
+          if (partResponse.ChecksumCRC32C)
+            completedPart.ChecksumCRC32C = partResponse.ChecksumCRC32C;
+          if (partResponse.ChecksumCRC64NVME)
+            completedPart.ChecksumCRC64NVME = partResponse.ChecksumCRC64NVME;
+          if (partResponse.ChecksumSHA1)
+            completedPart.ChecksumSHA1 = partResponse.ChecksumSHA1;
+          if (partResponse.ChecksumSHA256)
+            completedPart.ChecksumSHA256 = partResponse.ChecksumSHA256;
 
           completedParts.push(completedPart);
 
@@ -2665,7 +3206,7 @@ export class S3TransferManager implements IS3TransferManager {
                 transferredBytes: bytesUploaded,
                 totalBytes: contentLength,
               },
-            })
+            }),
           );
         }
       };
@@ -2676,14 +3217,16 @@ export class S3TransferManager implements IS3TransferManager {
           uploadPart(dataFeeder).catch((error) => {
             abortController.abort();
             throw error;
-          })
+          }),
         );
       }
 
       await Promise.all(partUploads);
 
       if (completedParts.length !== expectedPartsCount) {
-        throw new Error(`Expected ${expectedPartsCount} parts but uploaded ${completedParts.length} parts`);
+        throw new Error(
+          `Expected ${expectedPartsCount} parts but uploaded ${completedParts.length} parts`,
+        );
       }
 
       completedParts.sort((a, b) => a.PartNumber! - b.PartNumber!);
@@ -2699,16 +3242,22 @@ export class S3TransferManager implements IS3TransferManager {
 
       if (hasFullObjectChecksum) {
         completeRequest.ChecksumType = "FULL_OBJECT";
-        if (request.ChecksumCRC32) completeRequest.ChecksumCRC32 = request.ChecksumCRC32;
-        if (request.ChecksumCRC32C) completeRequest.ChecksumCRC32C = request.ChecksumCRC32C;
-        if (request.ChecksumCRC64NVME) completeRequest.ChecksumCRC64NVME = request.ChecksumCRC64NVME;
+        if (request.ChecksumCRC32)
+          completeRequest.ChecksumCRC32 = request.ChecksumCRC32;
+        if (request.ChecksumCRC32C)
+          completeRequest.ChecksumCRC32C = request.ChecksumCRC32C;
+        if (request.ChecksumCRC64NVME)
+          completeRequest.ChecksumCRC64NVME = request.ChecksumCRC64NVME;
       }
 
       try {
-        return await this.s3.send(new CompleteMultipartUploadCommand(completeRequest), transferOptions);
+        return await this.s3.send(
+          new CompleteMultipartUploadCommand(completeRequest),
+          transferOptions,
+        );
       } catch (completeMpuError) {
         this.logger.warn(
-          `CompleteMultipartUpload failed for upload ID ${uploadId}: ${(completeMpuError as Error).message}`
+          `CompleteMultipartUpload failed for upload ID ${uploadId}: ${(completeMpuError as Error).message}`,
         );
         throw completeMpuError;
       }
@@ -2720,9 +3269,15 @@ export class S3TransferManager implements IS3TransferManager {
       };
 
       try {
-        await this.s3.send(new AbortMultipartUploadCommand(abortRequest), transferOptions);
+        await this.s3.send(
+          new AbortMultipartUploadCommand(abortRequest),
+          transferOptions,
+        );
       } catch (abortError) {
-        this.logger.warn(`Failed to abort multipart upload ${uploadId}:`, abortError);
+        this.logger.warn(
+          `Failed to abort multipart upload ${uploadId}:`,
+          abortError,
+        );
       }
       throw error;
     }
@@ -2737,12 +3292,15 @@ export class S3TransferManager implements IS3TransferManager {
    */
   private async *traverseDirectory(
     source: string,
-    options: { recursive: boolean; followSymbolicLinks: boolean }
+    options: { recursive: boolean; followSymbolicLinks: boolean },
   ): AsyncGenerator<string> {
     const visited = new Set<string>();
     const dir = await opendir(source, { recursive: options.recursive });
     for await (const entry of dir) {
-      const fullPath = join((entry as any).parentPath ?? (entry as any).path ?? source, entry.name);
+      const fullPath = join(
+        (entry as any).parentPath ?? (entry as any).path ?? source,
+        entry.name,
+      );
 
       if (entry.isSymbolicLink()) {
         if (!options.followSymbolicLinks) continue;
@@ -2750,7 +3308,9 @@ export class S3TransferManager implements IS3TransferManager {
         const linkStat = await stat(realPath);
         if (linkStat.isDirectory()) {
           if (visited.has(realPath)) {
-            throw new Error(`Circular symbolic link detected: ${fullPath} -> ${realPath}`);
+            throw new Error(
+              `Circular symbolic link detected: ${fullPath} -> ${realPath}`,
+            );
           }
           visited.add(realPath);
           yield* this.traverseDirectory(realPath, options);
@@ -2772,7 +3332,11 @@ export class S3TransferManager implements IS3TransferManager {
    *
    * @internal
    */
-  private deriveS3Key(source: string, filePath: string, s3Prefix?: string): string {
+  private deriveS3Key(
+    source: string,
+    filePath: string,
+    s3Prefix?: string,
+  ): string {
     let relativePath = relative(source, filePath);
     if (sep !== "/") {
       relativePath = relativePath.split(sep).join("/");
@@ -2792,7 +3356,7 @@ export class S3TransferManager implements IS3TransferManager {
 
     if (actualPartSize === undefined) {
       throw new Error(
-        `A dataPart was generated without a measurable data chunk size for part number ${dataPart.partNumber}`
+        `A dataPart was generated without a measurable data chunk size for part number ${dataPart.partNumber}`,
       );
     }
 
@@ -2802,7 +3366,7 @@ export class S3TransferManager implements IS3TransferManager {
 
     if (!dataPart.lastPart && actualPartSize !== partSize) {
       throw new Error(
-        `The byte size for part number ${dataPart.partNumber}, size ${actualPartSize} does not match expected size ${partSize}`
+        `The byte size for part number ${dataPart.partNumber}, size ${actualPartSize} does not match expected size ${partSize}`,
       );
     }
   }
@@ -2817,7 +3381,9 @@ export class S3TransferManager implements IS3TransferManager {
  *
  * @internal
  */
-function parseContentRangeStart(contentRange: string | undefined): number | undefined {
+function parseContentRangeStart(
+  contentRange: string | undefined,
+): number | undefined {
   if (!contentRange) return undefined;
   const match = contentRange.match(/^bytes\s+(\d+)-/);
   return match ? Number(match[1]) : undefined;

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -24,6 +24,7 @@ import type { StreamingBlobPayloadOutputTypes } from "@smithy/types";
 import { createReadStream, existsSync } from "node:fs";
 import { open, opendir, realpath, stat } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
+import { Readable } from "node:stream";
 
 import { type RawDataPart, byteLength, getChunk } from "./chunker";
 import { handleFailure, Semaphore, validateDirectory } from "./directory-transfer-utils";
@@ -54,10 +55,12 @@ import type {
 import {
   type DataSource,
   type DownloadDataToFile,
+  type DownloadStreamOptions,
   createEmptyReadable,
   defaultWorkerCount,
   WorkerHttpHandler,
 } from "./worker-http-handler";
+import { OrderedPartQueue } from "./ordered-part-queue";
 
 /**
  * Client for efficient transfer of objects to and from Amazon S3.
@@ -393,27 +396,51 @@ export class S3TransferManager implements IS3TransferManager {
 
     try {
       if (this.multipartDownloadType === "PART") {
-        const responseMetadata = await this.downloadByPart(
-          request,
-          transferOptions ?? {},
-          streams,
-          requests,
-          metadata,
-          checksumValidationEnabled
-        );
-        totalSize = responseMetadata.totalSize;
-        onStreamConsumed = responseMetadata.onStreamConsumed;
+        if (this.workerHttpHandler) {
+          const responseMetadata = await this.downloadByPartWithWorkers(
+            request,
+            transferOptions ?? {},
+            streams,
+            requests,
+            metadata,
+            checksumValidationEnabled
+          );
+          totalSize = responseMetadata.totalSize;
+        } else {
+          const responseMetadata = await this.downloadByPart(
+            request,
+            transferOptions ?? {},
+            streams,
+            requests,
+            metadata,
+            checksumValidationEnabled
+          );
+          totalSize = responseMetadata.totalSize;
+          onStreamConsumed = responseMetadata.onStreamConsumed;
+        }
       } else if (this.multipartDownloadType === "RANGE") {
-        const responseMetadata = await this.downloadByRange(
-          request,
-          transferOptions ?? {},
-          streams,
-          requests,
-          metadata,
-          checksumValidationEnabled
-        );
-        totalSize = responseMetadata.totalSize;
-        onStreamConsumed = responseMetadata.onStreamConsumed;
+        if (this.workerHttpHandler && !request.Range) {
+          const responseMetadata = await this.downloadByRangeWithWorkers(
+            request,
+            transferOptions ?? {},
+            streams,
+            requests,
+            metadata,
+            checksumValidationEnabled
+          );
+          totalSize = responseMetadata.totalSize;
+        } else {
+          const responseMetadata = await this.downloadByRange(
+            request,
+            transferOptions ?? {},
+            streams,
+            requests,
+            metadata,
+            checksumValidationEnabled
+          );
+          totalSize = responseMetadata.totalSize;
+          onStreamConsumed = responseMetadata.onStreamConsumed;
+        }
       }
     } catch (error) {
       // On failure or abort, response bodies that were already received but not
@@ -485,7 +512,6 @@ export class S3TransferManager implements IS3TransferManager {
     request: DownloadToFileRequest,
     transferOptions?: TransferOptions
   ): Promise<DownloadToFileResponse> {
-
     if (!request.destination || request.destination === "") {
       throw new Error("destination must be a non-empty string");
     }
@@ -514,11 +540,7 @@ export class S3TransferManager implements IS3TransferManager {
 
     if (this.multipartDownloadType === "RANGE") {
       try {
-        const result = await this.downloadToFileByRange(
-          request,
-          resolvedDestination,
-          transferOptions
-        );
+        const result = await this.downloadToFileByRange(request, resolvedDestination, transferOptions);
         removeLocalEventListeners();
         return result;
       } catch (error) {
@@ -543,7 +565,7 @@ export class S3TransferManager implements IS3TransferManager {
 
     const totalSize = initialResponse.ContentRange
       ? Number.parseInt(initialResponse.ContentRange.split("/")[1])
-      : initialResponse.ContentLength ?? 0;
+      : (initialResponse.ContentLength ?? 0);
     const partsCount = initialResponse.PartsCount ?? 1;
     const eTag = initialResponse.ETag ?? undefined;
 
@@ -554,7 +576,6 @@ export class S3TransferManager implements IS3TransferManager {
 
     try {
       if (partsCount === 1) {
-      
         tempFilePath = await fileManager.createTempFile(resolvedDestination, totalSize);
         fileManager.registerCleanupHandler(tempFilePath);
 
@@ -651,7 +672,9 @@ export class S3TransferManager implements IS3TransferManager {
               } as any);
 
               // Retrieve the download result from the WorkerHttpHandler's side-channel.
-              const downloadResult = this.workerHttpHandler.getDownloadResult(resultToken);
+              const downloadResult = (this.s3.config.requestHandler as unknown as WorkerHttpHandler).getDownloadResult(
+                resultToken
+              );
               const bytesWritten = downloadResult?.bytesWritten ?? expectedLength;
 
               partResults.push({
@@ -660,10 +683,7 @@ export class S3TransferManager implements IS3TransferManager {
               });
             } else {
               // Main-thread fallback (workerThreadCount === 1)
-              const partResponse = await this.s3.send(
-                new GetObjectCommand(partGetRequest),
-                transferOptions
-              );
+              const partResponse = await this.s3.send(new GetObjectCommand(partGetRequest), transferOptions);
               await this.writeResponseBodyToFile(
                 partResponse.Body,
                 tempFilePath!,
@@ -888,7 +908,9 @@ export class S3TransferManager implements IS3TransferManager {
               this.validateRangeDownload(`bytes=${start}-${end}`, rangeResponse.ContentRange);
 
               // Retrieve the download result from the WorkerHttpHandler's side-channel.
-              const downloadResult = this.workerHttpHandler.getDownloadResult(resultToken);
+              const downloadResult = (this.s3.config.requestHandler as unknown as WorkerHttpHandler).getDownloadResult(
+                resultToken
+              );
               const bytesWritten = downloadResult?.bytesWritten ?? expectedLength;
 
               rangeResults.push({
@@ -946,9 +968,7 @@ export class S3TransferManager implements IS3TransferManager {
       // Validate total number of ranged GET requests matches expected count
       const actualRequestCount = rangeResults.length; // includes initial request
       if (actualRequestCount !== expectedRequestCount) {
-        const error = new Error(
-          `Expected ${expectedRequestCount} ranged GET requests but sent ${actualRequestCount}`
-        );
+        const error = new Error(`Expected ${expectedRequestCount} ranged GET requests but sent ${actualRequestCount}`);
         await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, error);
         throw error;
       }
@@ -1495,6 +1515,415 @@ export class S3TransferManager implements IS3TransferManager {
       totalSize,
       onStreamConsumed: streamConsumedCallback,
     };
+  }
+
+  /**
+   * Downloads object using part-based strategy with worker threads and ArrayBuffer transfer.
+   *
+   * Fetches PartNumber=1 on the main thread to discover object metadata (PartsCount,
+   * part size, ETag, total size); its body is returned directly as the first stream.
+   * Remaining parts are sent through the SDK pipeline where WorkerHttpHandler routes
+   * them to worker threads, which assemble response bytes into dedicated ArrayBuffers
+   * and transfer ownership back to main (zero-copy). The OrderedPartQueue delivers
+   * parts sequentially to the consumer stream regardless of arrival order.
+   *
+   * @internal
+   */
+  private async downloadByPartWithWorkers(
+    request: DownloadRequest,
+    transferOptions: TransferOptions,
+    streams: Promise<StreamingBlobPayloadOutputTypes>[],
+    requests: GetObjectCommandInput[],
+    metadata: Omit<DownloadResponse, "Body">,
+    checksumValidationEnabled: boolean
+  ): Promise<{ totalSize: number | undefined; onStreamConsumed?: (index: number) => void }> {
+    this.checkAborted(transferOptions);
+
+    // Fetch Part 1 to discover metadata: PartsCount, part size, ETag, total object size.
+    // Strip Range — S3 doesn't allow both Range and PartNumber in the same request.
+    const { Range: _range, ...requestWithoutRange } = request;
+    const initialPartRequest: GetObjectCommandInput = {
+      ...requestWithoutRange,
+      PartNumber: 1,
+      ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+    };
+
+    const initialPart = await this.s3.send(new GetObjectCommand(initialPartRequest), transferOptions);
+    await internalEventHandler.afterInitialGetObject();
+
+    const partSize = initialPart.ContentLength!;
+    const initialETag = initialPart.ETag ?? undefined;
+    const totalSize = initialPart.ContentRange
+      ? Number.parseInt(initialPart.ContentRange.split("/")[1])
+      : (initialPart.ContentLength ?? 0);
+    const partsCount = initialPart.PartsCount ?? 1;
+
+    this.dispatchTransferInitiatedEvent(request, totalSize);
+
+    // Stream part 1 body directly (no buffer copy needed for the first part).
+    if (initialPart.Body) {
+      if (typeof (initialPart.Body as any).getReader === "function") {
+        const reader = (initialPart.Body as any).getReader();
+        (initialPart.Body as any).getReader = function () {
+          return reader;
+        };
+      }
+      streams.push(Promise.resolve(initialPart.Body));
+      requests.push(initialPartRequest);
+    }
+
+    this.processResponseMetadata(initialPart, metadata, totalSize);
+
+    // Single-part object: nothing more to do.
+    if (partsCount <= 1) {
+      return { totalSize };
+    }
+
+    // Check abort after events have fired (listeners may trigger abort).
+    this.checkAborted(transferOptions);
+
+    // Multipart: dispatch remaining parts (2..N) via ArrayBuffer transfer + worker threads.
+    // Workers assemble each part into a dedicated ArrayBuffer and transfer ownership to main
+    // (zero-copy). The OrderedPartQueue delivers parts sequentially to the consumer stream.
+    const remainingParts = partsCount - 1;
+    const queue = new OrderedPartQueue(remainingParts);
+
+    const abortController = new AbortController();
+    const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
+    if (userSignal) {
+      userSignal.addEventListener("abort", () => abortController.abort(), { once: true });
+    }
+
+    // Concurrency limiter: bound in-flight requests to maxConcurrentDownloads.
+    // This provides backpressure — waitForSlot blocks when all slots are in use.
+    let inFlight = 0;
+    let nextDispatchResolve: (() => void) | null = null;
+
+    const waitForSlot = (): Promise<void> => {
+      if (inFlight < this.maxConcurrentDownloads) {
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) => {
+        nextDispatchResolve = resolve;
+      });
+    };
+
+    const releaseSlot = (): void => {
+      inFlight--;
+      if (nextDispatchResolve && inFlight < this.maxConcurrentDownloads) {
+        const resolve = nextDispatchResolve;
+        nextDispatchResolve = null;
+        resolve();
+      }
+    };
+
+    // Dispatch part GET requests via the SDK pipeline (WorkerHttpHandler intercepts them).
+    // Concurrency limiter provides backpressure — waitForSlot blocks when all slots are in use.
+    const dispatchPromise = (async () => {
+      for (let partNumber = 2; partNumber <= partsCount; partNumber++) {
+        if (abortController.signal.aborted || queue.hasError()) break;
+        this.checkAborted(transferOptions);
+
+        // Wait for a slot — blocks if all slots are in use (backpressure)
+        await waitForSlot();
+        if (abortController.signal.aborted || queue.hasError()) break;
+
+        inFlight++;
+        const rangeIndex = partNumber - 2;
+        const partGetRequest: GetObjectCommandInput = {
+          ...requestWithoutRange,
+          PartNumber: partNumber,
+          IfMatch: initialETag,
+          ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+        };
+
+        requests.push(partGetRequest);
+
+        const resultToken = `download-transfer-part-${rangeIndex}-${Date.now()}`;
+        const transferOptions_: DownloadStreamOptions = {
+          expectedSize: partSize,
+          rangeIndex,
+          checksumAlgorithm: checksumValidationEnabled ? "CRC32" : undefined,
+          resultToken,
+        };
+
+        // Send through SDK pipeline — WorkerHttpHandler.handle() intercepts downloadStream
+        // and dispatches to a worker. The worker assembles data into an ArrayBuffer and transfers
+        // ownership back to main (zero-copy). Fire-and-forget; completion tracked via queue.
+        this.s3
+          .send(new GetObjectCommand(partGetRequest), {
+            ...transferOptions,
+            downloadStream: transferOptions_,
+          } as any)
+          .then(() => {
+            const transferResult = (
+              this.s3.config.requestHandler as unknown as WorkerHttpHandler
+            ).getStreamDownloadResult(resultToken);
+            if (transferResult) {
+              queue.enqueue(rangeIndex, transferResult.buffer, transferResult.byteLength);
+
+              this.dispatchEvent(
+                Object.assign(new Event("bytesTransferred"), {
+                  request: partGetRequest,
+                  snapshot: { transferredBytes: transferResult.byteLength, totalBytes: totalSize },
+                })
+              );
+            }
+            releaseSlot();
+          })
+          .catch((error) => {
+            queue.setError(error);
+            abortController.abort();
+            releaseSlot();
+          });
+      }
+    })().catch((err) => {
+      // Dispatch loop threw (e.g. abort signal triggered checkAborted).
+      // Signal the queue so the consumer stream surfaces the error.
+      if (!queue.hasError()) {
+        queue.setError(err);
+      }
+    });
+
+    // Create a Readable stream that pulls parts sequentially from the ordered queue.
+    // Each chunk is a zero-copy Buffer view into the transferred ArrayBuffer.
+    const transferStream = new Readable({
+      read() {
+        queue
+          .dequeue()
+          .then((item) => {
+            if (item === null) {
+              // null means either all parts delivered OR an error was set.
+              // If an error was set, destroy the stream with that error so
+              // joinStreams calls onFailure instead of onCompletion.
+              if (queue.hasError()) {
+                this.destroy(queue.getError() as Error);
+                return;
+              }
+              this.push(null); // EOF — all parts delivered
+              return;
+            }
+
+            // Buffer.from(ArrayBuffer, offset, length) creates a VIEW — no copy.
+            // The consumer reads directly from the transferred memory.
+            const buf = Buffer.from(item.buffer, 0, item.byteLength);
+            this.push(buf);
+          })
+          .catch((err) => {
+            this.destroy(err as Error);
+          });
+      },
+      destroy(err, callback) {
+        // On stream destruction (abort/error), signal the queue to stop
+        if (err) {
+          queue.setError(err);
+          abortController.abort();
+        }
+        callback(err);
+      },
+    });
+
+    streams.push(Promise.resolve(transferStream as unknown as StreamingBlobPayloadOutputTypes));
+
+    return { totalSize };
+  }
+
+  /**
+   * Downloads an S3 object using Range GETs dispatched to worker threads.
+   * Workers download each range into a dedicated ArrayBuffer and transfer
+   * ownership to main (zero-copy). The OrderedPartQueue delivers ranges
+   * sequentially to the consumer Readable stream regardless of arrival order.
+   *
+   * Memory is bounded by maxConcurrentDownloads in-flight buffers plus the
+   * reorder window in the queue. Backpressure is applied via a concurrency
+   * limiter — dispatch blocks when all slots are in use.
+   *
+   * @internal
+   */
+  private async downloadByRangeWithWorkers(
+    request: DownloadRequest,
+    transferOptions: TransferOptions,
+    streams: Promise<StreamingBlobPayloadOutputTypes>[],
+    requests: GetObjectCommandInput[],
+    metadata: Omit<DownloadResponse, "Body">,
+    checksumValidationEnabled: boolean
+  ): Promise<{ totalSize: number | undefined; onStreamConsumed?: (index: number) => void }> {
+    this.checkAborted(transferOptions);
+
+    const headResponse = await this.s3.send(
+      new HeadObjectCommand({ Bucket: request.Bucket, Key: request.Key }),
+      transferOptions
+    );
+    await internalEventHandler.afterInitialGetObject();
+
+    if (headResponse.ContentLength === 0) {
+      const getObjectRequest = { ...request, ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }) };
+      const response = await this.s3.send(new GetObjectCommand(getObjectRequest), transferOptions);
+
+      this.dispatchTransferInitiatedEvent(request, 0);
+      if (response.Body) streams.push(Promise.resolve(response.Body));
+      requests.push(getObjectRequest);
+
+      this.processResponseMetadata(response, metadata, 0);
+      return { totalSize: 0 };
+    }
+
+    const totalSize = headResponse.ContentLength!;
+    const partSize = this.targetPartSizeBytes;
+    const totalParts = Math.ceil(totalSize / partSize);
+
+    // Use the initial HeadObject to extract metadata (ETag, etc.)
+    const eTag = headResponse.ETag ?? undefined;
+    this.dispatchTransferInitiatedEvent(request, totalSize);
+
+    // Assign metadata from HeadObject response
+    Object.assign(metadata, {
+      ContentLength: totalSize,
+      ContentRange: `bytes 0-${totalSize - 1}/${totalSize}`,
+      ContentType: headResponse.ContentType,
+      ETag: headResponse.ETag,
+      LastModified: headResponse.LastModified,
+      $metadata: headResponse.$metadata,
+    });
+
+    // OrderedPartQueue delivers parts sequentially regardless of arrival order.
+    const queue = new OrderedPartQueue(totalParts);
+
+    const abortController = new AbortController();
+    const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
+    if (userSignal) {
+      userSignal.addEventListener("abort", () => abortController.abort(), { once: true });
+    }
+
+    // Concurrency limiter: bound in-flight requests to maxConcurrentDownloads.
+    let inFlight = 0;
+    let nextDispatchResolve: (() => void) | null = null;
+
+    const waitForSlot = (): Promise<void> => {
+      if (inFlight < this.maxConcurrentDownloads) {
+        return Promise.resolve();
+      }
+      return new Promise<void>((resolve) => {
+        nextDispatchResolve = resolve;
+      });
+    };
+
+    const releaseSlot = (): void => {
+      inFlight--;
+      if (nextDispatchResolve && inFlight < this.maxConcurrentDownloads) {
+        const resolve = nextDispatchResolve;
+        nextDispatchResolve = null;
+        resolve();
+      }
+    };
+
+    // Dispatch all range requests via the SDK pipeline (WorkerHttpHandler intercepts them).
+    // Concurrency limiter provides backpressure — waitForSlot blocks when all slots are in use.
+    const dispatchPromise = (async () => {
+      for (let rangeIndex = 0; rangeIndex < totalParts; rangeIndex++) {
+        if (abortController.signal.aborted || queue.hasError()) break;
+        this.checkAborted(transferOptions);
+
+        // Wait for a slot — blocks if all slots are in use (backpressure)
+        await waitForSlot();
+        if (abortController.signal.aborted || queue.hasError()) break;
+
+        inFlight++;
+        const start = rangeIndex * partSize;
+        const end = Math.min(start + partSize - 1, totalSize - 1);
+        const expectedLength = end - start + 1;
+
+        const rangeGetRequest: GetObjectCommandInput = {
+          ...request,
+          Range: `bytes=${start}-${end}`,
+          IfMatch: eTag,
+          ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+        };
+
+        requests.push(rangeGetRequest);
+
+        const resultToken = `download-transfer-range-${rangeIndex}-${Date.now()}`;
+        const transferOpts: DownloadStreamOptions = {
+          expectedSize: expectedLength,
+          rangeIndex,
+          checksumAlgorithm: checksumValidationEnabled ? "CRC32" : undefined,
+          resultToken,
+        };
+
+        // Send through SDK pipeline — WorkerHttpHandler.handle() intercepts downloadStream
+        // and dispatches to a worker. The worker assembles data into an ArrayBuffer and transfers
+        // ownership back to main (zero-copy). Fire-and-forget; completion tracked via queue.
+        this.s3
+          .send(new GetObjectCommand(rangeGetRequest), {
+            ...transferOptions,
+            downloadStream: transferOpts,
+          } as any)
+          .then(() => {
+            const transferResult = (
+              this.s3.config.requestHandler as unknown as WorkerHttpHandler
+            ).getStreamDownloadResult(resultToken);
+            if (transferResult) {
+              queue.enqueue(rangeIndex, transferResult.buffer, transferResult.byteLength);
+
+              this.dispatchEvent(
+                Object.assign(new Event("bytesTransferred"), {
+                  request: rangeGetRequest,
+                  snapshot: { transferredBytes: transferResult.byteLength, totalBytes: totalSize },
+                })
+              );
+            }
+            releaseSlot();
+          })
+          .catch((error) => {
+            queue.setError(error);
+            abortController.abort();
+            releaseSlot();
+          });
+      }
+    })().catch((err) => {
+      if (!queue.hasError()) {
+        queue.setError(err);
+      }
+    });
+
+    // Create a Readable stream that pulls ranges sequentially from the ordered queue.
+    // Each chunk is a zero-copy Buffer view into the transferred ArrayBuffer.
+    const transferStream = new Readable({
+      read() {
+        queue
+          .dequeue()
+          .then((item) => {
+            if (item === null) {
+              if (queue.hasError()) {
+                this.destroy(queue.getError() as Error);
+                return;
+              }
+              this.push(null); // EOF — all ranges delivered
+              return;
+            }
+
+            // Buffer.from(ArrayBuffer, offset, length) creates a VIEW — no copy.
+            // The consumer reads directly from the transferred memory.
+            const buf = Buffer.from(item.buffer, 0, item.byteLength);
+            this.push(buf);
+          })
+          .catch((err) => {
+            this.destroy(err as Error);
+          });
+      },
+      destroy(err, callback) {
+        // On stream destruction (abort/error), signal the queue to stop
+        if (err) {
+          queue.setError(err);
+          abortController.abort();
+        }
+        callback(err);
+      },
+    });
+
+    streams.push(Promise.resolve(transferStream as unknown as StreamingBlobPayloadOutputTypes));
+
+    return { totalSize };
   }
 
   /**

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/S3TransferManager.ts
@@ -511,6 +511,22 @@ export class S3TransferManager implements IS3TransferManager {
       request.ChecksumMode === "ENABLED" || this.responseChecksumValidation === "WHEN_SUPPORTED";
 
     const { destination, failIfExists, ...getObjectFields } = request;
+
+    if (this.multipartDownloadType === "RANGE") {
+      try {
+        const result = await this.downloadToFileByRange(
+          request,
+          resolvedDestination,
+          transferOptions
+        );
+        removeLocalEventListeners();
+        return result;
+      } catch (error) {
+        removeLocalEventListeners();
+        throw error;
+      }
+    }
+
     const initialPartRequest: GetObjectCommandInput = {
       ...getObjectFields,
       PartNumber: 1,
@@ -549,35 +565,7 @@ export class S3TransferManager implements IS3TransferManager {
         await fileManager.atomicRename(tempFilePath, resolvedDestination);
         fileManager.unregisterCleanupHandler(tempFilePath);
 
-        // Construct response
-        const metadata: Record<string, any> = {};
-        this.assignMetadata(metadata, initialResponse);
-        metadata.ContentLength = totalSize;
-        metadata.ContentRange = `bytes 0-${totalSize - 1}/${totalSize}`;
-
-        // Handle COMPOSITE checksum type
-        if (initialResponse.ChecksumType === "COMPOSITE") {
-          metadata.ChecksumCRC32 = undefined;
-          metadata.ChecksumCRC32C = undefined;
-          metadata.ChecksumSHA1 = undefined;
-          metadata.ChecksumSHA256 = undefined;
-        }
-
-        const response: DownloadToFileResponse = {
-          ...metadata,
-          bytesWritten: totalSize,
-        } as DownloadToFileResponse;
-
-        this.dispatchEvent(
-          Object.assign(new Event("transferComplete"), {
-            request,
-            response,
-            snapshot: {
-              transferredBytes: totalSize,
-              totalBytes: totalSize,
-            },
-          })
-        );
+        const response = this.buildDownloadToFileResponse(initialResponse, totalSize, request);
         removeLocalEventListeners();
         return response;
       }
@@ -718,31 +706,25 @@ export class S3TransferManager implements IS3TransferManager {
       // Handle abort: if the abort signal was triggered (either user or internal),
       // reject with AbortError regardless of whether tasks have already failed.
       if (abortController.signal.aborted && !failed) {
-        await fileManager.deleteTempFile(tempFilePath);
-        fileManager.unregisterCleanupHandler(tempFilePath);
         const abortError = Object.assign(new Error("Transfer aborted."), { name: "AbortError" });
-        this.dispatchTransferFailedEvent(request, totalSize, abortError);
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, abortError);
         removeLocalEventListeners();
         throw abortError;
       }
 
       // Handle failure
       if (failed) {
-        await fileManager.deleteTempFile(tempFilePath);
-        fileManager.unregisterCleanupHandler(tempFilePath);
-        this.dispatchTransferFailedEvent(request, totalSize, failureError as Error);
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, failureError);
         removeLocalEventListeners();
         throw failureError;
       }
 
       // Verify request count
       if (partResults.length !== partsCount) {
-        await fileManager.deleteTempFile(tempFilePath);
-        fileManager.unregisterCleanupHandler(tempFilePath);
         const error = new Error(
           `The number of parts downloaded (${partResults.length}) does not match the expected number (${partsCount})`
         );
-        this.dispatchTransferFailedEvent(request, totalSize, error);
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, error);
         removeLocalEventListeners();
         throw error;
       }
@@ -750,12 +732,10 @@ export class S3TransferManager implements IS3TransferManager {
       // Verify total bytes written matches expected object size
       const totalBytesWritten = partResults.reduce((sum, p) => sum + p.bytesWritten, 0);
       if (totalBytesWritten !== totalSize) {
-        await fileManager.deleteTempFile(tempFilePath);
-        fileManager.unregisterCleanupHandler(tempFilePath);
         const error = new Error(
           `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalSize})`
         );
-        this.dispatchTransferFailedEvent(request, totalSize, error);
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalSize, error);
         removeLocalEventListeners();
         throw error;
       }
@@ -764,35 +744,7 @@ export class S3TransferManager implements IS3TransferManager {
       await fileManager.atomicRename(tempFilePath, resolvedDestination);
       fileManager.unregisterCleanupHandler(tempFilePath);
 
-      // Construct response metadata
-      const metadata: Record<string, any> = {};
-      this.assignMetadata(metadata, initialResponse);
-      metadata.ContentLength = totalSize;
-      metadata.ContentRange = `bytes 0-${totalSize - 1}/${totalSize}`;
-
-      // Handle COMPOSITE checksum type
-      if (initialResponse.ChecksumType === "COMPOSITE") {
-        metadata.ChecksumCRC32 = undefined;
-        metadata.ChecksumCRC32C = undefined;
-        metadata.ChecksumSHA1 = undefined;
-        metadata.ChecksumSHA256 = undefined;
-      }
-
-      const response: DownloadToFileResponse = {
-        ...metadata,
-        bytesWritten: totalSize,
-      } as DownloadToFileResponse;
-
-      this.dispatchEvent(
-        Object.assign(new Event("transferComplete"), {
-          request,
-          response,
-          snapshot: {
-            transferredBytes: totalSize,
-            totalBytes: totalSize,
-          },
-        })
-      );
+      const response = this.buildDownloadToFileResponse(initialResponse, totalSize, request);
       removeLocalEventListeners();
       return response;
     } catch (error) {
@@ -802,6 +754,224 @@ export class S3TransferManager implements IS3TransferManager {
         fileManager.unregisterCleanupHandler(tempFilePath);
       }
       removeLocalEventListeners();
+      throw error;
+    }
+  }
+
+  /**
+   * Downloads an S3 object to a local file using Range-based GET requests.
+   * @internal
+   */
+  private async downloadToFileByRange(
+    request: DownloadToFileRequest,
+    resolvedDestination: string,
+    transferOptions?: TransferOptions
+  ): Promise<DownloadToFileResponse> {
+    const { destination, failIfExists, ...getObjectFields } = request;
+    const checksumValidationEnabled =
+      request.ChecksumMode === "ENABLED" || this.responseChecksumValidation === "WHEN_SUPPORTED";
+
+    const fileManager = new FileManager();
+    let tempFilePath: string | undefined;
+
+    try {
+      // Create initial GetObject request with Range bytes=0-{targetPartSizeBytes-1}
+      const rangeSize = this.targetPartSizeBytes;
+      const initialRangeRequest: GetObjectCommandInput = {
+        ...getObjectFields,
+        Range: `bytes=0-${rangeSize - 1}`,
+        ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+      };
+
+      const initialResponse = await this.s3.send(new GetObjectCommand(initialRangeRequest), transferOptions);
+
+      // Validate ContentRange matches the requested range (also validates presence and format)
+      this.validateRangeDownload(`bytes=0-${rangeSize - 1}`, initialResponse.ContentRange);
+
+      // Parse total content length from ContentRange: "bytes 0-N/TOTAL"
+      const totalContentLength = Number.parseInt(initialResponse.ContentRange!.split("/")[1]);
+      const responseContentLength = initialResponse.ContentLength ?? 0;
+
+      // Compare parsed total content length with ContentLength
+      if (responseContentLength === totalContentLength) {
+        // Single-part object — this response contains all the data
+        tempFilePath = await fileManager.createTempFile(resolvedDestination, totalContentLength);
+        fileManager.registerCleanupHandler(tempFilePath);
+
+        await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
+
+        await fileManager.atomicRename(tempFilePath, resolvedDestination);
+        fileManager.unregisterCleanupHandler(tempFilePath);
+
+        this.dispatchTransferInitiatedEvent(request, totalContentLength);
+        return this.buildDownloadToFileResponse(initialResponse, totalContentLength, request);
+      }
+
+      // Save ETag and calculate expected number of ranged GET requests
+      const eTag = initialResponse.ETag ?? undefined;
+      const expectedRequestCount = Math.ceil(totalContentLength / rangeSize);
+
+      this.dispatchTransferInitiatedEvent(request, totalContentLength);
+
+      // Create temp file and write initial part
+      tempFilePath = await fileManager.createTempFile(resolvedDestination, totalContentLength);
+      fileManager.registerCleanupHandler(tempFilePath);
+
+      await this.writeResponseBodyToFile(initialResponse.Body, tempFilePath, initialResponse.ContentRange, 0);
+
+      const rangeResults: Array<{ index: number; bytesWritten: number }> = [];
+      rangeResults.push({ index: 0, bytesWritten: responseContentLength });
+
+      this.dispatchEvent(
+        Object.assign(new Event("bytesTransferred"), {
+          request: initialRangeRequest,
+          snapshot: { transferredBytes: responseContentLength, totalBytes: totalContentLength },
+        })
+      );
+
+      // Construct and dispatch remaining range GET requests concurrently
+      const semaphore = new Semaphore(this.maxConcurrentDownloads);
+      const abortController = new AbortController();
+      let failed = false;
+      let failureError: unknown;
+
+      const userSignal = transferOptions?.abortSignal as AbortSignal | undefined;
+      if (userSignal) {
+        userSignal.addEventListener("abort", () => abortController.abort(), { once: true });
+      }
+
+      const rangeTasks: Promise<void>[] = [];
+      let rangeIndex = 1;
+
+      for (let offset = rangeSize; offset < totalContentLength; offset += rangeSize) {
+        if (failed || abortController.signal.aborted) break;
+        this.checkAborted(transferOptions);
+
+        await semaphore.acquire();
+
+        if (failed || abortController.signal.aborted) {
+          semaphore.release();
+          break;
+        }
+
+        const start = offset;
+        const end = Math.min(offset + rangeSize - 1, totalContentLength - 1);
+        const currentIndex = rangeIndex++;
+
+        const rangeGetRequest: GetObjectCommandInput = {
+          ...getObjectFields,
+          Range: `bytes=${start}-${end}`,
+          IfMatch: eTag,
+          ...(checksumValidationEnabled && { ChecksumMode: "ENABLED" as const }),
+        };
+
+        const task = (async () => {
+          try {
+            const expectedLength = end - start + 1;
+
+            if (this.workerHttpHandler) {
+              // Worker-thread path: dispatch via WorkerHttpHandler for direct file-offset write
+              const resultToken = `download-range-${currentIndex}-${Date.now()}`;
+              const downloadOptions: DownloadDataToFile = {
+                filePath: tempFilePath!,
+                offset: start,
+                expectedLength,
+                resultToken,
+              };
+
+              const rangeResponse = await this.s3.send(new GetObjectCommand(rangeGetRequest), {
+                ...transferOptions,
+                downloadDataToFile: downloadOptions,
+              } as any);
+
+              // Validate ContentRange matches the requested range
+              this.validateRangeDownload(`bytes=${start}-${end}`, rangeResponse.ContentRange);
+
+              // Retrieve the download result from the WorkerHttpHandler's side-channel.
+              const downloadResult = this.workerHttpHandler.getDownloadResult(resultToken);
+              const bytesWritten = downloadResult?.bytesWritten ?? expectedLength;
+
+              rangeResults.push({
+                index: currentIndex,
+                bytesWritten,
+              });
+            } else {
+              // Main-thread fallback (workerThreadCount === 1)
+              const rangeResponse = await this.s3.send(new GetObjectCommand(rangeGetRequest), transferOptions);
+
+              // Validate ContentRange matches the requested range
+              this.validateRangeDownload(`bytes=${start}-${end}`, rangeResponse.ContentRange);
+
+              await this.writeResponseBodyToFile(rangeResponse.Body, tempFilePath!, rangeResponse.ContentRange, start);
+
+              rangeResults.push({
+                index: currentIndex,
+                bytesWritten: rangeResponse.ContentLength ?? expectedLength,
+              });
+            }
+
+            this.dispatchEvent(
+              Object.assign(new Event("bytesTransferred"), {
+                request: rangeGetRequest,
+                snapshot: { transferredBytes: end - start + 1, totalBytes: totalContentLength },
+              })
+            );
+          } catch (error) {
+            if (!failed) {
+              failed = true;
+              failureError = error;
+              abortController.abort();
+            }
+          } finally {
+            semaphore.release();
+          }
+        })();
+
+        rangeTasks.push(task);
+      }
+
+      await Promise.allSettled(rangeTasks);
+
+      if (abortController.signal.aborted && !failed) {
+        const abortError = Object.assign(new Error("Transfer aborted."), { name: "AbortError" });
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, abortError);
+        throw abortError;
+      }
+
+      if (failed) {
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, failureError);
+        throw failureError;
+      }
+
+      // Validate total number of ranged GET requests matches expected count
+      const actualRequestCount = rangeResults.length; // includes initial request
+      if (actualRequestCount !== expectedRequestCount) {
+        const error = new Error(
+          `Expected ${expectedRequestCount} ranged GET requests but sent ${actualRequestCount}`
+        );
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, error);
+        throw error;
+      }
+
+      // Verify total bytes written matches expected object size
+      const totalBytesWritten = rangeResults.reduce((sum, r) => sum + r.bytesWritten, 0);
+      if (totalBytesWritten !== totalContentLength) {
+        const error = new Error(
+          `Total bytes written (${totalBytesWritten}) does not match expected object size (${totalContentLength})`
+        );
+        await this.handleDownloadCleanup(fileManager, tempFilePath, request, totalContentLength, error);
+        throw error;
+      }
+
+      await fileManager.atomicRename(tempFilePath, resolvedDestination);
+      fileManager.unregisterCleanupHandler(tempFilePath);
+
+      return this.buildDownloadToFileResponse(initialResponse, totalContentLength, request);
+    } catch (error) {
+      if (tempFilePath) {
+        await fileManager.deleteTempFile(tempFilePath).catch(() => {});
+        fileManager.unregisterCleanupHandler(tempFilePath);
+      }
       throw error;
     }
   }
@@ -1365,6 +1535,67 @@ export class S3TransferManager implements IS3TransferManager {
       }
       container[key] = response[key];
     }
+  }
+
+  /**
+   * Builds the final DownloadToFileResponse from the initial response metadata.
+   * Copies all metadata fields, overrides ContentLength/ContentRange for the full object,
+   * nulls checksum fields for COMPOSITE types, and dispatches the transferComplete event.
+   *
+   * @internal
+   */
+  private buildDownloadToFileResponse(
+    initialResponse: DownloadResponse,
+    totalSize: number,
+    request: DownloadToFileRequest
+  ): DownloadToFileResponse {
+    const metadata: Record<string, any> = {};
+    this.assignMetadata(metadata, initialResponse);
+    metadata.ContentLength = totalSize;
+    metadata.ContentRange = `bytes 0-${totalSize - 1}/${totalSize}`;
+
+    if (initialResponse.ChecksumType === "COMPOSITE") {
+      metadata.ChecksumCRC32 = undefined;
+      metadata.ChecksumCRC32C = undefined;
+      metadata.ChecksumSHA1 = undefined;
+      metadata.ChecksumSHA256 = undefined;
+    }
+
+    const response: DownloadToFileResponse = {
+      ...metadata,
+      bytesWritten: totalSize,
+    } as DownloadToFileResponse;
+
+    this.dispatchEvent(
+      Object.assign(new Event("transferComplete"), {
+        request,
+        response,
+        snapshot: {
+          transferredBytes: totalSize,
+          totalBytes: totalSize,
+        },
+      })
+    );
+
+    return response;
+  }
+
+  /**
+   * Handles cleanup on download failure: deletes the temp file,
+   * unregisters process handlers, and dispatches transferFailed event.
+   *
+   * @internal
+   */
+  private async handleDownloadCleanup(
+    fileManager: FileManager,
+    tempFilePath: string,
+    request: DownloadToFileRequest,
+    totalSize: number,
+    error: unknown
+  ): Promise<void> {
+    await fileManager.deleteTempFile(tempFilePath);
+    fileManager.unregisterCleanupHandler(tempFilePath);
+    this.dispatchTransferFailedEvent(request, totalSize, error as Error);
   }
 
   /**

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/file-manager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/file-manager.ts
@@ -20,10 +20,7 @@ export class FileManager {
    * @param totalSize - Total byte size to set as the file length.
    * @returns The path to the created temp file.
    */
-  public async createTempFile(
-    destination: string,
-    totalSize: number,
-  ): Promise<string> {
+  public async createTempFile(destination: string, totalSize: number): Promise<string> {
     const tempFilePath = `${destination}.s3tmp.${this.generateUniqueId()}`;
 
     // "wx" creates the file exclusively, so a name collision with a concurrent
@@ -47,10 +44,7 @@ export class FileManager {
    * @param tempFilePath - Path to the temp file.
    * @param destination - Final destination path.
    */
-  public async atomicRename(
-    tempFilePath: string,
-    destination: string,
-  ): Promise<void> {
+  public async atomicRename(tempFilePath: string, destination: string): Promise<void> {
     try {
       await rename(tempFilePath, destination);
     } catch (renameError: any) {
@@ -61,15 +55,11 @@ export class FileManager {
           await rename(tempFilePath, destination);
         } catch (fallbackError: any) {
           await this.deleteTempFile(tempFilePath);
-          throw new Error(
-            `Failed to rename temp file to destination: ${fallbackError.message || fallbackError.code}`,
-          );
+          throw new Error(`Failed to rename temp file to destination: ${fallbackError.message || fallbackError.code}`);
         }
       } else {
         await this.deleteTempFile(tempFilePath);
-        throw new Error(
-          `Failed to rename temp file to destination: ${renameError.message || renameError.code}`,
-        );
+        throw new Error(`Failed to rename temp file to destination: ${renameError.message || renameError.code}`);
       }
     }
   }

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/file-manager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/file-manager.ts
@@ -59,9 +59,7 @@ export class FileManager {
           await rename(tempFilePath, destination);
         } catch (fallbackError: any) {
           await this.deleteTempFile(tempFilePath);
-          throw new Error(
-            `Failed to rename temp file to destination: ${fallbackError.message || fallbackError.code}`
-          );
+          throw new Error(`Failed to rename temp file to destination: ${fallbackError.message || fallbackError.code}`);
         }
       } else {
         await this.deleteTempFile(tempFilePath);

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/file-manager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/file-manager.ts
@@ -3,28 +3,27 @@ import { unlinkSync } from "node:fs";
 import { open, rename, unlink } from "node:fs/promises";
 
 /**
- * Utility class responsible for temp-file lifecycle management during downloads.
+ * Utility class responsible for temp-file lifecycle management during downloadToFile.
  * Handles creation, pre-allocation, atomic rename, and cleanup of temp files.
  *
  * @internal
  */
 export class FileManager {
-  private cleanupHandlers = new Map<string, { exitHandler: () => void; sigintHandler: () => void }>();
+  private cleanupHandlers = new Map<string, { exitHandler: () => void }>();
 
   /**
    * Creates a temporary file for the download with a unique identifier.
-   *
-   * The file is sized to `totalSize` up front so its final length is fixed
-   * regardless of the order in which parts complete. This is a sparse file:
-   * it records the length without allocating disk blocks, so it does not
-   * reserve space, and it is not required for concurrent writes to succeed
-   * (writes at an explicit offset extend a file on their own).
+   * Sets the file length to `totalSize` up front via truncate so concurrent
+   * part writes can target their offsets without coordination.
    *
    * @param destination - The final destination file path.
    * @param totalSize - Total byte size to set as the file length.
    * @returns The path to the created temp file.
    */
-  public async createTempFile(destination: string, totalSize: number): Promise<string> {
+  public async createTempFile(
+    destination: string,
+    totalSize: number,
+  ): Promise<string> {
     const tempFilePath = `${destination}.s3tmp.${this.generateUniqueId()}`;
 
     // "wx" creates the file exclusively, so a name collision with a concurrent
@@ -48,7 +47,10 @@ export class FileManager {
    * @param tempFilePath - Path to the temp file.
    * @param destination - Final destination path.
    */
-  public async atomicRename(tempFilePath: string, destination: string): Promise<void> {
+  public async atomicRename(
+    tempFilePath: string,
+    destination: string,
+  ): Promise<void> {
     try {
       await rename(tempFilePath, destination);
     } catch (renameError: any) {
@@ -59,21 +61,26 @@ export class FileManager {
           await rename(tempFilePath, destination);
         } catch (fallbackError: any) {
           await this.deleteTempFile(tempFilePath);
-          throw new Error(`Failed to rename temp file to destination: ${fallbackError.message || fallbackError.code}`);
+          throw new Error(
+            `Failed to rename temp file to destination: ${fallbackError.message || fallbackError.code}`,
+          );
         }
       } else {
         await this.deleteTempFile(tempFilePath);
-        throw new Error(`Failed to rename temp file to destination: ${renameError.message || renameError.code}`);
+        throw new Error(
+          `Failed to rename temp file to destination: ${renameError.message || renameError.code}`,
+        );
       }
     }
   }
 
   /**
-   * Deletes the temp file. Idempotent — no-op if the file doesn't exist.
+   * Deletes the temp file and unregisters any associated cleanup handlers.
    *
    * @param tempFilePath - Path to the temp file to delete.
    */
   public async deleteTempFile(tempFilePath: string): Promise<void> {
+    this.unregisterCleanupHandler(tempFilePath);
     try {
       await unlink(tempFilePath);
     } catch (error: any) {
@@ -94,23 +101,17 @@ export class FileManager {
       try {
         unlinkSync(tempFilePath);
       } catch {
-        // Ignore errors during cleanup (file may already be removed).
+        /* File may already be deleted by normal cleanup, and errors are
+         * unrecoverable since the process is exiting, so ignore the error.
+         */
       }
     };
 
-    const sigintHandler = () => {
-      try {
-        unlinkSync(tempFilePath);
-      } catch {
-        // Ignore errors during cleanup.
-      }
-      process.exit(1);
-    };
-
+    // The `exit` event covers SIGINT and SIGTERM — both trigger process
+    // termination by default, which fires `exit` before the process ends.
     process.on("exit", exitHandler);
-    process.on("SIGINT", sigintHandler);
 
-    this.cleanupHandlers.set(tempFilePath, { exitHandler, sigintHandler });
+    this.cleanupHandlers.set(tempFilePath, { exitHandler });
   }
 
   /**
@@ -122,7 +123,6 @@ export class FileManager {
     const handlers = this.cleanupHandlers.get(tempFilePath);
     if (handlers) {
       process.removeListener("exit", handlers.exitHandler);
-      process.removeListener("SIGINT", handlers.sigintHandler);
       this.cleanupHandlers.delete(tempFilePath);
     }
   }

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/file-manager.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/file-manager.ts
@@ -1,0 +1,138 @@
+import { randomBytes } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { open, rename, unlink } from "node:fs/promises";
+
+/**
+ * Utility class responsible for temp-file lifecycle management during downloads.
+ * Handles creation, pre-allocation, atomic rename, and cleanup of temp files.
+ *
+ * @internal
+ */
+export class FileManager {
+  private cleanupHandlers = new Map<string, { exitHandler: () => void; sigintHandler: () => void }>();
+
+  /**
+   * Creates a temporary file for the download with a unique identifier.
+   *
+   * The file is sized to `totalSize` up front so its final length is fixed
+   * regardless of the order in which parts complete. This is a sparse file:
+   * it records the length without allocating disk blocks, so it does not
+   * reserve space, and it is not required for concurrent writes to succeed
+   * (writes at an explicit offset extend a file on their own).
+   *
+   * @param destination - The final destination file path.
+   * @param totalSize - Total byte size to set as the file length.
+   * @returns The path to the created temp file.
+   */
+  public async createTempFile(destination: string, totalSize: number): Promise<string> {
+    const tempFilePath = `${destination}.s3tmp.${this.generateUniqueId()}`;
+
+    // "wx" creates the file exclusively, so a name collision with a concurrent
+    // download to the same destination fails with EEXIST rather than truncating
+    // the other download's temp file.
+    const fd = await open(tempFilePath, "wx");
+    try {
+      await fd.truncate(totalSize);
+    } finally {
+      await fd.close();
+    }
+
+    return tempFilePath;
+  }
+
+  /**
+   * Renames the temp file to the destination atomically.
+   * On platforms where rename doesn't overwrite, falls back to
+   * deleting the destination first.
+   *
+   * @param tempFilePath - Path to the temp file.
+   * @param destination - Final destination path.
+   */
+  public async atomicRename(tempFilePath: string, destination: string): Promise<void> {
+    try {
+      await rename(tempFilePath, destination);
+    } catch (renameError: any) {
+      // Fallback for platforms where rename doesn't overwrite an existing file.
+      if (renameError.code === "EEXIST" || renameError.code === "EPERM") {
+        try {
+          await unlink(destination);
+          await rename(tempFilePath, destination);
+        } catch (fallbackError: any) {
+          await this.deleteTempFile(tempFilePath);
+          throw new Error(
+            `Failed to rename temp file to destination: ${fallbackError.message || fallbackError.code}`
+          );
+        }
+      } else {
+        await this.deleteTempFile(tempFilePath);
+        throw new Error(`Failed to rename temp file to destination: ${renameError.message || renameError.code}`);
+      }
+    }
+  }
+
+  /**
+   * Deletes the temp file. Idempotent — no-op if the file doesn't exist.
+   *
+   * @param tempFilePath - Path to the temp file to delete.
+   */
+  public async deleteTempFile(tempFilePath: string): Promise<void> {
+    try {
+      await unlink(tempFilePath);
+    } catch (error: any) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Registers process-level cleanup handlers that remove the temp file
+   * if the process terminates unexpectedly.
+   *
+   * @param tempFilePath - Path to the temp file to clean up.
+   */
+  public registerCleanupHandler(tempFilePath: string): void {
+    const exitHandler = () => {
+      try {
+        unlinkSync(tempFilePath);
+      } catch {
+        // Ignore errors during cleanup (file may already be removed).
+      }
+    };
+
+    const sigintHandler = () => {
+      try {
+        unlinkSync(tempFilePath);
+      } catch {
+        // Ignore errors during cleanup.
+      }
+      process.exit(1);
+    };
+
+    process.on("exit", exitHandler);
+    process.on("SIGINT", sigintHandler);
+
+    this.cleanupHandlers.set(tempFilePath, { exitHandler, sigintHandler });
+  }
+
+  /**
+   * Removes the registered cleanup handlers for the given temp file.
+   *
+   * @param tempFilePath - Path to the temp file whose handlers should be removed.
+   */
+  public unregisterCleanupHandler(tempFilePath: string): void {
+    const handlers = this.cleanupHandlers.get(tempFilePath);
+    if (handlers) {
+      process.removeListener("exit", handlers.exitHandler);
+      process.removeListener("SIGINT", handlers.sigintHandler);
+      this.cleanupHandlers.delete(tempFilePath);
+    }
+  }
+
+  /**
+   * Generates a unique identifier of at most 8 alphanumeric characters.
+   */
+  private generateUniqueId(): string {
+    return randomBytes(4).toString("hex");
+  }
+}

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/index.browser.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/index.browser.ts
@@ -1,3 +1,3 @@
 // todo: bind browser implementations with dependency injection.
 export { S3TransferManager } from "./S3TransferManager";
-export type { IS3TransferManager } from "./types";
+export type { DownloadToFileRequest, DownloadToFileResponse, IS3TransferManager } from "./types";

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/index.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/index.ts
@@ -1,2 +1,2 @@
 export { S3TransferManager } from "./S3TransferManager";
-export type { IS3TransferManager } from "./types";
+export type { DownloadToFileRequest, DownloadToFileResponse, IS3TransferManager } from "./types";

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/ordered-part-queue.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/ordered-part-queue.ts
@@ -53,7 +53,6 @@ export class OrderedPartQueue {
    * Called when a worker delivers a part (may arrive out of order).
    * If the consumer is waiting for this exact part, delivers immediately.
    * Otherwise stores it until its turn.
-   * @internal
    */
   public enqueue(rangeIndex: number, buffer: ArrayBuffer, byteLength: number): void {
     if (this.error) return;
@@ -74,7 +73,6 @@ export class OrderedPartQueue {
    * Called by the Readable stream's read() to get the next sequential part.
    * Returns null when all parts have been consumed.
    * Waits asynchronously if the next part hasn't arrived yet.
-   * @internal
    */
   public async dequeue(): Promise<QueuedPart | null> {
     if (this.error) {
@@ -101,7 +99,6 @@ export class OrderedPartQueue {
 
   /**
    * Signals an error, waking up any waiting consumer.
-   * @internal
    */
   public setError(error: unknown): void {
     this.error = error;
@@ -115,7 +112,6 @@ export class OrderedPartQueue {
 
   /**
    * Returns whether an error has been set.
-   * @internal
    */
   public hasError(): boolean {
     return this.error !== undefined;
@@ -123,7 +119,6 @@ export class OrderedPartQueue {
 
   /**
    * Returns the stored error, if any.
-   * @internal
    */
   public getError(): unknown {
     return this.error;
@@ -132,7 +127,6 @@ export class OrderedPartQueue {
   /**
    * Returns the number of parts currently held (arrived but not yet delivered).
    * Useful for monitoring reorder buffer depth.
-   * @internal
    */
   public get pendingCount(): number {
     return this.pending.size;

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/ordered-part-queue.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/ordered-part-queue.ts
@@ -1,12 +1,4 @@
-/**
- * Ordered delivery queue for stream downloads using ArrayBuffer ownership transfer.
- *
- * Workers download parts in parallel and transfer ArrayBuffers (zero copy) to main in
- * arbitrary order. This queue holds out-of-order arrivals and delivers them
- * sequentially to the Readable stream consumer.
- *
- * @internal
- */
+// This module provides an ordered delivery queue for parallel stream downloads.
 
 export interface QueuedPart {
   /**
@@ -19,6 +11,12 @@ export interface QueuedPart {
   byteLength: number;
 }
 
+/**
+ * Reorder buffer that accepts out-of-order part arrivals from parallel download
+ * workers and delivers them sequentially to a Readable stream consumer.
+ *
+ * @internal
+ */
 export class OrderedPartQueue {
   /**
    * Out-of-order parts waiting for their turn. Keyed by rangeIndex.
@@ -98,7 +96,9 @@ export class OrderedPartQueue {
   }
 
   /**
-   * Signals an error, waking up any waiting consumer.
+   * Called when a worker part fails, when the dispatch loop throws
+   * or when the stream is destroyed. Unblocks the consumer
+   * if it's waiting so the stream can surface the error instead of hanging.
    */
   public setError(error: unknown): void {
     this.error = error;
@@ -111,14 +111,17 @@ export class OrderedPartQueue {
   }
 
   /**
-   * Returns whether an error has been set.
+   * The dispatch loop
+   * checks this to stop launching new part requests,
+   * and the Readable stream checks it to distinguish completion from failure
+   * when dequeue() returns null.
    */
   public hasError(): boolean {
     return this.error !== undefined;
   }
 
   /**
-   * Returns the stored error, if any.
+   * Called by the Readable stream's read() to pass the error to stream.destroy(err).
    */
   public getError(): unknown {
     return this.error;

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/ordered-part-queue.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/ordered-part-queue.ts
@@ -1,0 +1,140 @@
+/**
+ * Ordered delivery queue for stream downloads using ArrayBuffer ownership transfer.
+ *
+ * Workers download parts in parallel and transfer ArrayBuffers (zero copy) to main in
+ * arbitrary order. This queue holds out-of-order arrivals and delivers them
+ * sequentially to the Readable stream consumer.
+ *
+ * @internal
+ */
+
+export interface QueuedPart {
+  /**
+   * The transferred ArrayBuffer containing the part data.
+   */
+  buffer: ArrayBuffer;
+  /**
+   * Actual bytes written (may be less than buffer.byteLength for the last part).
+   */
+  byteLength: number;
+}
+
+export class OrderedPartQueue {
+  /**
+   * Out-of-order parts waiting for their turn. Keyed by rangeIndex.
+   */
+  private pending = new Map<number, QueuedPart>();
+
+  /**
+   * Next sequential rangeIndex the consumer expects.
+   */
+  private nextExpected = 0;
+
+  /**
+   * Total number of parts to deliver.
+   */
+  private readonly totalParts: number;
+
+  /**
+   * Resolve callback for the consumer waiting for the next part.
+   */
+  private waitingConsumer: ((value: QueuedPart | null) => void) | null = null;
+
+  /**
+   * Error from a failed download.
+   */
+  private error: unknown = undefined;
+
+  constructor(totalParts: number) {
+    this.totalParts = totalParts;
+  }
+
+  /**
+   * Called when a worker delivers a part (may arrive out of order).
+   * If the consumer is waiting for this exact part, delivers immediately.
+   * Otherwise stores it until its turn.
+   * @internal
+   */
+  public enqueue(rangeIndex: number, buffer: ArrayBuffer, byteLength: number): void {
+    if (this.error) return;
+
+    if (rangeIndex === this.nextExpected && this.waitingConsumer) {
+      // Consumer is already waiting for this exact part — deliver immediately
+      const consumer = this.waitingConsumer;
+      this.waitingConsumer = null;
+      this.nextExpected++;
+      consumer({ buffer, byteLength });
+    } else {
+      // Out of order — hold until it's this part's turn
+      this.pending.set(rangeIndex, { buffer, byteLength });
+    }
+  }
+
+  /**
+   * Called by the Readable stream's read() to get the next sequential part.
+   * Returns null when all parts have been consumed.
+   * Waits asynchronously if the next part hasn't arrived yet.
+   * @internal
+   */
+  public async dequeue(): Promise<QueuedPart | null> {
+    if (this.error) {
+      throw this.error;
+    }
+
+    if (this.nextExpected >= this.totalParts) {
+      return null; // All parts consumed
+    }
+
+    // Check if the next expected part already arrived out of order
+    const ready = this.pending.get(this.nextExpected);
+    if (ready) {
+      this.pending.delete(this.nextExpected);
+      this.nextExpected++;
+      return ready;
+    }
+
+    // Wait for it to arrive
+    return new Promise<QueuedPart | null>((resolve) => {
+      this.waitingConsumer = resolve;
+    });
+  }
+
+  /**
+   * Signals an error, waking up any waiting consumer.
+   * @internal
+   */
+  public setError(error: unknown): void {
+    this.error = error;
+
+    if (this.waitingConsumer) {
+      const consumer = this.waitingConsumer;
+      this.waitingConsumer = null;
+      consumer(null);
+    }
+  }
+
+  /**
+   * Returns whether an error has been set.
+   * @internal
+   */
+  public hasError(): boolean {
+    return this.error !== undefined;
+  }
+
+  /**
+   * Returns the stored error, if any.
+   * @internal
+   */
+  public getError(): unknown {
+    return this.error;
+  }
+
+  /**
+   * Returns the number of parts currently held (arrived but not yet delivered).
+   * Useful for monitoring reorder buffer depth.
+   * @internal
+   */
+  public get pendingCount(): number {
+    return this.pending.size;
+  }
+}

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/types.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/types.ts
@@ -107,6 +107,38 @@ export type DownloadRequest = GetObjectCommandInput;
 export type DownloadResponse = GetObjectCommandOutput;
 
 /**
+ * Features the same properties as DownloadRequest, with an additional
+ * file destination.
+ *
+ * @alpha
+ */
+export interface DownloadToFileRequest extends DownloadRequest {
+  /**
+   * The local file path to which the response body will be written.
+   * Must be a non-empty string.
+   */
+  destination: string;
+  /**
+   * Whether to fail the request if a file already exists at the destination.
+   * When false, the existing file is overwritten.
+   * Defaults to false.
+   */
+  failIfExists?: boolean;
+}
+
+/**
+ * Features the same properties as DownloadResponse, excluding Body.
+ *
+ * @alpha
+ */
+export interface DownloadToFileResponse extends Omit<DownloadResponse, "Body"> {
+  /**
+   * The total number of bytes written to the destination file.
+   */
+  bytesWritten: number;
+}
+
+/**
  * Options for transfer operations that combine HTTP handler options with transfer event listeners.
  *
  * @property eventListeners - Collection of callbacks for monitoring transfer lifecycle events
@@ -147,6 +179,16 @@ export interface IS3TransferManager {
    * @returns the response from the S3 API for the download request.
    */
   download(request: DownloadRequest, transferOptions?: TransferOptions): Promise<DownloadResponse>;
+
+  /**
+   * Downloads an S3 object to a local file.
+   *
+   * @param request - Download request including the local file destination path.
+   * @param transferOptions - Allows users to specify cancel functions for the request and a collection of callbacks for monitoring transfer lifecycle events. Allows tracking statuses per request.
+   *
+   * @returns the response containing bytes written, and object metadata.
+   */
+  downloadToFile(request: DownloadToFileRequest, transferOptions?: TransferOptions): Promise<DownloadToFileResponse>;
 
   /**
    * Uploads files in a directory to the provided S3 bucket.

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/worker-http-handler.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/worker-http-handler.ts
@@ -72,6 +72,20 @@ export interface HttpWorkerRAMRequestMessage extends BaseHttpWorkerRequestMessag
 
 export type HttpWorkerRequestMessage = HttpWorkerFileRequestMessage | HttpWorkerRAMRequestMessage;
 
+/**
+ * Main thread → Worker: download a part and write directly to a file offset.
+ * @internal
+ */
+export interface HttpWorkerDownloadToFileMessage {
+  type: "httpDownloadToFile";
+  id: number;
+  request: WorkerHttpRequest;
+  filePath: string;
+  offset: number;
+  expectedLength: number;
+  checksumAlgorithm?: string;
+}
+
 export interface HttpWorkerConfigMessage {
   type: "config";
   maxSockets: number;
@@ -81,7 +95,11 @@ export interface HttpWorkerDoneMessage {
   type: "done";
 }
 
-export type HttpWorkerInboundMessage = HttpWorkerRequestMessage | HttpWorkerConfigMessage | HttpWorkerDoneMessage;
+export type HttpWorkerInboundMessage =
+  | HttpWorkerRequestMessage
+  | HttpWorkerDownloadToFileMessage
+  | HttpWorkerConfigMessage
+  | HttpWorkerDoneMessage;
 
 export interface HttpWorkerResponseMessage {
   type: "httpResponse";
@@ -101,7 +119,37 @@ export interface HttpWorkerReadyMessage {
   type: "ready";
 }
 
-export type HttpWorkerOutboundMessage = HttpWorkerResponseMessage | HttpWorkerErrorMessage | HttpWorkerReadyMessage;
+/**
+ * Worker → Main thread: download part completed successfully.
+ * @internal
+ */
+export interface HttpWorkerDownloadResultMessage {
+  type: "httpDownloadResult";
+  id: number;
+  statusCode: number;
+  headers: Record<string, string>;
+  bytesWritten: number;
+  checksum?: string;
+}
+
+/**
+ * Worker → Main thread: download part failed.
+ * @internal
+ */
+export interface HttpWorkerDownloadErrorMessage {
+  type: "httpDownloadError";
+  id: number;
+  error: string;
+  code?: string;
+  name?: string;
+}
+
+export type HttpWorkerOutboundMessage =
+  | HttpWorkerResponseMessage
+  | HttpWorkerErrorMessage
+  | HttpWorkerReadyMessage
+  | HttpWorkerDownloadResultMessage
+  | HttpWorkerDownloadErrorMessage;
 
 /** @internal */
 export function defaultWorkerCount(): number {
@@ -144,11 +192,60 @@ export interface WorkerHttpHandlerOptions extends HttpHandlerOptions {
   dataSource?: DataSource;
 }
 
+/**
+ * Metadata passed to the worker instructing it to write the HTTP response body
+ * to a specific file offset rather than returning it over the message channel.
+ * @internal
+ */
+export interface DownloadDataToFile {
+  /** Absolute path to the temp file where the part body should be written. */
+  filePath: string;
+  /**
+   * Absolute byte offset in the file where writing should begin. Used only as a
+   * fallback: the worker prefers the start byte from the response's ContentRange
+   * header, since part sizes are not guaranteed to be uniform.
+   */
+  offset: number;
+  /**
+   * Expected byte length of the part body. Used only as a fallback, for the same
+   * reason as {@link DownloadDataToFile.offset}.
+   */
+  expectedLength: number;
+  /** Optional CRC algorithm for inline checksum computation. */
+  checksumAlgorithm?: string; // "CRC32" | "CRC32C" | "CRC64NVME"
+  /** Unique token for correlating the download result with the caller. */
+  resultToken?: string;
+}
+
+/**
+ * Options for WorkerHttpHandler.handle() that extend standard HttpHandlerOptions
+ * with download-to-file metadata for Part GET requests.
+ * @internal
+ */
+export interface WorkerHttpHandlerDownloadOptions extends HttpHandlerOptions {
+  downloadDataToFile?: DownloadDataToFile;
+}
+
+/**
+ * Result returned when a download-to-file request completes successfully.
+ * @internal
+ */
+export interface DownloadToFileResult {
+  statusCode: number;
+  headers: Record<string, string>;
+  bytesWritten: number;
+  checksum?: string;
+}
+
 export class WorkerHttpHandler {
   private workers: Worker[] = [];
   private inflightRequests = new Map<
     number,
     { resolve: (value: { response: HttpResponse }) => void; reject: (error: unknown) => void; workerIndex: number }
+  >();
+  private inflightDownloads = new Map<
+    number,
+    { resolve: (value: DownloadToFileResult) => void; reject: (error: unknown) => void; workerIndex: number }
   >();
   private nextRequestId = 0;
   private workerInflightCounts: number[] = [];
@@ -158,12 +255,33 @@ export class WorkerHttpHandler {
   private initPromise: Promise<void> | undefined;
   private fallbackHandler: NodeHttpHandler;
 
+  /**
+   * Stores completed download results keyed by a caller-provided token.
+   * The TM passes a unique token in the downloadDataToFile options and
+   * retrieves the result after this.s3.send() completes.
+   * @internal
+   */
+  private completedDownloads = new Map<string, { bytesWritten: number; checksum?: string }>();
+
   readonly metadata = { handlerProtocol: "http/1.1" };
 
   constructor(options?: { workerThreadCount?: number; maxConcurrentUploads?: number }) {
     this.workerThreadCount = options?.workerThreadCount ?? defaultWorkerCount();
     this.maxConcurrentUploads = options?.maxConcurrentUploads ?? 32;
     this.fallbackHandler = new NodeHttpHandler();
+  }
+
+  /**
+   * Retrieves and removes the completed download result for a given token.
+   * Returns undefined if no result is stored for that token.
+   * @internal
+   */
+  public getDownloadResult(token: string): { bytesWritten: number; checksum?: string } | undefined {
+    const result = this.completedDownloads.get(token);
+    if (result) {
+      this.completedDownloads.delete(token);
+    }
+    return result;
   }
 
   /**
@@ -242,6 +360,35 @@ export class WorkerHttpHandler {
             }
             return;
           }
+
+          if (msg.type === "httpDownloadResult") {
+            const pending = this.inflightDownloads.get(msg.id);
+            this.inflightDownloads.delete(msg.id);
+            if (pending) {
+              this.workerInflightCounts[pending.workerIndex]--;
+              pending.resolve({
+                statusCode: msg.statusCode,
+                headers: msg.headers,
+                bytesWritten: msg.bytesWritten,
+                checksum: msg.checksum,
+              });
+            }
+            return;
+          }
+
+          if (msg.type === "httpDownloadError") {
+            const pending = this.inflightDownloads.get(msg.id);
+            this.inflightDownloads.delete(msg.id);
+            if (pending) {
+              this.workerInflightCounts[pending.workerIndex]--;
+              const error = Object.assign(new Error(msg.error), {
+                ...(msg.code && { code: msg.code }),
+                ...(msg.name && { name: msg.name }),
+              });
+              pending.reject(error);
+            }
+            return;
+          }
         });
 
         worker.on("error", (err) => {
@@ -258,6 +405,12 @@ export class WorkerHttpHandler {
             if (pending.workerIndex === workerIndex) {
               pending.reject(err);
               this.inflightRequests.delete(id);
+            }
+          }
+          for (const [id, pending] of this.inflightDownloads) {
+            if (pending.workerIndex === workerIndex) {
+              pending.reject(err);
+              this.inflightDownloads.delete(id);
             }
           }
           // Mark this worker as dead so pickWorkerIndex() never routes to it.
@@ -294,6 +447,18 @@ export class WorkerHttpHandler {
     });
   }
 
+  /**
+   * Dispatches a download-to-file message to the least-busy worker and tracks the in-flight count.
+   */
+  private dispatchDownloadToWorker(id: number, message: HttpWorkerDownloadToFileMessage): Promise<DownloadToFileResult> {
+    const workerIndex = this.pickWorkerIndex();
+    this.workerInflightCounts[workerIndex]++;
+    return new Promise((resolve, reject) => {
+      this.inflightDownloads.set(id, { resolve, reject, workerIndex });
+      this.workers[workerIndex].postMessage(message);
+    });
+  }
+
   private extractPartNumber(request: HttpRequest): number | undefined {
     const partNumber = request.query?.partNumber;
     if (partNumber) {
@@ -302,8 +467,73 @@ export class WorkerHttpHandler {
     return undefined;
   }
 
-  async handle(request: HttpRequest, options?: WorkerHttpHandlerOptions): Promise<{ response: HttpResponse }> {
-    const dataSource = options?.dataSource;
+  async handle(request: HttpRequest, options?: WorkerHttpHandlerOptions | WorkerHttpHandlerDownloadOptions): Promise<{ response: HttpResponse }> {
+    // Download-to-file path: dispatch as httpDownloadToFile message.
+    // The worker handles the HTTP request and writes the body to file.
+    // We return a proper { response: HttpResponse } so the SDK middleware
+    // pipeline (checksums, deserialization, etc.) can process the response
+    // normally. The body is omitted since it was written directly to disk.
+    const downloadDataToFile = (options as WorkerHttpHandlerDownloadOptions | undefined)?.downloadDataToFile;
+    if (downloadDataToFile) {
+      await this.ensureInitialized();
+
+      const id = this.nextRequestId++;
+      const serializedRequest: WorkerHttpRequest = {
+        method: request.method,
+        protocol: request.protocol,
+        hostname: request.hostname,
+        port: request.port,
+        path: request.path,
+        query: request.query,
+        headers: request.headers,
+      };
+
+      const message: HttpWorkerDownloadToFileMessage = {
+        type: "httpDownloadToFile",
+        id,
+        request: serializedRequest,
+        filePath: downloadDataToFile.filePath,
+        offset: downloadDataToFile.offset,
+        expectedLength: downloadDataToFile.expectedLength,
+        checksumAlgorithm: downloadDataToFile.checksumAlgorithm,
+      };
+
+      const result = await this.dispatchDownloadToWorker(id, message);
+
+      // Store the download-specific result (bytesWritten, checksum) in the
+      // side-channel map so the TM can retrieve it after s3.send() returns.
+      if (downloadDataToFile.resultToken) {
+        this.completedDownloads.set(downloadDataToFile.resultToken, {
+          bytesWritten: result.bytesWritten,
+          checksum: result.checksum,
+        });
+      }
+
+      // Wrap the DownloadToFileResult in a proper HttpResponse so the SDK
+      // middleware pipeline can process it (flexible-checksums, deserialization, etc.).
+      //
+      // IMPORTANT: We strip per-part checksum headers (x-amz-checksum-*)
+      // because the flexible-checksums middleware would try to validate the
+      // body checksum against these headers — but there's no body to validate
+      // (it was written to file by the worker). The worker already validated
+      // the per-part CRC inline and stored the result in completedDownloads.
+      const responseHeaders: Record<string, string> = {};
+      for (const [key, value] of Object.entries(result.headers)) {
+        if (!key.startsWith("x-amz-checksum-")) {
+          responseHeaders[key] = value;
+        }
+      }
+
+      return {
+        response: new HttpResponse({
+          statusCode: result.statusCode,
+          headers: responseHeaders,
+          body: createEmptyReadable(),
+        }),
+      };
+    }
+
+    const dataSource = (options as WorkerHttpHandlerOptions | undefined)?.dataSource;
     const partNumber = this.extractPartNumber(request);
 
     // Fall back to default Node HTTP handler for non-upload-part requests

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/worker-http-handler.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/worker-http-handler.ts
@@ -12,6 +12,7 @@
 import { HttpResponse } from "@smithy/core/protocols";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import type { HttpHandlerOptions, HttpRequest, HttpResponse as HttpResponseShape } from "@smithy/types";
+import type { ChecksumAlgorithm } from "@aws-sdk/client-s3";
 import { existsSync } from "node:fs";
 import { cpus } from "node:os";
 import * as path from "node:path";
@@ -57,7 +58,7 @@ export interface HttpWorkerFileRequestMessage extends BaseHttpWorkerRequestMessa
   filePath: string;
   offset: number;
   length: number;
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
   checksumHeader?: string;
 }
 
@@ -66,7 +67,7 @@ export interface HttpWorkerRAMRequestMessage extends BaseHttpWorkerRequestMessag
   sharedBuffer: SharedArrayBuffer;
   offset: number;
   length: number;
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
   checksumHeader?: string;
 }
 
@@ -81,7 +82,7 @@ export interface HttpWorkerDownloadToFileMessage extends BaseHttpWorkerRequestMe
   filePath: string;
   offset: number;
   expectedLength: number;
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
 }
 
 /**
@@ -101,7 +102,7 @@ export interface HttpWorkerDownloadStreamMessage extends BaseHttpWorkerRequestMe
   /**
    * Optional CRC algorithm for inline checksum validation against S3 response headers.
    */
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
 }
 
 /**
@@ -215,7 +216,7 @@ export interface FileSource {
   filePath: string;
   partSize: number;
   totalFileSize: number;
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
   checksumHeader?: string;
 }
 
@@ -225,7 +226,7 @@ export interface SharedBufferSource {
   sharedBuffer: SharedArrayBuffer;
   partSize: number;
   totalSize: number;
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
   checksumHeader?: string;
 }
 
@@ -267,9 +268,9 @@ export interface DownloadDataToFile {
    */
   expectedLength: number;
   /**
-   * Optional CRC algorithm for inline checksum computation.
+   * Optional algorithm for inline checksum validation against S3 response headers.
    */
-  checksumAlgorithm?: string; // "CRC32" | "CRC32C" | "CRC64NVME"
+  checksumAlgorithm?: ChecksumAlgorithm;
   /**
    * Unique token for correlating the download result with the caller.
    */
@@ -291,9 +292,9 @@ export interface DownloadStreamOptions {
    */
   rangeIndex: number;
   /**
-   * Optional CRC algorithm for inline checksum computation.
+   * Optional algorithm for inline checksum validation against S3 response headers.
    */
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
   /**
    * Unique token for correlating the download result with the caller.
    */

--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/worker-http-handler.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/worker-http-handler.ts
@@ -76,14 +76,45 @@ export type HttpWorkerRequestMessage = HttpWorkerFileRequestMessage | HttpWorker
  * Main thread → Worker: download a part and write directly to a file offset.
  * @internal
  */
-export interface HttpWorkerDownloadToFileMessage {
+export interface HttpWorkerDownloadToFileMessage extends BaseHttpWorkerRequestMessage {
   type: "httpDownloadToFile";
-  id: number;
-  request: WorkerHttpRequest;
   filePath: string;
   offset: number;
   expectedLength: number;
   checksumAlgorithm?: string;
+}
+
+/**
+ * Main thread → Worker: download a part and stream the response back.
+ * @internal
+ */
+export interface HttpWorkerDownloadStreamMessage extends BaseHttpWorkerRequestMessage {
+  type: "httpDownloadStream";
+  /**
+   * Expected byte length of the part (used for buffer pre-allocation).
+   */
+  expectedSize: number;
+  /**
+   * Part/range index for in-order delivery on the main thread.
+   */
+  rangeIndex: number;
+  /**
+   * Optional CRC algorithm for inline checksum validation against S3 response headers.
+   */
+  checksumAlgorithm?: string;
+}
+
+/**
+ * Main thread → Worker: return a consumed ArrayBuffer for reuse.
+ * Sent after the main-thread consumer has finished reading a transferred buffer.
+ * @internal
+ */
+export interface HttpWorkerReturnBufferMessage {
+  type: "returnBuffer";
+  /**
+   * The ArrayBuffer being returned (transferred back to the worker).
+   */
+  buffer: ArrayBuffer;
 }
 
 export interface HttpWorkerConfigMessage {
@@ -98,6 +129,8 @@ export interface HttpWorkerDoneMessage {
 export type HttpWorkerInboundMessage =
   | HttpWorkerRequestMessage
   | HttpWorkerDownloadToFileMessage
+  | HttpWorkerDownloadStreamMessage
+  | HttpWorkerReturnBufferMessage
   | HttpWorkerConfigMessage
   | HttpWorkerDoneMessage;
 
@@ -144,12 +177,32 @@ export interface HttpWorkerDownloadErrorMessage {
   name?: string;
 }
 
+/**
+ * Worker → Main thread: stream-mode download completed.
+ * The ArrayBuffer is transferred (zero-copy) via the postMessage transfer list.
+ * @internal
+ */
+export interface HttpWorkerDownloadStreamResultMessage {
+  type: "httpDownloadStreamResult";
+  id: number;
+  rangeIndex: number;
+  /**
+   * The ArrayBuffer containing the downloaded part data (transferred, not copied).
+   */
+  buffer: ArrayBuffer;
+  byteLength: number;
+  statusCode: number;
+  headers: Record<string, string>;
+  checksum?: string;
+}
+
 export type HttpWorkerOutboundMessage =
   | HttpWorkerResponseMessage
   | HttpWorkerErrorMessage
   | HttpWorkerReadyMessage
   | HttpWorkerDownloadResultMessage
-  | HttpWorkerDownloadErrorMessage;
+  | HttpWorkerDownloadErrorMessage
+  | HttpWorkerDownloadStreamResultMessage;
 
 /** @internal */
 export function defaultWorkerCount(): number {
@@ -198,7 +251,9 @@ export interface WorkerHttpHandlerOptions extends HttpHandlerOptions {
  * @internal
  */
 export interface DownloadDataToFile {
-  /** Absolute path to the temp file where the part body should be written. */
+  /**
+   * Absolute path to the temp file where the part body should be written.
+   */
   filePath: string;
   /**
    * Absolute byte offset in the file where writing should begin. Used only as a
@@ -211,9 +266,37 @@ export interface DownloadDataToFile {
    * reason as {@link DownloadDataToFile.offset}.
    */
   expectedLength: number;
-  /** Optional CRC algorithm for inline checksum computation. */
+  /**
+   * Optional CRC algorithm for inline checksum computation.
+   */
   checksumAlgorithm?: string; // "CRC32" | "CRC32C" | "CRC64NVME"
-  /** Unique token for correlating the download result with the caller. */
+  /**
+   * Unique token for correlating the download result with the caller.
+   */
+  resultToken?: string;
+}
+
+/**
+ * Metadata passed to the worker instructing it to download a part into a
+ * worker-owned ArrayBuffer and transfer ownership to main (zero-copy).
+ * @internal
+ */
+export interface DownloadStreamOptions {
+  /**
+   * Expected byte length of the part (used for buffer pre-allocation).
+   */
+  expectedSize: number;
+  /**
+   * Part/range index for in-order delivery on the main thread.
+   */
+  rangeIndex: number;
+  /**
+   * Optional CRC algorithm for inline checksum computation.
+   */
+  checksumAlgorithm?: string;
+  /**
+   * Unique token for correlating the download result with the caller.
+   */
   resultToken?: string;
 }
 
@@ -224,6 +307,7 @@ export interface DownloadDataToFile {
  */
 export interface WorkerHttpHandlerDownloadOptions extends HttpHandlerOptions {
   downloadDataToFile?: DownloadDataToFile;
+  downloadStream?: DownloadStreamOptions;
 }
 
 /**
@@ -237,6 +321,23 @@ export interface DownloadToFileResult {
   checksum?: string;
 }
 
+/**
+ * Result returned when a transfer-mode download completes successfully.
+ * Contains the transferred ArrayBuffer (zero-copy from worker).
+ * @internal
+ */
+export interface DownloadStreamResult {
+  rangeIndex: number;
+  /**
+   * The ArrayBuffer transferred from the worker (zero-copy).
+   */
+  buffer: ArrayBuffer;
+  byteLength: number;
+  statusCode: number;
+  headers: Record<string, string>;
+  checksum?: string;
+}
+
 export class WorkerHttpHandler {
   private workers: Worker[] = [];
   private inflightRequests = new Map<
@@ -246,6 +347,10 @@ export class WorkerHttpHandler {
   private inflightDownloads = new Map<
     number,
     { resolve: (value: DownloadToFileResult) => void; reject: (error: unknown) => void; workerIndex: number }
+  >();
+  private inflightStreamDownloads = new Map<
+    number,
+    { resolve: (value: DownloadStreamResult) => void; reject: (error: unknown) => void; workerIndex: number }
   >();
   private nextRequestId = 0;
   private workerInflightCounts: number[] = [];
@@ -262,6 +367,13 @@ export class WorkerHttpHandler {
    * @internal
    */
   private completedDownloads = new Map<string, { bytesWritten: number; checksum?: string }>();
+
+  /**
+   * Stores completed stream-mode download results keyed by a caller-provided token.
+   * Unlike completedDownloads, this includes the ArrayBuffer with the response body.
+   * @internal
+   */
+  private completedTransfers = new Map<string, DownloadStreamResult>();
 
   readonly metadata = { handlerProtocol: "http/1.1" };
 
@@ -280,6 +392,19 @@ export class WorkerHttpHandler {
     const result = this.completedDownloads.get(token);
     if (result) {
       this.completedDownloads.delete(token);
+    }
+    return result;
+  }
+
+  /**
+   * Retrieves and removes the completed stream-mode download result for a given token.
+   * Includes the ArrayBuffer with the response body (zero-copy from worker).
+   * @internal
+   */
+  public getStreamDownloadResult(token: string): DownloadStreamResult | undefined {
+    const result = this.completedTransfers.get(token);
+    if (result) {
+      this.completedTransfers.delete(token);
     }
     return result;
   }
@@ -377,6 +502,7 @@ export class WorkerHttpHandler {
           }
 
           if (msg.type === "httpDownloadError") {
+            // First, check if it's a file-mode download that failed
             const pending = this.inflightDownloads.get(msg.id);
             this.inflightDownloads.delete(msg.id);
             if (pending) {
@@ -386,6 +512,35 @@ export class WorkerHttpHandler {
                 ...(msg.name && { name: msg.name }),
               });
               pending.reject(error);
+              return;
+            }
+            // Check stream downloads if not found in file downloads.
+            const pendingTransfer = this.inflightStreamDownloads.get(msg.id);
+            this.inflightStreamDownloads.delete(msg.id);
+            if (pendingTransfer) {
+              this.workerInflightCounts[pendingTransfer.workerIndex]--;
+              const error = Object.assign(new Error(msg.error), {
+                ...(msg.code && { code: msg.code }),
+                ...(msg.name && { name: msg.name }),
+              });
+              pendingTransfer.reject(error);
+            }
+            return;
+          }
+
+          if (msg.type === "httpDownloadStreamResult") {
+            const pending = this.inflightStreamDownloads.get(msg.id);
+            this.inflightStreamDownloads.delete(msg.id);
+            if (pending) {
+              this.workerInflightCounts[pending.workerIndex]--;
+              pending.resolve({
+                rangeIndex: msg.rangeIndex,
+                buffer: msg.buffer,
+                byteLength: msg.byteLength,
+                statusCode: msg.statusCode,
+                headers: msg.headers,
+                checksum: msg.checksum,
+              });
             }
             return;
           }
@@ -411,6 +566,12 @@ export class WorkerHttpHandler {
             if (pending.workerIndex === workerIndex) {
               pending.reject(err);
               this.inflightDownloads.delete(id);
+            }
+          }
+          for (const [id, pending] of this.inflightStreamDownloads) {
+            if (pending.workerIndex === workerIndex) {
+              pending.reject(err);
+              this.inflightStreamDownloads.delete(id);
             }
           }
           // Mark this worker as dead so pickWorkerIndex() never routes to it.
@@ -450,7 +611,10 @@ export class WorkerHttpHandler {
   /**
    * Dispatches a download-to-file message to the least-busy worker and tracks the in-flight count.
    */
-  private dispatchDownloadToWorker(id: number, message: HttpWorkerDownloadToFileMessage): Promise<DownloadToFileResult> {
+  private dispatchDownloadToWorker(
+    id: number,
+    message: HttpWorkerDownloadToFileMessage
+  ): Promise<DownloadToFileResult> {
     const workerIndex = this.pickWorkerIndex();
     this.workerInflightCounts[workerIndex]++;
     return new Promise((resolve, reject) => {
@@ -467,7 +631,22 @@ export class WorkerHttpHandler {
     return undefined;
   }
 
-  async handle(request: HttpRequest, options?: WorkerHttpHandlerOptions | WorkerHttpHandlerDownloadOptions): Promise<{ response: HttpResponse }> {
+  /**
+   * Returns a consumed ArrayBuffer to the worker that originally sent it,
+   * so it can be reused for future downloads.
+   * @internal
+   */
+  public returnBuffer(buffer: ArrayBuffer, workerIndex?: number): void {
+    // Round-robin or send to any available worker if index not specified
+    const targetIndex = workerIndex ?? this.nextRequestId % this.workers.length;
+    const message: HttpWorkerReturnBufferMessage = { type: "returnBuffer", buffer };
+    this.workers[targetIndex]?.postMessage(message, [buffer]);
+  }
+
+  async handle(
+    request: HttpRequest,
+    options?: WorkerHttpHandlerOptions | WorkerHttpHandlerDownloadOptions
+  ): Promise<{ response: HttpResponse }> {
     // Download-to-file path: dispatch as httpDownloadToFile message.
     // The worker handles the HTTP request and writes the body to file.
     // We return a proper { response: HttpResponse } so the SDK middleware
@@ -529,6 +708,71 @@ export class WorkerHttpHandler {
           statusCode: result.statusCode,
           headers: responseHeaders,
           body: createEmptyReadable(),
+        }),
+      };
+    }
+
+    // Download-to-stream path: send the request to a worker thread.
+    // The worker assembles the response body into its own ArrayBuffer and transfers
+    // ownership to main. The transferred buffer is stored in the
+    // map for the caller to retrieve, not returned in the HttpResponse.
+    const downloadStream = (options as WorkerHttpHandlerDownloadOptions | undefined)?.downloadStream;
+    if (downloadStream) {
+      await this.ensureInitialized();
+
+      const id = this.nextRequestId++;
+      const serializedRequest: WorkerHttpRequest = {
+        method: request.method,
+        protocol: request.protocol,
+        hostname: request.hostname,
+        port: request.port,
+        path: request.path,
+        query: request.query,
+        headers: request.headers,
+      };
+
+      const message: HttpWorkerDownloadStreamMessage = {
+        type: "httpDownloadStream",
+        id,
+        request: serializedRequest,
+        expectedSize: downloadStream.expectedSize,
+        rangeIndex: downloadStream.rangeIndex,
+        checksumAlgorithm: downloadStream.checksumAlgorithm,
+      };
+
+      const workerIndex = this.pickWorkerIndex();
+      this.workerInflightCounts[workerIndex]++;
+      const result = await new Promise<DownloadStreamResult>((resolve, reject) => {
+        this.inflightStreamDownloads.set(id, { resolve, reject, workerIndex });
+        this.workers[workerIndex].postMessage(message);
+      });
+
+      // Strip per-part checksum headers (validated inline by the worker)
+      const responseHeaders: Record<string, string> = {};
+      for (const [key, value] of Object.entries(result.headers)) {
+        if (!key.startsWith("x-amz-checksum-")) {
+          responseHeaders[key] = value;
+        }
+      }
+
+      // For error responses (4xx/5xx), pass the body through so the SDK can
+      // deserialize the proper error type (e.g. PreconditionFailed).
+      let body: Readable | undefined;
+      if (result.statusCode >= 400) {
+        const bodyBuf = Buffer.from(result.buffer, 0, result.byteLength);
+        body = Readable.from([bodyBuf]);
+      }
+
+      // Store the transfer result only for successful responses.
+      if (result.statusCode < 400 && downloadStream.resultToken) {
+        this.completedTransfers.set(downloadStream.resultToken, result);
+      }
+
+      return {
+        response: new HttpResponse({
+          statusCode: result.statusCode,
+          headers: responseHeaders,
+          body: body ?? createEmptyReadable(),
         }),
       };
     }

--- a/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
+++ b/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
@@ -71,6 +71,11 @@ function spreadLookup(
  * Types duplicated from worker-http-handler to avoid cross-submodule imports.
  * @internal
  */
+
+/**
+ * Serializable subset of HttpRequest sent from main thread to worker.
+ * Contains the signed request data without the body (body is sourced separately).
+ */
 interface WorkerHttpRequest {
   method: string;
   protocol: string;
@@ -109,16 +114,53 @@ type HttpWorkerRequestMessage =
   | HttpWorkerFileRequestMessage
   | HttpWorkerRAMRequestMessage;
 
-interface HttpWorkerDownloadToFileMessage {
+/**
+ * Main thread → Worker: download a part and write the response body directly
+ * to a file at the specified offset. Used for downloadToFile operations.
+ */
+interface HttpWorkerDownloadToFileMessage extends BaseHttpWorkerRequestMessage {
   type: "httpDownloadToFile";
-  id: number;
-  request: WorkerHttpRequest;
   filePath: string;
   offset: number;
   expectedLength: number;
   checksumAlgorithm?: string;
 }
 
+/**
+ * Main thread → Worker: download a part and stream the response back.
+ */
+interface HttpWorkerDownloadStreamMessage extends BaseHttpWorkerRequestMessage {
+  type: "httpDownloadStream";
+  /**
+   * Expected response body size in bytes; used to pre-allocate the ArrayBuffer.
+   */
+  expectedSize: number;
+  /**
+   * Sequential part/range index for ordered delivery on the main thread.
+   */
+  rangeIndex: number;
+  /**
+   * Optional CRC algorithm for inline checksum validation against S3 response headers.
+   */
+  checksumAlgorithm?: string;
+}
+
+/**
+ * Main thread → Worker: return a consumed ArrayBuffer for reuse.
+ * Sent after the main-thread consumer has finished reading a transferred buffer.
+ */
+interface HttpWorkerReturnBufferMessage {
+  type: "returnBuffer";
+  /**
+   * A consumed ArrayBuffer transferred back to the worker for reuse (zero-copy recycling).
+   */
+  buffer: ArrayBuffer;
+}
+
+/**
+ * Worker → Main thread: download-to-file completed successfully.
+ * Reports status, headers, bytes written, and optional checksum.
+ */
 interface HttpWorkerDownloadResultMessage {
   type: "httpDownloadResult";
   id: number;
@@ -128,6 +170,24 @@ interface HttpWorkerDownloadResultMessage {
   checksum?: string;
 }
 
+/**
+ * Worker → Main thread: stream-mode download completed.
+ * The ArrayBuffer is transferred (zero-copy) via the postMessage transfer list.
+ */
+interface HttpWorkerDownloadStreamResultMessage {
+  type: "httpDownloadStreamResult";
+  id: number;
+  rangeIndex: number;
+  buffer: ArrayBuffer;
+  byteLength: number;
+  statusCode: number;
+  headers: Record<string, string>;
+  checksum?: string;
+}
+
+/**
+ * Worker → Main thread: a download request (file or transfer) failed.
+ */
 interface HttpWorkerDownloadErrorMessage {
   type: "httpDownloadError";
   id: number;
@@ -136,11 +196,18 @@ interface HttpWorkerDownloadErrorMessage {
   name?: string;
 }
 
+/**
+ * Main thread → Worker: configure the worker's HTTP agent (e.g., max sockets).
+ * Sent once after the worker signals "ready".
+ */
 interface HttpWorkerConfigMessage {
   type: "config";
   maxSockets: number;
 }
 
+/**
+ * Main thread → Worker: shut down gracefully. Worker destroys its HTTP handler and exits.
+ */
 interface HttpWorkerDoneMessage {
   type: "done";
 }
@@ -148,9 +215,15 @@ interface HttpWorkerDoneMessage {
 type HttpWorkerInboundMessage =
   | HttpWorkerRequestMessage
   | HttpWorkerDownloadToFileMessage
+  | HttpWorkerDownloadStreamMessage
+  | HttpWorkerReturnBufferMessage
   | HttpWorkerConfigMessage
   | HttpWorkerDoneMessage;
 
+/**
+ * Worker → Main thread: upload request completed successfully.
+ * Contains the HTTP response (status, headers, body).
+ */
 interface HttpWorkerResponseMessage {
   type: "httpResponse";
   id: number;
@@ -161,6 +234,9 @@ interface HttpWorkerResponseMessage {
   };
 }
 
+/**
+ * Worker → Main thread: an upload request failed.
+ */
 interface HttpWorkerErrorMessage {
   type: "httpError";
   id: number;
@@ -169,6 +245,9 @@ interface HttpWorkerErrorMessage {
   name?: string;
 }
 
+/**
+ * Worker → Main thread: worker has initialized and is ready to accept requests.
+ */
 interface HttpWorkerReadyMessage {
   type: "ready";
 }
@@ -405,7 +484,7 @@ if (parentPort) {
     } = msg;
 
     try {
-      // 1. Send the signed HTTP request
+      // Send the signed HTTP request
       const request = new HttpRequest({
         method: serialized.method,
         protocol: serialized.protocol,
@@ -418,28 +497,26 @@ if (parentPort) {
 
       const { response } = await handler!.handle(request);
 
-      // 2. Resolve where and how much to write from the response's ContentRange.
+      // Resolve where and how much to write from the response's ContentRange.
       //
-      // The header is authoritative: S3 permits multipart objects whose parts
-      // differ in size, so the offset and length supplied by the caller are
-      // derived from part 1 and are only a fallback for when the header is
-      // missing. Trusting the header lets non-uniform objects download
-      // correctly instead of being rejected as a mismatch.
+      // ContentRange is the source of truth since S3 multipart objects can
+      // have parts of different sizes. The caller's offset/length are based on
+      // part 1 and only used as a fallback when the header is missing.
       const contentRange = response.headers["content-range"];
       const range = parseContentRange(contentRange);
       const writeOffset = range ? range.start : offset;
       const targetLength = range ? range.end - range.start + 1 : expectedLength;
 
-      // 3. Open the file with r+ flag (file is pre-allocated)
+      // open the file (file is pre-allocated)
       const fh = await open(filePath, "r+");
       try {
-        // 4. Initialize inline CRC computation if requested
+        // Initialize inline CRC computation if requested
         let crcChecksum: Checksum | undefined;
         if (checksumAlgorithm) {
           crcChecksum = createCrcChecksum(checksumAlgorithm);
         }
 
-        // 5. Stream response body chunks to file at positioned offsets
+        // Stream response body chunks to file at positioned offsets
         let bytesWritten = 0;
 
         if (response.body) {
@@ -478,7 +555,7 @@ if (parentPort) {
 
         await fh.close();
 
-        // 6. Validate bytesWritten matches the range's length
+        // Validate bytesWritten matches the range's length
         if (bytesWritten !== targetLength) {
           port.postMessage({
             type: "httpDownloadError",
@@ -490,7 +567,7 @@ if (parentPort) {
           return;
         }
 
-        // 7. Finalize checksum and validate against S3 header if present
+        // Finalize checksum and validate against S3 header if present
         let checksumBase64: string | undefined;
         if (crcChecksum && checksumAlgorithm) {
           checksumBase64 = await finalizeChecksumToBase64(crcChecksum);
@@ -512,7 +589,7 @@ if (parentPort) {
           }
         }
 
-        // 8. Post success result
+        // Post success result
         port.postMessage({
           type: "httpDownloadResult",
           id,
@@ -525,6 +602,144 @@ if (parentPort) {
         await fh.close().catch(() => {});
         throw err;
       }
+    } catch (err) {
+      port.postMessage({
+        type: "httpDownloadError",
+        id,
+        error: (err as Error).message ?? String(err),
+        code: (err as any).code,
+        name: (err as Error).name,
+      } satisfies HttpWorkerDownloadErrorMessage);
+    }
+  };
+
+  // Pool of reusable ArrayBuffers for stream-mode downloads.
+  // Buffers are allocated once and transferred between worker and main thread.
+  const reusableBufferPool: ArrayBuffer[] = [];
+
+  /**
+   * Acquire a reusable ArrayBuffer of at least `size` bytes.
+   * Uses Buffer.allocUnsafeSlow to get a dedicated (non-pooled) ArrayBuffer
+   * that is safe to transfer without detaching unrelated Buffers.
+   * @internal
+   */
+  function acquireTransferBuffer(size: number): ArrayBuffer {
+    for (let i = 0; i < reusableBufferPool.length; i++) {
+      if (reusableBufferPool[i].byteLength >= size) {
+        return reusableBufferPool.splice(i, 1)[0];
+      }
+    }
+    return Buffer.allocUnsafeSlow(size).buffer;
+  }
+
+  /**
+   * Downloads a part into a worker-owned ArrayBuffer and transfers ownership
+   * to the main thread via postMessage transfer list (zero-copy).
+   * @internal
+   */
+  const processDownloadToTransfer = async (
+    msg: HttpWorkerDownloadStreamMessage,
+  ): Promise<void> => {
+    const {
+      id,
+      request: serialized,
+      expectedSize,
+      rangeIndex,
+      checksumAlgorithm,
+    } = msg;
+
+    try {
+      // 1. Send the signed HTTP request
+      const request = new HttpRequest({
+        method: serialized.method,
+        protocol: serialized.protocol,
+        hostname: serialized.hostname,
+        port: serialized.port,
+        path: serialized.path,
+        query: serialized.query,
+        headers: serialized.headers,
+      });
+
+      const { response } = await handler!.handle(request);
+
+      // 2. Acquire a buffer for assembling the response body
+      const ab = acquireTransferBuffer(expectedSize);
+      const view = new Uint8Array(ab, 0, expectedSize);
+
+      // 3. Initialize inline CRC computation if requested
+      let crcChecksum: Checksum | undefined;
+      if (checksumAlgorithm) {
+        crcChecksum = createCrcChecksum(checksumAlgorithm);
+      }
+
+      // 4. Stream response body chunks into the ArrayBuffer
+      let bytesWritten = 0;
+
+      if (response.body) {
+        for await (const chunk of response.body) {
+          const buf: Uint8Array =
+            typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+
+          // Guard against writing beyond buffer boundary
+          if (bytesWritten + buf.length > expectedSize) {
+            port.postMessage({
+              type: "httpDownloadError",
+              id,
+              error: `Bytes received (${bytesWritten + buf.length}) exceeds expected size (${expectedSize}) for range index ${rangeIndex}`,
+              code: "BYTES_EXCEEDED",
+              name: "DownloadValidationError",
+            } satisfies HttpWorkerDownloadErrorMessage);
+            return;
+          }
+
+          // Copy chunk into the ArrayBuffer (this copy happens on the WORKER thread)
+          view.set(buf, bytesWritten);
+
+          // Update CRC inline
+          if (crcChecksum) {
+            crcChecksum.update(buf);
+          }
+
+          bytesWritten += buf.length;
+        }
+      }
+
+      // 5. Finalize checksum and validate against S3 header if present
+      let checksumBase64: string | undefined;
+      if (crcChecksum && checksumAlgorithm) {
+        checksumBase64 = await finalizeChecksumToBase64(crcChecksum);
+
+        const s3ChecksumValue = getChecksumHeaderValue(
+          response.headers,
+          checksumAlgorithm,
+        );
+        if (s3ChecksumValue && s3ChecksumValue !== checksumBase64) {
+          port.postMessage({
+            type: "httpDownloadError",
+            id,
+            error: `Checksum mismatch: computed ${checksumBase64}, S3 returned ${s3ChecksumValue}`,
+            code: "CHECKSUM_MISMATCH",
+            name: "ChecksumValidationError",
+          } satisfies HttpWorkerDownloadErrorMessage);
+          return;
+        }
+      }
+
+      // 6. Send the buffer to main thread (zero-copy). The buffer becomes
+      // detached on this worker.
+      port.postMessage(
+        {
+          type: "httpDownloadStreamResult",
+          id,
+          rangeIndex,
+          buffer: ab,
+          byteLength: bytesWritten,
+          statusCode: response.statusCode,
+          headers: response.headers,
+          checksum: checksumBase64,
+        } satisfies HttpWorkerDownloadStreamResultMessage,
+        [ab],
+      );
     } catch (err) {
       port.postMessage({
         type: "httpDownloadError",
@@ -574,6 +789,15 @@ if (parentPort) {
 
     if (msg.type === "httpDownloadToFile") {
       processDownloadToFile(msg);
+    }
+
+    if (msg.type === "httpDownloadStream") {
+      processDownloadToTransfer(msg);
+    }
+
+    if (msg.type === "returnBuffer") {
+      // Main thread returned a consumed ArrayBuffer for reuse
+      reusableBufferPool.push(msg.buffer);
     }
   });
 

--- a/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
+++ b/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
@@ -1,12 +1,12 @@
 /**
  * Worker thread that receives signed HTTP requests and sends them.
- * For file-based requests, reads the file slice, computes CRC32,
+ * For file-based requests, reads the file slice, computes a checksum,
  * and sends the body in aws-chunked format with a trailing checksum.
  *
  * For download-to-file requests, sends the signed HTTP request,
  * validates the ContentRange offset, streams the response body
  * directly to a file at the specified offset, and optionally
- * computes an inline CRC checksum.
+ * computes an inline checksum.
  *
  * @internal
  */
@@ -16,11 +16,13 @@ import dns from "node:dns";
 import { openSync, readSync, closeSync } from "node:fs";
 import type { LookupOptions } from "node:dns";
 import type { Checksum } from "@smithy/types";
-import { Crc32cJs, Crc64NvmeJs } from "@aws-sdk/checksums/crc";
+import type { ChecksumAlgorithm } from "@aws-sdk/client-s3";
+import { Crc32, Crc32c, Crc64Nvme } from "@aws-sdk/checksums/crc";
+import { Sha1, Sha256 } from "@aws-sdk/checksums/sha";
+import { Md5 } from "@aws-sdk/checksums/md5";
 import { open } from "node:fs/promises";
 import { Agent as httpsAgent } from "node:https";
 import { parentPort } from "node:worker_threads";
-import { crc32 } from "node:zlib";
 
 const DNS_TTL_MS = 1000;
 const dnsCache = new Map<string, { ips: string[]; ts: number }>();
@@ -93,7 +95,7 @@ interface HttpWorkerFileRequestMessage extends BaseHttpWorkerRequestMessage {
   filePath: string;
   offset: number;
   length: number;
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
   checksumHeader?: string;
 }
 
@@ -102,7 +104,7 @@ interface HttpWorkerRAMRequestMessage extends BaseHttpWorkerRequestMessage {
   sharedBuffer: SharedArrayBuffer;
   offset: number;
   length: number;
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
   checksumHeader?: string;
 }
 
@@ -117,7 +119,7 @@ interface HttpWorkerDownloadToFileMessage extends BaseHttpWorkerRequestMessage {
   filePath: string;
   offset: number;
   expectedLength: number;
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
 }
 
 /**
@@ -134,9 +136,9 @@ interface HttpWorkerDownloadStreamMessage extends BaseHttpWorkerRequestMessage {
    */
   rangeIndex: number;
   /**
-   * Optional CRC algorithm for inline checksum validation against S3 response headers.
+   * Optional algorithm for inline checksum validation against S3 response headers.
    */
-  checksumAlgorithm?: string;
+  checksumAlgorithm?: ChecksumAlgorithm;
 }
 
 /**
@@ -246,47 +248,25 @@ interface HttpWorkerReadyMessage {
   type: "ready";
 }
 
-function toBase64(n: number): string {
-  const buf = Buffer.allocUnsafe(4);
-  buf.writeUInt32BE(n >>> 0, 0);
-  return buf.toString("base64");
-}
+// Checksum Helpers for Download.
 
-// CRC Computation Helpers for Download.
-
-function createCrcChecksum(algorithm: string): Checksum {
-  if (algorithm === "CRC64NVME") {
-    return new Crc64NvmeJs();
-  }
-  if (algorithm === "CRC32C") {
-    return new Crc32cJs();
-  }
-  // CRC32 — use node:zlib wrapper that conforms to Checksum interface
-  return new NodeCrc32();
-}
-
-/**
- * Thin wrapper around node:zlib crc32 to conform to the Checksum interface.
- */
-class NodeCrc32 implements Checksum {
-  private value = 0;
-
-  update(data: Uint8Array): void {
-    this.value = crc32(data, this.value);
-  }
-
-  async digest(): Promise<Uint8Array> {
-    const buf = new Uint8Array(4);
-    const v = this.value >>> 0;
-    buf[0] = v >>> 24;
-    buf[1] = (v >>> 16) & 0xff;
-    buf[2] = (v >>> 8) & 0xff;
-    buf[3] = v & 0xff;
-    return buf;
-  }
-
-  reset(): void {
-    this.value = 0;
+function createChecksum(algorithm: ChecksumAlgorithm): Checksum | undefined {
+  switch (algorithm) {
+    case "CRC64NVME":
+      return new Crc64Nvme();
+    case "CRC32C":
+      return new Crc32c();
+    case "CRC32":
+      return new Crc32();
+    case "SHA1":
+      return new Sha1();
+    case "SHA256":
+      return new Sha256();
+    case "MD5":
+      return new Md5();
+    default:
+      // Algorithms without a local implementation (e.g. XXHASH64, SHA512) skip inline validation.
+      return undefined;
   }
 }
 
@@ -367,8 +347,9 @@ if (parentPort) {
         const fileData = Buffer.from(msg.sharedBuffer, msg.offset, msg.length);
 
         if (msg.checksumAlgorithm && msg.checksumHeader) {
-          const crcValue = crc32(fileData);
-          const checksumValue = toBase64(crcValue);
+          const crc = new Crc32();
+          crc.update(fileData);
+          const checksumValue = Buffer.from(await crc.digest()).toString("base64");
           body = buildAwsChunkedBody(fileData, msg.checksumHeader, checksumValue);
         } else {
           body = fileData;
@@ -377,8 +358,9 @@ if (parentPort) {
         const fileData = readFileSlice(msg.filePath, msg.offset, msg.length);
 
         if (msg.checksumAlgorithm && msg.checksumHeader) {
-          const crcValue = crc32(fileData);
-          const checksumValue = toBase64(crcValue);
+          const crc = new Crc32();
+          crc.update(fileData);
+          const checksumValue = Buffer.from(await crc.digest()).toString("base64");
           body = buildAwsChunkedBody(fileData, msg.checksumHeader, checksumValue);
         } else {
           body = fileData;
@@ -468,10 +450,10 @@ if (parentPort) {
       // open the file (file is pre-allocated)
       const fh = await open(filePath, "r+");
       try {
-        // Initialize inline CRC computation if requested
-        let crcChecksum: Checksum | undefined;
+        // Initialize inline checksum computation if requested
+        let checksum: Checksum | undefined;
         if (checksumAlgorithm) {
-          crcChecksum = createCrcChecksum(checksumAlgorithm);
+          checksum = createChecksum(checksumAlgorithm);
         }
 
         // Stream response body chunks to file at positioned offsets
@@ -498,9 +480,9 @@ if (parentPort) {
             // Write chunk to file at the correct position
             await fh.write(buf, 0, buf.length, writeOffset + bytesWritten);
 
-            // Update CRC inline
-            if (crcChecksum) {
-              crcChecksum.update(buf);
+            // Update checksum inline
+            if (checksum) {
+              checksum.update(buf);
             }
 
             bytesWritten += buf.length;
@@ -523,8 +505,8 @@ if (parentPort) {
 
         // Finalize checksum and validate against S3 header if present
         let checksumBase64: string | undefined;
-        if (crcChecksum && checksumAlgorithm) {
-          checksumBase64 = await finalizeChecksumToBase64(crcChecksum);
+        if (checksum && checksumAlgorithm) {
+          checksumBase64 = await finalizeChecksumToBase64(checksum);
 
           // Check if S3 returned a per-part checksum header
           const s3ChecksumValue = getChecksumHeaderValue(response.headers, checksumAlgorithm);
@@ -609,10 +591,10 @@ if (parentPort) {
       const ab = acquireTransferBuffer(expectedSize);
       const view = new Uint8Array(ab, 0, expectedSize);
 
-      // 3. Initialize inline CRC computation if requested
-      let crcChecksum: Checksum | undefined;
+      // 3. Initialize inline checksum computation if requested
+      let checksum: Checksum | undefined;
       if (checksumAlgorithm) {
-        crcChecksum = createCrcChecksum(checksumAlgorithm);
+        checksum = createChecksum(checksumAlgorithm);
       }
 
       // 4. Stream response body chunks into the ArrayBuffer
@@ -637,9 +619,9 @@ if (parentPort) {
           // Copy chunk into the ArrayBuffer (this copy happens on the WORKER thread)
           view.set(buf, bytesWritten);
 
-          // Update CRC inline
-          if (crcChecksum) {
-            crcChecksum.update(buf);
+          // Update checksum inline
+          if (checksum) {
+            checksum.update(buf);
           }
 
           bytesWritten += buf.length;
@@ -648,8 +630,8 @@ if (parentPort) {
 
       // 5. Finalize checksum and validate against S3 header if present
       let checksumBase64: string | undefined;
-      if (crcChecksum && checksumAlgorithm) {
-        checksumBase64 = await finalizeChecksumToBase64(crcChecksum);
+      if (checksum && checksumAlgorithm) {
+        checksumBase64 = await finalizeChecksumToBase64(checksum);
 
         const s3ChecksumValue = getChecksumHeaderValue(response.headers, checksumAlgorithm);
         if (s3ChecksumValue && s3ChecksumValue !== checksumBase64) {

--- a/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
+++ b/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
@@ -3,6 +3,11 @@
  * For file-based requests, reads the file slice, computes CRC32,
  * and sends the body in aws-chunked format with a trailing checksum.
  *
+ * For download-to-file requests, sends the signed HTTP request,
+ * validates the ContentRange offset, streams the response body
+ * directly to a file at the specified offset, and optionally
+ * computes an inline CRC checksum.
+ *
  * @internal
  */
 import { HttpRequest } from "@smithy/core/protocols";
@@ -10,6 +15,9 @@ import { NodeHttpHandler } from "@smithy/node-http-handler";
 import dns from "node:dns";
 import { openSync, readSync, closeSync } from "node:fs";
 import type { LookupOptions } from "node:dns";
+import type { Checksum } from "@smithy/types";
+import { Crc32cJs, Crc64NvmeJs } from "@aws-sdk/checksums/crc";
+import { open } from "node:fs/promises";
 import { Agent as httpsAgent } from "node:https";
 import { parentPort } from "node:worker_threads";
 import { crc32 } from "node:zlib";
@@ -26,7 +34,11 @@ const dnsCache = new Map<string, { ips: string[]; ts: number }>();
 function spreadLookup(
   hostname: string,
   options: LookupOptions,
-  callback: (err: NodeJS.ErrnoException | null, address: string | dns.LookupAddress[], family?: number) => void
+  callback: (
+    err: NodeJS.ErrnoException | null,
+    address: string | dns.LookupAddress[],
+    family?: number,
+  ) => void,
 ): void {
   if (options && options.family === 6) {
     return dns.lookup(hostname, options, callback);
@@ -93,7 +105,36 @@ interface HttpWorkerRAMRequestMessage extends BaseHttpWorkerRequestMessage {
   checksumHeader?: string;
 }
 
-type HttpWorkerRequestMessage = HttpWorkerFileRequestMessage | HttpWorkerRAMRequestMessage;
+type HttpWorkerRequestMessage =
+  | HttpWorkerFileRequestMessage
+  | HttpWorkerRAMRequestMessage;
+
+interface HttpWorkerDownloadToFileMessage {
+  type: "httpDownloadToFile";
+  id: number;
+  request: WorkerHttpRequest;
+  filePath: string;
+  offset: number;
+  expectedLength: number;
+  checksumAlgorithm?: string;
+}
+
+interface HttpWorkerDownloadResultMessage {
+  type: "httpDownloadResult";
+  id: number;
+  statusCode: number;
+  headers: Record<string, string>;
+  bytesWritten: number;
+  checksum?: string;
+}
+
+interface HttpWorkerDownloadErrorMessage {
+  type: "httpDownloadError";
+  id: number;
+  error: string;
+  code?: string;
+  name?: string;
+}
 
 interface HttpWorkerConfigMessage {
   type: "config";
@@ -104,12 +145,20 @@ interface HttpWorkerDoneMessage {
   type: "done";
 }
 
-type HttpWorkerInboundMessage = HttpWorkerRequestMessage | HttpWorkerConfigMessage | HttpWorkerDoneMessage;
+type HttpWorkerInboundMessage =
+  | HttpWorkerRequestMessage
+  | HttpWorkerDownloadToFileMessage
+  | HttpWorkerConfigMessage
+  | HttpWorkerDoneMessage;
 
 interface HttpWorkerResponseMessage {
   type: "httpResponse";
   id: number;
-  response: { statusCode: number; headers: Record<string, string>; body?: Uint8Array };
+  response: {
+    statusCode: number;
+    headers: Record<string, string>;
+    body?: Uint8Array;
+  };
 }
 
 interface HttpWorkerErrorMessage {
@@ -130,6 +179,79 @@ function toBase64(n: number): string {
   return buf.toString("base64");
 }
 
+// CRC Computation Helpers for Download.
+
+function createCrcChecksum(algorithm: string): Checksum {
+  if (algorithm === "CRC64NVME") {
+    return new Crc64NvmeJs();
+  }
+  if (algorithm === "CRC32C") {
+    return new Crc32cJs();
+  }
+  // CRC32 — use node:zlib wrapper that conforms to Checksum interface
+  return new NodeCrc32();
+}
+
+/**
+ * Thin wrapper around node:zlib crc32 to conform to the Checksum interface.
+ */
+class NodeCrc32 implements Checksum {
+  private value = 0;
+
+  update(data: Uint8Array): void {
+    this.value = crc32(data, this.value);
+  }
+
+  async digest(): Promise<Uint8Array> {
+    const buf = new Uint8Array(4);
+    const v = this.value >>> 0;
+    buf[0] = v >>> 24;
+    buf[1] = (v >>> 16) & 0xff;
+    buf[2] = (v >>> 8) & 0xff;
+    buf[3] = v & 0xff;
+    return buf;
+  }
+
+  reset(): void {
+    this.value = 0;
+  }
+}
+
+async function finalizeChecksumToBase64(checksum: Checksum): Promise<string> {
+  const bytes = await checksum.digest();
+  return Buffer.from(bytes).toString("base64");
+}
+
+/**
+ * Parses the inclusive byte bounds from a ContentRange header.
+ * Expected format: "bytes START-END/TOTAL".
+ *
+ * @returns The START and END values, or undefined if absent or unparseable.
+ */
+function parseContentRange(
+  contentRange: string | undefined,
+): { start: number; end: number } | undefined {
+  if (!contentRange) return undefined;
+  const match = contentRange.match(/^bytes\s+(\d+)-(\d+)\//);
+  if (!match) return undefined;
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  if (end < start) return undefined;
+  return { start, end };
+}
+
+/**
+ * Finds the checksum header value in the response headers for the given algorithm.
+ * S3 returns per-part checksums in headers like `x-amz-checksum-crc32`.
+ */
+function getChecksumHeaderValue(
+  headers: Record<string, string>,
+  algorithm: string,
+): string | undefined {
+  const headerName = `x-amz-checksum-${algorithm.toLowerCase()}`;
+  return headers[headerName];
+}
+
 if (parentPort) {
   let handler: NodeHttpHandler | undefined;
   const port = parentPort;
@@ -145,7 +267,11 @@ if (parentPort) {
     return fd;
   }
 
-  const readFileSlice = (filePath: string, offset: number, length: number): Buffer => {
+  const readFileSlice = (
+    filePath: string,
+    offset: number,
+    length: number,
+  ): Buffer => {
     const fd = getFd(filePath);
     const buffer = Buffer.allocUnsafe(length);
     let read = 0;
@@ -157,9 +283,17 @@ if (parentPort) {
     return buffer;
   };
 
-  const buildAwsChunkedBody = (data: Buffer, checksumHeader?: string, checksumValue?: string): Buffer => {
+  const buildAwsChunkedBody = (
+    data: Buffer,
+    checksumHeader?: string,
+    checksumValue?: string,
+  ): Buffer => {
     const hexLen = data.byteLength.toString(16);
-    const parts: Buffer[] = [Buffer.from(`${hexLen}\r\n`), data, Buffer.from("\r\n0\r\n")];
+    const parts: Buffer[] = [
+      Buffer.from(`${hexLen}\r\n`),
+      data,
+      Buffer.from("\r\n0\r\n"),
+    ];
     if (checksumHeader && checksumValue) {
       parts.push(Buffer.from(`${checksumHeader}:${checksumValue}\r\n`));
     }
@@ -167,7 +301,9 @@ if (parentPort) {
     return Buffer.concat(parts);
   };
 
-  const processRequest = async (msg: HttpWorkerRequestMessage): Promise<void> => {
+  const processRequest = async (
+    msg: HttpWorkerRequestMessage,
+  ): Promise<void> => {
     const { id, request: serialized } = msg;
 
     try {
@@ -179,7 +315,11 @@ if (parentPort) {
         if (msg.checksumAlgorithm && msg.checksumHeader) {
           const crcValue = crc32(fileData);
           const checksumValue = toBase64(crcValue);
-          body = buildAwsChunkedBody(fileData, msg.checksumHeader, checksumValue);
+          body = buildAwsChunkedBody(
+            fileData,
+            msg.checksumHeader,
+            checksumValue,
+          );
         } else {
           body = fileData;
         }
@@ -189,7 +329,11 @@ if (parentPort) {
         if (msg.checksumAlgorithm && msg.checksumHeader) {
           const crcValue = crc32(fileData);
           const checksumValue = toBase64(crcValue);
-          body = buildAwsChunkedBody(fileData, msg.checksumHeader, checksumValue);
+          body = buildAwsChunkedBody(
+            fileData,
+            msg.checksumHeader,
+            checksumValue,
+          );
         } else {
           body = fileData;
         }
@@ -235,7 +379,7 @@ if (parentPort) {
             body: responseBody,
           },
         } satisfies HttpWorkerResponseMessage,
-        transferList
+        transferList,
       );
     } catch (err) {
       port.postMessage({
@@ -245,6 +389,150 @@ if (parentPort) {
         code: (err as any).code,
         name: (err as Error).name,
       } satisfies HttpWorkerErrorMessage);
+    }
+  };
+
+  const processDownloadToFile = async (
+    msg: HttpWorkerDownloadToFileMessage,
+  ): Promise<void> => {
+    const {
+      id,
+      request: serialized,
+      filePath,
+      offset,
+      expectedLength,
+      checksumAlgorithm,
+    } = msg;
+
+    try {
+      // 1. Send the signed HTTP request
+      const request = new HttpRequest({
+        method: serialized.method,
+        protocol: serialized.protocol,
+        hostname: serialized.hostname,
+        port: serialized.port,
+        path: serialized.path,
+        query: serialized.query,
+        headers: serialized.headers,
+      });
+
+      const { response } = await handler!.handle(request);
+
+      // 2. Resolve where and how much to write from the response's ContentRange.
+      //
+      // The header is authoritative: S3 permits multipart objects whose parts
+      // differ in size, so the offset and length supplied by the caller are
+      // derived from part 1 and are only a fallback for when the header is
+      // missing. Trusting the header lets non-uniform objects download
+      // correctly instead of being rejected as a mismatch.
+      const contentRange = response.headers["content-range"];
+      const range = parseContentRange(contentRange);
+      const writeOffset = range ? range.start : offset;
+      const targetLength = range ? range.end - range.start + 1 : expectedLength;
+
+      // 3. Open the file with r+ flag (file is pre-allocated)
+      const fh = await open(filePath, "r+");
+      try {
+        // 4. Initialize inline CRC computation if requested
+        let crcChecksum: Checksum | undefined;
+        if (checksumAlgorithm) {
+          crcChecksum = createCrcChecksum(checksumAlgorithm);
+        }
+
+        // 5. Stream response body chunks to file at positioned offsets
+        let bytesWritten = 0;
+
+        if (response.body) {
+          for await (const chunk of response.body) {
+            const buf =
+              typeof chunk === "string"
+                ? Buffer.from(chunk)
+                : Buffer.isBuffer(chunk)
+                  ? chunk
+                  : Buffer.from(chunk);
+
+            // Verify cumulative bytes do not exceed the range's length
+            if (bytesWritten + buf.length > targetLength) {
+              await fh.close();
+              port.postMessage({
+                type: "httpDownloadError",
+                id,
+                error: `Bytes written (${bytesWritten + buf.length}) exceeds expected length (${targetLength})`,
+                code: "BYTES_EXCEEDED",
+                name: "DownloadValidationError",
+              } satisfies HttpWorkerDownloadErrorMessage);
+              return;
+            }
+
+            // Write chunk to file at the correct position
+            await fh.write(buf, 0, buf.length, writeOffset + bytesWritten);
+
+            // Update CRC inline
+            if (crcChecksum) {
+              crcChecksum.update(buf);
+            }
+
+            bytesWritten += buf.length;
+          }
+        }
+
+        await fh.close();
+
+        // 6. Validate bytesWritten matches the range's length
+        if (bytesWritten !== targetLength) {
+          port.postMessage({
+            type: "httpDownloadError",
+            id,
+            error: `Bytes written (${bytesWritten}) does not match expected length (${targetLength})`,
+            code: "LENGTH_MISMATCH",
+            name: "DownloadValidationError",
+          } satisfies HttpWorkerDownloadErrorMessage);
+          return;
+        }
+
+        // 7. Finalize checksum and validate against S3 header if present
+        let checksumBase64: string | undefined;
+        if (crcChecksum && checksumAlgorithm) {
+          checksumBase64 = await finalizeChecksumToBase64(crcChecksum);
+
+          // Check if S3 returned a per-part checksum header
+          const s3ChecksumValue = getChecksumHeaderValue(
+            response.headers,
+            checksumAlgorithm,
+          );
+          if (s3ChecksumValue && s3ChecksumValue !== checksumBase64) {
+            port.postMessage({
+              type: "httpDownloadError",
+              id,
+              error: `Checksum mismatch: computed ${checksumBase64}, S3 returned ${s3ChecksumValue}`,
+              code: "CHECKSUM_MISMATCH",
+              name: "ChecksumValidationError",
+            } satisfies HttpWorkerDownloadErrorMessage);
+            return;
+          }
+        }
+
+        // 8. Post success result
+        port.postMessage({
+          type: "httpDownloadResult",
+          id,
+          statusCode: response.statusCode,
+          headers: response.headers,
+          bytesWritten,
+          checksum: checksumBase64,
+        } satisfies HttpWorkerDownloadResultMessage);
+      } catch (err) {
+        await fh.close().catch(() => {});
+        throw err;
+      }
+    } catch (err) {
+      port.postMessage({
+        type: "httpDownloadError",
+        id,
+        error: (err as Error).message ?? String(err),
+        code: (err as any).code,
+        name: (err as Error).name,
+      } satisfies HttpWorkerDownloadErrorMessage);
     }
   };
 
@@ -268,13 +556,24 @@ if (parentPort) {
     if (msg.type === "config") {
       const { maxSockets } = msg as HttpWorkerConfigMessage;
       handler = new NodeHttpHandler({
-        httpsAgent: new httpsAgent({ maxSockets, keepAlive: true, lookup: spreadLookup }),
+        httpsAgent: new httpsAgent({
+          maxSockets,
+          keepAlive: true,
+          lookup: spreadLookup,
+        }),
       });
       return;
     }
 
-    if (msg.type === "httpRequestFromFile" || msg.type === "httpRequestFromRAM") {
+    if (
+      msg.type === "httpRequestFromFile" ||
+      msg.type === "httpRequestFromRAM"
+    ) {
       processRequest(msg);
+    }
+
+    if (msg.type === "httpDownloadToFile") {
+      processDownloadToFile(msg);
     }
   });
 

--- a/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
+++ b/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
@@ -34,11 +34,7 @@ const dnsCache = new Map<string, { ips: string[]; ts: number }>();
 function spreadLookup(
   hostname: string,
   options: LookupOptions,
-  callback: (
-    err: NodeJS.ErrnoException | null,
-    address: string | dns.LookupAddress[],
-    family?: number,
-  ) => void,
+  callback: (err: NodeJS.ErrnoException | null, address: string | dns.LookupAddress[], family?: number) => void
 ): void {
   if (options && options.family === 6) {
     return dns.lookup(hostname, options, callback);
@@ -110,9 +106,7 @@ interface HttpWorkerRAMRequestMessage extends BaseHttpWorkerRequestMessage {
   checksumHeader?: string;
 }
 
-type HttpWorkerRequestMessage =
-  | HttpWorkerFileRequestMessage
-  | HttpWorkerRAMRequestMessage;
+type HttpWorkerRequestMessage = HttpWorkerFileRequestMessage | HttpWorkerRAMRequestMessage;
 
 /**
  * Main thread → Worker: download a part and write the response body directly
@@ -307,9 +301,7 @@ async function finalizeChecksumToBase64(checksum: Checksum): Promise<string> {
  *
  * @returns The START and END values, or undefined if absent or unparseable.
  */
-function parseContentRange(
-  contentRange: string | undefined,
-): { start: number; end: number } | undefined {
+function parseContentRange(contentRange: string | undefined): { start: number; end: number } | undefined {
   if (!contentRange) return undefined;
   const match = contentRange.match(/^bytes\s+(\d+)-(\d+)\//);
   if (!match) return undefined;
@@ -323,10 +315,7 @@ function parseContentRange(
  * Finds the checksum header value in the response headers for the given algorithm.
  * S3 returns per-part checksums in headers like `x-amz-checksum-crc32`.
  */
-function getChecksumHeaderValue(
-  headers: Record<string, string>,
-  algorithm: string,
-): string | undefined {
+function getChecksumHeaderValue(headers: Record<string, string>, algorithm: string): string | undefined {
   const headerName = `x-amz-checksum-${algorithm.toLowerCase()}`;
   return headers[headerName];
 }
@@ -346,11 +335,7 @@ if (parentPort) {
     return fd;
   }
 
-  const readFileSlice = (
-    filePath: string,
-    offset: number,
-    length: number,
-  ): Buffer => {
+  const readFileSlice = (filePath: string, offset: number, length: number): Buffer => {
     const fd = getFd(filePath);
     const buffer = Buffer.allocUnsafe(length);
     let read = 0;
@@ -362,17 +347,9 @@ if (parentPort) {
     return buffer;
   };
 
-  const buildAwsChunkedBody = (
-    data: Buffer,
-    checksumHeader?: string,
-    checksumValue?: string,
-  ): Buffer => {
+  const buildAwsChunkedBody = (data: Buffer, checksumHeader?: string, checksumValue?: string): Buffer => {
     const hexLen = data.byteLength.toString(16);
-    const parts: Buffer[] = [
-      Buffer.from(`${hexLen}\r\n`),
-      data,
-      Buffer.from("\r\n0\r\n"),
-    ];
+    const parts: Buffer[] = [Buffer.from(`${hexLen}\r\n`), data, Buffer.from("\r\n0\r\n")];
     if (checksumHeader && checksumValue) {
       parts.push(Buffer.from(`${checksumHeader}:${checksumValue}\r\n`));
     }
@@ -380,9 +357,7 @@ if (parentPort) {
     return Buffer.concat(parts);
   };
 
-  const processRequest = async (
-    msg: HttpWorkerRequestMessage,
-  ): Promise<void> => {
+  const processRequest = async (msg: HttpWorkerRequestMessage): Promise<void> => {
     const { id, request: serialized } = msg;
 
     try {
@@ -394,11 +369,7 @@ if (parentPort) {
         if (msg.checksumAlgorithm && msg.checksumHeader) {
           const crcValue = crc32(fileData);
           const checksumValue = toBase64(crcValue);
-          body = buildAwsChunkedBody(
-            fileData,
-            msg.checksumHeader,
-            checksumValue,
-          );
+          body = buildAwsChunkedBody(fileData, msg.checksumHeader, checksumValue);
         } else {
           body = fileData;
         }
@@ -408,11 +379,7 @@ if (parentPort) {
         if (msg.checksumAlgorithm && msg.checksumHeader) {
           const crcValue = crc32(fileData);
           const checksumValue = toBase64(crcValue);
-          body = buildAwsChunkedBody(
-            fileData,
-            msg.checksumHeader,
-            checksumValue,
-          );
+          body = buildAwsChunkedBody(fileData, msg.checksumHeader, checksumValue);
         } else {
           body = fileData;
         }
@@ -458,7 +425,7 @@ if (parentPort) {
             body: responseBody,
           },
         } satisfies HttpWorkerResponseMessage,
-        transferList,
+        transferList
       );
     } catch (err) {
       port.postMessage({
@@ -471,17 +438,8 @@ if (parentPort) {
     }
   };
 
-  const processDownloadToFile = async (
-    msg: HttpWorkerDownloadToFileMessage,
-  ): Promise<void> => {
-    const {
-      id,
-      request: serialized,
-      filePath,
-      offset,
-      expectedLength,
-      checksumAlgorithm,
-    } = msg;
+  const processDownloadToFile = async (msg: HttpWorkerDownloadToFileMessage): Promise<void> => {
+    const { id, request: serialized, filePath, offset, expectedLength, checksumAlgorithm } = msg;
 
     try {
       // Send the signed HTTP request
@@ -522,11 +480,7 @@ if (parentPort) {
         if (response.body) {
           for await (const chunk of response.body) {
             const buf =
-              typeof chunk === "string"
-                ? Buffer.from(chunk)
-                : Buffer.isBuffer(chunk)
-                  ? chunk
-                  : Buffer.from(chunk);
+              typeof chunk === "string" ? Buffer.from(chunk) : Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
 
             // Verify cumulative bytes do not exceed the range's length
             if (bytesWritten + buf.length > targetLength) {
@@ -573,10 +527,7 @@ if (parentPort) {
           checksumBase64 = await finalizeChecksumToBase64(crcChecksum);
 
           // Check if S3 returned a per-part checksum header
-          const s3ChecksumValue = getChecksumHeaderValue(
-            response.headers,
-            checksumAlgorithm,
-          );
+          const s3ChecksumValue = getChecksumHeaderValue(response.headers, checksumAlgorithm);
           if (s3ChecksumValue && s3ChecksumValue !== checksumBase64) {
             port.postMessage({
               type: "httpDownloadError",
@@ -637,16 +588,8 @@ if (parentPort) {
    * to the main thread via postMessage transfer list (zero-copy).
    * @internal
    */
-  const processDownloadToTransfer = async (
-    msg: HttpWorkerDownloadStreamMessage,
-  ): Promise<void> => {
-    const {
-      id,
-      request: serialized,
-      expectedSize,
-      rangeIndex,
-      checksumAlgorithm,
-    } = msg;
+  const processDownloadToTransfer = async (msg: HttpWorkerDownloadStreamMessage): Promise<void> => {
+    const { id, request: serialized, expectedSize, rangeIndex, checksumAlgorithm } = msg;
 
     try {
       // 1. Send the signed HTTP request
@@ -677,8 +620,7 @@ if (parentPort) {
 
       if (response.body) {
         for await (const chunk of response.body) {
-          const buf: Uint8Array =
-            typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+          const buf: Uint8Array = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
 
           // Guard against writing beyond buffer boundary
           if (bytesWritten + buf.length > expectedSize) {
@@ -709,10 +651,7 @@ if (parentPort) {
       if (crcChecksum && checksumAlgorithm) {
         checksumBase64 = await finalizeChecksumToBase64(crcChecksum);
 
-        const s3ChecksumValue = getChecksumHeaderValue(
-          response.headers,
-          checksumAlgorithm,
-        );
+        const s3ChecksumValue = getChecksumHeaderValue(response.headers, checksumAlgorithm);
         if (s3ChecksumValue && s3ChecksumValue !== checksumBase64) {
           port.postMessage({
             type: "httpDownloadError",
@@ -738,7 +677,7 @@ if (parentPort) {
           headers: response.headers,
           checksum: checksumBase64,
         } satisfies HttpWorkerDownloadStreamResultMessage,
-        [ab],
+        [ab]
       );
     } catch (err) {
       port.postMessage({
@@ -780,10 +719,7 @@ if (parentPort) {
       return;
     }
 
-    if (
-      msg.type === "httpRequestFromFile" ||
-      msg.type === "httpRequestFromRAM"
-    ) {
+    if (msg.type === "httpRequestFromFile" || msg.type === "httpRequestFromRAM") {
       processRequest(msg);
     }
 

--- a/scripts/validation/api.json
+++ b/scripts/validation/api.json
@@ -599,6 +599,8 @@
     "S3TransferManager": "function"
   },
   "@aws-sdk/lib-transfer-manager/transfer-manager": {
+    "DownloadToFileRequest": "type(interface)",
+    "DownloadToFileResponse": "type(interface)",
     "IS3TransferManager": "type(interface)",
     "S3TransferManager": "function"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10335,6 +10335,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk/lib-transfer-manager@workspace:lib/lib-transfer-manager"
   dependencies:
+    "@aws-sdk/checksums": "workspace:^3.1000.28"
     "@aws-sdk/client-s3": "workspace:3.1113.0"
     "@smithy/core": "npm:^3.31.1"
     "@smithy/node-http-handler": "npm:^4.9.13"


### PR DESCRIPTION
### Issue 
Internal JS-7054

### Description
- Adds `downloadToFile` API which takes a destination file path and downloads an S3 object to that location. It supports both PART based and RANGE based strategy. It uses a temp file with atomic rename, the destination file only appears once the download complete successfully. On failure or abort, the temp file is cleaned up.
- Adds `downloadByPartWithWorkers` and `downloadByRangeWithWorkers` for the `download()` API. When `workerThreadCount > 1`, download requests are routed through these methods based on the configured multipart strategy. Internally, Part 1 is fetched on the main thread to discover object metadata(PartsCount, ETag, total size). Remaining parts/range requests are dispatched to worker threads via WorkerHttpHandler, which assembles response bytes into dedicated ArrayBuffers and transfers ownership back to the main thread (zero-copy). An `OrderedPartQueue` reorders parts that arrive out-of-order, while a Readable stream pulls from the queue sequentially and is passed to joinStreams to deliver a single ordered body to the caller.

### Testing
How was this change tested?
```
$ yarn test
 ✓ src/submodules/transfer-manager/join-streams.spec.ts (10 tests) 578ms
     ✓ should handle backpressure when consumer is slow  554ms
 ✓ src/submodules/transfer-manager/S3TransferManager.spec.ts (101 tests) 377ms

 Test Files  2 passed (2)
      Tests  111 passed (111)
   Start at  14:39:19
   Duration  952ms (transform 418ms, setup 0ms, import 663ms, tests 954ms, environment 0ms)
   ```
 ```
   $ yarn test:e2e
    Test Files  1 passed (1)
      Tests  39 passed (39)
   Start at  14:40:53
   Duration  37.66s (transform 412ms, setup 0ms, import 616ms, tests 36.90s, environment 0ms)
```
   
### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [ ] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [ ] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
