### PR TITLE
chore(codegen): smithy-aws-typescript-codegen 0.53.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Commit logs](https://github.com/aws/aws-sdk-js-v3/commits/main/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen)
 
+## 0.53.0 (2026-08-24)
+
+### Chores
+
+- Upgraded to smithy-typescript 0.53.0 ([Release Notes](https://github.com/smithy-lang/smithy-typescript/blob/main/CHANGELOG.md#0530-2026-08-24))
+
 ## 0.52.0 (2026-08-07)
 
 ### Chores

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -37,7 +37,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.52.0"
+    version = "0.53.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 
 dependencies {
     // Smithy TypeScript
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.52.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.53.0")
 
     // Smithy generic dependencies
     api("software.amazon.smithy:smithy-model:$smithyVersion")

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/e9151f3e043a19032caad09b05937a4962c5bd13...6815d3e96f3abc32e238bf6d806523aab81c6a8e
-  SMITHY_TS_COMMIT: "6815d3e96f3abc32e238bf6d806523aab81c6a8e",
+  // https://github.com/smithy-lang/smithy-typescript/compare/6815d3e96f3abc32e238bf6d806523aab81c6a8e...TBD
+  SMITHY_TS_COMMIT: "TBD",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {

--- a/scripts/generate-clients/config.js
+++ b/scripts/generate-clients/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   // Use full commit hash as we explicitly fetch it.
   // Comparison link (update with previous hash):
-  // https://github.com/smithy-lang/smithy-typescript/compare/6815d3e96f3abc32e238bf6d806523aab81c6a8e...TBD
-  SMITHY_TS_COMMIT: "TBD",
+  // https://github.com/smithy-lang/smithy-typescript/compare/6815d3e96f3abc32e238bf6d806523aab81c6a8e...ba65259ff1d5cd084445dd0d274c3716470c8588
+  SMITHY_TS_COMMIT: "ba65259ff1d5cd084445dd0d274c3716470c8588",
 };
 
 if (module.exports.SMITHY_TS_COMMIT.length < 40) {


### PR DESCRIPTION
Bumps the Maven version of smithy-aws-typescript-codegen to 0.53.0
Relevant Smithy PR https://github.com/smithy-lang/smithy-typescript/pull/2248