### PR TITLE
feat(lib-dynamodb): add item-level paginators

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -6,11 +6,16 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.PaginatedIndex;
+import software.amazon.smithy.model.knowledge.PaginationInfo;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -20,6 +25,9 @@ final class DocumentClientPaginationGenerator implements Runnable {
 
     static final String PAGINATION_FOLDER = "pagination";
 
+    private final Model model;
+    private final ServiceShape service;
+    private final OperationShape operation;
     private final TypeScriptWriter writer;
 
     private final String operationTypeName;
@@ -37,6 +45,9 @@ final class DocumentClientPaginationGenerator implements Runnable {
         SymbolProvider symbolProvider,
         TypeScriptWriter writer
     ) {
+        this.model = model;
+        this.service = service;
+        this.operation = operation;
         this.writer = writer;
 
         Symbol operationSymbol = symbolProvider.toSymbol(operation);
@@ -82,6 +93,7 @@ final class DocumentClientPaginationGenerator implements Runnable {
         writer.write("export type { Paginator };");
 
         writePager();
+        writeItemsPager();
     }
 
     static String getOutputFilelocation(OperationShape operation) {
@@ -144,5 +156,50 @@ final class DocumentClientPaginationGenerator implements Runnable {
                        $4L
                      >(DynamoDBDocumentClient, $1LCommand, "ExclusiveStartKey", "LastEvaluatedKey", "Limit");
                              """, operationName, paginationType, inputTypeName, outputTypeName);
+    }
+
+    /**
+     * Emits an item-level paginator when the @paginated trait declares an items member.
+     * List items yield their elements; map items yield [key, value] entries.
+     */
+    private void writeItemsPager() {
+        List<MemberShape> itemsPath = PaginatedIndex.of(model)
+            .getPaginationInfo(service, operation)
+            .map(PaginationInfo::getItemsMemberPath)
+            .orElse(List.of());
+        if (itemsPath.isEmpty()) {
+            return;
+        }
+
+        String itemsPathString = operation.expectTrait(PaginatedTrait.class).getItems().get();
+        MemberShape itemsMember = itemsPath.get(itemsPath.size() - 1);
+        String accessPath = itemsPath.stream()
+            .map(MemberShape::getMemberName)
+            .reduce(outputTypeName, (acc, name) -> "NonNullable<" + acc + "[\"" + name + "\"]>");
+        String itemType = model.expectShape(itemsMember.getTarget()).isMapShape()
+            ? "[string, " + accessPath + "[string]]"
+            : accessPath + "[number]";
+
+        writer.addImport("createItemsPaginator", "createItemsPaginator", TypeScriptDependency.SMITHY_CORE);
+
+        writer.writeDocs("@public");
+        writer.write(
+            """
+            export const paginate$1LItems: (
+              config: $2L,
+              input: $3L,
+              ...additionalArguments: any
+            ) => Paginator<$4L> = createItemsPaginator<
+              $2L,
+              $3L,
+              $4L
+            >(paginate$1L, $5S);
+                    """,
+            operationName,
+            paginationType,
+            inputTypeName,
+            itemType,
+            itemsPathString
+        );
     }
 }

--- a/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { createPaginator } from "@smithy/core";
+import { createItemsPaginator, createPaginator } from "@smithy/core";
 import { Paginator } from "@smithy/types";
 
 import { type QueryCommandInput, type QueryCommandOutput, QueryCommand } from "../commands/QueryCommand";
@@ -22,3 +22,16 @@ export const paginateQuery: (
   QueryCommandInput,
   QueryCommandOutput
 >(DynamoDBDocumentClient, QueryCommand, "ExclusiveStartKey", "LastEvaluatedKey", "Limit");
+
+/**
+ * @public
+ */
+export const paginateQueryItems: (
+  config: DynamoDBDocumentPaginationConfiguration,
+  input: QueryCommandInput,
+  ...additionalArguments: any
+) => Paginator<NonNullable<QueryCommandOutput["Items"]>[number]> = createItemsPaginator<
+  DynamoDBDocumentPaginationConfiguration,
+  QueryCommandInput,
+  NonNullable<QueryCommandOutput["Items"]>[number]
+>(paginateQuery, "Items");

--- a/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { createPaginator } from "@smithy/core";
+import { createItemsPaginator, createPaginator } from "@smithy/core";
 import { Paginator } from "@smithy/types";
 
 import { type ScanCommandInput, type ScanCommandOutput, ScanCommand } from "../commands/ScanCommand";
@@ -22,3 +22,16 @@ export const paginateScan: (
   ScanCommandInput,
   ScanCommandOutput
 >(DynamoDBDocumentClient, ScanCommand, "ExclusiveStartKey", "LastEvaluatedKey", "Limit");
+
+/**
+ * @public
+ */
+export const paginateScanItems: (
+  config: DynamoDBDocumentPaginationConfiguration,
+  input: ScanCommandInput,
+  ...additionalArguments: any
+) => Paginator<NonNullable<ScanCommandOutput["Items"]>[number]> = createItemsPaginator<
+  DynamoDBDocumentPaginationConfiguration,
+  ScanCommandInput,
+  NonNullable<ScanCommandOutput["Items"]>[number]
+>(paginateScan, "Items");

--- a/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
+++ b/lib/lib-dynamodb/src/test/lib-dynamodb.e2e.spec.ts
@@ -823,6 +823,20 @@ describe(
       });
     });
 
+    it("can paginate items (paginateScanItems) yielding unmarshalled items", async () => {
+      const { paginateScanItems } = await import("@aws-sdk/lib-dynamodb");
+      const seen: Record<string, any> = {};
+      for await (const item of paginateScanItems({ client: doc, pageSize: 1 }, { TableName, ConsistentRead: true })) {
+        // each yielded value is an item (native JS object), not a page
+        expect(item).not.toHaveProperty("Items");
+        if (item?.id) {
+          seen[item.id] = item.data;
+        }
+      }
+      expect(seen["map"]).toEqual(data.map);
+      expect(seen["list"]).toEqual(data.list);
+    });
+
     for (const [key, value] of Object.entries(data)) {
       it(`can write data of type ${key}`, async () => {
         throwIfError(log.write[key]);


### PR DESCRIPTION
### Issue
#2328  / Internal JS-7029

### Description
Mirroring https://github.com/smithy-lang/smithy-typescript/pull/2256 for ddb doc client

### Testing
test cases added

### Checklist
- [x] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [ ] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
