### PR TITLE
fix(token-providers): fromSso 30s refresh throttle leaks across unrelated SSO sessions

### DIFF
--- a/packages/token-providers/src/fromSso.spec.ts
+++ b/packages/token-providers/src/fromSso.spec.ts
@@ -206,6 +206,60 @@ describe(fromSso.name, () => {
     });
   });
 
+  it("does not skip refresh for a different profile/sso_session within the same 30 seconds", async () => {
+    const { fromSso } = await import("./fromSso");
+
+    // First profile: refresh happens normally.
+    await expect(fromSso(mockInit)()).resolves.toStrictEqual(mockNewToken);
+    expect(getNewSsoOidcToken).toHaveBeenCalledTimes(1);
+
+    // A second, unrelated profile pointing at a different sso_session, whose token is also
+    // independently expired. This must still be allowed to refresh even though it's within
+    // 30 seconds of the first profile's refresh -- the 30 second throttle is meant to protect
+    // a single sso_session from being hammered, not to block unrelated sessions from ever
+    // refreshing in the same window.
+    const otherSsoSessionName = "other_mock_sso_session_name";
+    const otherProfileName = "otherMockProfileName";
+    const otherInit = { profile: otherProfileName };
+    const otherSsoProfile = { sso_session: otherSsoSessionName };
+    const otherSsoSession = {
+      sso_start_url: "other_mock_sso_start_url",
+      sso_region: "other_mock_sso_region",
+    };
+    const otherSsoToken = {
+      accessToken: "otherMockAccessToken",
+      expiresAt: new Date(mockDateNow - 1000).toISOString(),
+      clientId: "otherClientId",
+      clientSecret: "otherClientSecret",
+      refreshToken: "otherRefreshToken",
+    };
+    const otherNewTokenFromService = {
+      accessToken: "otherMockNewAccessToken",
+      expiresIn: 3600,
+      refreshToken: "otherMockNewRefreshToken",
+      $metadata: {},
+    };
+
+    vi.mocked(getProfileName).mockReturnValueOnce(otherProfileName);
+    vi.mocked(parseKnownFiles).mockResolvedValueOnce({ [otherProfileName]: otherSsoProfile });
+    vi.mocked(loadSsoSessionData).mockResolvedValueOnce({ [otherSsoSessionName]: otherSsoSession });
+    vi.mocked(getSSOTokenFromFile).mockResolvedValueOnce(otherSsoToken);
+    vi.mocked(getNewSsoOidcToken).mockResolvedValueOnce(otherNewTokenFromService);
+
+    await expect(fromSso(otherInit)()).resolves.toStrictEqual({
+      token: otherNewTokenFromService.accessToken,
+      expiration: new Date(mockDateNow + otherNewTokenFromService.expiresIn * 1000),
+    });
+    // The other profile's refresh must actually have happened, not been silently skipped.
+    expect(getNewSsoOidcToken).toHaveBeenCalledTimes(2);
+    expect(getNewSsoOidcToken).toHaveBeenLastCalledWith(
+      otherSsoToken,
+      otherSsoSession.sso_region,
+      otherInit,
+      undefined
+    );
+  });
+
   it.each(["clientId", "clientSecret", "refreshToken"])(
     "throws error if %s is missing in SSO Token from file",
     async (key) => {

--- a/packages/token-providers/src/fromSso.ts
+++ b/packages/token-providers/src/fromSso.ts
@@ -15,9 +15,12 @@ import { validateTokenKey } from "./validateTokenKey";
 import { writeSSOTokenToFile } from "./writeSSOTokenToFile";
 
 /**
- * Last refresh attempt time to ensure refresh is not attempted more than once every 30 seconds.
+ * Last refresh attempt time per SSO session, to ensure refresh for a given session is not
+ * attempted more than once every 30 seconds. Keyed by sso_session name rather than a single
+ * shared timestamp, so that refreshing one profile's token does not suppress a refresh for an
+ * unrelated profile/session that happens to also be due within the same 30-second window.
  */
-const lastRefreshAttemptTime = new Date(0);
+const lastRefreshAttemptTime = new Map<string, number>();
 
 export interface FromSsoInit extends SourceProfileInit, CredentialProviderOptions {
   /**
@@ -94,8 +97,9 @@ export const fromSso =
       return existingToken;
     }
 
-    // Skip new refresh, if last refresh was done within 30 seconds.
-    if (Date.now() - lastRefreshAttemptTime.getTime() < 30 * 1000) {
+    // Skip new refresh, if last refresh for this SSO session was done within 30 seconds.
+    const lastRefreshAttempt = lastRefreshAttemptTime.get(ssoSessionName) ?? 0;
+    if (Date.now() - lastRefreshAttempt < 30 * 1000) {
       /// return existing token if it's still valid.
       validateTokenExpiry(existingToken);
       return existingToken;
@@ -106,7 +110,7 @@ export const fromSso =
     validateTokenKey("refreshToken", ssoToken.refreshToken, true);
 
     try {
-      lastRefreshAttemptTime.setTime(Date.now());
+      lastRefreshAttemptTime.set(ssoSessionName, Date.now());
       const newSsoOidcToken = await getNewSsoOidcToken(ssoToken, ssoRegion, init, callerClientConfig);
       validateTokenKey("accessToken", newSsoOidcToken.accessToken);
       validateTokenKey("expiresIn", newSsoOidcToken.expiresIn);


### PR DESCRIPTION
### Motivation and Context

fixes #8266

`fromSso`'s 30-second "don't hammer the OIDC refresh endpoint" throttle uses a single `Date` declared at module scope:

```ts
const lastRefreshAttemptTime = new Date(0);
...
if (Date.now() - lastRefreshAttemptTime.getTime() < 30 * 1000) {
  validateTokenExpiry(existingToken);
  return existingToken;
}
...
lastRefreshAttemptTime.setTime(Date.now());
```

This timestamp is shared by every `fromSso` provider in the process, regardless of profile/`sso_session`. Refreshing profile A's expired token sets it; if profile B — an unrelated profile on a different `sso_session`, also independently expired — is resolved within the next 30 seconds, its refresh is silently skipped and it falls through to `validateTokenExpiry()` on its own still-stale token, throwing `Token is expired` even though B was never actually rate-limited.

### Description

Replaced the single shared `Date` with a `Map<string, number>` keyed by `ssoSessionName`:

```ts
const lastRefreshAttemptTime = new Map<string, number>();
...
const lastRefreshAttempt = lastRefreshAttemptTime.get(ssoSessionName) ?? 0;
if (Date.now() - lastRefreshAttempt < 30 * 1000) {
  validateTokenExpiry(existingToken);
  return existingToken;
}
...
lastRefreshAttemptTime.set(ssoSessionName, Date.now());
```

This preserves the original intent (don't hammer refresh calls for the *same* session within 30 seconds — including across multiple `fromSso()` instances pointed at the same session, which is correct and desirable) while no longer blocking unrelated sessions from refreshing in the same window.

### Testing

Added `does not skip refresh for a different profile/sso_session within the same 30 seconds` to `fromSso.spec.ts`, exercising two profiles (different `sso_session`s, both independently expired) against a single imported `fromSso` module (no `vi.resetModules()` between the two calls, matching real single-process usage). Confirmed it fails against the pre-fix code (`git stash` the fix, rerun — the second profile incorrectly returns its stale unrefreshed token instead of a real refresh) and passes with the fix.

```
$ yarn g:vitest run src/fromSso.spec.ts
Test Files  1 passed (1)
     Tests  23 passed (23)
```

Also independently verified against the real, byte-for-byte source (only import specifiers redirected to stub dependency files) with a standalone driver simulating two profiles/sessions:

```
=== before fix ===
profileB THREW: Token is expired. ...
getNewSsoOidcToken calls so far: [ 'tokenA' ]

=== after fix ===
profileB result: { token: 'tokenB-REFRESHED', ... }
getNewSsoOidcToken calls so far: [ 'tokenA', 'tokenB' ]
```

And confirmed the original same-session throttle behavior is unchanged (a second call for the *same* session within 30s still returns the existing token / throws if it's expired, without triggering a duplicate refresh call).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed