### PR TITLE
fix(lib-transfer-manager): retry worker path download part failures

### DIFF
--- a/lib/lib-transfer-manager/src/submodules/transfer-manager/worker-http-handler.ts
+++ b/lib/lib-transfer-manager/src/submodules/transfer-manager/worker-http-handler.ts
@@ -20,6 +20,24 @@ import { Readable } from "node:stream";
 import { Worker } from "node:worker_threads";
 
 /**
+ * Build an Error from a worker download-error message. For non-2xx responses
+ * (statusCode present), attach `$response`/`$metadata`/`$fault` so the SDK's
+ * retry middleware can classify and retry it.
+ * @internal
+ */
+function buildDownloadError(msg: HttpWorkerDownloadErrorMessage): Error {
+  const error = new Error(msg.error) as Error & Record<string, unknown>;
+  if (msg.name) error.name = msg.name;
+  if (msg.code) error.code = msg.code;
+  if (typeof msg.statusCode === "number") {
+    error.$response = { statusCode: msg.statusCode };
+    error.$metadata = { httpStatusCode: msg.statusCode };
+    error.$fault = msg.statusCode >= 500 ? "server" : "client";
+  }
+  return error;
+}
+
+/**
  * Creates an empty Readable stream that immediately ends.
  * Used as a placeholder body for UploadPart in threaded uploads.
  * @internal
@@ -176,6 +194,7 @@ export interface HttpWorkerDownloadErrorMessage {
   error: string;
   code?: string;
   name?: string;
+  statusCode?: number;
 }
 
 /**
@@ -508,11 +527,7 @@ export class WorkerHttpHandler {
             this.inflightDownloads.delete(msg.id);
             if (pending) {
               this.workerInflightCounts[pending.workerIndex]--;
-              const error = Object.assign(new Error(msg.error), {
-                ...(msg.code && { code: msg.code }),
-                ...(msg.name && { name: msg.name }),
-              });
-              pending.reject(error);
+              pending.reject(buildDownloadError(msg));
               return;
             }
             // Check stream downloads if not found in file downloads.
@@ -520,11 +535,7 @@ export class WorkerHttpHandler {
             this.inflightStreamDownloads.delete(msg.id);
             if (pendingTransfer) {
               this.workerInflightCounts[pendingTransfer.workerIndex]--;
-              const error = Object.assign(new Error(msg.error), {
-                ...(msg.code && { code: msg.code }),
-                ...(msg.name && { name: msg.name }),
-              });
-              pendingTransfer.reject(error);
+              pendingTransfer.reject(buildDownloadError(msg));
             }
             return;
           }

--- a/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
+++ b/lib/lib-transfer-manager/src/submodules/worker/http-request-worker.ts
@@ -28,6 +28,55 @@ const DNS_TTL_MS = 1000;
 const dnsCache = new Map<string, { ips: string[]; ts: number }>();
 
 /**
+ * Drain a small error-response body to text so its S3 error <Code> can be
+ * surfaced. Bounded to avoid buffering large bodies.
+ * @internal
+ */
+const readErrorBody = async (body: any): Promise<string | undefined> => {
+  if (!body) return undefined;
+  try {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for await (const chunk of body) {
+      const buf = typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk);
+      chunks.push(buf);
+      total += buf.length;
+      if (total >= 16 * 1024) break;
+    }
+    return Buffer.concat(chunks).toString("utf8");
+  } catch {
+    return undefined;
+  }
+};
+
+/** Extract the S3 error <Code> from an XML error body, if present. @internal */
+const parseS3ErrorCode = (bodyText?: string): string | undefined => {
+  if (!bodyText) return undefined;
+  const m = /<Code>([^<]+)<\/Code>/.exec(bodyText);
+  return m ? m[1] : undefined;
+};
+
+/**
+ * Build the download-error message for a non-2xx response, reading the S3 error
+ * <Code> from the (bounded) error body. Shared by the file and stream handlers.
+ * @internal
+ */
+const buildHttpStatusError = async (
+  id: number,
+  response: { statusCode: number; body?: any }
+): Promise<HttpWorkerDownloadErrorMessage> => {
+  const s3Code = parseS3ErrorCode(await readErrorBody(response.body));
+  return {
+    type: "httpDownloadError",
+    id,
+    error: `S3 responded with HTTP ${response.statusCode}${s3Code ? ` (${s3Code})` : ""}`,
+    code: s3Code,
+    name: s3Code ?? "HttpStatusError",
+    statusCode: response.statusCode,
+  };
+};
+
+/**
  * Resolves all A records for a hostname, picks one at random per connection
  * to spread load across S3's fleet. Falls back to dns.lookup for IPv6 or
  * on resolution failure.
@@ -190,6 +239,7 @@ interface HttpWorkerDownloadErrorMessage {
   error: string;
   code?: string;
   name?: string;
+  statusCode?: number;
 }
 
 /**
@@ -437,6 +487,12 @@ if (parentPort) {
 
       const { response } = await handler!.handle(request);
 
+      // Non-2xx: report the error; its XML body is not object data, so never write it.
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        port.postMessage(await buildHttpStatusError(id, response));
+        return;
+      }
+
       // Resolve where and how much to write from the response's ContentRange.
       //
       // ContentRange is the source of truth since S3 multipart objects can
@@ -586,6 +642,12 @@ if (parentPort) {
       });
 
       const { response } = await handler!.handle(request);
+
+      // Non-2xx: report the error; its XML body is not object data, so never assemble it.
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        port.postMessage(await buildHttpStatusError(id, response));
+        return;
+      }
 
       // 2. Acquire a buffer for assembling the response body
       const ab = acquireTransferBuffer(expectedSize);


### PR DESCRIPTION
### Description
In the worker download path, the worker writes response bytes directly to the file offset (or assembles them into the transfer buffer) and the response body does not go through the SDK middleware. So when S3 returns a non-2xx like 503 SlowDown, the worker was writing the small XML error body (<Error><Code>SlowDown</Code>...) to the file as if it were object data. The download then failed downstream with a "part size doesn't match expected part size" error, and because the failure never reached the retry middleware, the transient error was not retried.
  
This change makes the worker check the response status before touching the file/buffer: on a non-2xx it reads the error body, extracts the S3 error code, and reports it back to the main thread with the HTTP status code instead of writing it. The main thread then rebuilds the error with $response/$metadata/$fault so it flows through the SDK's retry middleware and gets classified and retried.

### Testing
CI 

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [ ] My E2E tests are resilient to concurrent i/o.
  - [x] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
