### PR TITLE
fix(credential-provider-node): handle passive credential refresh rejection

### DIFF
--- a/packages-internal/credential-provider-node/src/runtime/memoize-chain.spec.ts
+++ b/packages-internal/credential-provider-node/src/runtime/memoize-chain.spec.ts
@@ -192,6 +192,66 @@ describe("memoize runtime config aware AWS credential chain", () => {
     expect(cached).toBe(refreshed);
   });
 
+  it("should not surface an unhandled rejection when the passive refresh fails", async () => {
+    // own expiration so the case stays on the passive path regardless of
+    // cumulative suite time (the shared 5s constant is captured at collection).
+    const farExpiration = new Date(Date.now() + 60_000);
+    let sequence = 0;
+    const flakyExpiringCredentials: RuntimeConfigAwsCredentialIdentityProvider = vi
+      .fn()
+      .mockImplementation(async () => {
+        await new Promise((r) => setTimeout(r, 100));
+        const current = sequence++;
+        if (current === 1) {
+          throw new CredentialsProviderError("transient refresh failure", { tryNextLink: false });
+        }
+        return {
+          accessKeyId: "",
+          secretAccessKey: "",
+          expiration: farExpiration,
+          sequence: current,
+        };
+      });
+
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const provider = memoizeChain([flakyExpiringCredentials], credentialsWillNeedRefresh);
+
+      // initial invocation caches sequence-0 credentials via the active lock.
+      const initial = await provider();
+      expect(initial).toMatchObject({ sequence: 0 });
+
+      // second invocation returns the stale-but-valid credentials and starts the
+      // passive background refresh, which rejects (sequence-1).
+      const stale = await provider();
+      expect(stale).toMatchObject({ sequence: 0 });
+
+      // allow the rejected background refresh to settle and node to dispatch
+      // any unhandled rejection.
+      await new Promise((r) => setTimeout(r, 200));
+      await new Promise((r) => setImmediate(r));
+
+      expect(unhandled).toEqual([]);
+
+      // the failed refresh released the lock: the next invocation retries the
+      // chain (sequence-2) while still returning the cached credentials.
+      const retried = await provider();
+      expect(retried).toMatchObject({ sequence: 0 });
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      const settled = await provider();
+      expect(settled).toMatchObject({ sequence: 2 });
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
   it("should release locks on credential resolution failure at the end of the chain", async () => {
     const neverAvailableCredentialProvider: () => RuntimeConfigAwsCredentialIdentityProvider = () => async () => {
       throw new CredentialsProviderError("never available", { tryNextLink: true });

--- a/packages-internal/credential-provider-node/src/runtime/memoize-chain.ts
+++ b/packages-internal/credential-provider-node/src/runtime/memoize-chain.ts
@@ -60,6 +60,11 @@ export function memoizeChain(
             .then((c) => {
               credentials = c;
             })
+            .catch(() => {
+              // contained: this promise is intentionally not awaited, the cached
+              // credentials are still valid, and the finally block releases the
+              // lock so the next invocation retries the chain.
+            })
             .finally(() => {
               passiveLock = undefined;
             });


### PR DESCRIPTION
### Issue

Fixes #8280

### Description

The passive background refresh in `memoizeChain` is the only one of the three locks that is never awaited, and it had no rejection handler, so a transient failure of the background `chain(options)` call escaped as a process-level `unhandledRejection` that consumer code cannot catch. Trigger sequence and production details are in the linked issue.

The failure is safe to contain: the cached credentials returned on the passive path are still valid, and the `.finally()` from #7692 already releases the lock so the next invocation retries the chain. This adds a `.catch()` between the `.then` and the `.finally`, with a comment explaining why containment is correct there. No change to the success path or to the active and force-refresh locks.

### Testing

Added "should not surface an unhandled rejection when the passive refresh fails" to `memoize-chain.spec.ts`. It listens for `unhandledRejection`, caches valid credentials, then triggers a passive refresh that rejects. It asserts the listener captures nothing while the caller keeps receiving the cached credentials, and that a later invocation retries the chain and picks up the refreshed set.

### Checklist

- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Without the fix the new case fails (`AssertionError: expected [ …(1) ] to deeply equal []`, the captured entry being the `CredentialsProviderError`); suite: 1 failed | 22 passed. With the fix: 3 files, 23 tests, all passing.

Drafted with AI assistance; reviewed and tested by the author.
