### PR TITLE
chore(scripts): prune stale lib-dynamodb files on copy during codegen

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -152,6 +152,22 @@ const copyToClients = async (sourceDir, destinationDir, solo) => {
           const destinationFileName = packageSub.replace("doc-client-", "");
           const docClientArtifactPath = join(artifactPath, packageSub);
           const docClientDestPath = join(destinationDir, "..", "lib", "lib-dynamodb", "src", destinationFileName);
+
+          // Prune orphaned generated files codegen no longer emits, preserving hand-written files.
+          if (existsSync(docClientDestPath) && lstatSync(docClientDestPath).isDirectory()) {
+            const incoming = new Set(readdirSync(docClientArtifactPath));
+            for (const existing of readdirSync(docClientDestPath)) {
+              const existingPath = join(docClientDestPath, existing);
+              if (
+                !incoming.has(existing) &&
+                lstatSync(existingPath).isFile() &&
+                readFileSync(existingPath, "utf-8").startsWith("// smithy-typescript generated code")
+              ) {
+                removeSync(existingPath);
+              }
+            }
+          }
+
           copySync(docClientArtifactPath, docClientDestPath, { overwrite: true });
           removeSync(docClientArtifactPath);
         }


### PR DESCRIPTION
### Issue
Internal V2314583170

### Description
Clean up orphaned generated files under `lib/lib-dynamodb/src` that the regenration of clients no longer produces, so operations removed from the DynamoDB model don't break lib-dynamodb build:types by importing symbols that client-dynamodb no longer exports.

### Testing
Re-generated the clients and tested it.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
