### PR TITLE
 fix(lib-storage): fix symlink stream sizing and abort on part-count mismatch

### DIFF
--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -998,6 +998,28 @@ describe(Upload.name, () => {
       await expect(upload.done()).rejects.toThrow(/Expected \d+ part\(s\) but uploaded \d+ part\(s\)\./);
     });
 
+    it("should abort the multipart upload when the parts count check fails (leavePartsOnError=false)", async () => {
+      const client = new S3({});
+      const upload = new Upload({
+        params: { ...params, Body: Buffer.from("#".repeat(MOCK_PART_SIZE * 2 + 100)) },
+        client,
+      });
+
+      // Uploads happened (uploadId + prepared abort command) but the part count disagrees.
+      const abortCommand = { input: { UploadId: "mockuploadId" } };
+      Object.assign(upload as any, {
+        __doConcurrentUpload: vi.fn().mockResolvedValue(undefined),
+        uploadedParts: [{ PartNumber: 1, ETag: "etag1" }],
+        isMultiPart: true,
+        uploadId: "mockuploadId",
+        abortMultipartUploadCommand: abortCommand,
+      });
+
+      await expect(upload.done()).rejects.toThrow(/Expected \d+ part\(s\) but uploaded \d+ part\(s\)\./);
+
+      expect(client.send).toHaveBeenCalledWith(abortCommand);
+    });
+
     it("should throw error when part size doesn't match expected size except for last part", () => {
       const upload = new Upload({
         params,

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -390,6 +390,7 @@ export class Upload extends EventEmitter {
     if (this.isMultiPart) {
       const { expectedPartsCount, uploadedParts, totalBytes, totalBytesSource } = this;
       if (totalBytes !== undefined && expectedPartsCount !== undefined && uploadedParts.length !== expectedPartsCount) {
+        await this.markUploadAsAborted();
         throw new Error(`Expected ${expectedPartsCount} part(s) but uploaded ${uploadedParts.length} part(s).
 The expected part count is based on the byte-count of the input.params.Body,
 which was read from ${totalBytesSource} and is ${totalBytes}.

--- a/lib/lib-storage/src/byteLength.spec.ts
+++ b/lib/lib-storage/src/byteLength.spec.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { byteLength } from "./byteLength";
@@ -72,7 +74,23 @@ describe("byteLength", () => {
   describe("filestreams", () => {
     it("should handle readable streams", () => {
       const stream = fs.createReadStream(__filename);
-      expect(byteLength(stream)).toBe(fs.lstatSync(__filename).size);
+      expect(byteLength(stream)).toBe(fs.statSync(__filename).size);
+    });
+
+    it("should follow symlinks and report the target file size", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-storage-byte-length-"));
+      const target = path.join(dir, "target.bin");
+      const link = path.join(dir, "link.bin");
+      fs.writeFileSync(target, Buffer.alloc(5 * 1024 * 1024));
+      fs.symlinkSync(target, link);
+
+      const stream = fs.createReadStream(link);
+      try {
+        expect(byteLength(stream)).toBe(5 * 1024 * 1024);
+        expect(byteLength(stream)).toBe(fs.statSync(link).size);
+      } finally {
+        stream.destroy();
+      }
     });
   });
 });

--- a/lib/lib-storage/src/byteLength.ts
+++ b/lib/lib-storage/src/byteLength.ts
@@ -32,7 +32,7 @@ export const byteLength = (input: any): number | undefined => {
     return input.end + 1 - input.start;
   } else if (runtimeConfig.isFileReadStream(input)) {
     try {
-      return runtimeConfig.lstatSync(input.path).size;
+      return runtimeConfig.statSync(input.path).size;
     } catch (error) {
       return undefined;
     }

--- a/lib/lib-storage/src/byteLengthSource.spec.ts
+++ b/lib/lib-storage/src/byteLengthSource.spec.ts
@@ -41,12 +41,12 @@ describe("byteLengthSource", () => {
     expect(byteLengthSource(input)).toBe(BYTE_LENGTH_SOURCE.START_END_DIFF);
   });
 
-  it("should return LSTAT for input with path that exists", () => {
+  it("should return STAT for input with path that exists", () => {
     const input = fs.createReadStream(__filename);
-    vi.spyOn(runtimeConfig, "lstatSync");
+    vi.spyOn(runtimeConfig, "statSync");
 
-    expect(byteLengthSource(input)).toBe(BYTE_LENGTH_SOURCE.LSTAT);
-    expect(runtimeConfig.lstatSync).toHaveBeenCalledWith(__filename);
+    expect(byteLengthSource(input)).toBe(BYTE_LENGTH_SOURCE.STAT);
+    expect(runtimeConfig.statSync).toHaveBeenCalledWith(__filename);
   });
 
   it("ignores objects with a path property that aren't fs.ReadStream objects", () => {

--- a/lib/lib-storage/src/byteLengthSource.ts
+++ b/lib/lib-storage/src/byteLengthSource.ts
@@ -11,7 +11,7 @@ export enum BYTE_LENGTH_SOURCE {
   LENGTH = "the value of Body.length",
   SIZE = "the value of Body.size",
   START_END_DIFF = "the numeric difference between Body.start and Body.end",
-  LSTAT = "the size of the file given by Body.path on disk as reported by lstatSync",
+  STAT = "the size of the file given by Body.path on disk as reported by statSync",
 }
 
 /**
@@ -44,8 +44,8 @@ export const byteLengthSource = (input: any, override?: number): BYTE_LENGTH_SOU
     return BYTE_LENGTH_SOURCE.START_END_DIFF;
   } else if (runtimeConfig.isFileReadStream(input)) {
     try {
-      runtimeConfig.lstatSync(input.path).size;
-      return BYTE_LENGTH_SOURCE.LSTAT;
+      runtimeConfig.statSync(input.path).size;
+      return BYTE_LENGTH_SOURCE.STAT;
     } catch (error) {
       return undefined;
     }

--- a/lib/lib-storage/src/index.spec.ts
+++ b/lib/lib-storage/src/index.spec.ts
@@ -17,7 +17,7 @@ describe("runtimeConfig", () => {
     const configs = [runtimeConfig, runtimeConfigBrowser, runtimeConfigNative];
 
     for (const config of configs) {
-      expect(typeof config.lstatSync).toBe("function");
+      expect(typeof config.statSync).toBe("function");
       expect(typeof config.isFileReadStream).toBe("function");
     }
 

--- a/lib/lib-storage/src/lib-storage.e2e.spec.ts
+++ b/lib/lib-storage/src/lib-storage.e2e.spec.ts
@@ -242,7 +242,7 @@ describe("@aws-sdk/lib-storage", () => {
       expect(error).toBeInstanceOf(Error);
       expect(error.message).toEqual(`Expected 0 part(s) but uploaded 2 part(s).
 The expected part count is based on the byte-count of the input.params.Body,
-which was read from the size of the file given by Body.path on disk as reported by lstatSync and is 0.
+which was read from the size of the file given by Body.path on disk as reported by statSync and is 0.
 If this is not correct, provide an override value by setting a number
 to input.params.ContentLength in bytes.
 `);

--- a/lib/lib-storage/src/runtimeConfig.shared.ts
+++ b/lib/lib-storage/src/runtimeConfig.shared.ts
@@ -2,7 +2,7 @@
  * @internal
  */
 export const runtimeConfigShared = {
-  lstatSync: () => {},
+  statSync: () => {},
   isFileReadStream(f: unknown) {
     return false;
   },

--- a/lib/lib-storage/src/runtimeConfig.ts
+++ b/lib/lib-storage/src/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { lstatSync, ReadStream } from "node:fs";
+import { ReadStream, statSync } from "node:fs";
 
 import { runtimeConfigShared as shared } from "./runtimeConfig.shared";
 
@@ -8,7 +8,9 @@ import { runtimeConfigShared as shared } from "./runtimeConfig.shared";
 export const runtimeConfig = {
   ...shared,
   runtime: "node",
-  lstatSync,
+  // Use statSync (follows symlinks) rather than lstatSync so that the size of an
+  // fs.ReadStream opened on a symlink matches the target file the stream reads.
+  statSync,
   isFileReadStream(f: unknown): f is ReadStream {
     return f instanceof ReadStream;
   },


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/8298, https://github.com/aws/aws-sdk-js-v3/issues/8299

### Description
`lstatSync` doesn't follow symlinks, so an fs.ReadStream opened on a symlink was sized as the link, not the target it actually streams. Wrong size broke the part-count check. Switched to `statSync`. The part-count check also threw error without aborting, so with leavePartsOnError false the uploaded parts were stranded in the bucket. Now it aborts first before throwing.

### Testing
Added unit test

### Checklist
- [ ] If the PR is a feature, add integration tests (`*.integ.spec.ts`) or E2E tests.
  - [x] It's not a feature.
- [x] My E2E tests are resilient to concurrent i/o.
  - [ ] I didn't write any E2E tests.
- [ ] I added access level annotations e.g. `@public`, `@internal` tags and enabled doc generation on the package. Remember that access level annotations go below the description, not above.
  - [x] I didn't add any public functions.
- [ ] Streams - how do they work?? My WebStream readers/locks are properly lifecycled. Node.js stream backpressure is handled. Error handling.
  - [x] No streams here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
