### PR TITLE
fix(token-providers): update SSO refresh throttle per session

### DIFF
--- a/packages/token-providers/src/fromSso.spec.ts
+++ b/packages/token-providers/src/fromSso.spec.ts
@@ -206,6 +206,46 @@ describe(fromSso.name, () => {
     });
   });
 
+  it("should not skip refresh for a different SSO session refreshed within 30 seconds", async () => {
+    const { fromSso } = await import("./fromSso");
+
+    // Profile A: its expired token is refreshed, recording a throttle timestamp for session A.
+    await expect(fromSso(mockInit)()).resolves.toStrictEqual(mockNewToken);
+    expect(getNewSsoOidcToken).toHaveBeenCalledTimes(1);
+
+    // Profile B: an other profile pointing at a different sso_session, whose cached token
+    // (the default expired mockSsoToken) is also expired, resolved within 30 seconds.
+    const mockProfileNameB = "mockProfileNameB";
+    const mockSsoSessionNameB = "mock_sso_session_name_b";
+    const mockInitB = { profile: mockProfileNameB };
+    const mockSsoProfileB = { sso_session: mockSsoSessionNameB };
+    const mockSsoSessionB = {
+      sso_start_url: "mock_sso_start_url_b",
+      sso_region: "mock_sso_region_b",
+    };
+
+    vi.mocked(parseKnownFiles).mockResolvedValue({
+      [mockProfileNameB]: mockSsoProfileB,
+    });
+    vi.mocked(getProfileName).mockReturnValue(mockProfileNameB);
+    vi.mocked(loadSsoSessionData).mockResolvedValue({
+      [mockSsoSessionNameB]: mockSsoSessionB,
+    });
+
+    // Profile B's refresh must NOT be throttled by profile A's refresh, and hence returns a new token.
+    await expect(fromSso(mockInitB)()).resolves.toStrictEqual(mockNewToken);
+    // Refresh endpoint is hit second time.
+    expect(getNewSsoOidcToken).toHaveBeenCalledTimes(2);
+    // The second call used B's own session config (region and init).
+    expect(getNewSsoOidcToken).toHaveBeenNthCalledWith(
+      2,
+      mockSsoToken,
+      mockSsoSessionB.sso_region,
+      mockInitB,
+      undefined
+    );
+  });
+
   it.each(["clientId", "clientSecret", "refreshToken"])(
     "throws error if %s is missing in SSO Token from file",
     async (key) => {

--- a/packages/token-providers/src/fromSso.ts
+++ b/packages/token-providers/src/fromSso.ts
@@ -15,9 +15,10 @@ import { validateTokenKey } from "./validateTokenKey";
 import { writeSSOTokenToFile } from "./writeSSOTokenToFile";
 
 /**
- * Last refresh attempt time to ensure refresh is not attempted more than once every 30 seconds.
+ * Last refresh attempt time per SSO session to ensure refresh is not attempted more than once
+ * every 30 seconds per session rather than globally across sessions.
  */
-const lastRefreshAttemptTime = new Date(0);
+const lastRefreshAttemptTimes = new Map<string, number>();
 
 export interface FromSsoInit extends SourceProfileInit, CredentialProviderOptions {
   /**
@@ -88,14 +89,18 @@ export const fromSso =
     validateTokenKey("expiresAt", ssoToken.expiresAt);
 
     const { accessToken, expiresAt } = ssoToken;
-    const existingToken: TokenIdentity = { token: accessToken, expiration: new Date(expiresAt) };
+    const existingToken: TokenIdentity = {
+      token: accessToken,
+      expiration: new Date(expiresAt),
+    };
     if (existingToken.expiration!.getTime() - Date.now() > EXPIRE_WINDOW_MS) {
       // Token is valid and not expired.
       return existingToken;
     }
 
-    // Skip new refresh, if last refresh was done within 30 seconds.
-    if (Date.now() - lastRefreshAttemptTime.getTime() < 30 * 1000) {
+    // Skip new refresh, if last refresh for this SSO session was done within 30 seconds.
+    const lastRefreshAttemptTime = lastRefreshAttemptTimes.get(ssoSessionName) ?? 0;
+    if (Date.now() - lastRefreshAttemptTime < 30 * 1000) {
       /// return existing token if it's still valid.
       validateTokenExpiry(existingToken);
       return existingToken;
@@ -106,7 +111,7 @@ export const fromSso =
     validateTokenKey("refreshToken", ssoToken.refreshToken, true);
 
     try {
-      lastRefreshAttemptTime.setTime(Date.now());
+      lastRefreshAttemptTimes.set(ssoSessionName, Date.now());
       const newSsoOidcToken = await getNewSsoOidcToken(ssoToken, ssoRegion, init, callerClientConfig);
       validateTokenKey("accessToken", newSsoOidcToken.accessToken);
       validateTokenKey("expiresIn", newSsoOidcToken.expiresIn);


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8266

### Description
Replaced the single module-scope `Date` with a `Map<string, number>` keyed by sso_session name for last refresh attempt.  Refreshing one session's token no longer suppresses the refresh of an unrelated session.

### Testing
Added a unit test.
```
$ yarn test
Test Files  9 passed (9)
      Tests  51 passed (51)
   Start at  19:48:03
   Duration  375ms (transform 1.11s, setup 0ms, import 1.62s, tests 91ms, environment 1ms)
 ```

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
