### PR TITLE
fix(cloudfront-signer): preserve plus in query strings when signing URLs

### DIFF
--- a/packages/cloudfront-signer/src/cloudfront-signer.e2e.spec.ts
+++ b/packages/cloudfront-signer/src/cloudfront-signer.e2e.spec.ts
@@ -308,4 +308,23 @@ describe("@aws-sdk/cloudfront-signer e2e", () => {
     expect(response.status).toBe(200);
     expect(await response.text()).toBe(OBJECT_BODY);
   });
+
+  // https://github.com/aws/aws-sdk-js-v3/issues/8277
+  it("should access content when query contains + (space encoded as +)", async () => {
+    const url = new URL(`https://${domain}/${OBJECT_KEY}`);
+    url.searchParams.set("response-content-disposition", "inline; filename*=filename.pdf");
+    const signedUrl = getSignedUrl({
+      url: url.toString(),
+      keyPairId,
+      privateKey,
+      dateLessThan: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // + must be preserved in the signed URL, not converted to %20
+    expect(signedUrl).toContain("inline%3B+filename*%3Dfilename.pdf");
+
+    const response = await fetch(signedUrl);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(OBJECT_BODY);
+  });
 }, 660_000);

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -973,6 +973,81 @@ describe("url component encoding", () => {
     expect(signedUrl.slice(0, target.length)).toBe(target);
   });
 
+  // https://github.com/aws/aws-sdk-js-v3/issues/8277
+  it("should preserve + in query strings without converting to %20", () => {
+    const url = new URL("http://example.com/path/to/file.pdf");
+    url.searchParams.set("response-content-disposition", "inline; filename*=filename.pdf");
+    const href = url.toString();
+    // URL.searchParams.set encodes space as +
+    expect(href).toContain("inline%3B+filename*%3Dfilename.pdf");
+
+    const signedUrl = getSignedUrl({
+      url: href,
+      keyPairId,
+      privateKey,
+      passphrase,
+      dateLessThan: "2026-01-01",
+    });
+
+    // The + must be preserved in the signed URL, not converted to %20
+    const cfParamStart = signedUrl.search(/[?&]Expires=/);
+    expect(cfParamStart).toBeGreaterThan(0);
+    const baseUrl = signedUrl.slice(0, cfParamStart);
+    expect(baseUrl).toContain("inline%3B+filename*%3Dfilename.pdf");
+    expect(baseUrl).not.toContain("%20");
+
+    // Verify signature matches a policy over the original URL (with +)
+    const parsedUrl = parseUrl(signedUrl);
+    const signature = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: href,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": Math.round(new Date("2026-01-01").getTime() / 1000),
+            },
+          },
+        },
+      ],
+    });
+    expect(verifySignature(signature, policyStr)).toBeTruthy();
+  });
+
+  // https://github.com/aws/aws-sdk-js-v3/issues/8277
+  it("should preserve raw + as literal in query strings", () => {
+    const inputUrl = "http://example.com/file.pdf?q=a+b";
+    const signedUrl = getSignedUrl({
+      url: inputUrl,
+      keyPairId,
+      privateKey,
+      passphrase,
+      dateLessThan: "2026-01-01",
+    });
+
+    const cfParamStart = signedUrl.search(/[?&]Expires=/);
+    expect(cfParamStart).toBeGreaterThan(0);
+    const baseUrl = signedUrl.slice(0, cfParamStart);
+    expect(baseUrl).toBe("http://example.com/file.pdf?q=a+b");
+
+    // Verify signature matches a policy over the original URL (with +)
+    const parsedUrl = parseUrl(signedUrl);
+    const signature = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: inputUrl,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": Math.round(new Date("2026-01-01").getTime() / 1000),
+            },
+          },
+        },
+      ],
+    });
+    expect(verifySignature(signature, policyStr)).toBeTruthy();
+  });
+
   // https://github.com/aws/aws-sdk-js-v3/issues/8113
   it("should encode single quotes in filename*=UTF-8'' query values", () => {
     const encodedFilename = encodeURIComponent("文件");

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -307,20 +307,52 @@ function encodeUrlPath(url: string): string {
     }
   });
 
-  // Re-encode query parameters if present.
-  // Single quotes must be encoded as %27 because CloudFront normalizes them
-  // before verifying signatures. encodeURIComponent does not encode quotes,
-  // so we replace them explicitly.
+  // Re-encode query parameters if present. Encode by hand rather than via
+  // URLSearchParams, which would read `+` as a space and re-emit it as %20 —
+  // in an RFC 3986 query `+` is literal, and rewriting it changes the resource
+  // being signed (#8277).
   let encodedQuery = "";
   if (rawQuery) {
-    for (const [key, value] of new URLSearchParams(rawQuery.slice(1)).entries()) {
-      encodedQuery += `${encodedQuery ? "&" : "?"}${encodeURIComponent(key).replace(/'/g, "%27")}=${encodeURIComponent(
-        value
-      ).replace(/'/g, "%27")}`;
-    }
+    const pairs = rawQuery
+      .slice(1)
+      .split("&")
+      .filter((p) => p.length > 0)
+      .map((pair) => {
+        const eqIdx = pair.indexOf("=");
+        const rawKey = eqIdx === -1 ? pair : pair.slice(0, eqIdx);
+        const rawValue = eqIdx === -1 ? "" : pair.slice(eqIdx + 1);
+        return `${encodeQueryComponent(rawKey)}=${encodeQueryComponent(rawValue)}`;
+      });
+    encodedQuery = pairs.length > 0 ? `?${pairs.join("&")}` : "";
   }
 
   return origin + encodedPath + encodedQuery;
+}
+
+/**
+ * Percent-encodes a query component (key or value) preserving `+` literally
+ * and uppercasing existing %xx hex to match what the previous decode/re-encode
+ * emitted. Single quotes are encoded as %27 for CloudFront compatibility.
+ *
+ * `+` is preserved in query strings but encoded as %2B in path segments by
+ * the path encoder above. The query behavior matches ≤3.1034.0, which signed
+ * query `+` literally; the path behavior was introduced in #7763 and is not
+ * covered by an e2e test.
+ * @internal
+ */
+function encodeQueryComponent(component: string): string {
+  return component
+    .split(/(%[0-9A-Fa-f]{2}|\+)/g)
+    .map((part, i) => {
+      // Odd indices are the captured separators (%XX or +). Preserve them,
+      // uppercasing hex to match what the previous decode/re-encode emitted —
+      // and what the path encoder above still emits.
+      if (i % 2 === 1) {
+        return part === "+" ? "+" : part.toUpperCase();
+      }
+      return encodeURIComponent(part).replace(/'/g, "%27");
+    })
+    .join("");
 }
 
 /**


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8277

### Description
`encodeUrlPath` [re-encoded](https://github.com/aws/aws-sdk-js-v3/blob/ba4e4498a7610ec0b5ad7af195db137f618e09bc/packages/cloudfront-signer/src/sign.ts#L316) query strings via `new URLSearchParams()` which applies form-encoding semantics where `+` means space, so `+` came back out as `%20`.

Since #8039, the policy `Resource` is built from that re-encoded URL so the signature covers `%20` when the caller asked for `+` and CloudFront 403s. Shows up most often with `response-content-disposition`, since `URL.searchParams.set()` emits `+` for spaces.

This PR replaces the `URLSearchParams` round-trip with `encodeQueryComponent` which splits on existing `%XX` escapes and `+`, passes those through untouched, and runs `encodeURIComponent` on the rest. Single quotes still become `%27` for #8113 and preserved hex is still uppercased which the old decode/re-encode did that implicitly. That keeps `+` the only behavior change here.

### Testing
- all unit tests pass, plus 2 new ones that check the URL output and verify the signature against explicit policy                             
- new e2e that fetches a signed URL with `+` in query from a live distribution                                                                                                                                  
- confirmed lowercase `%2b` still normalizes to `%2B`


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
