### PR TITLE
fix(cloudfront-signer): preserve plus in query strings when signing URLs

### DIFF
--- a/packages/cloudfront-signer/src/cloudfront-signer.e2e.spec.ts
+++ b/packages/cloudfront-signer/src/cloudfront-signer.e2e.spec.ts
@@ -308,4 +308,23 @@ describe("@aws-sdk/cloudfront-signer e2e", () => {
     expect(response.status).toBe(200);
     expect(await response.text()).toBe(OBJECT_BODY);
   });
+
+  // https://github.com/aws/aws-sdk-js-v3/issues/8277
+  it("should access content when query contains + (space encoded as +)", async () => {
+    const url = new URL(`https://${domain}/${OBJECT_KEY}`);
+    url.searchParams.set("response-content-disposition", "inline; filename*=filename.pdf");
+    const signedUrl = getSignedUrl({
+      url: url.toString(),
+      keyPairId,
+      privateKey,
+      dateLessThan: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // + must be preserved in the signed URL, not converted to %20
+    expect(signedUrl).toContain("inline%3B+filename*%3Dfilename.pdf");
+
+    const response = await fetch(signedUrl);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(OBJECT_BODY);
+  });
 }, 660_000);

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -973,6 +973,115 @@ describe("url component encoding", () => {
     expect(signedUrl.slice(0, target.length)).toBe(target);
   });
 
+  // https://github.com/aws/aws-sdk-js-v3/issues/8277
+  it("should preserve + in query strings without converting to %20", () => {
+    const url = new URL("http://example.com/path/to/file.pdf");
+    url.searchParams.set("response-content-disposition", "inline; filename*=filename.pdf");
+    const href = url.toString();
+    // URL.searchParams.set encodes space as +
+    expect(href).toContain("inline%3B+filename*%3Dfilename.pdf");
+
+    const signedUrl = getSignedUrl({
+      url: href,
+      keyPairId,
+      privateKey,
+      passphrase,
+      dateLessThan: "2026-01-01",
+    });
+
+    // The + must be preserved in the signed URL, not converted to %20
+    const cfParamStart = signedUrl.search(/[?&]Expires=/);
+    expect(cfParamStart).toBeGreaterThan(0);
+    const baseUrl = signedUrl.slice(0, cfParamStart);
+    expect(baseUrl).toContain("inline%3B+filename*%3Dfilename.pdf");
+    expect(baseUrl).not.toContain("%20");
+
+    // Verify signature matches a policy over the original URL (with +)
+    const parsedUrl = parseUrl(signedUrl);
+    const signature = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: href,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": Math.round(new Date("2026-01-01").getTime() / 1000),
+            },
+          },
+        },
+      ],
+    });
+    expect(verifySignature(signature, policyStr)).toBeTruthy();
+  });
+
+  // https://github.com/aws/aws-sdk-js-v3/issues/8277
+  it("should preserve raw + as literal in query strings", () => {
+    const inputUrl = "http://example.com/file.pdf?q=a+b";
+    const signedUrl = getSignedUrl({
+      url: inputUrl,
+      keyPairId,
+      privateKey,
+      passphrase,
+      dateLessThan: "2026-01-01",
+    });
+
+    const cfParamStart = signedUrl.search(/[?&]Expires=/);
+    expect(cfParamStart).toBeGreaterThan(0);
+    const baseUrl = signedUrl.slice(0, cfParamStart);
+    expect(baseUrl).toBe("http://example.com/file.pdf?q=a+b");
+
+    // Verify signature matches a policy over the original URL (with +)
+    const parsedUrl = parseUrl(signedUrl);
+    const signature = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: inputUrl,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": Math.round(new Date("2026-01-01").getTime() / 1000),
+            },
+          },
+        },
+      ],
+    });
+    expect(verifySignature(signature, policyStr)).toBeTruthy();
+  });
+
+  // https://github.com/aws/aws-sdk-js-v3/issues/8277
+  it("should normalize lowercase %xx hex to uppercase in query", () => {
+    const signedUrl = getSignedUrl({
+      url: "http://example.com/file.pdf?q=c%2b%2b",
+      keyPairId,
+      privateKey,
+      passphrase,
+      dateLessThan: "2026-01-01",
+    });
+
+    const cfParamStart = signedUrl.search(/[?&]Expires=/);
+    expect(cfParamStart).toBeGreaterThan(0);
+    const baseUrl = signedUrl.slice(0, cfParamStart);
+    expect(baseUrl).toBe("http://example.com/file.pdf?q=c%2B%2B");
+  });
+
+  // https://github.com/aws/aws-sdk-js-v3/issues/8277
+  it("should encode a literal % in query without double-encoding existing %XX", () => {
+    const signedUrl = getSignedUrl({
+      url: "http://example.com/file.pdf?q=100%&tag=%E6%96%87",
+      keyPairId,
+      privateKey,
+      passphrase,
+      dateLessThan: "2026-01-01",
+    });
+
+    const cfParamStart = signedUrl.search(/[?&]Expires=/);
+    expect(cfParamStart).toBeGreaterThan(0);
+    const baseUrl = signedUrl.slice(0, cfParamStart);
+    // Bare % gets encoded to %25, existing %E6 stays (uppercased)
+    expect(baseUrl).toContain("q=100%25");
+    expect(baseUrl).toContain("tag=%E6%96%87");
+  });
+
   // https://github.com/aws/aws-sdk-js-v3/issues/8113
   it("should encode single quotes in filename*=UTF-8'' query values", () => {
     const encodedFilename = encodeURIComponent("文件");

--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -1082,6 +1082,44 @@ describe("url component encoding", () => {
     expect(baseUrl).toContain("tag=%E6%96%87");
   });
 
+  // https://github.com/aws/aws-sdk-js-v3/issues/8277
+  it.each([
+    { label: "lone high surrogate", input: "\uD800", expected: "%EF%BF%BD" },
+    { label: "lone low surrogate", input: "\uDC00", expected: "%EF%BF%BD" },
+    { label: "valid surrogate pair", input: "\uD83D\uDE00", expected: "%F0%9F%98%80" },
+  ])("should handle $label in query values", ({ input, expected }) => {
+    const inputUrl = `http://example.com/file.pdf?q=${input}`;
+    const signedUrl = getSignedUrl({
+      url: inputUrl,
+      keyPairId,
+      privateKey,
+      passphrase,
+      dateLessThan: "2026-01-01",
+    });
+
+    const cfParamStart = signedUrl.search(/[?&]Expires=/);
+    expect(cfParamStart).toBeGreaterThan(0);
+    const baseUrl = signedUrl.slice(0, cfParamStart);
+    expect(baseUrl).toContain(`q=${expected}`);
+
+    // Verify the signature matches a policy over the encoded URL
+    const parsedUrl = parseUrl(signedUrl);
+    const signature = denormalizeBase64(parsedUrl.query!["Signature"] as string);
+    const policyStr = JSON.stringify({
+      Statement: [
+        {
+          Resource: baseUrl,
+          Condition: {
+            DateLessThan: {
+              "AWS:EpochTime": Math.round(new Date("2026-01-01").getTime() / 1000),
+            },
+          },
+        },
+      ],
+    });
+    expect(verifySignature(signature, policyStr)).toBeTruthy();
+  });
+
   // https://github.com/aws/aws-sdk-js-v3/issues/8113
   it("should encode single quotes in filename*=UTF-8'' query values", () => {
     const encodedFilename = encodeURIComponent("文件");

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -307,20 +307,41 @@ function encodeUrlPath(url: string): string {
     }
   });
 
-  // Re-encode query parameters if present.
-  // Single quotes must be encoded as %27 because CloudFront normalizes them
-  // before verifying signatures. encodeURIComponent does not encode quotes,
-  // so we replace them explicitly.
+  // Re-encode query without URLSearchParams, which converts + to %20 (#8277).
   let encodedQuery = "";
   if (rawQuery) {
-    for (const [key, value] of new URLSearchParams(rawQuery.slice(1)).entries()) {
-      encodedQuery += `${encodedQuery ? "&" : "?"}${encodeURIComponent(key).replace(/'/g, "%27")}=${encodeURIComponent(
-        value
-      ).replace(/'/g, "%27")}`;
-    }
+    const pairs = rawQuery
+      .slice(1)
+      .split("&")
+      .filter((p) => p.length > 0)
+      .map((pair) => {
+        const eqIdx = pair.indexOf("=");
+        const rawKey = eqIdx === -1 ? pair : pair.slice(0, eqIdx);
+        const rawValue = eqIdx === -1 ? "" : pair.slice(eqIdx + 1);
+        return `${encodeQueryComponent(rawKey)}=${encodeQueryComponent(rawValue)}`;
+      });
+    encodedQuery = pairs.length > 0 ? `?${pairs.join("&")}` : "";
   }
 
   return origin + encodedPath + encodedQuery;
+}
+
+/**
+ * Percent-encodes a query component preserving `+` literally and uppercasing
+ * existing %xx hex. Single quotes become %27 for CloudFront.
+ * @internal
+ */
+function encodeQueryComponent(component: string): string {
+  return component
+    .split(/(%[0-9A-Fa-f]{2}|\+)/g)
+    .map((part, i) => {
+      // Preserved separators (%XX or +); uppercase hex to match prior behavior.
+      if (i % 2 === 1) {
+        return part === "+" ? "+" : part.toUpperCase();
+      }
+      return encodeURIComponent(part).replace(/'/g, "%27");
+    })
+    .join("");
 }
 
 /**

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -332,7 +332,8 @@ function encodeUrlPath(url: string): string {
  * @internal
  */
 function encodeQueryComponent(component: string): string {
-  return component
+  const wellFormedComponent = component.replace(/[\uD800-\uDFFF]/gu, "\uFFFD");
+  return wellFormedComponent
     .split(/(%[0-9A-Fa-f]{2}|\+)/g)
     .map((part, i) => {
       // Preserved separators (%XX or +); uppercase hex to match prior behavior.


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8277

### Description
`encodeUrlPath` [re-encoded](https://github.com/aws/aws-sdk-js-v3/blob/ba4e4498a7610ec0b5ad7af195db137f618e09bc/packages/cloudfront-signer/src/sign.ts#L316) query strings via `new URLSearchParams()` which applies form-encoding semantics where `+` means space, so `+` came back out as `%20`.

Since #8039, the policy `Resource` is built from that re-encoded URL so the signature covers `%20` when the caller asked for `+` and CloudFront 403s. Shows up most often with `response-content-disposition`, since `URL.searchParams.set()` emits `+` for spaces.

This PR replaces the `URLSearchParams` round-trip with `encodeQueryComponent` which splits on existing `%XX` escapes and `+`, passes those through untouched, and runs `encodeURIComponent` on the rest. Single quotes still become `%27` for #8113 and preserved hex is still uppercased which the old decode/re-encode did that implicitly. That keeps `+` the only behavior change here.

### Testing
- all unit tests pass, plus 2 new ones that check the URL output and verify the signature against explicit policy                             
- new e2e that fetches a signed URL with `+` in query from a live distribution                                                                                                                                  
- confirmed lowercase `%2b` still normalizes to `%2B`


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
