### PR TITLE
fix(cloudfront-signer): preserve query spelling when signing urls

### DIFF
--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -973,6 +973,89 @@ describe("url component encoding", () => {
     expect(signedUrl.slice(0, target.length)).toBe(target);
   });
 
+  // https://github.com/aws/aws-sdk-js-v3/issues/8277
+  it("should preserve the last-known-good signature when a query value contains a space", () => {
+    const url = new URL("http://example.com/path/to/file.pdf");
+    url.searchParams.set("response-content-disposition", "inline; filename*=filename.pdf");
+    const href = url.toString();
+    const encodedHref =
+      "http://example.com/path/to/file.pdf?response-content-disposition=inline%3B%20filename*%3Dfilename.pdf";
+
+    expect(href).toBe(
+      "http://example.com/path/to/file.pdf?response-content-disposition=inline%3B+filename*%3Dfilename.pdf"
+    );
+
+    const policyFor = (resource: string) =>
+      JSON.stringify({
+        Statement: [
+          {
+            Resource: resource,
+            Condition: {
+              DateLessThan: {
+                "AWS:EpochTime": epochDateLessThan,
+              },
+            },
+          },
+        ],
+      });
+    const lastKnownGoodSignedUrl =
+      "http://example.com/path/to/file.pdf?response-content-disposition=inline%3B%20filename*%3Dfilename.pdf&Expires=1577836800&Key-Pair-Id=APKAEIBAERJR2EXAMPLE&Signature=JBs7DvOuSvgzWJQS~I03~90rFF-yVftF9gNpKd9TrRXrs6oLMITJ7htEnL2RU4XnZWx9-RY5uudGMIOCgkDGSmlmpk2-DXykCq00ZhRdawHHFIMOm~lc-e0ARIxWkcdRvyNBNsGJphyrPZIkcmWKHqlUUIi75gkjKCugcB96T09vjdEQ-rPVE-TYkF5RUjGVRBb8VLZHzC5nQsnf2nLi9-u4mCaq4obNWT1cGsIUJ3I4JbNd8N2nG5O3u0Y10Kye3HRkCstSBgqPX56CZqxFxUxIbcCrHgQUYTzQe60e76oqYPfk3ItRV4Ec3lan07gmO4e~zRp4xKN9wUmZm0sGMg__";
+    const lastKnownGood = parseUrl(lastKnownGoodSignedUrl);
+    const lastKnownGoodSignature = denormalizeBase64(lastKnownGood.query!["Signature"] as string);
+
+    // 3.1034.0 emitted `%20` on the wire but signed the original `+` representation.
+    expect(verifySignature(lastKnownGoodSignature, policyFor(href))).toBeTruthy();
+    expect(verifySignature(lastKnownGoodSignature, policyFor(encodedHref))).toBeFalsy();
+
+    const signedUrl = getSignedUrl({
+      url: href,
+      keyPairId,
+      dateLessThan,
+      privateKey,
+      passphrase,
+    });
+    const parsedUrl = parseUrl(signedUrl);
+    const signature = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+
+    // The output query is normalized, but the policy Resource retains the
+    // pre-normalization representation used by the last-known-good release.
+    expect(signedUrl).toContain(`${encodedHref}&Expires=${epochDateLessThan}`);
+    expect(verifySignature(signature, policyFor(href))).toBeTruthy();
+    expect(verifySignature(signature, policyFor(encodedHref))).toBeFalsy();
+
+    // Exact output from the last-known-good @aws-sdk/cloudfront-signer 3.1034.0.
+    expect(signedUrl).toBe(lastKnownGoodSignedUrl);
+  });
+
+  it("should keep query space and plus representations distinct when signing", () => {
+    const cases = [
+      { query: "value=a b", output: "value=a%20b" },
+      { query: "value=a%20b", output: "value=a%20b" },
+      { query: "value=a+b", output: "value=a%20b" },
+      { query: "value=a%2Bb", output: "value=a%2Bb" },
+    ];
+    const signatures = cases.map(({ query, output }) => {
+      const resource = `http://example.com/file?${query}`;
+      const signedUrl = getSignedUrl({ url: resource, keyPairId, dateLessThan, privateKey, passphrase });
+      const parsedUrl = parseUrl(signedUrl);
+      const signature = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+      const policy = JSON.stringify({
+        Statement: [
+          {
+            Resource: resource,
+            Condition: { DateLessThan: { "AWS:EpochTime": epochDateLessThan } },
+          },
+        ],
+      });
+
+      expect(signedUrl).toContain(`http://example.com/file?${output}&Expires=${epochDateLessThan}`);
+      expect(verifySignature(signature, policy)).toBeTruthy();
+      return parsedUrl.query!["Signature"];
+    });
+
+    expect(new Set(signatures).size).toBe(cases.length);
+  });
+
   // https://github.com/aws/aws-sdk-js-v3/issues/8113
   it("should encode single quotes in filename*=UTF-8'' query values", () => {
     const encodedFilename = encodeURIComponent("文件");

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -135,12 +135,14 @@ export function getSignedUrl({
   }
 
   let baseUrl: string | undefined;
+  let resourceUrl: string | undefined;
   if (url) {
-    // Encode the URL up front so the policy Resource matches the URL on the
-    // wire. CloudFront verifies the signature against the encoded URL, so
-    // signing the unencoded form would produce 403 AccessDenied whenever the
-    // path contains characters like '=', ',', or spaces.
+    // Encode the URL for output, while preserving the input representation of
+    // query spaces in the policy Resource. Path characters must be encoded in
+    // both representations, but changing `+` to `%20` before signing changes
+    // the signature even though both forms produce the same output URL.
     baseUrl = encodeUrlPath(url);
+    resourceUrl = encodeUrlPath(url, true);
   } else if (policy) {
     const resources = getPolicyResources(policy!);
     if (!resources[0]) {
@@ -155,7 +157,7 @@ export function getSignedUrl({
     cloudfrontSignBuilder.setCustomPolicy(policy);
   } else {
     cloudfrontSignBuilder.setPolicyParameters({
-      url: baseUrl,
+      url: resourceUrl,
       dateLessThan,
       dateGreaterThan,
       ipAddress,
@@ -277,7 +279,7 @@ interface CloudfrontAttributes {
  * Already percent-encoded sequences are preserved (no double-encoding).
  * @internal
  */
-function encodeUrlPath(url: string): string {
+function encodeUrlPath(url: string, preserveQuerySpaceEncoding = false): string {
   const protocolEnd = url.indexOf("//");
   if (protocolEnd === -1) {
     return url;
@@ -313,14 +315,54 @@ function encodeUrlPath(url: string): string {
   // so we replace them explicitly.
   let encodedQuery = "";
   if (rawQuery) {
-    for (const [key, value] of new URLSearchParams(rawQuery.slice(1)).entries()) {
-      encodedQuery += `${encodedQuery ? "&" : "?"}${encodeURIComponent(key).replace(/'/g, "%27")}=${encodeURIComponent(
-        value
-      ).replace(/'/g, "%27")}`;
+    if (preserveQuerySpaceEncoding) {
+      encodedQuery = encodeQueryForSigning(rawQuery);
+    } else {
+      for (const [key, value] of new URLSearchParams(rawQuery.slice(1)).entries()) {
+        encodedQuery += `${encodedQuery ? "&" : "?"}${encodeURIComponent(key).replace(/'/g, "%27")}=${encodeURIComponent(
+          value
+        ).replace(/'/g, "%27")}`;
+      }
     }
   }
 
   return origin + encodedPath + encodedQuery;
+}
+
+/**
+ * Encodes a query for a policy Resource without collapsing distinct space
+ * representations. All other component encoding matches the output URL.
+ * @internal
+ */
+function encodeQueryForSigning(rawQuery: string): string {
+  const entries = rawQuery
+    .slice(1)
+    .split("&")
+    .filter((entry) => entry.length > 0)
+    .map((entry) => {
+      const separatorIndex = entry.indexOf("=");
+      const key = separatorIndex === -1 ? entry : entry.slice(0, separatorIndex);
+      const value = separatorIndex === -1 ? "" : entry.slice(separatorIndex + 1);
+      return `${encodeQueryComponentForSigning(key)}=${encodeQueryComponentForSigning(value)}`;
+    });
+
+  return entries.length > 0 ? `?${entries.join("&")}` : "";
+}
+
+function encodeQueryComponentForSigning(component: string): string {
+  return component
+    .split(/(%20|\+| )/gi)
+    .map((part) => {
+      if (part === "+" || part === " " || part.toUpperCase() === "%20") {
+        return part;
+      }
+      try {
+        return encodeURIComponent(decodeURIComponent(part)).replace(/'/g, "%27");
+      } catch {
+        return encodeURIComponent(part).replace(/'/g, "%27");
+      }
+    })
+    .join("");
 }
 
 /**


### PR DESCRIPTION
### Issue
Fixes #8277

### Description
`getSignedUrl` normalized query values before building the canned-policy Resource. For query values containing spaces, this could change the Resource string used for signing even though the emitted URL remained validly encoded.

### Fix
Keep separate internal representations for:

- the encoded URL returned to the caller
- the Resource string used to build the signing policy

Path encoding remains unchanged. The output query continues to use the existing URL encoding, while the signing Resource preserves the input query spelling for raw spaces, `+`, `%20`, and `%2B`.

### Compatibility
The #8277 fixture now exactly matches the signed URL and signature produced by `@aws-sdk/cloudfront-signer` 3.1034.0. The emitted query still uses `%20`, while the signature is again computed from the historical pre-normalization `+` Resource representation.

Focused controls verify that raw space, `+`, `%20`, and `%2B` inputs remain distinct in the signing Resource and produce four distinct signatures.

### Testing
- #8277 exact regression: 3/3 focused runs passed
- canonicalization and selected controls: 8/8 passed
- `cloudfront-signer` native suite: 44/44 passed
- package types, ES/CJS build, Oxfmt, Oxlint, API Extractor, and focused Turbo build passed
- `git diff --check` passed

`yarn generate-clients` was not run because this change does not touch code generation, service models, generated clients, or package manifests; the command regenerates unrelated service-client artifacts.

### Claim boundary
The local cryptographic regression was reproduced and its query-canonicalization cause was proven. This verification did not call live CloudFront, so the reported HTTP 403 was not independently reproduced. Upstream CI and the upstream Node.js matrix have not run yet.

### AI assistance
This contribution was generated with assistance from Codex (an AI tool) and reviewed by Shin Nagata. I reviewed the final diff and remain responsible for the submission.

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
