### PR TITLE
test(client-cloudwatch): update error tests for ValidationException

### DIFF
--- a/clients/client-cloudwatch/test/e2e/cloudwatch-features.e2e.spec.ts
+++ b/clients/client-cloudwatch/test/e2e/cloudwatch-features.e2e.spec.ts
@@ -58,8 +58,9 @@ describe(CloudWatch.name, () => {
           Period: 300,
         })
       ).rejects.toThrow(
+        // "ValidationException" when the model aliases that shape to the query code, else legacy "ValidationError".
         expect.objectContaining({
-          name: "ValidationError",
+          name: expect.stringMatching(/^(ValidationError|ValidationException)$/),
         })
       );
     });

--- a/clients/client-cloudwatch/test/e2e/query-compatibility.e2e.spec.ts
+++ b/clients/client-cloudwatch/test/e2e/query-compatibility.e2e.spec.ts
@@ -110,8 +110,9 @@ describe("CloudWatch Query Compatibility E2E", () => {
       expect(error).toBeInstanceOf(CloudWatchServiceException);
 
       expect(error.constructor.prototype.name).toBe("Error");
-      expect(error.constructor.name).toBe("CloudWatchServiceException");
-      expect(error.name).toBe("ValidationError");
+      // Modeling a ValidationException shape (aliased to query code "ValidationError") narrows this from the base class.
+      expect(["CloudWatchServiceException", "ValidationException"]).toContain(error.constructor.name);
+      expect(["ValidationError", "ValidationException"]).toContain(error.name);
 
       expect(error.message).toBe(msg);
       expect(error.Type).toEqual("Sender");


### PR DESCRIPTION
CloudWatch is expected to introduce a modeled exception called ValidationException, so previous `ValidationError`-coded synthetic service base exceptions will become this more specific error type.

The test assertions are being loosened to account for this.